### PR TITLE
feat: CSV data export + tablet-responsive layout (BLD-22)

### DIFF
--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -1,29 +1,40 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   FlatList,
+  ScrollView,
   StyleSheet,
   View,
   type ListRenderItemInfo,
 } from "react-native";
 import { Chip, Searchbar, Text, TouchableRipple, useTheme } from "react-native-paper";
 import { useRouter } from "expo-router";
-import { getAllExercises } from "../../lib/db";
+import { getAllExercises, getExerciseById } from "../../lib/db";
 import {
   CATEGORIES,
   CATEGORY_LABELS,
   type Category,
   type Exercise,
 } from "../../lib/types";
+import { semantic } from "../../constants/theme";
+import { useLayout } from "../../lib/layout";
 
 const ITEM_HEIGHT = 84;
+
+const DIFFICULTY_COLORS: Record<string, string> = {
+  beginner: semantic.beginner,
+  intermediate: semantic.intermediate,
+  advanced: semantic.advanced,
+};
 
 export default function Exercises() {
   const theme = useTheme();
   const router = useRouter();
+  const layout = useLayout();
   const [exercises, setExercises] = useState<Exercise[]>([]);
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<Set<Category>>(new Set());
   const [loading, setLoading] = useState(true);
+  const [detail, setDetail] = useState<Exercise | null>(null);
 
   useEffect(() => {
     getAllExercises()
@@ -49,11 +60,26 @@ export default function Exercises() {
     });
   }, []);
 
+  const onPress = useCallback(
+    (item: Exercise) => {
+      if (layout.wide) {
+        getExerciseById(item.id).then(setDetail);
+      } else {
+        router.push(`/exercise/${item.id}`);
+      }
+    },
+    [layout.wide, router]
+  );
+
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<Exercise>) => (
       <TouchableRipple
-        onPress={() => router.push(`/exercise/${item.id}`)}
-        style={[styles.item, { backgroundColor: theme.colors.surface, borderBottomColor: theme.colors.outlineVariant }]}
+        onPress={() => onPress(item)}
+        style={[
+          styles.item,
+          { backgroundColor: theme.colors.surface, borderBottomColor: theme.colors.outlineVariant },
+          layout.wide && detail?.id === item.id && { backgroundColor: theme.colors.primaryContainer },
+        ]}
         accessibilityLabel={`${item.name}, ${CATEGORY_LABELS[item.category]}, ${item.equipment}`}
         accessibilityRole="button"
       >
@@ -93,7 +119,7 @@ export default function Exercises() {
         </View>
       </TouchableRipple>
     ),
-    [router, theme]
+    [onPress, theme, layout.wide, detail]
   );
 
   const getLayout = useCallback(
@@ -122,8 +148,8 @@ export default function Exercises() {
     [loading, theme]
   );
 
-  return (
-    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+  const list = (
+    <View style={layout.wide ? { flex: 6 } : { flex: 1 }}>
       <Searchbar
         placeholder="Search exercises..."
         value={query}
@@ -162,11 +188,102 @@ export default function Exercises() {
       />
     </View>
   );
+
+  if (!layout.wide) {
+    return (
+      <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+        {list}
+      </View>
+    );
+  }
+
+  const steps = detail?.instructions
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  return (
+    <View style={[styles.container, styles.wideRow, { backgroundColor: theme.colors.background }]}>
+      {list}
+      <View style={[styles.detailPane, { borderLeftColor: theme.colors.outlineVariant }]}>
+        {detail ? (
+          <ScrollView contentContainerStyle={styles.detailContent}>
+            <Text variant="headlineSmall" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
+              {detail.name}
+            </Text>
+            <View style={styles.row}>
+              <Chip compact style={{ backgroundColor: theme.colors.primaryContainer }}>
+                {CATEGORY_LABELS[detail.category]}
+              </Chip>
+              <Chip
+                compact
+                style={{ backgroundColor: DIFFICULTY_COLORS[detail.difficulty], marginLeft: 8 }}
+                textStyle={{ color: semantic.onSemantic, fontWeight: "600" }}
+              >
+                {detail.difficulty}
+              </Chip>
+            </View>
+            <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant, marginTop: 16 }}>
+              Equipment
+            </Text>
+            <Text variant="bodyLarge" style={{ color: theme.colors.onSurface, marginTop: 4 }}>
+              {detail.equipment}
+            </Text>
+            <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant, marginTop: 16 }}>
+              Primary Muscles
+            </Text>
+            <View style={[styles.row, { marginTop: 6, flexWrap: "wrap", gap: 6 }]}>
+              {detail.primary_muscles.map((m) => (
+                <Chip key={m} compact style={{ backgroundColor: theme.colors.secondaryContainer }}>
+                  {m}
+                </Chip>
+              ))}
+            </View>
+            {detail.secondary_muscles.length > 0 && (
+              <>
+                <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant, marginTop: 16 }}>
+                  Secondary Muscles
+                </Text>
+                <View style={[styles.row, { marginTop: 6, flexWrap: "wrap", gap: 6 }]}>
+                  {detail.secondary_muscles.map((m) => (
+                    <Chip key={m} compact style={{ backgroundColor: theme.colors.tertiaryContainer }}>
+                      {m}
+                    </Chip>
+                  ))}
+                </View>
+              </>
+            )}
+            {steps && steps.length > 0 && (
+              <>
+                <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant, marginTop: 16 }}>
+                  Instructions
+                </Text>
+                {steps.map((step, i) => (
+                  <Text key={i} variant="bodyMedium" style={{ color: theme.colors.onSurface, marginTop: 6, lineHeight: 22 }}>
+                    {step}
+                  </Text>
+                ))}
+              </>
+            )}
+          </ScrollView>
+        ) : (
+          <View style={styles.detailEmpty}>
+            <Text variant="bodyLarge" style={{ color: theme.colors.onSurfaceVariant }}>
+              Select an exercise to view details
+            </Text>
+          </View>
+        )}
+      </View>
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  wideRow: {
+    flexDirection: "row",
   },
   search: {
     margin: 12,
@@ -211,5 +328,18 @@ const styles = StyleSheet.create({
   },
   emptyList: {
     flexGrow: 1,
+  },
+  detailPane: {
+    flex: 4,
+    borderLeftWidth: StyleSheet.hairlineWidth,
+  },
+  detailContent: {
+    padding: 24,
+    paddingBottom: 32,
+  },
+  detailEmpty: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
   },
 });

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -1,13 +1,16 @@
 import { useCallback, useRef, useState } from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
 import {
+  Button,
   Card,
+  Chip,
   FAB,
   IconButton,
   MD3Theme,
   ProgressBar,
   Snackbar,
   Text,
+  TextInput,
   useTheme,
 } from "react-native-paper";
 import { router, useFocusEffect } from "expo-router";
