### PR TITLE
fix: replace remaining hardcoded colors with theme tokens (BLD-21)

### DIFF
--- a/app/errors.tsx
+++ b/app/errors.tsx
@@ -118,7 +118,7 @@ export default function Errors() {
                 {item.message}
               </Text>
               {expanded === item.id && item.stack && (
-                <View style={styles.stackBox}>
+                <View style={[styles.stackBox, { backgroundColor: theme.colors.surfaceVariant }]}>
                   <Text
                     variant="bodySmall"
                     style={{
@@ -171,8 +171,8 @@ const styles = StyleSheet.create({
   },
   stackBox: {
     marginTop: 8,
-    backgroundColor: "rgba(0,0,0,0.15)",
     borderRadius: 6,
     padding: 8,
+    opacity: 0.85,
   },
 });

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -4,18 +4,20 @@ import { Button, Text } from "react-native-paper";
 import { File, Paths } from "expo-file-system";
 import * as Sharing from "expo-sharing";
 import { logError, generateReport } from "../lib/errors";
+import { light, dark as darkTheme } from "../constants/theme";
 
 type Props = { children: React.ReactNode };
 type State = { error: Error | null; expanded: boolean };
 
 function colors() {
-  const dark = Appearance.getColorScheme() !== "light";
+  const isDark = Appearance.getColorScheme() !== "light";
+  const t = isDark ? darkTheme : light;
   return {
-    bg: dark ? "#121212" : "#fafafa",
-    text: dark ? "#e0e0e0" : "#212121",
-    muted: dark ? "#9e9e9e" : "#757575",
-    code: dark ? "#e0e0e0" : "#424242",
-    codeBg: dark ? "#1e1e1e" : "#eeeeee",
+    bg: t.colors.background,
+    text: t.colors.onBackground,
+    muted: t.colors.onSurfaceVariant,
+    code: t.colors.onSurface,
+    codeBg: t.colors.surfaceVariant,
   };
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #9 — replaces remaining hardcoded hex colors in ErrorBoundary.tsx and rgba color in errors.tsx with theme tokens.

## Changes

- ErrorBoundary.tsx: Import light/dark themes from constants/theme.ts instead of hardcoded hex values
- errors.tsx: Replace rgba(0,0,0,0.15) background with theme.colors.surfaceVariant

## Testing

- `tsc --noEmit` passes with 0 errors
- No hardcoded hex colors remain in app/ or components/

## Issue

Follow-up for BLD-21