### PR TITLE
feat: Workout History & Calendar View (BLD-16)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -17,6 +17,7 @@ import { useFocusEffect, useRouter } from "expo-router";
 import {
   deleteTemplate,
   getActiveSession,
+  getAllCompletedSessionWeeks,
   getRecentSessions,
   getSessionSetCount,
   getTemplateExerciseCount,
@@ -24,6 +25,25 @@ import {
   startSession,
 } from "../../lib/db";
 import type { WorkoutSession, WorkoutTemplate } from "../../lib/types";
+
+function mondayOf(date: Date): number {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const day = (d.getDay() + 6) % 7; // Mon=0..Sun=6
+  d.setDate(d.getDate() - day);
+  return d.getTime();
+}
+
+function computeStreak(timestamps: number[]): number {
+  if (timestamps.length === 0) return 0;
+  const weeks = new Set(timestamps.map((ts) => mondayOf(new Date(ts))));
+  let current = mondayOf(new Date());
+  let count = 0;
+  while (weeks.has(current)) {
+    count++;
+    current -= 7 * 24 * 60 * 60 * 1000;
+  }
+  return count;
+}
 
 export default function Workouts() {
   const theme = useTheme();
@@ -33,16 +53,21 @@ export default function Workouts() {
   const [counts, setCounts] = useState<Record<string, number>>({});
   const [setCounts2, setSetCounts] = useState<Record<string, number>>({});
   const [active, setActive] = useState<WorkoutSession | null>(null);
+  const [streak, setStreak] = useState(0);
 
   const load = useCallback(async () => {
-    const [tpls, sess, act] = await Promise.all([
+    const [tpls, sess, act, timestamps] = await Promise.all([
       getTemplates(),
       getRecentSessions(5),
       getActiveSession(),
+      getAllCompletedSessionWeeks(),
     ]);
     setTemplates(tpls);
     setSessions(sess);
     setActive(act);
+
+    // Calculate streak in JS: consecutive weeks with >= 1 workout
+    setStreak(computeStreak(timestamps));
 
     const c: Record<string, number> = {};
     for (const t of tpls) {
@@ -216,14 +241,43 @@ export default function Workouts() {
         )}
       </View>
 
+      {/* Streak Card */}
+      {streak > 0 && (
+        <Card
+          style={[styles.streak, { backgroundColor: theme.colors.primaryContainer }]}
+          accessibilityLabel={`Training streak: ${streak} week${streak > 1 ? "s" : ""}`}
+        >
+          <Card.Content style={styles.streakContent}>
+            <Text variant="headlineSmall" style={{ color: theme.colors.onPrimaryContainer }}>
+              🔥 {streak}
+            </Text>
+            <Text variant="bodyMedium" style={{ color: theme.colors.onPrimaryContainer }}>
+              week streak
+            </Text>
+          </Card.Content>
+        </Card>
+      )}
+
       {/* Recent Workouts */}
       <View style={styles.section}>
-        <Text
-          variant="titleMedium"
-          style={[styles.sectionTitle, { color: theme.colors.onBackground }]}
-        >
-          Recent Workouts
-        </Text>
+        <View style={styles.sectionHeader}>
+          <Text
+            variant="titleMedium"
+            style={{ color: theme.colors.onBackground }}
+          >
+            Recent Workouts
+          </Text>
+          {sessions.length > 0 && (
+            <Button
+              mode="text"
+              compact
+              onPress={() => router.push("/history")}
+              accessibilityLabel="View all workout history"
+            >
+              View All History
+            </Button>
+          )}
+        </View>
         {sessions.length === 0 ? (
           <View style={styles.empty}>
             <Text
@@ -281,6 +335,14 @@ const styles = StyleSheet.create({
   },
   quickStart: {
     marginBottom: 20,
+  },
+  streak: {
+    marginBottom: 16,
+  },
+  streakContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
   },
   quickStartContent: {
     paddingVertical: 8,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -132,6 +132,15 @@ export default function RootLayout() {
                 headerTintColor,
               }}
             />
+            <Stack.Screen
+              name="history"
+              options={{
+                headerShown: true,
+                title: "Workout History",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
           </Stack>
           <StatusBar style="auto" />
         </ThemeProvider>

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   FlatList,
   Pressable,
@@ -17,6 +17,7 @@ import {
 } from "react-native-paper";
 import { useFocusEffect, useRouter } from "expo-router";
 import {
+  getRecentSessions,
   getSessionsByMonth,
   searchSessions,
 } from "../lib/db";
@@ -68,11 +69,22 @@ function HistoryScreen() {
   const [selected, setSelected] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SessionRow[] | null>(null);
+  const [hasAny, setHasAny] = useState(true);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
   const load = useCallback(async () => {
-    const data = await getSessionsByMonth(year, month);
+    const [data, any] = await Promise.all([
+      getSessionsByMonth(year, month),
+      getRecentSessions(1),
+    ]);
     setSessions(data);
+    setHasAny(any.length > 0);
   }, [year, month]);
 
   useFocusEffect(
@@ -161,8 +173,8 @@ function HistoryScreen() {
 
     const label =
       count > 0
-        ? `${day} ${monthLabel(year, month).split(" ")[0]}, ${count} workout${count > 1 ? "s" : ""}`
-        : `${day} ${monthLabel(year, month).split(" ")[0]}, rest day`;
+        ? `${day} ${monthLabel(year, month)}, ${count} workout${count > 1 ? "s" : ""}`
+        : `${day} ${monthLabel(year, month)}, rest day`;
 
     return (
       <Pressable
@@ -258,9 +270,7 @@ function HistoryScreen() {
   const emptyMessage = () => {
     if (query.trim()) return `No workouts matching "${query}"`;
     if (selected) return "Rest day!";
-    if (sessions.length === 0) {
-      return "No workouts yet. Start your first workout!";
-    }
+    if (!hasAny) return "No workouts yet. Start your first workout!";
     return `No workouts in ${monthLabel(year, month)}`;
   };
 

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -239,7 +239,7 @@ function HistoryScreen() {
     cells.push(renderDay(d));
   }
 
-  const renderSession = ({ item }: ListRenderItemInfo<SessionRow>) => {
+  const renderSession = useCallback(({ item }: ListRenderItemInfo<SessionRow>) => {
     const date = new Date(item.started_at).toLocaleDateString(undefined, {
       weekday: "short",
       month: "short",
@@ -265,7 +265,7 @@ function HistoryScreen() {
         </Card.Content>
       </Card>
     );
-  };
+  }, [theme, router]);
 
   const emptyMessage = () => {
     if (query.trim()) return `No workouts matching "${query}"`;

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -1,0 +1,412 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  FlatList,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+  type ListRenderItemInfo,
+} from "react-native";
+import {
+  Card,
+  Chip,
+  IconButton,
+  Searchbar,
+  Text,
+  useTheme,
+} from "react-native-paper";
+import { useFocusEffect, useRouter } from "expo-router";
+import {
+  getSessionsByMonth,
+  searchSessions,
+} from "../lib/db";
+import type { WorkoutSession } from "../lib/types";
+import { useLayout } from "../lib/layout";
+import ErrorBoundary from "../components/ErrorBoundary";
+
+type SessionRow = WorkoutSession & { set_count: number };
+
+const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function weekday(d: Date): number {
+  return (d.getDay() + 6) % 7; // Mon=0..Sun=6
+}
+
+function daysInMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+function dateKey(ts: number): string {
+  const d = new Date(ts);
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+function formatDuration(seconds: number | null): string {
+  if (!seconds) return "-";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+function monthLabel(year: number, month: number): string {
+  return new Date(year, month).toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+  });
+}
+
+function HistoryScreen() {
+  const theme = useTheme();
+  const router = useRouter();
+  const layout = useLayout();
+
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth());
+  const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SessionRow[] | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const load = useCallback(async () => {
+    const data = await getSessionsByMonth(year, month);
+    setSessions(data);
+  }, [year, month]);
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [load])
+  );
+
+  const dotMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const s of sessions) {
+      const key = dateKey(s.started_at);
+      map.set(key, (map.get(key) ?? 0) + 1);
+    }
+    return map;
+  }, [sessions]);
+
+  const filtered = useMemo(() => {
+    if (results) return results;
+    if (!selected) return sessions;
+    return sessions.filter((s) => dateKey(s.started_at) === selected);
+  }, [sessions, selected, results]);
+
+  const prevMonth = () => {
+    setSelected(null);
+    setQuery("");
+    setResults(null);
+    if (month === 0) {
+      setMonth(11);
+      setYear(year - 1);
+    } else {
+      setMonth(month - 1);
+    }
+  };
+
+  const nextMonth = () => {
+    setSelected(null);
+    setQuery("");
+    setResults(null);
+    if (month === 11) {
+      setMonth(0);
+      setYear(year + 1);
+    } else {
+      setMonth(month + 1);
+    }
+  };
+
+  const onSearch = (text: string) => {
+    setQuery(text);
+    setSelected(null);
+    if (timer.current) clearTimeout(timer.current);
+    if (!text.trim()) {
+      setResults(null);
+      return;
+    }
+    timer.current = setTimeout(async () => {
+      const data = await searchSessions(text.trim());
+      setResults(data);
+    }, 300);
+  };
+
+  const clearFilter = () => {
+    setSelected(null);
+    setQuery("");
+    setResults(null);
+  };
+
+  const tapDay = (key: string) => {
+    setQuery("");
+    setResults(null);
+    setSelected(selected === key ? null : key);
+  };
+
+  // Calendar grid
+  const total = daysInMonth(year, month);
+  const offset = weekday(new Date(year, month, 1));
+  const today = new Date();
+  const todayKey = `${today.getFullYear()}-${today.getMonth()}-${today.getDate()}`;
+  const cellSize = Math.max(44, Math.floor(layout.width / 7) - 4);
+
+  const renderDay = (day: number) => {
+    const key = `${year}-${month}-${day}`;
+    const count = dotMap.get(key) ?? 0;
+    const isToday = key === todayKey;
+    const isSel = key === selected;
+
+    const label =
+      count > 0
+        ? `${day} ${monthLabel(year, month).split(" ")[0]}, ${count} workout${count > 1 ? "s" : ""}`
+        : `${day} ${monthLabel(year, month).split(" ")[0]}, rest day`;
+
+    return (
+      <Pressable
+        key={key}
+        onPress={() => tapDay(key)}
+        accessibilityLabel={label}
+        accessibilityRole="button"
+        style={[
+          styles.cell,
+          {
+            width: cellSize,
+            height: cellSize,
+            borderRadius: cellSize / 2,
+            borderWidth: isToday ? 2 : 0,
+            borderColor: isToday ? theme.colors.primary : "transparent",
+            backgroundColor: isSel
+              ? theme.colors.primary
+              : "transparent",
+          },
+        ]}
+      >
+        <Text
+          variant="bodySmall"
+          style={{
+            color: isSel
+              ? theme.colors.onPrimary
+              : theme.colors.onBackground,
+            fontSize: 14 * layout.scale,
+          }}
+        >
+          {day}
+        </Text>
+        {count > 0 && (
+          <View style={styles.dots}>
+            <View
+              style={[
+                styles.dot,
+                { backgroundColor: isSel ? theme.colors.onPrimary : theme.colors.primary },
+              ]}
+            />
+            {count > 1 && (
+              <View
+                style={[
+                  styles.dot,
+                  { backgroundColor: isSel ? theme.colors.onPrimary : theme.colors.primary },
+                ]}
+              />
+            )}
+          </View>
+        )}
+      </Pressable>
+    );
+  };
+
+  const cells: React.ReactNode[] = [];
+  for (let i = 0; i < offset; i++) {
+    cells.push(
+      <View key={`pad-${i}`} style={{ width: cellSize, height: cellSize }} />
+    );
+  }
+  for (let d = 1; d <= total; d++) {
+    cells.push(renderDay(d));
+  }
+
+  const renderSession = ({ item }: ListRenderItemInfo<SessionRow>) => {
+    const date = new Date(item.started_at).toLocaleDateString(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+    });
+    return (
+      <Card
+        style={[styles.card, { backgroundColor: theme.colors.surface }]}
+        onPress={() => router.push(`/session/detail/${item.id}`)}
+        accessibilityLabel={`${item.name || "Untitled workout"}, ${date}, ${formatDuration(item.duration_seconds)}, ${item.set_count} sets`}
+        accessibilityRole="button"
+      >
+        <Card.Content>
+          <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>
+            {item.name || "Untitled workout"}
+          </Text>
+          <Text
+            variant="bodySmall"
+            style={{ color: theme.colors.onSurfaceVariant }}
+          >
+            {date} · {formatDuration(item.duration_seconds)} · {item.set_count} sets
+          </Text>
+        </Card.Content>
+      </Card>
+    );
+  };
+
+  const emptyMessage = () => {
+    if (query.trim()) return `No workouts matching "${query}"`;
+    if (selected) return "Rest day!";
+    if (sessions.length === 0) {
+      return "No workouts yet. Start your first workout!";
+    }
+    return `No workouts in ${monthLabel(year, month)}`;
+  };
+
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: theme.colors.background }}
+      contentContainerStyle={styles.container}
+    >
+      {/* Search */}
+      <Searchbar
+        placeholder="Search workouts"
+        value={query}
+        onChangeText={onSearch}
+        style={[styles.search, { backgroundColor: theme.colors.surface }]}
+        accessibilityLabel="Search workout history"
+      />
+
+      {/* Month Navigation */}
+      <View style={styles.monthNav}>
+        <IconButton
+          icon="chevron-left"
+          onPress={prevMonth}
+          accessibilityLabel="Previous month"
+        />
+        <Text
+          variant="titleMedium"
+          style={{ color: theme.colors.onBackground }}
+        >
+          {monthLabel(year, month)}
+        </Text>
+        <IconButton
+          icon="chevron-right"
+          onPress={nextMonth}
+          accessibilityLabel="Next month"
+        />
+      </View>
+
+      {/* Day-of-week headers */}
+      <View style={styles.grid}>
+        {DAYS.map((d) => (
+          <View key={d} style={[styles.cell, { width: cellSize, height: 28 }]}>
+            <Text
+              variant="labelSmall"
+              style={{ color: theme.colors.onSurfaceVariant, fontSize: 12 * layout.scale }}
+            >
+              {d}
+            </Text>
+          </View>
+        ))}
+      </View>
+
+      {/* Calendar Grid */}
+      <View style={styles.grid}>{cells}</View>
+
+      {/* Active filter chip */}
+      {(selected || query.trim()) && (
+        <Chip
+          icon="close"
+          onPress={clearFilter}
+          style={styles.chip}
+          accessibilityLabel="Clear filter"
+        >
+          {query.trim()
+            ? `Search: ${query}`
+            : `${new Date(year, month, Number(selected!.split("-")[2])).toLocaleDateString(undefined, { month: "short", day: "numeric" })}`}
+        </Chip>
+      )}
+
+      {/* Session List */}
+      {filtered.length === 0 ? (
+        <View style={styles.empty}>
+          <Text
+            variant="bodyMedium"
+            style={{ color: theme.colors.onSurfaceVariant }}
+          >
+            {emptyMessage()}
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={filtered}
+          keyExtractor={(item) => item.id}
+          scrollEnabled={false}
+          renderItem={renderSession}
+        />
+      )}
+    </ScrollView>
+  );
+}
+
+export default function History() {
+  return (
+    <ErrorBoundary>
+      <HistoryScreen />
+    </ErrorBoundary>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    paddingBottom: 40,
+  },
+  search: {
+    marginBottom: 12,
+  },
+  monthNav: {
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "flex-start",
+    paddingHorizontal: 2,
+  },
+  cell: {
+    alignItems: "center",
+    justifyContent: "center",
+    marginVertical: 2,
+    marginHorizontal: 2,
+    minHeight: 44,
+  },
+  dots: {
+    flexDirection: "row",
+    gap: 3,
+    position: "absolute",
+    bottom: 4,
+  },
+  dot: {
+    width: 5,
+    height: 5,
+    borderRadius: 2.5,
+  },
+  card: {
+    marginBottom: 8,
+  },
+  chip: {
+    alignSelf: "flex-start",
+    marginBottom: 12,
+    marginTop: 4,
+  },
+  empty: {
+    alignItems: "center",
+    paddingVertical: 24,
+  },
+});

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -608,6 +608,52 @@ export async function getSessionSetCount(
   return row?.count ?? 0;
 }
 
+// --------------- History & Calendar ---------------
+
+export async function getSessionsByMonth(
+  year: number,
+  month: number
+): Promise<(WorkoutSession & { set_count: number })[]> {
+  const database = await getDatabase();
+  const start = new Date(year, month, 1).getTime();
+  const end = new Date(year, month + 1, 1).getTime();
+  return database.getAllAsync<WorkoutSession & { set_count: number }>(
+    `SELECT wss.*,
+            (SELECT COUNT(*) FROM workout_sets ws WHERE ws.session_id = wss.id AND ws.completed = 1) AS set_count
+     FROM workout_sessions wss
+     WHERE wss.completed_at IS NOT NULL
+       AND wss.started_at >= ? AND wss.started_at < ?
+     ORDER BY wss.started_at DESC`,
+    [start, end]
+  );
+}
+
+export async function searchSessions(
+  query: string,
+  limit = 50
+): Promise<(WorkoutSession & { set_count: number })[]> {
+  const database = await getDatabase();
+  return database.getAllAsync<WorkoutSession & { set_count: number }>(
+    `SELECT wss.*,
+            (SELECT COUNT(*) FROM workout_sets ws WHERE ws.session_id = wss.id AND ws.completed = 1) AS set_count
+     FROM workout_sessions wss
+     WHERE wss.completed_at IS NOT NULL AND wss.name LIKE ?
+     ORDER BY wss.started_at DESC
+     LIMIT ?`,
+    [`%${query}%`, limit]
+  );
+}
+
+export async function getAllCompletedSessionWeeks(): Promise<number[]> {
+  const database = await getDatabase();
+  const rows = await database.getAllAsync<{ started_at: number }>(
+    `SELECT started_at FROM workout_sessions
+     WHERE completed_at IS NOT NULL
+     ORDER BY started_at DESC`
+  );
+  return rows.map((r) => r.started_at);
+}
+
 // --------------- Progress Queries ---------------
 
 export async function getWeeklySessionCounts(


### PR DESCRIPTION
## Summary

Add a Workout History screen with a monthly calendar heatmap and full session list, plus a streak counter card on the Workouts tab.

## Changes

- **New History screen** (`app/history.tsx`): Monthly calendar grid with workout day dots (single=1, double=2+), today circle, selectable days, month navigation, search bar with 300ms debounce
- **Workouts tab updates** (`app/(tabs)/index.tsx`): Streak card showing consecutive training weeks, "View All History" link below recent workouts
- **New DB queries** (`lib/db.ts`): `getSessionsByMonth` (epoch range), `searchSessions` (LIKE), `getAllCompletedSessionWeeks` for JS-based streak calculation
- **Navigation** (`app/_layout.tsx`): Registered history screen route

## Technical Decisions

- Single query loads all month sessions; dot counts computed client-side (per tech lead recommendation)
- Day filter is in-memory only (no extra DB call)
- Streak calculated in JS with Set of monday timestamps (no recursive CTE)
- Calendar cell minimum 44×44pt for touch targets
- Calendar font sizes scale with `useLayout().scale` for tablet
- All calendar colors from theme tokens (no hardcoded hex)

## Accessibility

- Calendar cells: `accessibilityLabel` with date and workout count or "rest day"
- Month arrows: labeled "Previous month" / "Next month"
- Streak card: labeled "Training streak: N weeks"
- Session items: labeled with name, date, duration, set count
- Search bar: labeled "Search workout history"

## Testing

- TypeScript type checking passes with zero errors (`tsc --noEmit`)
- Verified empty states, search, month navigation, day filtering logic
- No new dependencies added

## Issue

Resolves BLD-16