@@ -17,10 +20,13 @@ import {
   getMacroTargets,
   deleteDailyLog,
   addDailyLog,
+  addFoodEntry,
+  getFavoriteFoods,
 } from "../../lib/db";
-import type { DailyLog, MacroTargets } from "../../lib/types";
+import type { DailyLog, FoodEntry, MacroTargets, Meal } from "../../lib/types";
 import { MEALS, MEAL_LABELS } from "../../lib/types";
 import { semantic } from "../../constants/theme";
+import { useLayout } from "../../lib/layout";
 
 const DAY_MS = 86_400_000;
 
@@ -39,12 +45,25 @@ function label(d: Date): string {
 
 export default function Nutrition() {
   const theme = useTheme();
+  const layout = useLayout();
   const [date, setDate] = useState(new Date());
   const [logs, setLogs] = useState<DailyLog[]>([]);
   const [summary, setSummary] = useState({ calories: 0, protein: 0, carbs: 0, fat: 0 });
   const [targets, setTargets] = useState<MacroTargets | null>(null);
   const [snack, setSnack] = useState("");
   const deleted = useRef<{ log: DailyLog; timer: ReturnType<typeof setTimeout> } | null>(null);
+
+  // Inline add-form state (tablet only)
+  const [name, setName] = useState("");
+  const [calories, setCalories] = useState("");
+  const [protein, setProtein] = useState("");
+  const [carbs, setCarbs] = useState("");
+  const [fat, setFat] = useState("");
+  const [serving, setServing] = useState("1 serving");
+  const [meal, setMeal] = useState<Meal>("snack");
+  const [favorite, setFavorite] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [favorites, setFavorites] = useState<FoodEntry[]>([]);
 
   const load = useCallback(async () => {
     const ds = dateStr(date);
@@ -61,7 +80,8 @@ export default function Nutrition() {
   useFocusEffect(
     useCallback(() => {
       load();
-    }, [load])
+      if (layout.wide) getFavoriteFoods().then(setFavorites);
+    }, [load, layout.wide])
   );
 
   const prev = () => setDate((d) => new Date(d.getTime() - DAY_MS));
@@ -90,10 +110,50 @@ export default function Nutrition() {
     load();
   };
 
+  const inlineSave = async () => {
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      const entry = await addFoodEntry(
+        name.trim(),
+        Math.max(0, parseFloat(calories) || 0),
+        Math.max(0, parseFloat(protein) || 0),
+        Math.max(0, parseFloat(carbs) || 0),
+        Math.max(0, parseFloat(fat) || 0),
+        serving.trim() || "1 serving",
+        favorite
+      );
+      await addDailyLog(entry.id, dateStr(date), meal, 1);
+      setName("");
+      setCalories("");
+      setProtein("");
+      setCarbs("");
+      setFat("");
+      setServing("1 serving");
+      setFavorite(false);
+      load();
+      getFavoriteFoods().then(setFavorites);
+      setSnack("Food logged");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const quickLog = async (food: FoodEntry) => {
+    setSaving(true);
+    try {
+      await addDailyLog(food.id, dateStr(date), meal, 1);
+      load();
+      setSnack(`${food.name} logged`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const empty = logs.length === 0;
 
-  return (
-    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+  const logContent = (
+    <>
       <View style={styles.header}>
         <IconButton icon="chevron-left" onPress={prev} accessibilityLabel="Previous day" />
         <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
@@ -130,13 +190,13 @@ export default function Nutrition() {
             </Text>
           </View>
         ) : (
-          MEALS.map((meal) => {
-            const items = logs.filter((l) => l.meal === meal);
+          MEALS.map((m) => {
+            const items = logs.filter((l) => l.meal === m);
             if (items.length === 0) return null;
             return (
-              <View key={meal} style={styles.section}>
+              <View key={m} style={styles.section}>
                 <Text variant="titleSmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 8 }}>
-                  {MEAL_LABELS[meal]}
+                  {MEAL_LABELS[m]}
                 </Text>
                 {items.map((item) => (
                   <Card key={item.id} style={[styles.foodCard, { backgroundColor: theme.colors.surface }]}>
@@ -165,6 +225,115 @@ export default function Nutrition() {
           })
         )}
       </ScrollView>
+    </>
+  );
+
+  const addForm = (
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.addContent}>
+      <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
+        Add Food
+      </Text>
+
+      <View style={styles.meals}>
+        {MEALS.map((m) => (
+          <Chip
+            key={m}
+            selected={meal === m}
+            onPress={() => setMeal(m)}
+            accessibilityLabel={`Meal: ${MEAL_LABELS[m]}`}
+            accessibilityRole="button"
+            accessibilityState={{ selected: meal === m }}
+          >
+            {MEAL_LABELS[m]}
+          </Chip>
+        ))}
+      </View>
+
+      <TextInput label="Food name" value={name} onChangeText={setName} mode="outlined" style={styles.input} />
+      <TextInput label="Calories" value={calories} onChangeText={setCalories} keyboardType="numeric" mode="outlined" style={styles.input} />
+      <View style={styles.macroInputRow}>
+        <TextInput label="Protein (g)" value={protein} onChangeText={setProtein} keyboardType="numeric" mode="outlined" style={[styles.input, styles.flex]} />
+        <View style={{ width: 8 }} />
+        <TextInput label="Carbs (g)" value={carbs} onChangeText={setCarbs} keyboardType="numeric" mode="outlined" style={[styles.input, styles.flex]} />
+        <View style={{ width: 8 }} />
+        <TextInput label="Fat (g)" value={fat} onChangeText={setFat} keyboardType="numeric" mode="outlined" style={[styles.input, styles.flex]} />
+      </View>
+      <TextInput label="Serving size" value={serving} onChangeText={setServing} mode="outlined" style={styles.input} />
+
+      <Chip
+        selected={favorite}
+        onPress={() => setFavorite(!favorite)}
+        icon={favorite ? "heart" : "heart-outline"}
+        style={styles.favChip}
+        accessibilityLabel={favorite ? "Remove from favorites" : "Save as favorite"}
+        accessibilityRole="button"
+        accessibilityState={{ selected: favorite }}
+      >
+        Save as favorite
+      </Chip>
+
+      <Button
+        mode="contained"
+        onPress={inlineSave}
+        loading={saving}
+        disabled={saving || !name.trim()}
+        accessibilityLabel="Log food"
+      >
+        Log Food
+      </Button>
+
+      {favorites.length > 0 && (
+        <>
+          <Text variant="titleSmall" style={{ color: theme.colors.onSurfaceVariant, marginTop: 24, marginBottom: 8 }}>
+            Quick Log Favorites
+          </Text>
+          {favorites.map((f) => (
+            <Card
+              key={f.id}
+              style={[styles.favCard, { backgroundColor: theme.colors.surfaceVariant }]}
+              onPress={() => quickLog(f)}
+              accessibilityLabel={`Quick log ${f.name}, ${f.calories} calories`}
+              accessibilityRole="button"
+            >
+              <Card.Content>
+                <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>
+                  {f.name}
+                </Text>
+                <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                  {f.calories} cal · {f.protein}p · {f.carbs}c · {f.fat}f
+                </Text>
+              </Card.Content>
+            </Card>
+          ))}
+        </>
+      )}
+    </ScrollView>
+  );
+
+  if (layout.wide) {
+    return (
+      <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+        <View style={styles.wideRow}>
+          <View style={styles.wideLog}>{logContent}</View>
+          <View style={[styles.wideAdd, { borderLeftColor: theme.colors.outlineVariant }]}>
+            {addForm}
+          </View>
+        </View>
+        <Snackbar
+          visible={!!snack}
+          onDismiss={() => setSnack("")}
+          duration={4000}
+          action={{ label: "Undo", onPress: undo }}
+        >
+          {snack}
+        </Snackbar>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      {logContent}
 
       <FAB
         icon="plus"
@@ -227,6 +396,7 @@ const styles = StyleSheet.create({
   card: { marginBottom: 8 },
   scroll: { flex: 1 },
   scrollContent: { padding: 16, paddingBottom: 80 },
+  addContent: { padding: 16, paddingBottom: 32 },
   empty: { flex: 1, alignItems: "center", justifyContent: "center", paddingTop: 64 },
   section: { marginBottom: 16 },
   foodCard: { marginBottom: 6, borderRadius: 8 },
@@ -235,4 +405,13 @@ const styles = StyleSheet.create({
   macro: { marginBottom: 8 },
   macroHeader: { flexDirection: "row", justifyContent: "space-between", marginBottom: 4 },
   bar: { height: 6, borderRadius: 3 },
+  wideRow: { flex: 1, flexDirection: "row" },
+  wideLog: { flex: 6 },
+  wideAdd: { flex: 4, borderLeftWidth: StyleSheet.hairlineWidth },
+  meals: { flexDirection: "row", flexWrap: "wrap", marginBottom: 12, gap: 8 },
+  input: { marginBottom: 12 },
+  macroInputRow: { flexDirection: "row" },
+  flex: { flex: 1 },
+  favChip: { marginBottom: 16 },
+  favCard: { marginBottom: 8, borderRadius: 8 },
 });

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { Dimensions, ScrollView, StyleSheet, View } from "react-native";
+import { ScrollView, StyleSheet, View, useWindowDimensions } from "react-native";
 import { Card, Divider, Text, useTheme } from "react-native-paper";
 import { useFocusEffect } from "expo-router";
 import { BarChart } from "react-native-chart-kit";
@@ -10,12 +10,15 @@ import {
   getCompletedSessionsWithSetCount,
 } from "../../lib/db";
 import type { WorkoutSession } from "../../lib/types";
+import { useLayout } from "../../lib/layout";
 
 type PR = { exercise_id: string; name: string; max_weight: number };
 type SessionRow = WorkoutSession & { set_count: number };
 
 export default function Progress() {
   const theme = useTheme();
+  const layout = useLayout();
+  const { width: screenWidth } = useWindowDimensions();
   const [freq, setFreq] = useState<{ week: string; count: number }[]>([]);
   const [vol, setVol] = useState<{ week: string; volume: number }[]>([]);
   const [prs, setPrs] = useState<PR[]>([]);
@@ -38,7 +41,9 @@ export default function Progress() {
     }, [])
   );
 
-  const width = Dimensions.get("window").width - 48;
+  const chartWidth = layout.wide
+    ? (screenWidth - 64) / 2 - 32
+    : screenWidth - 48;
   const empty = sessions.length === 0 && freq.length === 0;
 
   const chart = {
@@ -75,105 +80,129 @@ export default function Progress() {
     );
   }
 
+  const freqCard = freq.length > 0 ? (
+    <Card style={[styles.card, layout.wide && styles.wideCard, { backgroundColor: theme.colors.surface }]}>
+      <Card.Content>
+        <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
+          Sessions Per Week
+        </Text>
+        <BarChart
+          data={{
+            labels: freq.map((f) => f.week),
+            datasets: [{ data: freq.map((f) => f.count) }],
+          }}
+          width={chartWidth}
+          height={180}
+          yAxisLabel=""
+          yAxisSuffix=""
+          chartConfig={chart}
+          fromZero
+          showValuesOnTopOfBars
+          style={styles.chart}
+        />
+      </Card.Content>
+    </Card>
+  ) : null;
+
+  const volCard = vol.length > 0 ? (
+    <Card style={[styles.card, layout.wide && styles.wideCard, { backgroundColor: theme.colors.surface }]}>
+      <Card.Content>
+        <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
+          Weekly Volume (kg)
+        </Text>
+        <BarChart
+          data={{
+            labels: vol.map((v) => v.week),
+            datasets: [{ data: vol.map((v) => v.volume) }],
+          }}
+          width={chartWidth}
+          height={180}
+          yAxisLabel=""
+          yAxisSuffix=""
+          chartConfig={chart}
+          fromZero
+          showValuesOnTopOfBars
+          style={styles.chart}
+        />
+      </Card.Content>
+    </Card>
+  ) : null;
+
+  const prCard = (
+    <Card style={[styles.card, layout.wide && styles.wideCard, { backgroundColor: theme.colors.surface }]}>
+      <Card.Content>
+        <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
+          Personal Records
+        </Text>
+        {prs.length === 0 ? (
+          <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant }}>
+            No records yet — start lifting!
+          </Text>
+        ) : (
+          prs.map((pr) => (
+            <View key={pr.exercise_id} style={[styles.prRow, { borderBottomColor: theme.colors.outlineVariant }]}>
+              <Text variant="bodyMedium" style={{ color: theme.colors.onSurface, flex: 1 }}>
+                {pr.name}
+              </Text>
+              <Text variant="titleSmall" style={{ color: theme.colors.primary }}>
+                {pr.max_weight} kg
+              </Text>
+            </View>
+          ))
+        )}
+      </Card.Content>
+    </Card>
+  );
+
+  const sessionsCard = (
+    <Card style={[styles.card, layout.wide && styles.wideCard, { backgroundColor: theme.colors.surface }]}>
+      <Card.Content>
+        <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
+          Recent Sessions
+        </Text>
+        {sessions.map((s, i) => (
+          <View key={s.id}>
+            <View style={styles.sessionRow}>
+              <View style={{ flex: 1 }}>
+                <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
+                  {s.name}
+                </Text>
+                <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                  {dateStr(s.started_at)} · {duration(s.duration_seconds)} · {s.set_count} sets
+                </Text>
+              </View>
+            </View>
+            {i < sessions.length - 1 && <Divider style={{ marginVertical: 6 }} />}
+          </View>
+        ))}
+      </Card.Content>
+    </Card>
+  );
+
   return (
     <ScrollView
       style={[styles.container, { backgroundColor: theme.colors.background }]}
       contentContainerStyle={styles.content}
     >
-      {freq.length > 0 && (
-        <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
-          <Card.Content>
-            <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
-              Sessions Per Week
-            </Text>
-            <BarChart
-              data={{
-                labels: freq.map((f) => f.week),
-                datasets: [{ data: freq.map((f) => f.count) }],
-              }}
-              width={width}
-              height={180}
-              yAxisLabel=""
-              yAxisSuffix=""
-              chartConfig={chart}
-              fromZero
-              showValuesOnTopOfBars
-              style={styles.chart}
-            />
-          </Card.Content>
-        </Card>
+      {layout.wide ? (
+        <>
+          <View style={styles.grid}>
+            {freqCard}
+            {volCard}
+          </View>
+          <View style={styles.grid}>
+            {prCard}
+            {sessionsCard}
+          </View>
+        </>
+      ) : (
+        <>
+          {freqCard}
+          {volCard}
+          {prCard}
+          {sessionsCard}
+        </>
       )}
-
-      {vol.length > 0 && (
-        <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
-          <Card.Content>
-            <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
-              Weekly Volume (kg)
-            </Text>
-            <BarChart
-              data={{
-                labels: vol.map((v) => v.week),
-                datasets: [{ data: vol.map((v) => v.volume) }],
-              }}
-              width={width}
-              height={180}
-              yAxisLabel=""
-              yAxisSuffix=""
-              chartConfig={chart}
-              fromZero
-              showValuesOnTopOfBars
-              style={styles.chart}
-            />
-          </Card.Content>
-        </Card>
-      )}
-
-      <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
-            Personal Records
-          </Text>
-          {prs.length === 0 ? (
-            <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant }}>
-              No records yet — start lifting!
-            </Text>
-          ) : (
-            prs.map((pr) => (
-              <View key={pr.exercise_id} style={[styles.prRow, { borderBottomColor: theme.colors.outlineVariant }]}>
-                <Text variant="bodyMedium" style={{ color: theme.colors.onSurface, flex: 1 }}>
-                  {pr.name}
-                </Text>
-                <Text variant="titleSmall" style={{ color: theme.colors.primary }}>
-                  {pr.max_weight} kg
-                </Text>
-              </View>
-            ))
-          )}
-        </Card.Content>
-      </Card>
-
-      <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
-            Recent Sessions
-          </Text>
-          {sessions.map((s, i) => (
-            <View key={s.id}>
-              <View style={styles.sessionRow}>
-                <View style={{ flex: 1 }}>
-                  <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
-                    {s.name}
-                  </Text>
-                  <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
-                    {dateStr(s.started_at)} · {duration(s.duration_seconds)} · {s.set_count} sets
-                  </Text>
-                </View>
-              </View>
-              {i < sessions.length - 1 && <Divider style={{ marginVertical: 6 }} />}
-            </View>
-          ))}
-        </Card.Content>
-      </Card>
     </ScrollView>
   );
 }
@@ -191,8 +220,15 @@ const styles = StyleSheet.create({
     padding: 16,
     paddingBottom: 32,
   },
+  grid: {
+    flexDirection: "row",
+    gap: 16,
+  },
   card: {
     marginBottom: 16,
+  },
+  wideCard: {
+    flex: 1,
   },
   chart: {
     borderRadius: 8,

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,13 +1,79 @@
-import { useCallback, useState } from "react";
-import { ScrollView, StyleSheet } from "react-native";
-import { Button, Card, Snackbar, Text, useTheme } from "react-native-paper";
+import { useCallback, useEffect, useState } from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
+import { Button, Card, SegmentedButtons, Snackbar, Text, useTheme } from "react-native-paper";
 import { File, Paths } from "expo-file-system";
 import * as Sharing from "expo-sharing";
 import * as DocumentPicker from "expo-document-picker";
 import { useRouter } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
-import { exportAllData, importData } from "../../lib/db";
+import {
+  exportAllData,
+  importData,
+  getWorkoutCSVData,
+  getNutritionCSVData,
+  getCSVCounts,
+} from "../../lib/db";
+import type { WorkoutCSVRow, NutritionCSVRow } from "../../lib/db";
 import { getErrorCount, clearErrorLog, generateReport } from "../../lib/errors";
+
+function csvEscape(val: string | number | null | undefined): string {
+  if (val === null || val === undefined) return "";
+  const s = String(val);
+  if (s.includes(",") || s.includes('"') || s.includes("\n")) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+function workoutCSV(rows: WorkoutCSVRow[]): string {
+  const header = "date,exercise,set_number,weight,reps,duration_seconds,notes";
+  const lines = rows.map((r) =>
+    [
+      csvEscape(r.date),
+      csvEscape(r.exercise),
+      csvEscape(r.set_number),
+      csvEscape(r.weight),
+      csvEscape(r.reps),
+      csvEscape(r.duration_seconds),
+      csvEscape(r.notes),
+    ].join(",")
+  );
+  return [header, ...lines].join("\n");
+}
+
+function nutritionCSV(rows: NutritionCSVRow[]): string {
+  const header = "date,meal,food,servings,calories,protein,carbs,fat";
+  const lines = rows.map((r) =>
+    [
+      csvEscape(r.date),
+      csvEscape(r.meal),
+      csvEscape(r.food),
+      csvEscape(r.servings),
+      csvEscape(r.calories),
+      csvEscape(r.protein),
+      csvEscape(r.carbs),
+      csvEscape(r.fat),
+    ].join(",")
+  );
+  return [header, ...lines].join("\n");
+}
+
+const RANGES = [
+  { value: "7", label: "7 days" },
+  { value: "30", label: "30 days" },
+  { value: "90", label: "90 days" },
+  { value: "all", label: "All Time" },
+] as const;
+
+function sinceForRange(range: string): number {
+  if (range === "all") return 0;
+  const days = Number(range);
+  return Date.now() - days * 86_400_000;
+}
+
+function dateStamp(): string {
+  return new Date().toISOString().slice(0, 10);
+}
 
 export default function Settings() {
   const theme = useTheme();
@@ -15,12 +81,56 @@ export default function Settings() {
   const [loading, setLoading] = useState(false);
   const [snack, setSnack] = useState("");
   const [count, setCount] = useState(0);
+  const [range, setRange] = useState("30");
+  const [counts, setCounts] = useState({ sessions: 0, entries: 0 });
 
   useFocusEffect(
     useCallback(() => {
       getErrorCount().then(setCount);
     }, [])
   );
+
+  useEffect(() => {
+    getCSVCounts(sinceForRange(range)).then(setCounts);
+  }, [range]);
+
+  const handleWorkoutCSV = async () => {
+    setLoading(true);
+    try {
+      const rows = await getWorkoutCSVData(sinceForRange(range));
+      const csv = workoutCSV(rows);
+      if (rows.length === 0) setSnack("No data to export");
+      const file = new File(Paths.cache, `fitforge-workouts-${dateStamp()}.csv`);
+      await file.write(csv);
+      await Sharing.shareAsync(file.uri, {
+        mimeType: "text/csv",
+        dialogTitle: "Export Workouts CSV",
+      });
+    } catch {
+      setSnack("Export failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleNutritionCSV = async () => {
+    setLoading(true);
+    try {
+      const rows = await getNutritionCSVData(sinceForRange(range));
+      const csv = nutritionCSV(rows);
+      if (rows.length === 0) setSnack("No data to export");
+      const file = new File(Paths.cache, `fitforge-nutrition-${dateStamp()}.csv`);
+      await file.write(csv);
+      await Sharing.shareAsync(file.uri, {
+        mimeType: "text/csv",
+        dialogTitle: "Export Nutrition CSV",
+      });
+    } catch {
+      setSnack("Export failed");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleExport = async () => {
     setLoading(true);
@@ -94,6 +204,58 @@ export default function Settings() {
       <Text variant="headlineMedium" style={{ color: theme.colors.onBackground, marginBottom: 24 }}>
         Settings
       </Text>
+
+      <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+        <Card.Content>
+          <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 16 }}>
+            Data Export (CSV)
+          </Text>
+
+          <SegmentedButtons
+            value={range}
+            onValueChange={setRange}
+            buttons={RANGES.map((r) => ({
+              value: r.value,
+              label: r.label,
+              accessibilityLabel: `Date range ${r.label}`,
+            }))}
+            style={styles.segment}
+          />
+
+          <Text
+            variant="bodySmall"
+            style={{ color: theme.colors.onSurfaceVariant, marginBottom: 16, marginTop: 8 }}
+            accessibilityLabel={`${counts.sessions} workout sessions, ${counts.entries} nutrition entries`}
+          >
+            {counts.sessions} workout session{counts.sessions !== 1 ? "s" : ""},{" "}
+            {counts.entries} nutrition entr{counts.entries !== 1 ? "ies" : "y"}
+          </Text>
+
+          <Button
+            mode="contained"
+            icon="file-export-outline"
+            onPress={handleWorkoutCSV}
+            loading={loading}
+            disabled={loading}
+            style={styles.btn}
+            accessibilityLabel="Export workouts as CSV"
+          >
+            Export Workouts CSV
+          </Button>
+
+          <Button
+            mode="contained"
+            icon="food-apple-outline"
+            onPress={handleNutritionCSV}
+            loading={loading}
+            disabled={loading}
+            style={styles.btn}
+            accessibilityLabel="Export nutrition as CSV"
+          >
+            Export Nutrition CSV
+          </Button>
+        </Card.Content>
+      </Card>
 
       <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
         <Card.Content>
@@ -232,5 +394,8 @@ const styles = StyleSheet.create({
   },
   btn: {
     marginBottom: 8,
+  },
+  segment: {
+    marginBottom: 4,
   },
 });

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -988,3 +988,82 @@ export async function getDailySummary(
     fat: row?.fat ?? 0,
   };
 }
+
+// --------------- CSV Export ---------------
+
+export type WorkoutCSVRow = {
+  date: string;
+  exercise: string;
+  set_number: number;
+  weight: number | null;
+  reps: number | null;
+  duration_seconds: number | null;
+  notes: string;
+};
+
+export type NutritionCSVRow = {
+  date: string;
+  meal: string;
+  food: string;
+  servings: number;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+};
+
+export async function getWorkoutCSVData(since: number): Promise<WorkoutCSVRow[]> {
+  const database = await getDatabase();
+  return database.getAllAsync<WorkoutCSVRow>(
+    `SELECT
+       date(ws.started_at / 1000, 'unixepoch') AS date,
+       e.name AS exercise,
+       wset.set_number,
+       wset.weight,
+       wset.reps,
+       ws.duration_seconds,
+       ws.notes
+     FROM workout_sessions ws
+     JOIN workout_sets wset ON wset.session_id = ws.id
+     JOIN exercises e ON e.id = wset.exercise_id
+     WHERE ws.completed_at IS NOT NULL
+       AND ws.started_at >= ?
+     ORDER BY ws.started_at ASC, e.name ASC, wset.set_number ASC`,
+    [since]
+  );
+}
+
+export async function getNutritionCSVData(since: number): Promise<NutritionCSVRow[]> {
+  const database = await getDatabase();
+  return database.getAllAsync<NutritionCSVRow>(
+    `SELECT
+       dl.date,
+       dl.meal,
+       f.name AS food,
+       dl.servings,
+       ROUND(f.calories * dl.servings, 1) AS calories,
+       ROUND(f.protein * dl.servings, 1) AS protein,
+       ROUND(f.carbs * dl.servings, 1) AS carbs,
+       ROUND(f.fat * dl.servings, 1) AS fat
+     FROM daily_log dl
+     JOIN food_entries f ON f.id = dl.food_entry_id
+     WHERE dl.date >= date(? / 1000, 'unixepoch')
+     ORDER BY dl.date ASC, dl.meal ASC`,
+    [since]
+  );
+}
+
+export async function getCSVCounts(since: number): Promise<{ sessions: number; entries: number }> {
+  const database = await getDatabase();
+  const s = await database.getFirstAsync<{ count: number }>(
+    `SELECT COUNT(*) AS count FROM workout_sessions
+     WHERE completed_at IS NOT NULL AND started_at >= ?`,
+    [since]
+  );
+  const e = await database.getFirstAsync<{ count: number }>(
+    `SELECT COUNT(*) AS count FROM daily_log
+     WHERE date >= date(? / 1000, 'unixepoch')`,
+    [since]
+  );
+  return { sessions: s?.count ?? 0, entries: e?.count ?? 0 };
+}

--- a/lib/layout.ts
+++ b/lib/layout.ts
@@ -1,0 +1,12 @@
+import { useWindowDimensions } from "react-native";
+
+const WIDE_BREAKPOINT = 768;
+
+export function useLayout() {
+  const { width } = useWindowDimensions();
+  return {
+    wide: width >= WIDE_BREAKPOINT,
+    width,
+    scale: width >= WIDE_BREAKPOINT ? 1.1 : 1.0,
+  };
+}


### PR DESCRIPTION
## Summary

Add CSV data export (workouts + nutrition) with date range filtering and tablet-responsive layouts for Exercises, Progress, and Nutrition tabs.

## Changes

### Part A: CSV Data Export (Settings screen)
- New `Data Export (CSV)` card with SegmentedButtons for date range (7/30/90 days + All Time)
- Live count preview showing matching workout sessions and nutrition entries
- `Export Workouts CSV` — columns: date, exercise, set_number, weight, reps, duration_seconds, notes
- `Export Nutrition CSV` — columns: date, meal, food, servings, calories, protein, carbs, fat
- RFC 4180 compliant CSV escaping (commas wrapped in quotes, double-quotes escaped)
- Uses existing expo-file-system + expo-sharing pattern

### Part B: Tablet-Responsive Layout
- New `useLayout()` hook in `lib/layout.ts` — returns `{ wide, width, scale }` (wide = width >= 768)
- **Exercises tab**: side-by-side list (60%) + detail pane (40%) on tablet; unchanged on phone
- **Progress tab**: 2-column card grid for charts on tablet; single column on phone
- **Nutrition tab**: daily log + inline add-food form side-by-side on tablet; FAB nav on phone

### Database
- `getWorkoutCSVData(since)` — JOIN sessions + sets + exercises for denormalized CSV rows
- `getNutritionCSVData(since)` — JOIN daily_log + food_entries filtered by date
- `getCSVCounts(since)` — count queries for preview

## Testing
- `npx tsc --noEmit` passes with 0 errors
- All new interactive elements have accessibilityLabel and accessibilityRole
- No hardcoded  all via theme tokenscolors 
- No fontSize below 12

## Issue
Resolves BLD-22