### PR TITLE
feat: Custom Exercises CRUD (Phase 9) (BLD-3)

### DIFF
--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   FlatList,
   ScrollView,
@@ -6,8 +6,8 @@ import {
   View,
   type ListRenderItemInfo,
 } from "react-native";
-import { Chip, Searchbar, Text, TouchableRipple, useTheme } from "react-native-paper";
-import { useRouter } from "expo-router";
+import { Chip, FAB, Searchbar, Text, TouchableRipple, useTheme } from "react-native-paper";
+import { useFocusEffect, useRouter } from "expo-router";
 import { getAllExercises, getExerciseById } from "../../lib/db";
 import {
   CATEGORIES,
@@ -26,36 +26,44 @@ const DIFFICULTY_COLORS: Record<string, string> = {
   advanced: semantic.advanced,
 };
 
+type FilterType = Category | "custom";
+const FILTER_ALL: FilterType[] = [...CATEGORIES, "custom"];
+
 export default function Exercises() {
   const theme = useTheme();
   const router = useRouter();
   const layout = useLayout();
   const [exercises, setExercises] = useState<Exercise[]>([]);
   const [query, setQuery] = useState("");
-  const [selected, setSelected] = useState<Set<Category>>(new Set());
+  const [selected, setSelected] = useState<Set<FilterType>>(new Set());
   const [loading, setLoading] = useState(true);
   const [detail, setDetail] = useState<Exercise | null>(null);
 
-  useEffect(() => {
-    getAllExercises()
-      .then(setExercises)
-      .finally(() => setLoading(false));
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      getAllExercises()
+        .then(setExercises)
+        .finally(() => setLoading(false));
+    }, [])
+  );
 
   const filtered = useMemo(() => {
     const q = query.toLowerCase();
+    const customFilter = selected.has("custom");
+    const cats = new Set([...selected].filter((s): s is Category => s !== "custom"));
     return exercises.filter((ex) => {
       if (q && !ex.name.toLowerCase().includes(q)) return false;
-      if (selected.size > 0 && !selected.has(ex.category)) return false;
+      if (customFilter && !ex.is_custom) return false;
+      if (cats.size > 0 && !cats.has(ex.category)) return false;
       return true;
     });
   }, [exercises, query, selected]);
 
-  const toggle = useCallback((cat: Category) => {
+  const toggle = useCallback((f: FilterType) => {
     setSelected((prev) => {
       const next = new Set(prev);
-      if (next.has(cat)) next.delete(cat);
-      else next.add(cat);
+      if (next.has(f)) next.delete(f);
+      else next.add(f);
       return next;
     });
   }, []);
@@ -80,13 +88,24 @@ export default function Exercises() {
           { backgroundColor: theme.colors.surface, borderBottomColor: theme.colors.outlineVariant },
           layout.wide && detail?.id === item.id && { backgroundColor: theme.colors.primaryContainer },
         ]}
-        accessibilityLabel={`${item.name}, ${CATEGORY_LABELS[item.category]}, ${item.equipment}`}
+        accessibilityLabel={`${item.name}${item.is_custom ? ", Custom" : ""}, ${CATEGORY_LABELS[item.category]}, ${item.equipment}`}
         accessibilityRole="button"
       >
         <View>
-          <Text variant="titleSmall" numberOfLines={1} style={{ color: theme.colors.onSurface }}>
-            {item.name}
-          </Text>
+          <View style={styles.titleRow}>
+            <Text variant="titleSmall" numberOfLines={1} style={[{ color: theme.colors.onSurface }, styles.titleText]}>
+              {item.name}
+            </Text>
+            {item.is_custom && (
+              <Chip
+                compact
+                textStyle={styles.customText}
+                style={[styles.customChip, { backgroundColor: theme.colors.tertiaryContainer }]}
+              >
+                Custom
+              </Chip>
+            )}
+          </View>
           <View style={styles.row}>
             <Chip
               compact
@@ -148,6 +167,8 @@ export default function Exercises() {
     [loading, theme]
   );
 
+  const filterLabel = (f: FilterType) => (f === "custom" ? "Custom" : CATEGORY_LABELS[f]);
+
   const list = (
     <View style={layout.wide ? { flex: 6 } : { flex: 1 }}>
       <Searchbar
@@ -161,19 +182,19 @@ export default function Exercises() {
         <FlatList
           horizontal
           showsHorizontalScrollIndicator={false}
-          data={CATEGORIES}
+          data={FILTER_ALL}
           keyExtractor={(c) => c}
-          renderItem={({ item: cat }) => (
+          renderItem={({ item: f }) => (
             <Chip
-              selected={selected.has(cat)}
-              onPress={() => toggle(cat)}
+              selected={selected.has(f)}
+              onPress={() => toggle(f)}
               style={styles.filterChip}
               compact
-              accessibilityLabel={`Filter by ${CATEGORY_LABELS[cat]}`}
+              accessibilityLabel={`Filter by ${filterLabel(f)}`}
               accessibilityRole="button"
-              accessibilityState={{ selected: selected.has(cat) }}
+              accessibilityState={{ selected: selected.has(f) }}
             >
-              {CATEGORY_LABELS[cat]}
+              {filterLabel(f)}
             </Chip>
           )}
         />
@@ -185,6 +206,14 @@ export default function Exercises() {
         getItemLayout={getLayout}
         ListEmptyComponent={empty}
         contentContainerStyle={filtered.length === 0 ? styles.emptyList : undefined}
+      />
+      <FAB
+        icon="plus"
+        onPress={() => router.push("/exercise/create")}
+        style={[styles.fab, { backgroundColor: theme.colors.primary }]}
+        color={theme.colors.onPrimary}
+        accessibilityLabel="Add custom exercise"
+        accessibilityRole="button"
       />
     </View>
   );
@@ -211,6 +240,15 @@ export default function Exercises() {
             <Text variant="headlineSmall" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
               {detail.name}
             </Text>
+            {detail.is_custom && (
+              <Chip
+                compact
+                style={{ backgroundColor: theme.colors.tertiaryContainer, alignSelf: "flex-start", marginBottom: 8 }}
+                textStyle={{ fontSize: 12 }}
+              >
+                Custom
+              </Chip>
+            )}
             <View style={styles.row}>
               <Chip compact style={{ backgroundColor: theme.colors.primaryContainer }}>
                 {CATEGORY_LABELS[detail.category]}
@@ -303,6 +341,20 @@ const styles = StyleSheet.create({
     minHeight: ITEM_HEIGHT,
     justifyContent: "center",
   },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  titleText: {
+    flexShrink: 1,
+  },
+  customChip: {
+    height: 20,
+  },
+  customText: {
+    fontSize: 10,
+  },
   row: {
     flexDirection: "row",
     alignItems: "center",
@@ -328,6 +380,16 @@ const styles = StyleSheet.create({
   },
   emptyList: {
     flexGrow: 1,
+  },
+  fab: {
+    position: "absolute",
+    right: 16,
+    bottom: 16,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    justifyContent: "center",
+    alignItems: "center",
   },
   detailPane: {
     flex: 4,

--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -350,10 +350,10 @@ const styles = StyleSheet.create({
     flexShrink: 1,
   },
   customChip: {
-    height: 20,
+    height: 24,
   },
   customText: {
-    fontSize: 10,
+    fontSize: 12,
   },
   row: {
     flexDirection: "row",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -43,6 +43,24 @@ export default function RootLayout() {
               }}
             />
             <Stack.Screen
+              name="exercise/create"
+              options={{
+                headerShown: true,
+                title: "New Exercise",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="exercise/edit/[id]"
+              options={{
+                headerShown: true,
+                title: "Edit Exercise",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
               name="template/create"
               options={{
                 headerShown: true,

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -1,8 +1,12 @@
-import { useEffect, useState } from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
-import { Chip, Text, useTheme } from "react-native-paper";
-import { Stack, useLocalSearchParams } from "expo-router";
-import { getExerciseById } from "../../lib/db";
+import { useCallback, useEffect, useState } from "react";
+import { Alert, ScrollView, StyleSheet, View } from "react-native";
+import { Chip, IconButton, Snackbar, Text, useTheme } from "react-native-paper";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import {
+  getExerciseById,
+  softDeleteCustomExercise,
+  getTemplatesUsingExercise,
+} from "../../lib/db";
 import { CATEGORY_LABELS, type Exercise } from "../../lib/types";
 import { semantic } from "../../constants/theme";
 
@@ -14,12 +18,42 @@ const DIFFICULTY_COLORS: Record<string, string> = {
 
 export default function ExerciseDetail() {
   const theme = useTheme();
+  const router = useRouter();
   const { id } = useLocalSearchParams<{ id: string }>();
   const [exercise, setExercise] = useState<Exercise | null>(null);
+  const [toast, setToast] = useState("");
 
   useEffect(() => {
     if (id) getExerciseById(id).then(setExercise);
   }, [id]);
+
+  const edit = useCallback(() => {
+    if (id) router.push(`/exercise/edit/${id}`);
+  }, [id, router]);
+
+  const remove = useCallback(async () => {
+    if (!id || !exercise) return;
+    const templates = await getTemplatesUsingExercise(id);
+    const msg = templates.length > 0
+      ? `Delete ${exercise.name}? This exercise is used in ${templates.length} template(s). It will be removed from those templates.`
+      : `Delete ${exercise.name}? This exercise will be removed from the library.`;
+    Alert.alert("Delete Exercise", msg, [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            await softDeleteCustomExercise(id);
+            setToast("Exercise deleted");
+            setTimeout(() => router.back(), 400);
+          } catch {
+            setToast("Failed to delete exercise");
+          }
+        },
+      },
+    ]);
+  }, [id, exercise, router]);
 
   if (!exercise) {
     return (
@@ -39,9 +73,42 @@ export default function ExerciseDetail() {
 
   return (
     <>
-      <Stack.Screen options={{ title: exercise.name }} />
-      <ScrollView style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <Stack.Screen
+        options={{
+          title: exercise.name,
+          headerRight: exercise.is_custom
+            ? () => (
+                <View style={styles.headerActions}>
+                  <IconButton
+                    icon="pencil"
+                    size={22}
+                    onPress={edit}
+                    accessibilityLabel="Edit exercise"
+                  />
+                  <IconButton
+                    icon="delete"
+                    size={22}
+                    onPress={remove}
+                    accessibilityLabel="Delete exercise"
+                  />
+                </View>
+              )
+            : undefined,
+        }}
+      />
+      <ScrollView style={[styles.scrollContainer, { backgroundColor: theme.colors.background }]}>
         <View style={styles.content}>
+          {/* Custom badge */}
+          {exercise.is_custom && (
+            <Chip
+              compact
+              style={[styles.customBadge, { backgroundColor: theme.colors.tertiaryContainer }]}
+              textStyle={{ fontSize: 12 }}
+            >
+              Custom
+            </Chip>
+          )}
+
           {/* Category & Difficulty */}
           <View style={styles.row}>
             <Chip
@@ -109,28 +176,34 @@ export default function ExerciseDetail() {
           )}
 
           {/* Instructions */}
-          <View style={styles.section}>
-            <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
-              Instructions
-            </Text>
-            {steps.map((step, i) => (
-              <Text
-                key={i}
-                variant="bodyMedium"
-                style={[styles.step, { color: theme.colors.onSurface }]}
-              >
-                {step}
+          {steps.length > 0 && (
+            <View style={styles.section}>
+              <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
+                Instructions
               </Text>
-            ))}
-          </View>
+              {steps.map((step, i) => (
+                <Text
+                  key={i}
+                  variant="bodyMedium"
+                  style={[styles.step, { color: theme.colors.onSurface }]}
+                >
+                  {step}
+                </Text>
+              ))}
+            </View>
+          )}
         </View>
       </ScrollView>
+
+      <Snackbar visible={!!toast} onDismiss={() => setToast("")} duration={3000}>
+        {toast}
+      </Snackbar>
     </>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  scrollContainer: {
     flex: 1,
   },
   center: {
@@ -141,6 +214,13 @@ const styles = StyleSheet.create({
   content: {
     padding: 16,
     paddingBottom: 32,
+  },
+  headerActions: {
+    flexDirection: "row",
+  },
+  customBadge: {
+    alignSelf: "flex-start",
+    marginBottom: 8,
   },
   row: {
     flexDirection: "row",

--- a/app/exercise/create.tsx
+++ b/app/exercise/create.tsx
@@ -1,0 +1,32 @@
+import { useCallback, useState } from "react";
+import { Stack, useRouter } from "expo-router";
+import { Snackbar, useTheme } from "react-native-paper";
+import { View } from "react-native";
+import ExerciseForm from "../../components/ExerciseForm";
+import { createCustomExercise } from "../../lib/db";
+import type { Exercise } from "../../lib/types";
+
+export default function CreateExercise() {
+  const theme = useTheme();
+  const router = useRouter();
+  const [toast, setToast] = useState("");
+
+  const save = useCallback(
+    async (data: Omit<Exercise, "id" | "is_custom">) => {
+      await createCustomExercise(data);
+      setToast("Exercise created");
+      setTimeout(() => router.back(), 400);
+    },
+    [router]
+  );
+
+  return (
+    <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
+      <Stack.Screen options={{ title: "New Exercise" }} />
+      <ExerciseForm title="exercise" onSave={save} />
+      <Snackbar visible={!!toast} onDismiss={() => setToast("")} duration={2000}>
+        {toast}
+      </Snackbar>
+    </View>
+  );
+}

--- a/app/exercise/edit/[id].tsx
+++ b/app/exercise/edit/[id].tsx
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from "react";
+import { View } from "react-native";
+import { Snackbar, Text, useTheme } from "react-native-paper";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import ExerciseForm from "../../../components/ExerciseForm";
+import { getExerciseById, updateCustomExercise } from "../../../lib/db";
+import type { Exercise } from "../../../lib/types";
+
+export default function EditExercise() {
+  const theme = useTheme();
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [exercise, setExercise] = useState<Exercise | null>(null);
+  const [toast, setToast] = useState("");
+
+  useEffect(() => {
+    if (id) getExerciseById(id).then(setExercise);
+  }, [id]);
+
+  const save = useCallback(
+    async (data: Omit<Exercise, "id" | "is_custom">) => {
+      if (!id) return;
+      await updateCustomExercise(id, data);
+      setToast("Exercise updated");
+      setTimeout(() => router.back(), 400);
+    },
+    [id, router]
+  );
+
+  if (!exercise) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: theme.colors.background }}>
+        <Stack.Screen options={{ title: "Edit Exercise" }} />
+        <Text style={{ color: theme.colors.onSurfaceVariant }}>Loading...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
+      <Stack.Screen options={{ title: `Edit ${exercise.name}` }} />
+      <ExerciseForm title="exercise" initial={exercise} onSave={save} />
+      <Snackbar visible={!!toast} onDismiss={() => setToast("")} duration={2000}>
+        {toast}
+      </Snackbar>
+    </View>
+  );
+}

--- a/app/template/pick-exercise.tsx
+++ b/app/template/pick-exercise.tsx
@@ -96,7 +96,7 @@ export default function PickExercise() {
             borderBottomColor: theme.colors.outlineVariant,
           },
         ]}
-        accessibilityLabel={`Select ${item.name}, ${CATEGORY_LABELS[item.category]}, ${item.equipment}`}
+        accessibilityLabel={`Select ${item.name}${item.is_custom ? " (Custom)" : ""}, ${CATEGORY_LABELS[item.category]}, ${item.equipment}`}
         accessibilityRole="button"
       >
         <View>
@@ -105,7 +105,7 @@ export default function PickExercise() {
             numberOfLines={1}
             style={{ color: theme.colors.onSurface }}
           >
-            {item.name}
+            {item.name}{item.is_custom ? " (Custom)" : ""}
           </Text>
           <View style={styles.row}>
             <Chip

--- a/components/ExerciseForm.tsx
+++ b/components/ExerciseForm.tsx
@@ -1,0 +1,324 @@
+import { useCallback, useState } from "react";
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
+import {
+  Button,
+  Chip,
+  SegmentedButtons,
+  Snackbar,
+  Text,
+  TextInput,
+  useTheme,
+} from "react-native-paper";
+import { useRouter } from "expo-router";
+import {
+  CATEGORIES,
+  CATEGORY_LABELS,
+  type Category,
+  DIFFICULTIES,
+  DIFFICULTY_LABELS,
+  type Difficulty,
+  EQUIPMENT_LIST,
+  EQUIPMENT_LABELS,
+  type Equipment,
+  type Exercise,
+  type MuscleGroup,
+  MUSCLE_GROUPS_BY_REGION,
+  MUSCLE_LABELS,
+} from "../lib/types";
+
+type Props = {
+  initial?: Exercise;
+  onSave: (data: Omit<Exercise, "id" | "is_custom">) => Promise<void>;
+  title: string;
+};
+
+export default function ExerciseForm({ initial, onSave, title }: Props) {
+  const theme = useTheme();
+  const router = useRouter();
+  const [name, setName] = useState(initial?.name ?? "");
+  const [category, setCategory] = useState<Category | null>(initial?.category ?? null);
+  const [equipment, setEquipment] = useState<Equipment>(initial?.equipment ?? "bodyweight");
+  const [difficulty, setDifficulty] = useState<Difficulty>(initial?.difficulty ?? "beginner");
+  const [primary, setPrimary] = useState<Set<MuscleGroup>>(
+    new Set(initial?.primary_muscles ?? [])
+  );
+  const [secondary, setSecondary] = useState<Set<MuscleGroup>>(
+    new Set(initial?.secondary_muscles ?? [])
+  );
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [errors, setErrors] = useState<{ name?: string; category?: string; muscles?: string }>({});
+  const [toast, setToast] = useState("");
+
+  const toggleMuscle = useCallback(
+    (set: Set<MuscleGroup>, setter: (s: Set<MuscleGroup>) => void, muscle: MuscleGroup) => {
+      const next = new Set(set);
+      if (next.has(muscle)) next.delete(muscle);
+      else next.add(muscle);
+      setter(next);
+      setDirty(true);
+    },
+    []
+  );
+
+  const validate = useCallback(() => {
+    const e: typeof errors = {};
+    if (!name.trim()) e.name = "Name is required";
+    if (!category) e.category = "Category is required";
+    if (primary.size === 0) e.muscles = "Select at least one primary muscle";
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  }, [name, category, primary]);
+
+  const save = useCallback(async () => {
+    if (!validate()) return;
+    setSaving(true);
+    try {
+      await onSave({
+        name: name.trim(),
+        category: category!,
+        equipment,
+        difficulty,
+        primary_muscles: Array.from(primary),
+        secondary_muscles: Array.from(secondary),
+        instructions: "",
+      });
+    } catch {
+      setToast("Failed to save exercise");
+    } finally {
+      setSaving(false);
+    }
+  }, [validate, onSave, name, category, equipment, difficulty, primary, secondary]);
+
+  const back = useCallback(() => {
+    if (dirty) {
+      Alert.alert("Discard changes?", "You have unsaved changes.", [
+        { text: "Keep editing", style: "cancel" },
+        { text: "Discard", style: "destructive", onPress: () => router.back() },
+      ]);
+      return;
+    }
+    router.back();
+  }, [dirty, router]);
+
+  return (
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+    >
+      <ScrollView
+        style={[styles.container, { backgroundColor: theme.colors.background }]}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* Name */}
+        <TextInput
+          label="Exercise Name"
+          value={name}
+          onChangeText={(v) => { setName(v); setDirty(true); setErrors((e) => ({ ...e, name: undefined })); }}
+          mode="outlined"
+          maxLength={100}
+          error={!!errors.name}
+          accessibilityLabel="Exercise name"
+          style={styles.input}
+        />
+        <View style={styles.counter}>
+          <Text
+            variant="bodySmall"
+            style={{ color: errors.name ? theme.colors.error : theme.colors.onSurfaceVariant }}
+            accessibilityLabel={errors.name ?? `${name.length} of 100 characters used`}
+            accessibilityLiveRegion="polite"
+          >
+            {errors.name ?? `${name.length}/100`}
+          </Text>
+        </View>
+
+        {/* Category */}
+        <Text variant="labelLarge" style={[styles.label, { color: theme.colors.onSurface }]}>
+          Category *
+        </Text>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.chipScroll}>
+          <View style={styles.chipRow}>
+            {CATEGORIES.map((cat) => (
+              <Chip
+                key={cat}
+                selected={category === cat}
+                onPress={() => { setCategory(cat); setDirty(true); setErrors((e) => ({ ...e, category: undefined })); }}
+                style={styles.chip}
+                compact
+                accessibilityLabel={`Category: ${CATEGORY_LABELS[cat]}`}
+                accessibilityRole="radio"
+                accessibilityState={{ selected: category === cat }}
+              >
+                {CATEGORY_LABELS[cat]}
+              </Chip>
+            ))}
+          </View>
+        </ScrollView>
+        {errors.category && (
+          <Text
+            variant="bodySmall"
+            style={{ color: theme.colors.error, marginTop: 2, marginHorizontal: 16 }}
+            accessibilityLiveRegion="polite"
+          >
+            {errors.category}
+          </Text>
+        )}
+
+        {/* Equipment */}
+        <Text variant="labelLarge" style={[styles.label, { color: theme.colors.onSurface }]}>
+          Equipment
+        </Text>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.chipScroll}>
+          <View style={styles.chipRow}>
+            {EQUIPMENT_LIST.map((eq) => (
+              <Chip
+                key={eq}
+                selected={equipment === eq}
+                onPress={() => { setEquipment(eq); setDirty(true); }}
+                style={styles.chip}
+                compact
+                accessibilityLabel={`Equipment: ${EQUIPMENT_LABELS[eq]}`}
+                accessibilityRole="radio"
+                accessibilityState={{ selected: equipment === eq }}
+              >
+                {EQUIPMENT_LABELS[eq]}
+              </Chip>
+            ))}
+          </View>
+        </ScrollView>
+
+        {/* Difficulty */}
+        <Text variant="labelLarge" style={[styles.label, { color: theme.colors.onSurface }]}>
+          Difficulty
+        </Text>
+        <SegmentedButtons
+          value={difficulty}
+          onValueChange={(v) => { setDifficulty(v as Difficulty); setDirty(true); }}
+          buttons={DIFFICULTIES.map((d) => ({ value: d, label: DIFFICULTY_LABELS[d] }))}
+          style={styles.segment}
+        />
+
+        {/* Primary Muscles */}
+        <Text variant="labelLarge" style={[styles.label, { color: theme.colors.onSurface }]}>
+          Primary Muscles *
+        </Text>
+        {MUSCLE_GROUPS_BY_REGION.map((region) => (
+          <View key={region.label} style={styles.region}>
+            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 4 }}>
+              {region.label}
+            </Text>
+            <View style={styles.chipWrap}>
+              {region.muscles.map((m) => (
+                <Chip
+                  key={m}
+                  selected={primary.has(m)}
+                  onPress={() => { toggleMuscle(primary, setPrimary, m); setErrors((e) => ({ ...e, muscles: undefined })); }}
+                  style={styles.chip}
+                  compact
+                  accessibilityLabel={`Primary muscle: ${MUSCLE_LABELS[m]}`}
+                  accessibilityRole="checkbox"
+                  accessibilityState={{ selected: primary.has(m) }}
+                >
+                  {MUSCLE_LABELS[m]}
+                </Chip>
+              ))}
+            </View>
+          </View>
+        ))}
+        {errors.muscles && (
+          <Text
+            variant="bodySmall"
+            style={{ color: theme.colors.error, marginHorizontal: 16 }}
+            accessibilityLiveRegion="polite"
+          >
+            {errors.muscles}
+          </Text>
+        )}
+
+        {/* Secondary Muscles */}
+        <Text variant="labelLarge" style={[styles.label, { color: theme.colors.onSurface }]}>
+          Secondary Muscles
+        </Text>
+        {MUSCLE_GROUPS_BY_REGION.map((region) => (
+          <View key={region.label} style={styles.region}>
+            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 4 }}>
+              {region.label}
+            </Text>
+            <View style={styles.chipWrap}>
+              {region.muscles.map((m) => (
+                <Chip
+                  key={m}
+                  selected={secondary.has(m)}
+                  onPress={() => toggleMuscle(secondary, setSecondary, m)}
+                  style={styles.chip}
+                  compact
+                  accessibilityLabel={`Secondary muscle: ${MUSCLE_LABELS[m]}`}
+                  accessibilityRole="checkbox"
+                  accessibilityState={{ selected: secondary.has(m) }}
+                >
+                  {MUSCLE_LABELS[m]}
+                </Chip>
+              ))}
+            </View>
+          </View>
+        ))}
+
+        {/* Save / Cancel */}
+        <View style={styles.actions}>
+          <Button
+            mode="contained"
+            onPress={save}
+            loading={saving}
+            disabled={saving}
+            style={styles.saveBtn}
+            accessibilityLabel={`Save ${title.toLowerCase()}`}
+          >
+            Save
+          </Button>
+          <Button
+            mode="outlined"
+            onPress={back}
+            disabled={saving}
+            style={styles.cancelBtn}
+            accessibilityLabel="Cancel"
+          >
+            Cancel
+          </Button>
+        </View>
+      </ScrollView>
+
+      <Snackbar
+        visible={!!toast}
+        onDismiss={() => setToast("")}
+        duration={3000}
+      >
+        {toast}
+      </Snackbar>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: 16, paddingBottom: 48 },
+  input: { marginBottom: 0 },
+  counter: { alignItems: "flex-end", marginBottom: 8, marginRight: 4 },
+  label: { marginTop: 16, marginBottom: 8 },
+  chipScroll: { marginBottom: 4 },
+  chipRow: { flexDirection: "row", gap: 6, paddingRight: 16 },
+  chipWrap: { flexDirection: "row", flexWrap: "wrap", gap: 6 },
+  chip: { marginBottom: 2 },
+  segment: { marginHorizontal: 0 },
+  region: { marginBottom: 8, marginLeft: 4 },
+  actions: { marginTop: 24, gap: 12 },
+  saveBtn: { borderRadius: 8 },
+  cancelBtn: { borderRadius: 8 },
+});

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -156,6 +156,16 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
       updated_at INTEGER NOT NULL
     );
   `);
+
+  // Migration: add deleted_at column for soft-delete
+  const cols = await database.getAllAsync<{ name: string }>(
+    "PRAGMA table_info(exercises)"
+  );
+  if (!cols.some((c) => c.name === "deleted_at")) {
+    await database.execAsync(
+      "ALTER TABLE exercises ADD COLUMN deleted_at INTEGER DEFAULT NULL"
+    );
+  }
 }
 
 async function seed(database: SQLite.SQLiteDatabase): Promise<void> {
@@ -217,7 +227,7 @@ function mapRow(row: ExerciseRow): Exercise {
 export async function getAllExercises(): Promise<Exercise[]> {
   const database = await getDatabase();
   const rows = await database.getAllAsync<ExerciseRow>(
-    "SELECT * FROM exercises ORDER BY name ASC"
+    "SELECT * FROM exercises WHERE deleted_at IS NULL ORDER BY name ASC"
   );
   return rows.map(mapRow);
 }
@@ -230,6 +240,77 @@ export async function getExerciseById(id: string): Promise<Exercise | null> {
   );
   if (!row) return null;
   return mapRow(row);
+}
+
+export async function createCustomExercise(
+  exercise: Omit<Exercise, "id" | "is_custom">
+): Promise<Exercise> {
+  const database = await getDatabase();
+  const id = crypto.randomUUID();
+  await database.runAsync(
+    `INSERT INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty, is_custom)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)`,
+    [
+      id,
+      exercise.name,
+      exercise.category,
+      JSON.stringify(exercise.primary_muscles),
+      JSON.stringify(exercise.secondary_muscles),
+      exercise.equipment,
+      exercise.instructions,
+      exercise.difficulty,
+    ]
+  );
+  return { ...exercise, id, is_custom: true };
+}
+
+export async function updateCustomExercise(
+  id: string,
+  exercise: Partial<Omit<Exercise, "id" | "is_custom">>
+): Promise<void> {
+  const database = await getDatabase();
+  const fields: string[] = [];
+  const values: (string | number)[] = [];
+  if (exercise.name !== undefined) { fields.push("name = ?"); values.push(exercise.name); }
+  if (exercise.category !== undefined) { fields.push("category = ?"); values.push(exercise.category); }
+  if (exercise.primary_muscles !== undefined) { fields.push("primary_muscles = ?"); values.push(JSON.stringify(exercise.primary_muscles)); }
+  if (exercise.secondary_muscles !== undefined) { fields.push("secondary_muscles = ?"); values.push(JSON.stringify(exercise.secondary_muscles)); }
+  if (exercise.equipment !== undefined) { fields.push("equipment = ?"); values.push(exercise.equipment); }
+  if (exercise.instructions !== undefined) { fields.push("instructions = ?"); values.push(exercise.instructions); }
+  if (exercise.difficulty !== undefined) { fields.push("difficulty = ?"); values.push(exercise.difficulty); }
+  if (fields.length === 0) return;
+  values.push(id);
+  await database.runAsync(
+    `UPDATE exercises SET ${fields.join(", ")} WHERE id = ? AND is_custom = 1`,
+    values
+  );
+}
+
+export async function softDeleteCustomExercise(id: string): Promise<void> {
+  const database = await getDatabase();
+  await database.withTransactionAsync(async () => {
+    await database.runAsync(
+      "DELETE FROM template_exercises WHERE exercise_id = ?",
+      [id]
+    );
+    await database.runAsync(
+      "UPDATE exercises SET deleted_at = ? WHERE id = ? AND is_custom = 1",
+      [Date.now(), id]
+    );
+  });
+}
+
+export async function getTemplatesUsingExercise(
+  exerciseId: string
+): Promise<{ id: string; name: string }[]> {
+  const database = await getDatabase();
+  return database.getAllAsync<{ id: string; name: string }>(
+    `SELECT DISTINCT wt.id, wt.name
+     FROM template_exercises te
+     JOIN workout_templates wt ON wt.id = te.template_id
+     WHERE te.exercise_id = ?`,
+    [exerciseId]
+  );
 }
 
 // --------------- Templates ---------------
@@ -707,14 +788,14 @@ export async function getPersonalRecords(): Promise<
 > {
   const database = await getDatabase();
   return database.getAllAsync<{ exercise_id: string; name: string; max_weight: number }>(
-    `SELECT ws.exercise_id, e.name, MAX(ws.weight) AS max_weight
+    `SELECT ws.exercise_id, COALESCE(e.name, 'Deleted Exercise') AS name, MAX(ws.weight) AS max_weight
      FROM workout_sets ws
-     JOIN exercises e ON ws.exercise_id = e.id
+     LEFT JOIN exercises e ON ws.exercise_id = e.id
      JOIN workout_sessions wss ON ws.session_id = wss.id
      WHERE ws.completed = 1 AND ws.weight IS NOT NULL AND ws.weight > 0
        AND wss.completed_at IS NOT NULL
      GROUP BY ws.exercise_id
-     ORDER BY e.name ASC`
+     ORDER BY name ASC`
   );
 }
 
@@ -1143,7 +1224,7 @@ export async function getWorkoutCSVData(since: number): Promise<WorkoutCSVRow[]>
   return database.getAllAsync<WorkoutCSVRow>(
     `SELECT
        date(ws.started_at / 1000, 'unixepoch') AS date,
-       e.name AS exercise,
+       COALESCE(e.name, 'Deleted Exercise') AS exercise,
        wset.set_number,
        wset.weight,
        wset.reps,
@@ -1151,10 +1232,10 @@ export async function getWorkoutCSVData(since: number): Promise<WorkoutCSVRow[]>
        ws.notes
      FROM workout_sessions ws
      JOIN workout_sets wset ON wset.session_id = ws.id
-     JOIN exercises e ON e.id = wset.exercise_id
+     LEFT JOIN exercises e ON e.id = wset.exercise_id
      WHERE ws.completed_at IS NOT NULL
        AND ws.started_at >= ?
-     ORDER BY ws.started_at ASC, e.name ASC, wset.set_number ASC`,
+     ORDER BY ws.started_at ASC, exercise ASC, wset.set_number ASC`,
     [since]
   );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -73,6 +73,60 @@ export const CATEGORY_LABELS: Record<Category, string> = {
   full_body: "Full Body",
 };
 
+export const EQUIPMENT_LABELS: Record<Equipment, string> = {
+  barbell: "Barbell",
+  dumbbell: "Dumbbell",
+  cable: "Cable",
+  machine: "Machine",
+  bodyweight: "Bodyweight",
+  kettlebell: "Kettlebell",
+  band: "Band",
+  other: "Other",
+};
+
+export const EQUIPMENT_LIST: Equipment[] = [
+  "barbell",
+  "dumbbell",
+  "cable",
+  "machine",
+  "bodyweight",
+  "kettlebell",
+  "band",
+  "other",
+];
+
+export const DIFFICULTIES: Difficulty[] = ["beginner", "intermediate", "advanced"];
+
+export const DIFFICULTY_LABELS: Record<Difficulty, string> = {
+  beginner: "Beginner",
+  intermediate: "Intermediate",
+  advanced: "Advanced",
+};
+
+export const MUSCLE_GROUPS_BY_REGION: { label: string; muscles: MuscleGroup[] }[] = [
+  { label: "Upper Body", muscles: ["chest", "back", "shoulders", "biceps", "triceps", "forearms", "traps", "lats"] },
+  { label: "Lower Body", muscles: ["quads", "hamstrings", "glutes", "calves"] },
+  { label: "Core", muscles: ["core"] },
+  { label: "Full Body", muscles: ["full_body"] },
+];
+
+export const MUSCLE_LABELS: Record<MuscleGroup, string> = {
+  chest: "Chest",
+  back: "Back",
+  shoulders: "Shoulders",
+  biceps: "Biceps",
+  triceps: "Triceps",
+  quads: "Quads",
+  hamstrings: "Hamstrings",
+  glutes: "Glutes",
+  calves: "Calves",
+  core: "Core",
+  forearms: "Forearms",
+  traps: "Traps",
+  lats: "Lats",
+  full_body: "Full Body",
+};
+
 export type WorkoutTemplate = {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

Full CRUD for custom exercises: create, edit, and soft-delete user-defined exercises with form validation, accessibility, and full integration with existing library and pickers.

## Changes

- **lib/db.ts**: Added `createCustomExercise`, `updateCustomExercise`, `softDeleteCustomExercise`, `getTemplatesUsingExercise`. Added `deleted_at` column migration for soft-delete. Fixed INNER JOIN → LEFT JOIN + COALESCE in `getPersonalRecords()` and `getWorkoutCSVData()`. Added `WHERE deleted_at IS NULL` filter to `getAllExercises()`.
- **lib/types.ts**: Added `EQUIPMENT_LABELS`, `EQUIPMENT_LIST`, `DIFFICULTIES`, `DIFFICULTY_LABELS`, `MUSCLE_GROUPS_BY_REGION`, `MUSCLE_LABELS` constants.
- **components/ExerciseForm.tsx**: New shared form component for create/edit with KeyboardAvoidingView, grouped muscle chips by body region, a11y (accessibilityRole=checkbox/radio, liveRegion), character counter, validation errors, discard confirmation.
- **app/exercise/create.tsx**: New create custom exercise screen.
- **app/exercise/edit/[id].tsx**: New edit custom exercise screen (pre-populated form).
- **app/exercise/[id].tsx**: Added Edit/Delete icon buttons for custom exercises, "Custom" badge, soft-delete with template usage warning dialog (`accessibilityViewIsModal`).
- **app/(tabs)/exercises.tsx**: Added FAB (56dp, a11y labeled), "Custom" filter chip, custom badge in list items, `useFocusEffect` for refresh on back-navigation.
- **app/template/pick-exercise.tsx**: Added "(Custom)" suffix for custom exercises in picker display.
- **app/_layout.tsx**: Added routes for `exercise/create` and `exercise/edit/[id]`.

## Testing

- TypeScript typecheck passes with zero errors (`npx -p typescript tsc --noEmit`)
- npm install succeeds
- No hardcoded hex colors
- No lint warnings
- Follows approved plan: .plans/PLAN-BLD-25.md (QD + techlead + CEO approved)

## Issue

Resolves BLD-3