### PR TITLE
feat: crash reporting — error boundary, error log, and report UX (BLD-19)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,15 +1,26 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { ScrollView, StyleSheet } from "react-native";
 import { Button, Card, Snackbar, Text, useTheme } from "react-native-paper";
 import { File, Paths } from "expo-file-system";
 import * as Sharing from "expo-sharing";
 import * as DocumentPicker from "expo-document-picker";
+import { useRouter } from "expo-router";
+import { useFocusEffect } from "@react-navigation/native";
 import { exportAllData, importData } from "../../lib/db";
+import { getErrorCount, clearErrorLog, generateReport } from "../../lib/errors";
 
 export default function Settings() {
   const theme = useTheme();
+  const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [snack, setSnack] = useState("");
+  const [count, setCount] = useState(0);
+
+  useFocusEffect(
+    useCallback(() => {
+      getErrorCount().then(setCount);
+    }, [])
+  );
 
   const handleExport = async () => {
     setLoading(true);
@@ -119,6 +130,64 @@ export default function Settings() {
           <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
             Import a previously exported FitForge JSON file. Duplicate records are skipped.
           </Text>
+        </Card.Content>
+      </Card>
+
+      <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+        <Card.Content>
+          <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 16 }}>
+            Crash Reporting ({count} {count === 1 ? "error" : "errors"})
+          </Text>
+
+          <Button
+            mode="contained"
+            icon="bug-outline"
+            onPress={() => router.push("/errors")}
+            style={styles.btn}
+          >
+            View Error Log
+          </Button>
+
+          <Button
+            mode="outlined"
+            icon="share-variant"
+            onPress={async () => {
+              setLoading(true);
+              try {
+                const report = await generateReport();
+                const file = new File(Paths.cache, "fitforge-crash-report.json");
+                await file.write(report);
+                await Sharing.shareAsync(file.uri, {
+                  mimeType: "application/json",
+                  dialogTitle: "Share Crash Report",
+                });
+                setSnack("Crash report shared");
+              } catch {
+                setSnack("Unable to share");
+              } finally {
+                setLoading(false);
+              }
+            }}
+            loading={loading}
+            disabled={loading}
+            style={styles.btn}
+          >
+            Share Crash Report
+          </Button>
+
+          <Button
+            mode="outlined"
+            icon="delete-outline"
+            onPress={async () => {
+              await clearErrorLog();
+              setCount(0);
+              setSnack("Error log cleared");
+            }}
+            style={styles.btn}
+            textColor={theme.colors.error}
+          >
+            Clear Error Log
+          </Button>
         </Card.Content>
       </Card>
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,6 +6,8 @@ import { StatusBar } from "expo-status-bar";
 import { useEffect } from "react";
 import { light, dark, navigationLight, navigationDark } from "../constants/theme";
 import { getDatabase } from "../lib/db";
+import { setupGlobalHandler } from "../lib/errors";
+import ErrorBoundary from "../components/ErrorBoundary";
 
 export default function RootLayout() {
   const scheme = useColorScheme();
@@ -14,6 +16,7 @@ export default function RootLayout() {
 
   useEffect(() => {
     getDatabase();
+    setupGlobalHandler();
   }, []);
 
   const headerStyle = {
@@ -22,88 +25,99 @@ export default function RootLayout() {
   const headerTintColor = paperTheme.colors.onSurface;
 
   return (
-    <PaperProvider theme={paperTheme}>
-      <ThemeProvider value={isDark ? navigationDark : navigationLight}>
-        <Stack
-          screenOptions={{
-            headerShown: false,
-          }}
-        >
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen
-            name="exercise/[id]"
-            options={{
-              headerShown: true,
-              headerStyle,
-              headerTintColor,
+    <ErrorBoundary>
+      <PaperProvider theme={paperTheme}>
+        <ThemeProvider value={isDark ? navigationDark : navigationLight}>
+          <Stack
+            screenOptions={{
+              headerShown: false,
             }}
-          />
-          <Stack.Screen
-            name="template/create"
-            options={{
-              headerShown: true,
-              title: "New Template",
-              headerStyle,
-              headerTintColor,
-            }}
-          />
-          <Stack.Screen
-            name="template/[id]"
-            options={{
-              headerShown: true,
-              title: "Edit Template",
-              headerStyle,
-              headerTintColor,
-            }}
-          />
-          <Stack.Screen
-            name="template/pick-exercise"
-            options={{
-              headerShown: true,
-              title: "Pick Exercise",
-              headerStyle,
-              headerTintColor,
-            }}
-          />
-          <Stack.Screen
-            name="session/[id]"
-            options={{
-              headerShown: true,
-              title: "Workout",
-              headerStyle,
-              headerTintColor,
-            }}
-          />
-          <Stack.Screen
-            name="session/detail/[id]"
-            options={{
-              headerShown: true,
-              title: "Workout Summary",
-              headerStyle,
-              headerTintColor,
-            }}
-          />
-          <Stack.Screen
-            name="nutrition/add"
-            options={{
-              headerShown: true,
-              title: "Add Food",
-              headerStyle,
-              headerTintColor,
-            }}
-          />
-          <Stack.Screen
-            name="nutrition/targets"
-            options={{
-              headerShown: true,
-              title: "Macro Targets",
-              headerStyle,
-              headerTintColor,
-            }}
-          />
-        </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
-    </PaperProvider>
+          >
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen
+              name="exercise/[id]"
+              options={{
+                headerShown: true,
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="template/create"
+              options={{
+                headerShown: true,
+                title: "New Template",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="template/[id]"
+              options={{
+                headerShown: true,
+                title: "Edit Template",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="template/pick-exercise"
+              options={{
+                headerShown: true,
+                title: "Pick Exercise",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="session/[id]"
+              options={{
+                headerShown: true,
+                title: "Workout",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="session/detail/[id]"
+              options={{
+                headerShown: true,
+                title: "Workout Summary",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="nutrition/add"
+              options={{
+                headerShown: true,
+                title: "Add Food",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="nutrition/targets"
+              options={{
+                headerShown: true,
+                title: "Macro Targets",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="errors"
+              options={{
+                headerShown: true,
+                title: "Error Log",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+          </Stack>
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </PaperProvider>
+    </ErrorBoundary>
   );
 }

--- a/app/errors.tsx
+++ b/app/errors.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useState } from "react";
+import { FlatList, StyleSheet, View } from "react-native";
+import { Button, Card, Chip, Snackbar, Text, useTheme } from "react-native-paper";
+import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { getRecentErrors, clearErrorLog } from "../lib/errors";
+import type { ErrorEntry } from "../lib/types";
+
+export default function Errors() {
+  const theme = useTheme();
+  const nav = useNavigation();
+  const [errors, setErrors] = useState<ErrorEntry[]>([]);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [snack, setSnack] = useState("");
+
+  const load = useCallback(async () => {
+    const rows = await getRecentErrors(50);
+    setErrors(rows);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [load])
+  );
+
+  const handleClear = async () => {
+    await clearErrorLog();
+    setErrors([]);
+    setSnack("Error log cleared");
+  };
+
+  // Set header action
+  useFocusEffect(
+    useCallback(() => {
+      nav.setOptions({
+        headerRight: () =>
+          errors.length > 0 ? (
+            <Button onPress={handleClear} compact textColor={theme.colors.error}>
+              Clear All
+            </Button>
+          ) : null,
+      });
+    }, [errors.length, nav, theme.colors.error])
+  );
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => (prev === id ? null : id));
+  };
+
+  const fmt = (ts: number) => {
+    const d = new Date(ts);
+    return d.toLocaleDateString() + " " + d.toLocaleTimeString();
+  };
+
+  if (errors.length === 0) {
+    return (
+      <View style={[styles.empty, { backgroundColor: theme.colors.background }]}>
+        <MaterialCommunityIcons
+          name="check-circle-outline"
+          size={64}
+          color={theme.colors.primary}
+        />
+        <Text
+          variant="titleMedium"
+          style={{ color: theme.colors.onBackground, marginTop: 16 }}
+        >
+          No errors recorded
+        </Text>
+        <Snackbar
+          visible={!!snack}
+          onDismiss={() => setSnack("")}
+          duration={3000}
+          action={{ label: "OK", onPress: () => setSnack("") }}
+        >
+          {snack}
+        </Snackbar>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <FlatList
+        data={errors}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <Card
+            style={[styles.card, { backgroundColor: theme.colors.surface }]}
+            onPress={() => toggle(item.id)}
+          >
+            <Card.Content>
+              <View style={styles.row}>
+                <Text
+                  variant="bodySmall"
+                  style={{ color: theme.colors.onSurfaceVariant }}
+                >
+                  {fmt(item.timestamp)}
+                </Text>
+                {item.fatal && (
+                  <Chip
+                    compact
+                    textStyle={{ fontSize: 10 }}
+                    style={{ backgroundColor: theme.colors.errorContainer }}
+                  >
+                    FATAL
+                  </Chip>
+                )}
+              </View>
+              <Text
+                variant="bodyMedium"
+                numberOfLines={expanded === item.id ? undefined : 2}
+                style={{ color: theme.colors.onSurface, marginTop: 4 }}
+              >
+                {item.message}
+              </Text>
+              {expanded === item.id && item.stack && (
+                <View style={styles.stackBox}>
+                  <Text
+                    variant="bodySmall"
+                    style={{
+                      fontFamily: "monospace",
+                      color: theme.colors.onSurfaceVariant,
+                      fontSize: 11,
+                    }}
+                    selectable
+                  >
+                    {item.stack}
+                  </Text>
+                </View>
+              )}
+            </Card.Content>
+          </Card>
+        )}
+      />
+      <Snackbar
+        visible={!!snack}
+        onDismiss={() => setSnack("")}
+        duration={3000}
+        action={{ label: "OK", onPress: () => setSnack("") }}
+      >
+        {snack}
+      </Snackbar>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  empty: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  list: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  card: {
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  stackBox: {
+    marginTop: 8,
+    backgroundColor: "rgba(0,0,0,0.15)",
+    borderRadius: 6,
+    padding: 8,
+  },
+});

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
+import { Button, Text } from "react-native-paper";
+import { File, Paths } from "expo-file-system";
+import * as Sharing from "expo-sharing";
+import { logError, generateReport } from "../lib/errors";
+
+type Props = { children: React.ReactNode };
+type State = { error: Error | null; expanded: boolean };
+
+export default class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null, expanded: false };
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    logError(error, { component: info.componentStack ?? undefined, fatal: true });
+  }
+
+  handleRestart = () => {
+    this.setState({ error: null, expanded: false });
+  };
+
+  handleShare = async () => {
+    try {
+      const report = await generateReport();
+      const file = new File(Paths.cache, "fitforge-crash-report.json");
+      await file.write(report);
+      await Sharing.shareAsync(file.uri, {
+        mimeType: "application/json",
+        dialogTitle: "Share Crash Report",
+      });
+    } catch {
+      // If sharing fails, silently ignore — we're already in a crash state
+    }
+  };
+
+  render() {
+    if (!this.state.error) return this.props.children;
+
+    return (
+      <View style={styles.container}>
+        <ScrollView contentContainerStyle={styles.content}>
+          <Text variant="headlineLarge" style={styles.heading}>
+            Something went wrong
+          </Text>
+          <Text variant="bodyMedium" style={styles.sub}>
+            The app encountered an unexpected error. You can share a crash
+            report to help us fix the issue, or restart the app.
+          </Text>
+
+          <Button
+            mode="outlined"
+            onPress={() => this.setState((s) => ({ expanded: !s.expanded }))}
+            style={styles.btn}
+            icon={this.state.expanded ? "chevron-up" : "chevron-down"}
+          >
+            {this.state.expanded ? "Hide Details" : "Show Details"}
+          </Button>
+
+          {this.state.expanded && (
+            <ScrollView style={styles.stack} nestedScrollEnabled>
+              <Text variant="bodySmall" style={styles.mono}>
+                {this.state.error.message}
+                {"\n\n"}
+                {this.state.error.stack}
+              </Text>
+            </ScrollView>
+          )}
+
+          <Button
+            mode="contained"
+            icon="share-variant"
+            onPress={this.handleShare}
+            style={styles.btn}
+          >
+            Share Crash Report
+          </Button>
+
+          <Button
+            mode="contained-tonal"
+            icon="restart"
+            onPress={this.handleRestart}
+            style={styles.btn}
+          >
+            Restart
+          </Button>
+        </ScrollView>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#121212",
+  },
+  content: {
+    padding: 24,
+    paddingTop: 80,
+    alignItems: "center",
+  },
+  heading: {
+    color: "#fff",
+    marginBottom: 16,
+    textAlign: "center",
+  },
+  sub: {
+    color: "#aaa",
+    marginBottom: 24,
+    textAlign: "center",
+  },
+  btn: {
+    marginBottom: 12,
+    width: "100%",
+  },
+  stack: {
+    maxHeight: 200,
+    width: "100%",
+    backgroundColor: "#1e1e1e",
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+  },
+  mono: {
+    fontFamily: "monospace",
+    color: "#e0e0e0",
+    fontSize: 11,
+  },
+});

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -105,6 +105,18 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
       fat REAL DEFAULT 65,
       updated_at INTEGER NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS error_log (
+      id TEXT PRIMARY KEY,
+      message TEXT NOT NULL,
+      stack TEXT,
+      component TEXT,
+      fatal INTEGER NOT NULL DEFAULT 0,
+      timestamp INTEGER NOT NULL,
+      app_version TEXT,
+      platform TEXT,
+      os_version TEXT
+    );
   `);
 }
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,115 @@
+import { Platform } from "react-native";
+import Constants from "expo-constants";
+import { getDatabase } from "./db";
+import type { ErrorEntry } from "./types";
+
+declare const ErrorUtils: {
+  setGlobalHandler: (callback: (error: Error, isFatal?: boolean) => void) => void;
+  getGlobalHandler: () => (error: Error, isFatal?: boolean) => void;
+};
+
+const MAX_ERRORS = 50;
+
+type ErrorRow = {
+  id: string;
+  message: string;
+  stack: string | null;
+  component: string | null;
+  fatal: number;
+  timestamp: number;
+  app_version: string | null;
+  platform: string | null;
+  os_version: string | null;
+};
+
+function mapRow(row: ErrorRow): ErrorEntry {
+  return {
+    ...row,
+    fatal: row.fatal === 1,
+  };
+}
+
+export async function logError(
+  error: Error,
+  opts?: { component?: string; fatal?: boolean }
+): Promise<void> {
+  try {
+    const database = await getDatabase();
+    const id = crypto.randomUUID();
+    await database.runAsync(
+      `INSERT INTO error_log (id, message, stack, component, fatal, timestamp, app_version, platform, os_version)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        error.message || "Unknown error",
+        error.stack ?? null,
+        opts?.component ?? null,
+        opts?.fatal ? 1 : 0,
+        Date.now(),
+        Constants.expoConfig?.version ?? null,
+        Platform.OS,
+        String(Platform.Version),
+      ]
+    );
+    // trim to MAX_ERRORS
+    await database.runAsync(
+      `DELETE FROM error_log WHERE id NOT IN (
+        SELECT id FROM error_log ORDER BY timestamp DESC LIMIT ?
+      )`,
+      [MAX_ERRORS]
+    );
+  } catch {
+    // If DB write fails, silently ignore — never crash the crash handler
+  }
+}
+
+export async function getRecentErrors(limit = 20): Promise<ErrorEntry[]> {
+  const database = await getDatabase();
+  const rows = await database.getAllAsync<ErrorRow>(
+    "SELECT * FROM error_log ORDER BY timestamp DESC LIMIT ?",
+    [limit]
+  );
+  return rows.map(mapRow);
+}
+
+export async function getErrorCount(): Promise<number> {
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{ count: number }>(
+    "SELECT COUNT(*) as count FROM error_log"
+  );
+  return row?.count ?? 0;
+}
+
+export async function clearErrorLog(): Promise<void> {
+  const database = await getDatabase();
+  await database.runAsync("DELETE FROM error_log");
+}
+
+export async function generateReport(): Promise<string> {
+  const errors = await getRecentErrors(MAX_ERRORS);
+  return JSON.stringify(
+    {
+      generated_at: new Date().toISOString(),
+      app_version: Constants.expoConfig?.version ?? "unknown",
+      platform: Platform.OS,
+      os_version: String(Platform.Version),
+      error_count: errors.length,
+      errors,
+    },
+    null,
+    2
+  );
+}
+
+let installed = false;
+
+export function setupGlobalHandler(): void {
+  if (installed) return;
+  installed = true;
+
+  const prev = ErrorUtils.getGlobalHandler();
+  ErrorUtils.setGlobalHandler((error: Error, fatal?: boolean) => {
+    logError(error, { fatal: fatal ?? true });
+    prev(error, fatal);
+  });
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -156,3 +156,17 @@ export type MacroTargets = {
   fat: number;
   updated_at: number;
 };
+
+// --------------- Error Log ---------------
+
+export type ErrorEntry = {
+  id: string;
+  message: string;
+  stack: string | null;
+  component: string | null;
+  fatal: boolean;
+  timestamp: number;
+  app_version: string | null;
+  platform: string | null;
+  os_version: string | null;
+};


### PR DESCRIPTION
## Summary

Adds crash reporting infrastructure to FitForge: an ErrorBoundary that catches React render errors, a global JS error handler for unhandled exceptions, an error log SQLite table with max 50 entries, and user-facing UI to view/share/clear crash reports.

## Changes

- **`components/ErrorBoundary.tsx`** — Class component wrapping the app; shows crash screen with "Share Crash Report" and "Restart" buttons
- **`lib/errors.ts`** — Global error handler setup (`ErrorUtils.setGlobalHandler`), `logError`, `getRecentErrors`, `clearErrorLog`, `generateReport` helpers
- **`lib/db.ts`** — Added `error_log` table to migration (IF NOT EXISTS)
- **`lib/types.ts`** — Added `ErrorEntry` type
- **`app/_layout.tsx`** — Wrapped app in ErrorBoundary, initialized global handler, registered errors screen
- **`app/errors.tsx`** — Error log screen with expandable list, fatal badges, empty state, and "Clear All" header action
- **`app/(tabs)/settings.tsx`** — Added "Crash Reporting" card with error count badge, View/Share/Clear buttons

## Testing

- TypeScript typecheck passes with zero errors (`tsc --noEmit`)
- Follows existing patterns (expo-sharing for report sharing, SQLite for storage)
- Error log auto-trims to 50 entries on each insert
- ErrorBoundary catches its own errors gracefully (no infinite loop)

## Issue

Resolves BLD-19