### PR TITLE
fix: add metro.config.js for WASM asset resolution (BLD-14)

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,5 @@
+const { getDefaultConfig } = require("expo/metro-config");
+
+const config = getDefaultConfig(__dirname);
+config.resolver.assetExts.push("wasm");
+module.exports = config;


### PR DESCRIPTION
## Summary

Adds `metro.config.js` to resolve the web export failure caused by Metro's inability to resolve `.wasm` files. This is the final fix for the BLD-14 pipeline halt.

## Root Cause

`expo-sqlite`'s web implementation requires `wa-sqlite.wasm`, but Metro bundler doesn't include `.wasm` in its default asset extensions. This caused `expo export --platform web` to fail with:

```
Error: Unable to resolve module ./wa-sqlite/wa-sqlite.wasm
```

## Fix

Single file: `metro.config.js` — extends the default Expo Metro config and adds `.wasm` to `resolver.assetExts`.

## Verification (all pass)

| Check | Result |
|-------|--------|
| `npm install` | ✅ 1045 packages, 0 vulnerabilities |
| `tsc --noEmit` | ✅ zero errors |
| `expo export --platform web` | ✅ 1007 modules bundled, wa-sqlite.wasm included as asset |
| `expo export --platform ios` | ✅ passes |

## Issue
Resolves BLD-14