### PR TITLE
feat: comprehensive accessibility — labels, font sizes, theme colors (BLD-21)

### DIFF
--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -54,6 +54,8 @@ export default function Exercises() {
       <TouchableRipple
         onPress={() => router.push(`/exercise/${item.id}`)}
         style={[styles.item, { backgroundColor: theme.colors.surface, borderBottomColor: theme.colors.outlineVariant }]}
+        accessibilityLabel={`${item.name}, ${CATEGORY_LABELS[item.category]}, ${item.equipment}`}
+        accessibilityRole="button"
       >
         <View>
           <Text variant="titleSmall" numberOfLines={1} style={{ color: theme.colors.onSurface }}>
@@ -127,6 +129,7 @@ export default function Exercises() {
         value={query}
         onChangeText={setQuery}
         style={[styles.search, { backgroundColor: theme.colors.surface }]}
+        accessibilityLabel="Search exercises"
       />
       <View style={styles.chips}>
         <FlatList
@@ -140,6 +143,9 @@ export default function Exercises() {
               onPress={() => toggle(cat)}
               style={styles.filterChip}
               compact
+              accessibilityLabel={`Filter by ${CATEGORY_LABELS[cat]}`}
+              accessibilityRole="button"
+              accessibilityState={{ selected: selected.has(cat) }}
             >
               {CATEGORY_LABELS[cat]}
             </Chip>
@@ -190,14 +196,14 @@ const styles = StyleSheet.create({
     height: 24,
   },
   chipText: {
-    fontSize: 11,
+    fontSize: 12,
   },
   muscle: {
     marginRight: 4,
     height: 22,
   },
   muscleText: {
-    fontSize: 10,
+    fontSize: 12,
   },
   empty: {
     alignItems: "center",

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -116,6 +116,8 @@ export default function Workouts() {
         <Card
           style={[styles.banner, { backgroundColor: theme.colors.primaryContainer }]}
           onPress={() => router.push(`/session/${active.id}`)}
+          accessibilityLabel={`Resume active workout: ${active.name}`}
+          accessibilityRole="button"
         >
           <Card.Content>
             <Text variant="titleSmall" style={{ color: theme.colors.onPrimaryContainer }}>
@@ -135,6 +137,7 @@ export default function Workouts() {
         onPress={quickStart}
         style={styles.quickStart}
         contentStyle={styles.quickStartContent}
+        accessibilityLabel="Quick start workout"
       >
         Quick Start
       </Button>
@@ -150,6 +153,7 @@ export default function Workouts() {
             icon="plus"
             compact
             onPress={() => router.push("/template/create")}
+            accessibilityLabel="Create new template"
           >
             Create
           </Button>
@@ -166,6 +170,7 @@ export default function Workouts() {
               mode="outlined"
               onPress={() => router.push("/template/create")}
               style={styles.emptyBtn}
+              accessibilityLabel="Create your first template"
             >
               Create Template
             </Button>
@@ -180,6 +185,8 @@ export default function Workouts() {
                 style={[styles.card, { backgroundColor: theme.colors.surface }]}
                 onPress={() => startFromTemplate(item)}
                 onLongPress={() => confirmDelete(item)}
+                accessibilityLabel={`Start workout from template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
+                accessibilityRole="button"
               >
                 <Card.Content style={styles.cardContent}>
                   <View style={styles.cardInfo}>
@@ -200,6 +207,7 @@ export default function Workouts() {
                     icon="pencil"
                     size={20}
                     onPress={() => router.push(`/template/${item.id}`)}
+                    accessibilityLabel={`Edit template ${item.name}`}
                   />
                 </Card.Content>
               </Card>
@@ -236,6 +244,8 @@ export default function Workouts() {
                 onPress={() =>
                   router.push(`/session/detail/${item.id}`)
                 }
+                accessibilityLabel={`View workout: ${item.name}, ${dateStr(item.started_at)}, ${duration(item.duration_seconds)}, ${setCounts2[item.id] ?? 0} sets`}
+                accessibilityRole="button"
               >
                 <Card.Content>
                   <Text

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../lib/db";
 import type { DailyLog, MacroTargets } from "../../lib/types";
 import { MEALS, MEAL_LABELS } from "../../lib/types";
+import { semantic } from "../../constants/theme";
 
 const DAY_MS = 86_400_000;
 
@@ -94,24 +95,26 @@ export default function Nutrition() {
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
       <View style={styles.header}>
-        <IconButton icon="chevron-left" onPress={prev} />
+        <IconButton icon="chevron-left" onPress={prev} accessibilityLabel="Previous day" />
         <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
           {label(date)}
         </Text>
-        <IconButton icon="chevron-right" onPress={next} />
+        <IconButton icon="chevron-right" onPress={next} accessibilityLabel="Next day" />
       </View>
 
       {targets && (
         <Card style={[styles.card, { backgroundColor: theme.colors.surface, marginHorizontal: 16 }]}>
           <Card.Content>
             <MacroRow label="Calories" value={summary.calories} target={targets.calories} color={theme.colors.primary} theme={theme} />
-            <MacroRow label="Protein" value={summary.protein} target={targets.protein} color="#4caf50" unit="g" theme={theme} />
-            <MacroRow label="Carbs" value={summary.carbs} target={targets.carbs} color="#ff9800" unit="g" theme={theme} />
-            <MacroRow label="Fat" value={summary.fat} target={targets.fat} color="#f44336" unit="g" theme={theme} />
+            <MacroRow label="Protein" value={summary.protein} target={targets.protein} color={semantic.protein} unit="g" theme={theme} />
+            <MacroRow label="Carbs" value={summary.carbs} target={targets.carbs} color={semantic.carbs} unit="g" theme={theme} />
+            <MacroRow label="Fat" value={summary.fat} target={targets.fat} color={semantic.fat} unit="g" theme={theme} />
             <Text
               variant="labelSmall"
               style={{ color: theme.colors.primary, marginTop: 8 }}
               onPress={() => router.push("/nutrition/targets")}
+              accessibilityLabel="Edit macro targets"
+              accessibilityRole="link"
             >
               Edit Targets →
             </Text>
@@ -153,7 +156,7 @@ export default function Nutrition() {
                           {Math.round((item.food?.fat ?? 0) * item.servings)}f
                         </Text>
                       </View>
-                      <IconButton icon="delete-outline" size={20} onPress={() => remove(item)} />
+                      <IconButton icon="delete-outline" size={20} onPress={() => remove(item)} accessibilityLabel={`Remove ${item.food?.name ?? "food"}`} />
                     </Card.Content>
                   </Card>
                 ))}
@@ -168,6 +171,7 @@ export default function Nutrition() {
         style={[styles.fab, { backgroundColor: theme.colors.primary }]}
         color={theme.colors.onPrimary}
         onPress={() => router.push("/nutrition/add")}
+        accessibilityLabel="Add food"
       />
 
       <Snackbar

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -139,7 +139,7 @@ export default function Progress() {
             </Text>
           ) : (
             prs.map((pr) => (
-              <View key={pr.exercise_id} style={styles.prRow}>
+              <View key={pr.exercise_id} style={[styles.prRow, { borderBottomColor: theme.colors.outlineVariant }]}>
                 <Text variant="bodyMedium" style={{ color: theme.colors.onSurface, flex: 1 }}>
                   {pr.name}
                 </Text>
@@ -203,7 +203,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingVertical: 8,
     borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: "#e0e0e0",
   },
   sessionRow: {
     flexDirection: "row",

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -108,6 +108,7 @@ export default function Settings() {
             loading={loading}
             disabled={loading}
             style={styles.btn}
+            accessibilityLabel="Export all data"
           >
             Export All Data
           </Button>
@@ -123,6 +124,7 @@ export default function Settings() {
             loading={loading}
             disabled={loading}
             style={styles.btn}
+            accessibilityLabel="Import data"
           >
             Import Data
           </Button>
@@ -144,6 +146,7 @@ export default function Settings() {
             icon="bug-outline"
             onPress={() => router.push("/errors")}
             style={styles.btn}
+            accessibilityLabel={`View error log, ${count} ${count === 1 ? "error" : "errors"}`}
           >
             View Error Log
           </Button>
@@ -171,6 +174,7 @@ export default function Settings() {
             loading={loading}
             disabled={loading}
             style={styles.btn}
+            accessibilityLabel="Share crash report"
           >
             Share Crash Report
           </Button>
@@ -185,6 +189,7 @@ export default function Settings() {
             }}
             style={styles.btn}
             textColor={theme.colors.error}
+            accessibilityLabel="Clear error log"
           >
             Clear Error Log
           </Button>

--- a/app/errors.tsx
+++ b/app/errors.tsx
@@ -36,7 +36,7 @@ export default function Errors() {
       nav.setOptions({
         headerRight: () =>
           errors.length > 0 ? (
-            <Button onPress={handleClear} compact textColor={theme.colors.error}>
+            <Button onPress={handleClear} compact textColor={theme.colors.error} accessibilityLabel="Clear all errors">
               Clear All
             </Button>
           ) : null,
@@ -89,6 +89,8 @@ export default function Errors() {
           <Card
             style={[styles.card, { backgroundColor: theme.colors.surface }]}
             onPress={() => toggle(item.id)}
+            accessibilityLabel={`Error: ${item.message}, ${fmt(item.timestamp)}${item.fatal ? ", fatal" : ""}`}
+            accessibilityRole="button"
           >
             <Card.Content>
               <View style={styles.row}>
@@ -101,7 +103,7 @@ export default function Errors() {
                 {item.fatal && (
                   <Chip
                     compact
-                    textStyle={{ fontSize: 10 }}
+                    textStyle={{ fontSize: 12 }}
                     style={{ backgroundColor: theme.colors.errorContainer }}
                   >
                     FATAL
@@ -122,7 +124,7 @@ export default function Errors() {
                     style={{
                       fontFamily: "monospace",
                       color: theme.colors.onSurfaceVariant,
-                      fontSize: 11,
+                      fontSize: 12,
                     }}
                     selectable
                   >

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -4,11 +4,12 @@ import { Chip, Text, useTheme } from "react-native-paper";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { getExerciseById } from "../../lib/db";
 import { CATEGORY_LABELS, type Exercise } from "../../lib/types";
+import { semantic } from "../../constants/theme";
 
 const DIFFICULTY_COLORS: Record<string, string> = {
-  beginner: "#4CAF50",
-  intermediate: "#FF9800",
-  advanced: "#F44336",
+  beginner: semantic.beginner,
+  intermediate: semantic.intermediate,
+  advanced: semantic.advanced,
 };
 
 export default function ExerciseDetail() {
@@ -165,7 +166,7 @@ const styles = StyleSheet.create({
     borderRadius: 16,
   },
   difficultyText: {
-    color: "#ffffff",
+    color: semantic.onSemantic,
     fontWeight: "600",
   },
   step: {

--- a/app/nutrition/add.tsx
+++ b/app/nutrition/add.tsx
@@ -92,6 +92,9 @@ export default function AddFood() {
             selected={meal === m}
             onPress={() => setMeal(m)}
             style={styles.chip}
+            accessibilityLabel={`Meal: ${MEAL_LABELS[m]}`}
+            accessibilityRole="button"
+            accessibilityState={{ selected: meal === m }}
           >
             {MEAL_LABELS[m]}
           </Chip>
@@ -156,6 +159,9 @@ export default function AddFood() {
               onPress={() => setFavorite(!favorite)}
               icon={favorite ? "heart" : "heart-outline"}
               style={styles.favChip}
+              accessibilityLabel={favorite ? "Remove from favorites" : "Save as favorite"}
+              accessibilityRole="button"
+              accessibilityState={{ selected: favorite }}
             >
               Save as favorite
             </Chip>
@@ -165,6 +171,7 @@ export default function AddFood() {
               loading={saving}
               disabled={saving || !name.trim()}
               style={styles.btn}
+              accessibilityLabel="Log food"
             >
               Log Food
             </Button>
@@ -186,6 +193,8 @@ export default function AddFood() {
                   key={f.id}
                   style={[styles.favCard, { backgroundColor: theme.colors.surfaceVariant }]}
                   onPress={() => quickLog(f)}
+                  accessibilityLabel={`Quick log ${f.name}, ${f.calories} calories`}
+                  accessibilityRole="button"
                 >
                   <Card.Content>
                     <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>

--- a/app/nutrition/targets.tsx
+++ b/app/nutrition/targets.tsx
@@ -87,10 +87,10 @@ export default function Targets() {
             mode="outlined"
             style={styles.input}
           />
-          <Button mode="contained" onPress={save} loading={saving} disabled={saving} style={styles.btn}>
+          <Button mode="contained" onPress={save} loading={saving} disabled={saving} style={styles.btn} accessibilityLabel="Save macro targets">
             Save Targets
           </Button>
-          <Button mode="outlined" onPress={reset} style={styles.btn}>
+          <Button mode="outlined" onPress={reset} style={styles.btn} accessibilityLabel="Reset to default targets">
             Reset to Defaults
           </Button>
         </Card.Content>

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -297,8 +297,8 @@ export default function ActiveSession() {
         contentContainerStyle={styles.content}
       >
         {rest > 0 && (
-          <View style={[styles.restBanner, { backgroundColor: theme.colors.primaryContainer }]}>
-            <Text variant="headlineLarge" style={{ color: theme.colors.onPrimaryContainer, fontWeight: "700" }}>
+          <View style={[styles.restBanner, { backgroundColor: theme.colors.primaryContainer }]} accessibilityLiveRegion="polite">
+            <Text variant="headlineLarge" style={{ color: theme.colors.onPrimaryContainer, fontWeight: "700" }} accessibilityLabel={`Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds`}>
               {String(Math.floor(rest / 60)).padStart(2, "0")}:{String(rest % 60).padStart(2, "0")}
             </Text>
             <Text variant="bodySmall" style={{ color: theme.colors.onPrimaryContainer, marginTop: 4 }}>
@@ -310,6 +310,7 @@ export default function ActiveSession() {
               onPress={dismissRest}
               textColor={theme.colors.onPrimaryContainer}
               style={{ marginTop: 4 }}
+              accessibilityLabel="Skip rest timer"
             >
               Skip
             </Button>
@@ -387,6 +388,7 @@ export default function ActiveSession() {
                   value={set.weight != null ? String(set.weight) : ""}
                   onChangeText={(v) => handleUpdate(set.id, "weight", v)}
                   placeholder="-"
+                  accessibilityLabel={`Set ${set.set_number} weight`}
                 />
                 <TextInput
                   mode="outlined"
@@ -396,8 +398,9 @@ export default function ActiveSession() {
                   value={set.reps != null ? String(set.reps) : ""}
                   onChangeText={(v) => handleUpdate(set.id, "reps", v)}
                   placeholder="-"
+                  accessibilityLabel={`Set ${set.set_number} reps`}
                 />
-                <View style={styles.colCheck}>
+                <View style={styles.colCheck} accessible accessibilityLabel={`Mark set ${set.set_number} ${set.completed ? "incomplete" : "complete"}`} accessibilityRole="checkbox" accessibilityState={{ checked: set.completed }}>
                   <Checkbox
                     status={set.completed ? "checked" : "unchecked"}
                     onPress={() => handleCheck(set)}
@@ -412,6 +415,7 @@ export default function ActiveSession() {
               icon="plus"
               onPress={() => handleAddSet(group.exercise_id)}
               style={styles.addSetBtn}
+              accessibilityLabel={`Add set to ${group.name}`}
             >
               Add Set
             </Button>
@@ -424,6 +428,7 @@ export default function ActiveSession() {
           icon="plus"
           onPress={handleAddExercise}
           style={styles.addExercise}
+          accessibilityLabel="Add exercise to workout"
         >
           Add Exercise
         </Button>
@@ -433,6 +438,7 @@ export default function ActiveSession() {
           onPress={finish}
           style={styles.finishBtn}
           contentStyle={styles.finishContent}
+          accessibilityLabel="Finish workout"
         >
           Finish Workout
         </Button>
@@ -442,6 +448,7 @@ export default function ActiveSession() {
           onPress={cancel}
           textColor={theme.colors.error}
           style={styles.cancelBtn}
+          accessibilityLabel="Cancel workout"
         >
           Cancel Workout
         </Button>

--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -102,17 +102,20 @@ export default function EditTemplate() {
             size={18}
             onPress={() => move(index, -1)}
             disabled={index === 0}
+            accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} up`}
           />
           <IconButton
             icon="arrow-down"
             size={18}
             onPress={() => move(index, 1)}
             disabled={index === exercises.length - 1}
+            accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} down`}
           />
           <IconButton
             icon="close"
             size={18}
             onPress={() => remove(item.id)}
+            accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"}`}
           />
         </View>
       </View>
@@ -175,10 +178,11 @@ export default function EditTemplate() {
             router.push(`/template/pick-exercise?templateId=${id}&editId=${id}`)
           }
           style={styles.addBtn}
+          accessibilityLabel="Add exercise to template"
         >
           Add Exercise
         </Button>
-        <Button mode="contained" onPress={() => router.back()} style={styles.doneBtn}>
+        <Button mode="contained" onPress={() => router.back()} style={styles.doneBtn} accessibilityLabel="Done editing template">
           Done
         </Button>
       </View>

--- a/app/template/create.tsx
+++ b/app/template/create.tsx
@@ -137,17 +137,20 @@ export default function CreateTemplate() {
             size={18}
             onPress={() => move(index, -1)}
             disabled={index === 0}
+            accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} up`}
           />
           <IconButton
             icon="arrow-down"
             size={18}
             onPress={() => move(index, 1)}
             disabled={index === exercises.length - 1}
+            accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} down`}
           />
           <IconButton
             icon="close"
             size={18}
             onPress={() => remove(item.id)}
+            accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"}`}
           />
         </View>
       </View>
@@ -206,6 +209,7 @@ export default function CreateTemplate() {
                 )
               }
               style={styles.addBtn}
+              accessibilityLabel="Add exercise to template"
             >
               Add Exercise
             </Button>
@@ -217,6 +221,7 @@ export default function CreateTemplate() {
           loading={saving}
           disabled={saving}
           style={styles.saveBtn}
+          accessibilityLabel={template ? "Done editing template" : "Create template"}
         >
           {template ? "Done" : "Create Template"}
         </Button>

--- a/app/template/pick-exercise.tsx
+++ b/app/template/pick-exercise.tsx
@@ -96,6 +96,8 @@ export default function PickExercise() {
             borderBottomColor: theme.colors.outlineVariant,
           },
         ]}
+        accessibilityLabel={`Select ${item.name}, ${CATEGORY_LABELS[item.category]}, ${item.equipment}`}
+        accessibilityRole="button"
       >
         <View>
           <Text
@@ -143,6 +145,7 @@ export default function PickExercise() {
           value={query}
           onChangeText={setQuery}
           style={[styles.search, { backgroundColor: theme.colors.surface }]}
+          accessibilityLabel="Search exercises"
         />
         <View style={styles.chips}>
           <FlatList
@@ -156,6 +159,9 @@ export default function PickExercise() {
                 onPress={() => toggle(cat)}
                 style={styles.filterChip}
                 compact
+                accessibilityLabel={`Filter by ${CATEGORY_LABELS[cat]}`}
+                accessibilityRole="button"
+                accessibilityState={{ selected: selected.has(cat) }}
               >
                 {CATEGORY_LABELS[cat]}
               </Chip>
@@ -223,7 +229,7 @@ const styles = StyleSheet.create({
     height: 24,
   },
   chipText: {
-    fontSize: 11,
+    fontSize: 12,
   },
   empty: {
     alignItems: "center",

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { Appearance, ScrollView, StyleSheet, View } from "react-native";
 import { Button, Text } from "react-native-paper";
 import { File, Paths } from "expo-file-system";
 import * as Sharing from "expo-sharing";
@@ -7,6 +7,17 @@ import { logError, generateReport } from "../lib/errors";
 
 type Props = { children: React.ReactNode };
 type State = { error: Error | null; expanded: boolean };
+
+function colors() {
+  const dark = Appearance.getColorScheme() !== "light";
+  return {
+    bg: dark ? "#121212" : "#fafafa",
+    text: dark ? "#e0e0e0" : "#212121",
+    muted: dark ? "#9e9e9e" : "#757575",
+    code: dark ? "#e0e0e0" : "#424242",
+    codeBg: dark ? "#1e1e1e" : "#eeeeee",
+  };
+}
 
 export default class ErrorBoundary extends React.Component<Props, State> {
   state: State = { error: null, expanded: false };
@@ -40,13 +51,15 @@ export default class ErrorBoundary extends React.Component<Props, State> {
   render() {
     if (!this.state.error) return this.props.children;
 
+    const c = colors();
+
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, { backgroundColor: c.bg }]}>
         <ScrollView contentContainerStyle={styles.content}>
-          <Text variant="headlineLarge" style={styles.heading}>
+          <Text variant="headlineLarge" style={[styles.heading, { color: c.text }]}>
             Something went wrong
           </Text>
-          <Text variant="bodyMedium" style={styles.sub}>
+          <Text variant="bodyMedium" style={[styles.sub, { color: c.muted }]}>
             The app encountered an unexpected error. You can share a crash
             report to help us fix the issue, or restart the app.
           </Text>
@@ -56,13 +69,14 @@ export default class ErrorBoundary extends React.Component<Props, State> {
             onPress={() => this.setState((s) => ({ expanded: !s.expanded }))}
             style={styles.btn}
             icon={this.state.expanded ? "chevron-up" : "chevron-down"}
+            accessibilityLabel={this.state.expanded ? "Hide error details" : "Show error details"}
           >
             {this.state.expanded ? "Hide Details" : "Show Details"}
           </Button>
 
           {this.state.expanded && (
-            <ScrollView style={styles.stack} nestedScrollEnabled>
-              <Text variant="bodySmall" style={styles.mono}>
+            <ScrollView style={[styles.stack, { backgroundColor: c.codeBg }]} nestedScrollEnabled>
+              <Text variant="bodySmall" style={[styles.mono, { color: c.code }]}>
                 {this.state.error.message}
                 {"\n\n"}
                 {this.state.error.stack}
@@ -75,6 +89,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
             icon="share-variant"
             onPress={this.handleShare}
             style={styles.btn}
+            accessibilityLabel="Share crash report"
           >
             Share Crash Report
           </Button>
@@ -84,6 +99,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
             icon="restart"
             onPress={this.handleRestart}
             style={styles.btn}
+            accessibilityLabel="Restart app"
           >
             Restart
           </Button>
@@ -96,7 +112,6 @@ export default class ErrorBoundary extends React.Component<Props, State> {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#121212",
   },
   content: {
     padding: 24,
@@ -104,12 +119,10 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   heading: {
-    color: "#fff",
     marginBottom: 16,
     textAlign: "center",
   },
   sub: {
-    color: "#aaa",
     marginBottom: 24,
     textAlign: "center",
   },
@@ -120,14 +133,12 @@ const styles = StyleSheet.create({
   stack: {
     maxHeight: 200,
     width: "100%",
-    backgroundColor: "#1e1e1e",
     borderRadius: 8,
     padding: 12,
     marginBottom: 16,
   },
   mono: {
     fontFamily: "monospace",
-    color: "#e0e0e0",
-    fontSize: 11,
+    fontSize: 12,
   },
 });

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -17,6 +17,17 @@ const colors = {
   tertiaryContainer: "#E8F5E9",
 };
 
+// Custom semantic colors for domain-specific indicators
+export const semantic = {
+  protein: "#4caf50",
+  carbs: "#ff9800",
+  fat: "#f44336",
+  beginner: "#4CAF50",
+  intermediate: "#FF9800",
+  advanced: "#F44336",
+  onSemantic: "#ffffff",
+};
+
 export const light = {
   ...MD3LightTheme,
   colors: {


### PR DESCRIPTION
## Summary

Adds full accessibility support across all 12 FitForge screens. Every interactive element now has appropriate accessibility labels, roles, and states. Fixes all sub-12px font sizes and removes hardcoded hex colors in favor of theme tokens.

## Changes

- **Accessibility Labels**: Added `accessibilityLabel` and `accessibilityRole` on all 55+ interactive elements (TouchableRipple, IconButton, Button, Chip, Card, FAB, Checkbox)
- **Accessibility State**: Added `accessibilityState` on stateful elements (selected filter chips, meal chips, favorite toggle, checkbox)
- **Live Region**: Added `accessibilityLiveRegion="polite"` on rest timer for screen reader announcements
- **Font Sizes**: Increased all sub-12px font sizes to 12px minimum (exercises.tsx chipText/muscleText, pick-exercise.tsx, errors.tsx, ErrorBoundary.tsx)
- **Hardcoded Colors**: Replaced all hardcoded hex colors with theme tokens:
  - exercise/[id].tsx: difficulty colors + `#ffffff` text → semantic constants
  - progress.tsx: `#e0e0e0` border → `theme.colors.outlineVariant`
  - nutrition.tsx: macro bar colors → semantic constants
  - ErrorBoundary.tsx: all hardcoded dark theme colors → `Appearance.getColorScheme()`-aware colors
- **Theme Constants**: Added `semantic` color export in constants/theme.ts for domain-specific colors (protein/carbs/fat, difficulty levels)

## Testing

- `npm install --legacy-peer-deps` ✅
- `npx -p typescript tsc --noEmit` — 0 errors ✅
- Grep verification: 0 files with onPress but zero a11y attributes ✅
- Grep verification: 0 fontSize below 12 ✅
- Grep verification: 0 hardcoded hex colors in app/ styles ✅

## Issue

Resolves BLD-21