### PR TITLE
feat: Workout Insights — PR Detection & Post-Workout Summary (BLD-5)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,11 +13,13 @@ import {
   Text,
   useTheme,
 } from "react-native-paper";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useFocusEffect, useRouter } from "expo-router";
 import {
   deleteTemplate,
   getActiveSession,
   getAllCompletedSessionWeeks,
+  getRecentPRs,
   getRecentSessions,
   getSessionSetCount,
   getTemplateExerciseCount,
@@ -54,17 +56,20 @@ export default function Workouts() {
   const [setCounts2, setSetCounts] = useState<Record<string, number>>({});
   const [active, setActive] = useState<WorkoutSession | null>(null);
   const [streak, setStreak] = useState(0);
+  const [recentPRs, setRecentPRs] = useState<{ exercise_id: string; name: string; weight: number; session_id: string; date: number }[]>([]);
 
   const load = useCallback(async () => {
-    const [tpls, sess, act, timestamps] = await Promise.all([
+    const [tpls, sess, act, timestamps, prData] = await Promise.all([
       getTemplates(),
       getRecentSessions(5),
       getActiveSession(),
       getAllCompletedSessionWeeks(),
+      getRecentPRs(5),
     ]);
     setTemplates(tpls);
     setSessions(sess);
     setActive(act);
+    setRecentPRs(prData);
 
     // Calculate streak in JS: consecutive weeks with >= 1 workout
     setStreak(computeStreak(timestamps));
@@ -258,6 +263,65 @@ export default function Workouts() {
         </Card>
       )}
 
+      {/* Recent Personal Records */}
+      <Card
+        style={[styles.prCard, { backgroundColor: theme.colors.surface }]}
+        accessibilityLabel="Recent personal records"
+      >
+        <Card.Content>
+          <View style={styles.prHeader}>
+            <MaterialCommunityIcons name="trophy" size={20} color={theme.colors.primary} />
+            <Text
+              variant="titleMedium"
+              style={{ color: theme.colors.onSurface, marginLeft: 8, fontWeight: "700" }}
+            >
+              Recent Personal Records
+            </Text>
+          </View>
+          {recentPRs.length === 0 ? (
+            <Text
+              variant="bodyMedium"
+              style={{ color: theme.colors.onSurfaceVariant, textAlign: "center", paddingVertical: 12 }}
+              accessibilityLabel="No personal records yet. Complete workouts to start tracking."
+            >
+              Complete workouts to start tracking PRs!
+            </Text>
+          ) : (
+            recentPRs.map((pr, i) => (
+              <Card
+                key={`${pr.session_id}-${pr.exercise_id}`}
+                style={[styles.prRow, i < recentPRs.length - 1 && styles.prRowSpaced]}
+                onPress={() => router.push(`/session/detail/${pr.session_id}`)}
+                accessibilityLabel={`Personal record: ${pr.name}, ${pr.weight}, achieved on ${new Date(pr.date).toLocaleDateString()}`}
+                accessibilityRole="button"
+              >
+                <Card.Content style={styles.prRowContent}>
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: theme.colors.onSurface, flex: 1 }}
+                    numberOfLines={1}
+                  >
+                    {pr.name}
+                  </Text>
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: theme.colors.primary, fontWeight: "600", marginHorizontal: 8 }}
+                  >
+                    {pr.weight}
+                  </Text>
+                  <Text
+                    variant="bodySmall"
+                    style={{ color: theme.colors.onSurfaceVariant }}
+                  >
+                    {new Date(pr.date).toLocaleDateString(undefined, { month: "short", day: "numeric" })}
+                  </Text>
+                </Card.Content>
+              </Card>
+            ))
+          )}
+        </Card.Content>
+      </Card>
+
       {/* Recent Workouts */}
       <View style={styles.section}>
         <View style={styles.sectionHeader}>
@@ -343,6 +407,26 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
+  },
+  prCard: {
+    marginBottom: 16,
+  },
+  prHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  prRow: {
+    elevation: 0,
+    minHeight: 48,
+  },
+  prRowSpaced: {
+    marginBottom: 4,
+  },
+  prRowContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    minHeight: 48,
   },
   quickStartContent: {
     paddingVertical: 8,

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -8,6 +8,7 @@ import {
 import {
   Button,
   Checkbox,
+  Chip,
   Divider,
   Text,
   TextInput,
@@ -20,6 +21,7 @@ import {
   cancelSession,
   completeSession,
   completeSet,
+  getMaxWeightByExercise,
   getSessionById,
   getSessionSets,
   getTemplateById,
@@ -55,6 +57,9 @@ export default function ActiveSession() {
   const initialized = useRef(false);
   const [rest, setRest] = useState(0);
   const restRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [maxes, setMaxes] = useState<Record<string, number>>({});
+  const prevExerciseIds = useRef<string>("");
+  const prHapticFired = useRef<Set<string>>(new Set());
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -74,6 +79,14 @@ export default function ActiveSession() {
     const exerciseIds = [...new Set(sets.map((s) => s.exercise_id))];
     for (const eid of exerciseIds) {
       prevCache[eid] = await getPreviousSets(eid, id);
+    }
+
+    // Fetch historical maxes for PR detection (only when exercise list changes)
+    const key = exerciseIds.sort().join(",");
+    if (key !== prevExerciseIds.current) {
+      prevExerciseIds.current = key;
+      const m = await getMaxWeightByExercise(exerciseIds, id);
+      setMaxes(m);
     }
 
     // Group by exercise
@@ -223,6 +236,28 @@ export default function ActiveSession() {
   const handleAddExercise = () => {
     router.push(`/template/pick-exercise?sessionId=${id}`);
   };
+
+  const isPR = (set: SetWithMeta) => {
+    if (!set.completed || !set.weight || set.weight <= 0) return false;
+    const max = maxes[set.exercise_id];
+    if (max === undefined) return false;
+    return set.weight > max;
+  };
+
+  // Haptic feedback on new PR detection
+  useEffect(() => {
+    for (const g of groups) {
+      for (const s of g.sets) {
+        if (isPR(s) && !prHapticFired.current.has(s.id)) {
+          prHapticFired.current.add(s.id);
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        }
+        if (!isPR(s) && prHapticFired.current.has(s.id)) {
+          prHapticFired.current.delete(s.id);
+        }
+      }
+    }
+  }, [groups, maxes]);
 
   const finish = () => {
     Alert.alert(
@@ -406,6 +441,18 @@ export default function ActiveSession() {
                     onPress={() => handleCheck(set)}
                   />
                 </View>
+                {isPR(set) && (
+                  <Chip
+                    compact
+                    icon="trophy"
+                    style={{ backgroundColor: theme.colors.tertiaryContainer }}
+                    textStyle={styles.prChipText}
+                    accessibilityLabel="New personal record"
+                    accessibilityRole="text"
+                  >
+                    PR
+                  </Chip>
+                )}
               </View>
             ))}
 
@@ -508,6 +555,9 @@ const styles = StyleSheet.create({
   colCheck: {
     width: 40,
     alignItems: "center",
+  },
+  prChipText: {
+    fontSize: 12,
   },
   addSetBtn: {
     alignSelf: "flex-start",

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
 import { Card, Divider, Text, useTheme } from "react-native-paper";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Stack, useLocalSearchParams } from "expo-router";
-import { getSessionById, getSessionSets } from "../../../lib/db";
+import { getSessionById, getSessionPRs, getSessionSets } from "../../../lib/db";
 import type { WorkoutSession, WorkoutSet } from "../../../lib/types";
 
 type SetWithName = WorkoutSet & { exercise_name?: string };
@@ -18,6 +19,7 @@ export default function SessionDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [session, setSession] = useState<WorkoutSession | null>(null);
   const [groups, setGroups] = useState<ExerciseGroup[]>([]);
+  const [prs, setPrs] = useState<{ exercise_id: string; name: string; weight: number; previous_max: number }[]>([]);
 
   useEffect(() => {
     if (!id) return;
@@ -26,7 +28,11 @@ export default function SessionDetail() {
       if (!sess) return;
       setSession(sess);
 
-      const sets = await getSessionSets(id);
+      const [sets, prData] = await Promise.all([
+        getSessionSets(id),
+        getSessionPRs(id),
+      ]);
+      setPrs(prData);
       const map = new Map<string, ExerciseGroup>();
       for (const s of sets) {
         if (!map.has(s.exercise_id)) {
@@ -166,6 +172,43 @@ export default function SessionDetail() {
           </Card.Content>
         </Card>
 
+        {/* Personal Records */}
+        {prs.length > 0 && (
+          <Card
+            style={[styles.prCard, { backgroundColor: theme.colors.tertiaryContainer }]}
+            accessibilityLabel={`${prs.length} new personal record${prs.length > 1 ? "s" : ""} achieved in this workout`}
+          >
+            <Card.Content>
+              <View style={styles.prHeader}>
+                <MaterialCommunityIcons name="trophy" size={20} color={theme.colors.onTertiaryContainer} />
+                <Text
+                  variant="titleMedium"
+                  style={{ color: theme.colors.onTertiaryContainer, marginLeft: 8, fontWeight: "700" }}
+                >
+                  {prs.length} New PR{prs.length > 1 ? "s" : ""}
+                </Text>
+              </View>
+              {prs.map((pr) => (
+                <View key={pr.exercise_id} style={styles.prRow}>
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: theme.colors.onTertiaryContainer, flex: 1 }}
+                    accessibilityLabel={`New personal record: ${pr.name}, ${pr.previous_max} to ${pr.weight}`}
+                  >
+                    {pr.name}
+                  </Text>
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: theme.colors.onTertiaryContainer }}
+                  >
+                    {pr.previous_max} → {pr.weight}
+                  </Text>
+                </View>
+              ))}
+            </Card.Content>
+          </Card>
+        )}
+
         {/* Exercise breakdown */}
         {groups.map((group) => (
           <View key={group.exercise_id} style={styles.group}>
@@ -234,6 +277,20 @@ const styles = StyleSheet.create({
   },
   summary: {
     marginBottom: 20,
+  },
+  prCard: {
+    marginBottom: 20,
+  },
+  prHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  prRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 6,
   },
   stats: {
     flexDirection: "row",

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1460,3 +1460,104 @@ export async function getBodyMeasurementsCSVData(since: number): Promise<BodyMea
     [cutoff]
   );
 }
+
+// --------------- Workout Insights (PR Detection) ---------------
+
+export async function getMaxWeightByExercise(
+  exerciseIds: string[],
+  excludeSessionId: string
+): Promise<Record<string, number>> {
+  if (exerciseIds.length === 0) return {};
+  const database = await getDatabase();
+  const placeholders = exerciseIds.map(() => "?").join(", ");
+  const rows = await database.getAllAsync<{ exercise_id: string; max_weight: number }>(
+    `SELECT ws.exercise_id, MAX(ws.weight) AS max_weight
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.exercise_id IN (${placeholders})
+       AND ws.session_id != ?
+       AND ws.completed = 1
+       AND ws.weight IS NOT NULL
+       AND ws.weight > 0
+       AND wss.completed_at IS NOT NULL
+     GROUP BY ws.exercise_id`,
+    [...exerciseIds, excludeSessionId]
+  );
+  const result: Record<string, number> = {};
+  for (const r of rows) {
+    result[r.exercise_id] = r.max_weight;
+  }
+  return result;
+}
+
+export async function getSessionPRs(
+  sessionId: string
+): Promise<{ exercise_id: string; name: string; weight: number; previous_max: number }[]> {
+  const database = await getDatabase();
+  return database.getAllAsync<{ exercise_id: string; name: string; weight: number; previous_max: number }>(
+    `SELECT cur.exercise_id,
+            COALESCE(e.name, 'Deleted Exercise') AS name,
+            cur.max_weight AS weight,
+            hist.max_weight AS previous_max
+     FROM (
+       SELECT ws.exercise_id, MAX(ws.weight) AS max_weight
+       FROM workout_sets ws
+       WHERE ws.session_id = ?
+         AND ws.completed = 1
+         AND ws.weight IS NOT NULL
+         AND ws.weight > 0
+       GROUP BY ws.exercise_id
+     ) cur
+     JOIN (
+       SELECT ws.exercise_id, MAX(ws.weight) AS max_weight
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.session_id != ?
+         AND ws.completed = 1
+         AND ws.weight IS NOT NULL
+         AND ws.weight > 0
+         AND wss.completed_at IS NOT NULL
+       GROUP BY ws.exercise_id
+     ) hist ON cur.exercise_id = hist.exercise_id
+     LEFT JOIN exercises e ON cur.exercise_id = e.id
+     WHERE cur.max_weight > hist.max_weight
+     ORDER BY name ASC`,
+    [sessionId, sessionId]
+  );
+}
+
+export async function getRecentPRs(
+  limit: number = 5
+): Promise<{ exercise_id: string; name: string; weight: number; session_id: string; date: number }[]> {
+  const database = await getDatabase();
+  return database.getAllAsync<{ exercise_id: string; name: string; weight: number; session_id: string; date: number }>(
+    `SELECT ws.exercise_id,
+            COALESCE(e.name, 'Deleted Exercise') AS name,
+            MAX(ws.weight) AS weight,
+            ws.session_id,
+            wss.started_at AS date
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     LEFT JOIN exercises e ON ws.exercise_id = e.id
+     WHERE ws.completed = 1
+       AND ws.weight IS NOT NULL
+       AND ws.weight > 0
+       AND wss.completed_at IS NOT NULL
+       AND ws.weight > COALESCE(
+         (SELECT MAX(ws2.weight)
+          FROM workout_sets ws2
+          JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
+          WHERE ws2.exercise_id = ws.exercise_id
+            AND ws2.session_id != ws.session_id
+            AND ws2.completed = 1
+            AND ws2.weight IS NOT NULL
+            AND ws2.weight > 0
+            AND wss2.completed_at IS NOT NULL
+            AND wss2.started_at < wss.started_at
+         ), 0)
+     GROUP BY ws.session_id, ws.exercise_id
+     ORDER BY wss.started_at DESC
+     LIMIT ?`,
+    [limit]
+  );
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1543,8 +1543,7 @@ export async function getRecentPRs(
        AND ws.weight IS NOT NULL
        AND ws.weight > 0
        AND wss.completed_at IS NOT NULL
-       AND ws.weight > COALESCE(
-         (SELECT MAX(ws2.weight)
+       AND ws.weight > (SELECT MAX(ws2.weight)
           FROM workout_sets ws2
           JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
           WHERE ws2.exercise_id = ws.exercise_id
@@ -1554,7 +1553,7 @@ export async function getRecentPRs(
             AND ws2.weight > 0
             AND wss2.completed_at IS NOT NULL
             AND wss2.started_at < wss.started_at
-         ), 0)
+         )
      GROUP BY ws.session_id, ws.exercise_id
      ORDER BY wss.started_at DESC
      LIMIT ?`,


### PR DESCRIPTION
## Summary

Adds workout progress feedback through real-time PR (personal record) detection during workouts, post-workout PR summaries, and a Recent PRs widget on the home screen.

## Changes

- **lib/db.ts**: Added 3 new DB functions — `getMaxWeightByExercise`, `getSessionPRs`, `getRecentPRs`
- **app/session/[id].tsx**: PR chip on completed sets exceeding historical max, haptic feedback on first PR detection
- **app/session/detail/[id].tsx**: Personal Records section showing exercises with old → new weight
- **app/(tabs)/index.tsx**: Recent Personal Records card widget with last 5 PRs, navigation to session detail

## Key Decisions

- PR detection is weight-only (strict exceed, not equals)
- Historical maxes are cached and only re-fetched when exercise list changes
- Haptic feedback fires once per set via a ref-tracked Set
- No schema changes — all queries read existing workout_sets/workout_sessions
- LEFT JOIN exercises handles soft-deleted exercises gracefully

## Testing

- TypeScript typecheck passes with zero errors (`npx tsc --noEmit`)
- No hardcoded colors — all use theme tokens
- Full accessibility labels on all new elements
- PR badge uses tertiaryContainer background per spec
- Touch targets ≥ 48dp on Recent PRs rows

## Issue

Resolves BLD-5