### PR TITLE
feat: Workout Programs / Training Plans (BLD-7)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,6 +10,8 @@ import {
   Button,
   Card,
   IconButton,
+  SegmentedButtons,
+  Snackbar,
   Text,
   useTheme,
 } from "react-native-paper";
@@ -26,7 +28,13 @@ import {
   getTemplates,
   startSession,
 } from "../../lib/db";
-import type { WorkoutSession, WorkoutTemplate } from "../../lib/types";
+import {
+  getNextWorkout,
+  getPrograms,
+  getProgramDayCount,
+  softDeleteProgram,
+} from "../../lib/programs";
+import type { Program, ProgramDay, WorkoutSession, WorkoutTemplate } from "../../lib/types";
 
 function mondayOf(date: Date): number {
   const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
@@ -50,28 +58,41 @@ function computeStreak(timestamps: number[]): number {
 export default function Workouts() {
   const theme = useTheme();
   const router = useRouter();
+  const [segment, setSegment] = useState("templates");
   const [templates, setTemplates] = useState<WorkoutTemplate[]>([]);
+  const [programs, setPrograms] = useState<Program[]>([]);
+  const [dayCounts, setDayCounts] = useState<Record<string, number>>({});
   const [sessions, setSessions] = useState<WorkoutSession[]>([]);
   const [counts, setCounts] = useState<Record<string, number>>({});
   const [setCounts2, setSetCounts] = useState<Record<string, number>>({});
   const [active, setActive] = useState<WorkoutSession | null>(null);
   const [streak, setStreak] = useState(0);
   const [recentPRs, setRecentPRs] = useState<{ exercise_id: string; name: string; weight: number; session_id: string; date: number }[]>([]);
+  const [nextWorkout, setNextWorkout] = useState<{ program: Program; day: ProgramDay } | null>(null);
+  const [snackbar, setSnackbar] = useState("");
 
   const load = useCallback(async () => {
-    const [tpls, sess, act, timestamps, prData] = await Promise.all([
+    const [tpls, sess, act, timestamps, prData, progs, nw] = await Promise.all([
       getTemplates(),
       getRecentSessions(5),
       getActiveSession(),
       getAllCompletedSessionWeeks(),
       getRecentPRs(5),
+      getPrograms(),
+      getNextWorkout(),
     ]);
     setTemplates(tpls);
     setSessions(sess);
     setActive(act);
     setRecentPRs(prData);
+    setPrograms(progs);
+    setNextWorkout(nw);
 
-    // Calculate streak in JS: consecutive weeks with >= 1 workout
+    // Default segment: Programs if active program exists, else Templates
+    if (nw) {
+      setSegment("programs");
+    }
+
     setStreak(computeStreak(timestamps));
 
     const c: Record<string, number> = {};
@@ -85,6 +106,12 @@ export default function Workouts() {
       sc[s.id] = await getSessionSetCount(s.id);
     }
     setSetCounts(sc);
+
+    const dc: Record<string, number> = {};
+    for (const p of progs) {
+      dc[p.id] = await getProgramDayCount(p.id);
+    }
+    setDayCounts(dc);
   }, []);
 
   useFocusEffect(
@@ -101,6 +128,38 @@ export default function Workouts() {
   const startFromTemplate = async (tpl: WorkoutTemplate) => {
     const session = await startSession(tpl.id, tpl.name);
     router.push(`/session/${session.id}?templateId=${tpl.id}`);
+  };
+
+  const startNextWorkout = async () => {
+    if (!nextWorkout) return;
+    if (!nextWorkout.day.template_id) {
+      setSnackbar("Template no longer exists");
+      return;
+    }
+    const session = await startSession(
+      nextWorkout.day.template_id,
+      nextWorkout.day.label || nextWorkout.day.template_name || nextWorkout.program.name,
+      nextWorkout.day.id
+    );
+    router.push(`/session/${session.id}?templateId=${nextWorkout.day.template_id}`);
+  };
+
+  const confirmDeleteProgram = (prog: Program) => {
+    Alert.alert(
+      "Delete Program",
+      `Delete "${prog.name}"? Past workout data will be preserved.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: async () => {
+            await softDeleteProgram(prog.id);
+            await load();
+          },
+        },
+      ]
+    );
   };
 
   const confirmDelete = (tpl: WorkoutTemplate) => {
@@ -160,6 +219,28 @@ export default function Workouts() {
         </Card>
       )}
 
+      {/* Next Workout Banner (visible on both segments) */}
+      {nextWorkout && (
+        <Card
+          style={[styles.nextBanner, { backgroundColor: theme.colors.secondaryContainer }]}
+          onPress={startNextWorkout}
+          accessibilityLabel={`Next workout: ${nextWorkout.day.label || nextWorkout.day.template_name || "workout"} from ${nextWorkout.program.name}`}
+          accessibilityRole="button"
+        >
+          <Card.Content style={styles.nextContent}>
+            <MaterialCommunityIcons name="play-circle" size={24} color={theme.colors.onSecondaryContainer} />
+            <View style={styles.nextText}>
+              <Text variant="titleSmall" style={{ color: theme.colors.onSecondaryContainer }}>
+                Next: {nextWorkout.day.label || nextWorkout.day.template_name || "Workout"}
+              </Text>
+              <Text variant="bodySmall" style={{ color: theme.colors.onSecondaryContainer }}>
+                {nextWorkout.program.name} · Tap to start
+              </Text>
+            </View>
+          </Card.Content>
+        </Card>
+      )}
+
       {/* Quick Start */}
       <Button
         mode="contained"
@@ -172,79 +253,182 @@ export default function Workouts() {
         Quick Start
       </Button>
 
-      {/* Templates */}
-      <View style={styles.section}>
-        <View style={styles.sectionHeader}>
-          <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
-            My Templates
-          </Text>
-          <Button
-            mode="text"
-            icon="plus"
-            compact
-            onPress={() => router.push("/template/create")}
-            accessibilityLabel="Create new template"
-          >
-            Create
-          </Button>
-        </View>
-        {templates.length === 0 ? (
-          <View style={styles.empty}>
-            <Text
-              variant="bodyMedium"
-              style={{ color: theme.colors.onSurfaceVariant }}
-            >
-              Create your first workout template
-            </Text>
-            <Button
-              mode="outlined"
-              onPress={() => router.push("/template/create")}
-              style={styles.emptyBtn}
-              accessibilityLabel="Create your first template"
-            >
-              Create Template
-            </Button>
-          </View>
-        ) : (
-          <FlatList
-            data={templates}
-            keyExtractor={(item) => item.id}
-            scrollEnabled={false}
-            renderItem={({ item }: ListRenderItemInfo<WorkoutTemplate>) => (
-              <Card
-                style={[styles.card, { backgroundColor: theme.colors.surface }]}
-                onPress={() => startFromTemplate(item)}
-                onLongPress={() => confirmDelete(item)}
-                accessibilityLabel={`Start workout from template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
-                accessibilityRole="button"
+      {/* Segmented Control */}
+      <SegmentedButtons
+        value={segment}
+        onValueChange={setSegment}
+        buttons={[
+          {
+            value: "templates",
+            label: "Templates",
+            accessibilityLabel: "Templates tab",
+          },
+          {
+            value: "programs",
+            label: "Programs",
+            accessibilityLabel: "Programs tab",
+          },
+        ]}
+        style={styles.segmented}
+      />
+
+      {segment === "templates" ? (
+        <>
+          {/* Templates */}
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
+                My Templates
+              </Text>
+              <Button
+                mode="text"
+                icon="plus"
+                compact
+                onPress={() => router.push("/template/create")}
+                accessibilityLabel="Create new template"
               >
-                <Card.Content style={styles.cardContent}>
-                  <View style={styles.cardInfo}>
-                    <Text
-                      variant="titleSmall"
-                      style={{ color: theme.colors.onSurface }}
-                    >
-                      {item.name}
-                    </Text>
-                    <Text
-                      variant="bodySmall"
-                      style={{ color: theme.colors.onSurfaceVariant }}
-                    >
-                      {counts[item.id] ?? 0} exercises
-                    </Text>
-                  </View>
-                  <IconButton
-                    icon="pencil"
-                    size={20}
-                    onPress={() => router.push(`/template/${item.id}`)}
-                    accessibilityLabel={`Edit template ${item.name}`}
-                  />
-                </Card.Content>
-              </Card>
+                Create
+              </Button>
+            </View>
+            {templates.length === 0 ? (
+              <View style={styles.empty}>
+                <Text
+                  variant="bodyMedium"
+                  style={{ color: theme.colors.onSurfaceVariant }}
+                >
+                  Create your first workout template
+                </Text>
+                <Button
+                  mode="outlined"
+                  onPress={() => router.push("/template/create")}
+                  style={styles.emptyBtn}
+                  accessibilityLabel="Create your first template"
+                >
+                  Create Template
+                </Button>
+              </View>
+            ) : (
+              <FlatList
+                data={templates}
+                keyExtractor={(item) => item.id}
+                scrollEnabled={false}
+                renderItem={({ item }: ListRenderItemInfo<WorkoutTemplate>) => (
+                  <Card
+                    style={[styles.card, { backgroundColor: theme.colors.surface }]}
+                    onPress={() => startFromTemplate(item)}
+                    onLongPress={() => confirmDelete(item)}
+                    accessibilityLabel={`Start workout from template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
+                    accessibilityRole="button"
+                  >
+                    <Card.Content style={styles.cardContent}>
+                      <View style={styles.cardInfo}>
+                        <Text
+                          variant="titleSmall"
+                          style={{ color: theme.colors.onSurface }}
+                        >
+                          {item.name}
+                        </Text>
+                        <Text
+                          variant="bodySmall"
+                          style={{ color: theme.colors.onSurfaceVariant }}
+                        >
+                          {counts[item.id] ?? 0} exercises
+                        </Text>
+                      </View>
+                      <IconButton
+                        icon="pencil"
+                        size={20}
+                        onPress={() => router.push(`/template/${item.id}`)}
+                        accessibilityLabel={`Edit template ${item.name}`}
+                      />
+                    </Card.Content>
+                  </Card>
+                )}
+              />
             )}
-          />
-        )}
-      </View>
+          </View>
+        </>
+      ) : (
+        <>
+          {/* Programs */}
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
+                My Programs
+              </Text>
+              <Button
+                mode="text"
+                icon="plus"
+                compact
+                onPress={() => router.push("/program/create")}
+                accessibilityLabel="Create new program"
+              >
+                Create
+              </Button>
+            </View>
+            {programs.length === 0 ? (
+              <View style={styles.empty}>
+                <Text
+                  variant="bodyMedium"
+                  style={{ color: theme.colors.onSurfaceVariant }}
+                  accessibilityRole="text"
+                  accessibilityLabel="No programs yet. Create your first program."
+                >
+                  Create your first program
+                </Text>
+                <Button
+                  mode="outlined"
+                  onPress={() => router.push("/program/create")}
+                  style={styles.emptyBtn}
+                  accessibilityLabel="Create your first program"
+                >
+                  Create Program
+                </Button>
+              </View>
+            ) : (
+              <FlatList
+                data={programs}
+                keyExtractor={(item) => item.id}
+                scrollEnabled={false}
+                renderItem={({ item }: ListRenderItemInfo<Program>) => (
+                  <Card
+                    style={[styles.card, { backgroundColor: theme.colors.surface }]}
+                    onPress={() => router.push(`/program/${item.id}`)}
+                    onLongPress={() => confirmDeleteProgram(item)}
+                    accessibilityLabel={`Program: ${item.name}, ${dayCounts[item.id] ?? 0} days${item.is_active ? ", active" : ""}`}
+                    accessibilityRole="button"
+                  >
+                    <Card.Content style={styles.cardContent}>
+                      <View style={styles.cardInfo}>
+                        <Text
+                          variant="titleSmall"
+                          style={{ color: theme.colors.onSurface }}
+                        >
+                          {item.name}
+                        </Text>
+                        <Text
+                          variant="bodySmall"
+                          style={{ color: theme.colors.onSurfaceVariant }}
+                        >
+                          {dayCounts[item.id] ?? 0} days{item.is_active ? " · Active" : ""}
+                        </Text>
+                      </View>
+                      {item.is_active && (
+                        <MaterialCommunityIcons
+                          name="check-circle"
+                          size={20}
+                          color={theme.colors.primary}
+                          accessibilityLabel="Active program"
+                        />
+                      )}
+                    </Card.Content>
+                  </Card>
+                )}
+              />
+            )}
+          </View>
+        </>
+      )}
 
       {/* Streak Card */}
       {streak > 0 && (
@@ -385,6 +569,14 @@ export default function Workouts() {
           />
         )}
       </View>
+
+      <Snackbar
+        visible={!!snackbar}
+        onDismiss={() => setSnackbar("")}
+        duration={3000}
+      >
+        {snackbar}
+      </Snackbar>
     </View>
   );
 }
@@ -397,8 +589,22 @@ const styles = StyleSheet.create({
   banner: {
     marginBottom: 12,
   },
+  nextBanner: {
+    marginBottom: 12,
+  },
+  nextContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  nextText: {
+    flex: 1,
+  },
   quickStart: {
-    marginBottom: 20,
+    marginBottom: 12,
+  },
+  segmented: {
+    marginBottom: 16,
   },
   streak: {
     marginBottom: 16,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -88,6 +88,33 @@ export default function RootLayout() {
               }}
             />
             <Stack.Screen
+              name="program/[id]"
+              options={{
+                headerShown: true,
+                title: "Program",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="program/create"
+              options={{
+                headerShown: true,
+                title: "New Program",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
+              name="program/pick-template"
+              options={{
+                headerShown: true,
+                title: "Pick Template",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
               name="session/[id]"
               options={{
                 headerShown: true,

--- a/app/program/[id].tsx
+++ b/app/program/[id].tsx
@@ -1,0 +1,387 @@
+import { useCallback, useState } from "react";
+import {
+  Alert,
+  FlatList,
+  StyleSheet,
+  View,
+  type ListRenderItemInfo,
+  AccessibilityInfo,
+} from "react-native";
+import {
+  Button,
+  Card,
+  IconButton,
+  Text,
+  useTheme,
+} from "react-native-paper";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { useFocusEffect } from "expo-router";
+import {
+  getProgramById,
+  getProgramDays,
+  getProgramDayCount,
+  getProgramCycleCount,
+  getProgramHistory,
+  activateProgram,
+  deactivateProgram,
+  softDeleteProgram,
+  removeProgramDay,
+  reorderProgramDays,
+} from "../../lib/programs";
+import type { Program, ProgramDay } from "../../lib/types";
+
+export default function ProgramDetail() {
+  const theme = useTheme();
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [program, setProgram] = useState<Program | null>(null);
+  const [days, setDays] = useState<ProgramDay[]>([]);
+  const [cycle, setCycle] = useState(0);
+  const [history, setHistory] = useState<{ session_id: string; day_label: string; template_name: string | null; completed_at: number }[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!id) return;
+    try {
+      setLoading(true);
+      const [prog, d, c, h] = await Promise.all([
+        getProgramById(id),
+        getProgramDays(id),
+        getProgramCycleCount(id),
+        getProgramHistory(id, 10),
+      ]);
+      setProgram(prog);
+      setDays(d);
+      setCycle(c);
+      setHistory(h);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [load])
+  );
+
+  const toggle = async () => {
+    if (!program) return;
+    try {
+      setLoading(true);
+      if (program.is_active) {
+        await deactivateProgram(program.id);
+      } else {
+        if (days.length === 0) {
+          Alert.alert("Cannot Activate", "Add at least one day to this program.");
+          return;
+        }
+        await activateProgram(program.id);
+      }
+      await load();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const confirmDelete = () => {
+    if (!program) return;
+    Alert.alert(
+      "Delete Program",
+      `Delete "${program.name}"? Past workout data will be preserved.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: async () => {
+            await softDeleteProgram(program.id);
+            router.back();
+          },
+        },
+      ]
+    );
+  };
+
+  const remove = async (dayId: string) => {
+    await removeProgramDay(dayId);
+    await load();
+  };
+
+  const move = async (index: number, dir: -1 | 1) => {
+    if (!program) return;
+    const target = index + dir;
+    if (target < 0 || target >= days.length) return;
+    const ids = days.map((d) => d.id);
+    [ids[index], ids[target]] = [ids[target], ids[index]];
+    await reorderProgramDays(program.id, ids);
+    await load();
+  };
+
+  const dateStr = (ts: number) =>
+    new Date(ts).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+
+  const dayName = (day: ProgramDay) =>
+    day.label || day.template_name || "Deleted Template";
+
+  if (!program) {
+    return (
+      <>
+        <Stack.Screen options={{ title: "Program" }} />
+        <View style={[styles.center, { backgroundColor: theme.colors.background }]}>
+          <Text style={{ color: theme.colors.onSurfaceVariant }}>Loading...</Text>
+        </View>
+      </>
+    );
+  }
+
+  const currentIdx = days.findIndex((d) => d.id === program.current_day_id);
+
+  return (
+    <>
+      <Stack.Screen options={{ title: program.name }} />
+      <FlatList
+        style={[styles.container, { backgroundColor: theme.colors.background }]}
+        contentContainerStyle={styles.content}
+        data={days}
+        keyExtractor={(item) => item.id}
+        ListHeaderComponent={
+          <>
+            {program.description ? (
+              <Text
+                variant="bodyMedium"
+                style={[styles.desc, { color: theme.colors.onSurfaceVariant }]}
+              >
+                {program.description}
+              </Text>
+            ) : null}
+
+            <View style={styles.meta}>
+              <Text variant="bodyMedium" style={{ color: theme.colors.onBackground }}>
+                {days.length} day{days.length !== 1 ? "s" : ""} · {cycle} cycle{cycle !== 1 ? "s" : ""} completed
+              </Text>
+              {program.is_active && currentIdx >= 0 && (
+                <Text
+                  variant="bodyMedium"
+                  style={{ color: theme.colors.primary, fontWeight: "600" }}
+                  accessibilityLabel={`Currently on day ${currentIdx + 1} of ${days.length}: ${dayName(days[currentIdx])}`}
+                >
+                  Current: Day {currentIdx + 1} — {dayName(days[currentIdx])}
+                </Text>
+              )}
+            </View>
+
+            <View style={styles.actions}>
+              <Button
+                mode={program.is_active ? "outlined" : "contained"}
+                onPress={toggle}
+                disabled={loading}
+                style={styles.actionBtn}
+                accessibilityLabel={program.is_active ? "Deactivate program" : "Set program as active"}
+              >
+                {program.is_active ? "Deactivate" : "Set Active"}
+              </Button>
+              <Button
+                mode="outlined"
+                onPress={() => router.push(`/program/create?programId=${program.id}`)}
+                style={styles.actionBtn}
+                accessibilityLabel="Edit program"
+              >
+                Edit
+              </Button>
+              <IconButton
+                icon="delete"
+                onPress={confirmDelete}
+                accessibilityLabel="Delete program"
+              />
+            </View>
+
+            <View style={styles.sectionHeader}>
+              <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
+                Workout Days ({days.length})
+              </Text>
+              <Button
+                mode="text"
+                icon="plus"
+                compact
+                onPress={() => router.push(`/program/pick-template?programId=${program.id}`)}
+                accessibilityLabel="Add workout day"
+              >
+                Add Day
+              </Button>
+            </View>
+          </>
+        }
+        renderItem={({ item, index }: ListRenderItemInfo<ProgramDay>) => (
+          <Card
+            style={[
+              styles.card,
+              { backgroundColor: theme.colors.surface },
+              item.id === program.current_day_id && {
+                borderColor: theme.colors.primary,
+                borderWidth: 2,
+              },
+            ]}
+            accessibilityLabel={`Day ${index + 1}: ${dayName(item)}${item.id === program.current_day_id ? ", current day" : ""}`}
+          >
+            <Card.Content style={styles.cardContent}>
+              <View style={styles.cardInfo}>
+                <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>
+                  Day {index + 1}: {dayName(item)}
+                </Text>
+                {item.template_id === null && (
+                  <Text variant="bodySmall" style={{ color: theme.colors.error }}>
+                    Deleted Template
+                  </Text>
+                )}
+                {item.label && item.template_name && item.label !== item.template_name && (
+                  <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                    {item.template_name}
+                  </Text>
+                )}
+              </View>
+              <View style={styles.cardActions}>
+                <IconButton
+                  icon="arrow-up"
+                  size={18}
+                  onPress={() => move(index, -1)}
+                  disabled={index === 0}
+                  accessibilityLabel={`Move ${dayName(item)} up`}
+                  accessibilityHint="Reorders workout day"
+                />
+                <IconButton
+                  icon="arrow-down"
+                  size={18}
+                  onPress={() => move(index, 1)}
+                  disabled={index === days.length - 1}
+                  accessibilityLabel={`Move ${dayName(item)} down`}
+                  accessibilityHint="Reorders workout day"
+                />
+                <IconButton
+                  icon="close"
+                  size={18}
+                  onPress={() => remove(item.id)}
+                  accessibilityLabel={`Remove ${dayName(item)}`}
+                />
+              </View>
+            </Card.Content>
+          </Card>
+        )}
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text
+              variant="bodyMedium"
+              style={{ color: theme.colors.onSurfaceVariant }}
+              accessibilityRole="text"
+              accessibilityLabel="No workout days added yet"
+            >
+              No workout days yet. Add templates above.
+            </Text>
+          </View>
+        }
+        ListFooterComponent={
+          history.length > 0 ? (
+            <View style={styles.history}>
+              <Text variant="titleMedium" style={[styles.historyTitle, { color: theme.colors.onBackground }]}>
+                History
+              </Text>
+              {history.map((h) => (
+                <Card
+                  key={h.session_id}
+                  style={[styles.historyCard, { backgroundColor: theme.colors.surface }]}
+                  onPress={() => router.push(`/session/detail/${h.session_id}`)}
+                  accessibilityLabel={`Completed ${h.day_label || h.template_name || "workout"} on ${dateStr(h.completed_at)}`}
+                  accessibilityRole="button"
+                >
+                  <Card.Content style={styles.historyRow}>
+                    <Text variant="bodyMedium" style={{ color: theme.colors.onSurface, flex: 1 }}>
+                      {h.day_label || h.template_name || "Workout"}
+                    </Text>
+                    <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                      {dateStr(h.completed_at)}
+                    </Text>
+                  </Card.Content>
+                </Card>
+              ))}
+            </View>
+          ) : null
+        }
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 48,
+  },
+  desc: {
+    marginBottom: 12,
+  },
+  meta: {
+    marginBottom: 16,
+    gap: 4,
+  },
+  actions: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 16,
+    gap: 8,
+  },
+  actionBtn: {
+    flex: 1,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  card: {
+    marginBottom: 8,
+  },
+  cardContent: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  cardInfo: {
+    flex: 1,
+  },
+  cardActions: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  empty: {
+    alignItems: "center",
+    paddingVertical: 24,
+  },
+  history: {
+    marginTop: 24,
+  },
+  historyTitle: {
+    marginBottom: 8,
+  },
+  historyCard: {
+    marginBottom: 4,
+    minHeight: 48,
+  },
+  historyRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    minHeight: 48,
+  },
+});

--- a/app/program/create.tsx
+++ b/app/program/create.tsx
@@ -1,0 +1,290 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  FlatList,
+  StyleSheet,
+  View,
+  type ListRenderItemInfo,
+} from "react-native";
+import {
+  Button,
+  IconButton,
+  Text,
+  TextInput,
+  useTheme,
+} from "react-native-paper";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import {
+  createProgram,
+  getProgramById,
+  getProgramDays,
+  updateProgram,
+  addProgramDay,
+  removeProgramDay,
+  reorderProgramDays,
+} from "../../lib/programs";
+import { getTemplateById } from "../../lib/db";
+import type { Program, ProgramDay } from "../../lib/types";
+
+export default function CreateProgram() {
+  const theme = useTheme();
+  const router = useRouter();
+  const params = useLocalSearchParams<{
+    programId?: string;
+    addTemplateId?: string;
+  }>();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [program, setProgram] = useState<Program | null>(null);
+  const [days, setDays] = useState<ProgramDay[]>([]);
+  const [saving, setSaving] = useState(false);
+  const handled = useCallback(() => {}, []);
+  const [handledTemplate, setHandledTemplate] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!program) return;
+    const d = await getProgramDays(program.id);
+    setDays(d);
+  }, [program]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Hydrate existing program for edit
+  useEffect(() => {
+    if (!params.programId || program) return;
+    getProgramById(params.programId).then((p) => {
+      if (p) {
+        setProgram(p);
+        setName(p.name);
+        setDescription(p.description);
+        getProgramDays(p.id).then(setDays);
+      }
+    });
+  }, [params.programId, program]);
+
+  // Handle template added from picker
+  useEffect(() => {
+    if (!params.addTemplateId || !program || handledTemplate === params.addTemplateId) return;
+    setHandledTemplate(params.addTemplateId);
+    addProgramDay(program.id, params.addTemplateId, days.length).then(() => load());
+  }, [params.addTemplateId, program, days.length, load, handledTemplate]);
+
+  const save = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      Alert.alert("Validation", "Program name is required.");
+      return;
+    }
+    setSaving(true);
+    try {
+      if (!program) {
+        const p = await createProgram(trimmed, description.trim());
+        setProgram(p);
+        Alert.alert("Program Created", "Now add workout days to your program.");
+      } else {
+        await updateProgram(program.id, trimmed, description.trim());
+        router.back();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = useCallback(
+    async (dayId: string) => {
+      await removeProgramDay(dayId);
+      await load();
+    },
+    [load]
+  );
+
+  const move = useCallback(
+    async (index: number, dir: -1 | 1) => {
+      if (!program) return;
+      const target = index + dir;
+      if (target < 0 || target >= days.length) return;
+      const ids = days.map((d) => d.id);
+      [ids[index], ids[target]] = [ids[target], ids[index]];
+      await reorderProgramDays(program.id, ids);
+      await load();
+    },
+    [program, days, load]
+  );
+
+  const dayName = (day: ProgramDay) =>
+    day.label || day.template_name || "Deleted Template";
+
+  const renderItem = useCallback(
+    ({ item, index }: ListRenderItemInfo<ProgramDay>) => (
+      <View
+        style={[
+          styles.dayRow,
+          {
+            backgroundColor: theme.colors.surface,
+            borderBottomColor: theme.colors.outlineVariant,
+          },
+        ]}
+      >
+        <View style={styles.dayInfo}>
+          <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>
+            Day {index + 1}: {dayName(item)}
+          </Text>
+          {item.template_id === null && (
+            <Text variant="bodySmall" style={{ color: theme.colors.error }}>
+              Template has been deleted
+            </Text>
+          )}
+        </View>
+        <View style={styles.dayActions}>
+          <IconButton
+            icon="arrow-up"
+            size={18}
+            onPress={() => move(index, -1)}
+            disabled={index === 0}
+            accessibilityLabel={`Move ${dayName(item)} up`}
+            accessibilityHint="Reorders workout day"
+          />
+          <IconButton
+            icon="arrow-down"
+            size={18}
+            onPress={() => move(index, 1)}
+            disabled={index === days.length - 1}
+            accessibilityLabel={`Move ${dayName(item)} down`}
+            accessibilityHint="Reorders workout day"
+          />
+          <IconButton
+            icon="close"
+            size={18}
+            onPress={() => remove(item.id)}
+            accessibilityLabel={`Remove ${dayName(item)}`}
+          />
+        </View>
+      </View>
+    ),
+    [theme, days.length, move, remove]
+  );
+
+  return (
+    <>
+      <Stack.Screen
+        options={{ title: program ? "Edit Program" : "New Program" }}
+      />
+      <View
+        style={[styles.container, { backgroundColor: theme.colors.background }]}
+      >
+        <TextInput
+          label="Program Name"
+          value={name}
+          onChangeText={setName}
+          mode="outlined"
+          style={styles.input}
+          placeholder="e.g. Push/Pull/Legs"
+          accessibilityLabel="Program name"
+        />
+        <TextInput
+          label="Description (optional)"
+          value={description}
+          onChangeText={setDescription}
+          mode="outlined"
+          style={styles.input}
+          placeholder="e.g. 6-day PPL split"
+          accessibilityLabel="Program description"
+          multiline
+        />
+        {program && (
+          <>
+            <View style={styles.section}>
+              <Text
+                variant="titleMedium"
+                style={{ color: theme.colors.onBackground }}
+              >
+                Workout Days ({days.length})
+              </Text>
+            </View>
+            <FlatList
+              data={days}
+              renderItem={renderItem}
+              keyExtractor={(item) => item.id}
+              ListEmptyComponent={
+                <View style={styles.empty}>
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: theme.colors.onSurfaceVariant }}
+                    accessibilityRole="text"
+                    accessibilityLabel="No workout days added yet"
+                  >
+                    No days yet. Add workout templates below.
+                  </Text>
+                </View>
+              }
+              style={styles.list}
+            />
+            <Button
+              mode="outlined"
+              icon="plus"
+              onPress={() =>
+                router.push(`/program/pick-template?programId=${program.id}`)
+              }
+              style={styles.addBtn}
+              accessibilityLabel="Add workout day from template"
+            >
+              Add Day
+            </Button>
+          </>
+        )}
+        <Button
+          mode="contained"
+          onPress={save}
+          loading={saving}
+          disabled={saving}
+          style={styles.saveBtn}
+          accessibilityLabel={program ? "Done editing program" : "Create program"}
+        >
+          {program ? "Done" : "Create Program"}
+        </Button>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  input: {
+    marginBottom: 12,
+  },
+  section: {
+    marginBottom: 8,
+  },
+  list: {
+    flex: 1,
+  },
+  dayRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  dayInfo: {
+    flex: 1,
+  },
+  dayActions: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  addBtn: {
+    marginTop: 8,
+  },
+  saveBtn: {
+    marginTop: 16,
+  },
+  empty: {
+    alignItems: "center",
+    paddingVertical: 24,
+  },
+});

--- a/app/program/create.tsx
+++ b/app/program/create.tsx
@@ -38,7 +38,6 @@ export default function CreateProgram() {
   const [program, setProgram] = useState<Program | null>(null);
   const [days, setDays] = useState<ProgramDay[]>([]);
   const [saving, setSaving] = useState(false);
-  const handled = useCallback(() => {}, []);
   const [handledTemplate, setHandledTemplate] = useState<string | null>(null);
 
   const load = useCallback(async () => {

--- a/app/program/pick-template.tsx
+++ b/app/program/pick-template.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  FlatList,
+  StyleSheet,
+  View,
+  type ListRenderItemInfo,
+} from "react-native";
+import {
+  Searchbar,
+  Text,
+  TouchableRipple,
+  useTheme,
+} from "react-native-paper";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { getTemplates } from "../../lib/db";
+import type { WorkoutTemplate } from "../../lib/types";
+
+const ITEM_HEIGHT = 64;
+
+export default function PickTemplate() {
+  const theme = useTheme();
+  const router = useRouter();
+  const { programId } = useLocalSearchParams<{ programId: string }>();
+  const [templates, setTemplates] = useState<WorkoutTemplate[]>([]);
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getTemplates()
+      .then(setTemplates)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    if (!q) return templates;
+    return templates.filter((t) => t.name.toLowerCase().includes(q));
+  }, [templates, query]);
+
+  const pick = useCallback(
+    (tpl: WorkoutTemplate) => {
+      if (programId) {
+        router.replace(
+          `/program/create?programId=${programId}&addTemplateId=${tpl.id}`
+        );
+      } else {
+        router.back();
+      }
+    },
+    [programId, router]
+  );
+
+  const renderItem = useCallback(
+    ({ item }: ListRenderItemInfo<WorkoutTemplate>) => (
+      <TouchableRipple
+        onPress={() => pick(item)}
+        style={[
+          styles.item,
+          {
+            backgroundColor: theme.colors.surface,
+            borderBottomColor: theme.colors.outlineVariant,
+          },
+        ]}
+        accessibilityLabel={`Select template: ${item.name}`}
+        accessibilityRole="button"
+      >
+        <View>
+          <Text
+            variant="titleSmall"
+            numberOfLines={1}
+            style={{ color: theme.colors.onSurface }}
+          >
+            {item.name}
+          </Text>
+          <Text
+            variant="bodySmall"
+            style={{ color: theme.colors.onSurfaceVariant }}
+          >
+            Created {new Date(item.created_at).toLocaleDateString()}
+          </Text>
+        </View>
+      </TouchableRipple>
+    ),
+    [theme, pick]
+  );
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "Pick Template" }} />
+      <View
+        style={[styles.container, { backgroundColor: theme.colors.background }]}
+      >
+        <Searchbar
+          placeholder="Search templates..."
+          value={query}
+          onChangeText={setQuery}
+          style={[styles.search, { backgroundColor: theme.colors.surface }]}
+          accessibilityLabel="Search templates"
+        />
+        <FlatList
+          data={filtered}
+          renderItem={renderItem}
+          keyExtractor={(item) => item.id}
+          getItemLayout={(_, index) => ({
+            length: ITEM_HEIGHT,
+            offset: ITEM_HEIGHT * index,
+            index,
+          })}
+          ListEmptyComponent={
+            loading ? null : (
+              <View style={styles.empty}>
+                <Text
+                  variant="titleMedium"
+                  style={{ color: theme.colors.onSurfaceVariant }}
+                >
+                  {templates.length === 0
+                    ? "No templates yet. Create one first."
+                    : "No matching templates"}
+                </Text>
+              </View>
+            )
+          }
+          contentContainerStyle={
+            filtered.length === 0 ? styles.emptyList : undefined
+          }
+        />
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  search: {
+    margin: 12,
+    marginBottom: 4,
+  },
+  item: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    minHeight: ITEM_HEIGHT,
+    justifyContent: "center",
+  },
+  empty: {
+    alignItems: "center",
+    paddingTop: 48,
+  },
+  emptyList: {
+    flexGrow: 1,
+  },
+});

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -279,24 +279,27 @@ export default function ActiveSession() {
             await completeSession(id!);
 
             // Auto-advance program if this session was started from a program
-            const dayId = await getSessionProgramDayId(id!);
-            if (dayId) {
-              const day = await getProgramDayById(dayId);
-              if (day) {
-                const result = await advanceProgram(day.program_id, dayId, id!);
-                if (result.wrapped) {
-                  setSnackbar(`Cycle ${result.cycle} complete!`);
-                  AccessibilityInfo.announceForAccessibility(
-                    `Cycle ${result.cycle} complete! Program wrapping to day 1.`
-                  );
-                  // Brief delay so snackbar shows before navigating
-                  await new Promise((r) => setTimeout(r, 1500));
-                } else {
-                  AccessibilityInfo.announceForAccessibility(
-                    "Workout complete. Program advanced to next day."
-                  );
+            try {
+              const dayId = await getSessionProgramDayId(id!);
+              if (dayId) {
+                const day = await getProgramDayById(dayId);
+                if (day) {
+                  const result = await advanceProgram(day.program_id, dayId, id!);
+                  if (result.wrapped) {
+                    setSnackbar(`Cycle ${result.cycle} complete!`);
+                    AccessibilityInfo.announceForAccessibility(
+                      `Cycle ${result.cycle} complete! Program wrapping to day 1.`
+                    );
+                    await new Promise((r) => setTimeout(r, 1500));
+                  } else {
+                    AccessibilityInfo.announceForAccessibility(
+                      "Workout complete. Program advanced to next day."
+                    );
+                  }
                 }
               }
+            } catch {
+              // Program advance failed — session is already saved, navigate normally
             }
 
             router.replace(`/session/detail/${id}`);

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Alert,
+  AccessibilityInfo,
   ScrollView,
   StyleSheet,
   View,
@@ -10,6 +11,7 @@ import {
   Checkbox,
   Chip,
   Divider,
+  Snackbar,
   Text,
   TextInput,
   useTheme,
@@ -30,6 +32,11 @@ import {
   uncompleteSet,
   updateSet,
 } from "../../lib/db";
+import {
+  getSessionProgramDayId,
+  getProgramDayById,
+  advanceProgram,
+} from "../../lib/programs";
 import type { WorkoutSession, WorkoutSet } from "../../lib/types";
 
 type SetWithMeta = WorkoutSet & {
@@ -60,6 +67,7 @@ export default function ActiveSession() {
   const [maxes, setMaxes] = useState<Record<string, number>>({});
   const prevExerciseIds = useRef<string>("");
   const prHapticFired = useRef<Set<string>>(new Set());
+  const [snackbar, setSnackbar] = useState("");
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -269,6 +277,28 @@ export default function ActiveSession() {
           text: "Complete",
           onPress: async () => {
             await completeSession(id!);
+
+            // Auto-advance program if this session was started from a program
+            const dayId = await getSessionProgramDayId(id!);
+            if (dayId) {
+              const day = await getProgramDayById(dayId);
+              if (day) {
+                const result = await advanceProgram(day.program_id, dayId, id!);
+                if (result.wrapped) {
+                  setSnackbar(`Cycle ${result.cycle} complete!`);
+                  AccessibilityInfo.announceForAccessibility(
+                    `Cycle ${result.cycle} complete! Program wrapping to day 1.`
+                  );
+                  // Brief delay so snackbar shows before navigating
+                  await new Promise((r) => setTimeout(r, 1500));
+                } else {
+                  AccessibilityInfo.announceForAccessibility(
+                    "Workout complete. Program advanced to next day."
+                  );
+                }
+              }
+            }
+
             router.replace(`/session/detail/${id}`);
           },
         },
@@ -500,6 +530,14 @@ export default function ActiveSession() {
           Cancel Workout
         </Button>
       </ScrollView>
+      <Snackbar
+        visible={!!snackbar}
+        onDismiss={() => setSnackbar("")}
+        duration={3000}
+        accessibilityLiveRegion="polite"
+      >
+        {snackbar}
+      </Snackbar>
     </>
   );
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -12,6 +12,9 @@ import type {
   BodyWeight,
   BodyMeasurements,
   BodySettings,
+  Program,
+  ProgramDay,
+  ProgramLog,
 } from "./types";
 import { seedExercises } from "./seed";
 
@@ -155,6 +158,33 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
       body_fat_goal REAL,
       updated_at INTEGER NOT NULL
     );
+
+    CREATE TABLE IF NOT EXISTS programs (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT DEFAULT '',
+      is_active INTEGER DEFAULT 0,
+      current_day_id TEXT DEFAULT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER DEFAULT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS program_days (
+      id TEXT PRIMARY KEY,
+      program_id TEXT NOT NULL,
+      template_id TEXT DEFAULT NULL,
+      position INTEGER NOT NULL,
+      label TEXT DEFAULT ''
+    );
+
+    CREATE TABLE IF NOT EXISTS program_log (
+      id TEXT PRIMARY KEY,
+      program_id TEXT NOT NULL,
+      day_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      completed_at INTEGER NOT NULL
+    );
   `);
 
   // Migration: add deleted_at column for soft-delete
@@ -164,6 +194,16 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   if (!cols.some((c) => c.name === "deleted_at")) {
     await database.execAsync(
       "ALTER TABLE exercises ADD COLUMN deleted_at INTEGER DEFAULT NULL"
+    );
+  }
+
+  // Migration: add program_day_id to workout_sessions
+  const sessionCols = await database.getAllAsync<{ name: string }>(
+    "PRAGMA table_info(workout_sessions)"
+  );
+  if (!sessionCols.some((c) => c.name === "program_day_id")) {
+    await database.execAsync(
+      "ALTER TABLE workout_sessions ADD COLUMN program_day_id TEXT DEFAULT NULL"
     );
   }
 }
@@ -400,6 +440,7 @@ export async function getTemplateById(
 export async function deleteTemplate(id: string): Promise<void> {
   const database = await getDatabase();
   await database.runAsync("DELETE FROM template_exercises WHERE template_id = ?", [id]);
+  await database.runAsync("UPDATE program_days SET template_id = NULL WHERE template_id = ?", [id]);
   await database.runAsync("DELETE FROM workout_templates WHERE id = ?", [id]);
 }
 
@@ -482,14 +523,15 @@ export async function updateTemplateExercise(
 
 export async function startSession(
   templateId: string | null,
-  name: string
+  name: string,
+  programDayId?: string
 ): Promise<WorkoutSession> {
   const database = await getDatabase();
   const id = crypto.randomUUID();
   const now = Date.now();
   await database.runAsync(
-    "INSERT INTO workout_sessions (id, template_id, name, started_at, notes) VALUES (?, ?, ?, ?, '')",
-    [id, templateId, name, now]
+    "INSERT INTO workout_sessions (id, template_id, name, started_at, notes, program_day_id) VALUES (?, ?, ?, ?, '', ?)",
+    [id, templateId, name, now, programDayId ?? null]
   );
   return {
     id,

--- a/lib/programs.ts
+++ b/lib/programs.ts
@@ -107,12 +107,19 @@ export async function activateProgram(id: string): Promise<void> {
       [id]
     );
     const first = days.length > 0 ? days[0].id : null;
-    // Preserve current_day_id if it already belongs to this program
+    // Preserve current_day_id only if it still exists in program_days
     const prog = await database.getFirstAsync<{ current_day_id: string | null }>(
       "SELECT current_day_id FROM programs WHERE id = ?",
       [id]
     );
-    const dayId = prog?.current_day_id ?? first;
+    let dayId = first;
+    if (prog?.current_day_id) {
+      const exists = await database.getFirstAsync<{ id: string }>(
+        "SELECT id FROM program_days WHERE id = ? AND program_id = ?",
+        [prog.current_day_id, id]
+      );
+      if (exists) dayId = prog.current_day_id;
+    }
     await database.runAsync(
       "UPDATE programs SET is_active = 1, current_day_id = ?, updated_at = ? WHERE id = ?",
       [dayId, Date.now(), id]
@@ -185,8 +192,9 @@ export async function removeProgramDay(id: string): Promise<void> {
     "SELECT program_id FROM program_days WHERE id = ?",
     [id]
   );
-  await database.runAsync("DELETE FROM program_days WHERE id = ?", [id]);
-  if (row) {
+  if (!row) return;
+  await database.withTransactionAsync(async () => {
+    await database.runAsync("DELETE FROM program_days WHERE id = ?", [id]);
     const prog = await database.getFirstAsync<{ current_day_id: string | null }>(
       "SELECT current_day_id FROM programs WHERE id = ?",
       [row.program_id]
@@ -205,7 +213,7 @@ export async function removeProgramDay(id: string): Promise<void> {
       "UPDATE programs SET updated_at = ? WHERE id = ?",
       [Date.now(), row.program_id]
     );
-  }
+  });
 }
 
 export async function reorderProgramDays(
@@ -220,11 +228,11 @@ export async function reorderProgramDays(
         [i, orderedIds[i], programId]
       );
     }
+    await database.runAsync(
+      "UPDATE programs SET updated_at = ? WHERE id = ?",
+      [Date.now(), programId]
+    );
   });
-  await database.runAsync(
-    "UPDATE programs SET updated_at = ? WHERE id = ?",
-    [Date.now(), programId]
-  );
 }
 
 export async function advanceProgram(
@@ -243,23 +251,29 @@ export async function advanceProgram(
     return { wrapped: false, cycle: 0 };
   }
 
-  await database.runAsync(
-    "INSERT INTO program_log (id, program_id, day_id, session_id, completed_at) VALUES (?, ?, ?, ?, ?)",
-    [crypto.randomUUID(), programId, dayId, sessionId, now]
-  );
+  let wrapped = false;
+  await database.withTransactionAsync(async () => {
+    await database.runAsync(
+      "INSERT INTO program_log (id, program_id, day_id, session_id, completed_at) VALUES (?, ?, ?, ?, ?)",
+      [crypto.randomUUID(), programId, dayId, sessionId, now]
+    );
 
-  const days = await database.getAllAsync<{ id: string; position: number }>(
-    "SELECT id, position FROM program_days WHERE program_id = ? ORDER BY position ASC",
-    [programId]
-  );
-  const idx = days.findIndex((d) => d.id === dayId);
-  const next = idx + 1 < days.length ? days[idx + 1] : days[0];
-  const wrapped = idx + 1 >= days.length;
+    const days = await database.getAllAsync<{ id: string; position: number }>(
+      "SELECT id, position FROM program_days WHERE program_id = ? ORDER BY position ASC",
+      [programId]
+    );
+    const idx = days.findIndex((d) => d.id === dayId);
+    if (idx === -1 || days.length === 0) {
+      return;
+    }
+    const next = idx + 1 < days.length ? days[idx + 1] : days[0];
+    wrapped = idx + 1 >= days.length;
 
-  await database.runAsync(
-    "UPDATE programs SET current_day_id = ?, updated_at = ? WHERE id = ?",
-    [next?.id ?? null, now, programId]
-  );
+    await database.runAsync(
+      "UPDATE programs SET current_day_id = ?, updated_at = ? WHERE id = ?",
+      [next.id, now, programId]
+    );
+  });
 
   const cycle = await getProgramCycleCount(programId);
   return { wrapped, cycle };

--- a/lib/programs.ts
+++ b/lib/programs.ts
@@ -1,0 +1,349 @@
+import type { Program, ProgramDay, ProgramLog } from "./types";
+import { getDatabase } from "./db";
+
+// --------------- Programs ---------------
+
+export async function createProgram(
+  name: string,
+  description = ""
+): Promise<Program> {
+  const database = await getDatabase();
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  await database.runAsync(
+    "INSERT INTO programs (id, name, description, is_active, current_day_id, created_at, updated_at) VALUES (?, ?, ?, 0, NULL, ?, ?)",
+    [id, name, description, now, now]
+  );
+  return {
+    id,
+    name,
+    description,
+    is_active: false,
+    current_day_id: null,
+    created_at: now,
+    updated_at: now,
+    deleted_at: null,
+  };
+}
+
+export async function getPrograms(): Promise<Program[]> {
+  const database = await getDatabase();
+  const rows = await database.getAllAsync<{
+    id: string;
+    name: string;
+    description: string;
+    is_active: number;
+    current_day_id: string | null;
+    created_at: number;
+    updated_at: number;
+    deleted_at: number | null;
+  }>(
+    "SELECT * FROM programs WHERE deleted_at IS NULL ORDER BY is_active DESC, updated_at DESC"
+  );
+  return rows.map((r) => ({ ...r, is_active: r.is_active === 1 }));
+}
+
+export async function getProgramById(id: string): Promise<Program | null> {
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{
+    id: string;
+    name: string;
+    description: string;
+    is_active: number;
+    current_day_id: string | null;
+    created_at: number;
+    updated_at: number;
+    deleted_at: number | null;
+  }>("SELECT * FROM programs WHERE id = ? AND deleted_at IS NULL", [id]);
+  if (!row) return null;
+  return { ...row, is_active: row.is_active === 1 };
+}
+
+export async function updateProgram(
+  id: string,
+  name: string,
+  description: string
+): Promise<void> {
+  const database = await getDatabase();
+  await database.runAsync(
+    "UPDATE programs SET name = ?, description = ?, updated_at = ? WHERE id = ?",
+    [name, description, Date.now(), id]
+  );
+}
+
+export async function softDeleteProgram(id: string): Promise<void> {
+  const database = await getDatabase();
+  await database.runAsync(
+    "UPDATE programs SET deleted_at = ?, is_active = 0, updated_at = ? WHERE id = ?",
+    [Date.now(), Date.now(), id]
+  );
+}
+
+export async function getActiveProgram(): Promise<Program | null> {
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{
+    id: string;
+    name: string;
+    description: string;
+    is_active: number;
+    current_day_id: string | null;
+    created_at: number;
+    updated_at: number;
+    deleted_at: number | null;
+  }>("SELECT * FROM programs WHERE is_active = 1 AND deleted_at IS NULL LIMIT 1");
+  if (!row) return null;
+  return { ...row, is_active: true };
+}
+
+export async function activateProgram(id: string): Promise<void> {
+  const database = await getDatabase();
+  await database.withTransactionAsync(async () => {
+    await database.runAsync(
+      "UPDATE programs SET is_active = 0, updated_at = ? WHERE is_active = 1",
+      [Date.now()]
+    );
+    const days = await database.getAllAsync<{ id: string }>(
+      "SELECT id FROM program_days WHERE program_id = ? ORDER BY position ASC LIMIT 1",
+      [id]
+    );
+    const first = days.length > 0 ? days[0].id : null;
+    // Preserve current_day_id if it already belongs to this program
+    const prog = await database.getFirstAsync<{ current_day_id: string | null }>(
+      "SELECT current_day_id FROM programs WHERE id = ?",
+      [id]
+    );
+    const dayId = prog?.current_day_id ?? first;
+    await database.runAsync(
+      "UPDATE programs SET is_active = 1, current_day_id = ?, updated_at = ? WHERE id = ?",
+      [dayId, Date.now(), id]
+    );
+  });
+}
+
+export async function deactivateProgram(id: string): Promise<void> {
+  const database = await getDatabase();
+  await database.runAsync(
+    "UPDATE programs SET is_active = 0, updated_at = ? WHERE id = ?",
+    [Date.now(), id]
+  );
+}
+
+export async function getProgramDays(programId: string): Promise<ProgramDay[]> {
+  const database = await getDatabase();
+  const rows = await database.getAllAsync<{
+    id: string;
+    program_id: string;
+    template_id: string | null;
+    position: number;
+    label: string;
+    template_name: string | null;
+  }>(
+    `SELECT pd.*, wt.name AS template_name
+     FROM program_days pd
+     LEFT JOIN workout_templates wt ON pd.template_id = wt.id
+     WHERE pd.program_id = ?
+     ORDER BY pd.position ASC`,
+    [programId]
+  );
+  return rows.map((r) => ({
+    ...r,
+    template_name: r.template_name ?? undefined,
+  }));
+}
+
+export async function getProgramDayCount(programId: string): Promise<number> {
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{ count: number }>(
+    "SELECT COUNT(*) AS count FROM program_days WHERE program_id = ?",
+    [programId]
+  );
+  return row?.count ?? 0;
+}
+
+export async function addProgramDay(
+  programId: string,
+  templateId: string,
+  position: number,
+  label = ""
+): Promise<ProgramDay> {
+  const database = await getDatabase();
+  const id = crypto.randomUUID();
+  await database.runAsync(
+    "INSERT INTO program_days (id, program_id, template_id, position, label) VALUES (?, ?, ?, ?, ?)",
+    [id, programId, templateId, position, label]
+  );
+  await database.runAsync(
+    "UPDATE programs SET updated_at = ? WHERE id = ?",
+    [Date.now(), programId]
+  );
+  return { id, program_id: programId, template_id: templateId, position, label };
+}
+
+export async function removeProgramDay(id: string): Promise<void> {
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{ program_id: string }>(
+    "SELECT program_id FROM program_days WHERE id = ?",
+    [id]
+  );
+  await database.runAsync("DELETE FROM program_days WHERE id = ?", [id]);
+  if (row) {
+    const prog = await database.getFirstAsync<{ current_day_id: string | null }>(
+      "SELECT current_day_id FROM programs WHERE id = ?",
+      [row.program_id]
+    );
+    if (prog?.current_day_id === id) {
+      const first = await database.getFirstAsync<{ id: string }>(
+        "SELECT id FROM program_days WHERE program_id = ? ORDER BY position ASC LIMIT 1",
+        [row.program_id]
+      );
+      await database.runAsync(
+        "UPDATE programs SET current_day_id = ?, updated_at = ? WHERE id = ?",
+        [first?.id ?? null, Date.now(), row.program_id]
+      );
+    }
+    await database.runAsync(
+      "UPDATE programs SET updated_at = ? WHERE id = ?",
+      [Date.now(), row.program_id]
+    );
+  }
+}
+
+export async function reorderProgramDays(
+  programId: string,
+  orderedIds: string[]
+): Promise<void> {
+  const database = await getDatabase();
+  await database.withTransactionAsync(async () => {
+    for (let i = 0; i < orderedIds.length; i++) {
+      await database.runAsync(
+        "UPDATE program_days SET position = ? WHERE id = ? AND program_id = ?",
+        [i, orderedIds[i], programId]
+      );
+    }
+  });
+  await database.runAsync(
+    "UPDATE programs SET updated_at = ? WHERE id = ?",
+    [Date.now(), programId]
+  );
+}
+
+export async function advanceProgram(
+  programId: string,
+  dayId: string,
+  sessionId: string
+): Promise<{ wrapped: boolean; cycle: number }> {
+  const database = await getDatabase();
+  const now = Date.now();
+
+  const prog = await database.getFirstAsync<{ deleted_at: number | null }>(
+    "SELECT deleted_at FROM programs WHERE id = ?",
+    [programId]
+  );
+  if (!prog || prog.deleted_at !== null) {
+    return { wrapped: false, cycle: 0 };
+  }
+
+  await database.runAsync(
+    "INSERT INTO program_log (id, program_id, day_id, session_id, completed_at) VALUES (?, ?, ?, ?, ?)",
+    [crypto.randomUUID(), programId, dayId, sessionId, now]
+  );
+
+  const days = await database.getAllAsync<{ id: string; position: number }>(
+    "SELECT id, position FROM program_days WHERE program_id = ? ORDER BY position ASC",
+    [programId]
+  );
+  const idx = days.findIndex((d) => d.id === dayId);
+  const next = idx + 1 < days.length ? days[idx + 1] : days[0];
+  const wrapped = idx + 1 >= days.length;
+
+  await database.runAsync(
+    "UPDATE programs SET current_day_id = ?, updated_at = ? WHERE id = ?",
+    [next?.id ?? null, now, programId]
+  );
+
+  const cycle = await getProgramCycleCount(programId);
+  return { wrapped, cycle };
+}
+
+export async function getProgramCycleCount(programId: string): Promise<number> {
+  const database = await getDatabase();
+  const days = await database.getFirstAsync<{ count: number }>(
+    "SELECT COUNT(*) AS count FROM program_days WHERE program_id = ?",
+    [programId]
+  );
+  if (!days || days.count === 0) return 0;
+  const logs = await database.getFirstAsync<{ count: number }>(
+    "SELECT COUNT(*) AS count FROM program_log WHERE program_id = ?",
+    [programId]
+  );
+  return Math.floor((logs?.count ?? 0) / days.count);
+}
+
+export async function getProgramHistory(
+  programId: string,
+  limit = 20
+): Promise<{ session_id: string; day_label: string; template_name: string | null; completed_at: number }[]> {
+  const database = await getDatabase();
+  return database.getAllAsync<{ session_id: string; day_label: string; template_name: string | null; completed_at: number }>(
+    `SELECT pl.session_id, pd.label AS day_label, wt.name AS template_name, pl.completed_at
+     FROM program_log pl
+     LEFT JOIN program_days pd ON pl.day_id = pd.id
+     LEFT JOIN workout_templates wt ON pd.template_id = wt.id
+     WHERE pl.program_id = ?
+     ORDER BY pl.completed_at DESC
+     LIMIT ?`,
+    [programId, limit]
+  );
+}
+
+export async function getSessionProgramDayId(sessionId: string): Promise<string | null> {
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{ program_day_id: string | null }>(
+    "SELECT program_day_id FROM workout_sessions WHERE id = ?",
+    [sessionId]
+  );
+  return row?.program_day_id ?? null;
+}
+
+export async function getProgramDayById(dayId: string): Promise<(ProgramDay & { program_id: string }) | null> {
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{
+    id: string;
+    program_id: string;
+    template_id: string | null;
+    position: number;
+    label: string;
+  }>("SELECT * FROM program_days WHERE id = ?", [dayId]);
+  if (!row) return null;
+  return row;
+}
+
+export async function getNextWorkout(): Promise<{
+  program: Program;
+  day: ProgramDay;
+} | null> {
+  const active = await getActiveProgram();
+  if (!active || !active.current_day_id) return null;
+
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{
+    id: string;
+    program_id: string;
+    template_id: string | null;
+    position: number;
+    label: string;
+    template_name: string | null;
+  }>(
+    `SELECT pd.*, wt.name AS template_name
+     FROM program_days pd
+     LEFT JOIN workout_templates wt ON pd.template_id = wt.id
+     WHERE pd.id = ?`,
+    [active.current_day_id]
+  );
+  if (!row) return null;
+
+  return {
+    program: active,
+    day: { ...row, template_name: row.template_name ?? undefined },
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -248,6 +248,36 @@ export type BodySettings = {
   updated_at: number;
 };
 
+// --------------- Programs ---------------
+
+export type Program = {
+  id: string;
+  name: string;
+  description: string;
+  is_active: boolean;
+  current_day_id: string | null;
+  created_at: number;
+  updated_at: number;
+  deleted_at: number | null;
+};
+
+export type ProgramDay = {
+  id: string;
+  program_id: string;
+  template_id: string | null;
+  position: number;
+  label: string;
+  template_name?: string;
+};
+
+export type ProgramLog = {
+  id: string;
+  program_id: string;
+  day_id: string;
+  session_id: string;
+  completed_at: number;
+};
+
 // --------------- Error Log ---------------
 
 export type ErrorEntry = {


### PR DESCRIPTION
## Summary

Add the ability to organize workout templates into structured training programs (e.g., Push/Pull/Legs), with automatic day advancement and cycle tracking.

## Changes

- **Data Model**: Added `programs`, `program_days`, `program_log` tables and `program_day_id` column migration on `workout_sessions`
- **Programs CRUD**: Full create/read/update/soft-delete for programs with single-active enforcement via transaction
- **Segmented Control**: Workouts tab now has Templates/Programs tabs (defaults to Programs if active program exists)
- **Next Workout Banner**: Shows on both segments when active program exists, starts session with program_day_id
- **Auto-advance**: After workout completion, if session was from a program, advances to next day (wraps with cycle count snackbar)
- **Program Screens**: Detail view with day list/reorder/history, create/edit with template picker
- **Template Delete Safety**: `deleteTemplate()` now NULLifies `program_days.template_id`, shows 'Deleted Template' fallback
- **Accessibility**: All new screens have proper a11y attributes, live region announcements on program advance

## Testing

- TypeScript typecheck passes with zero errors (`tsc --noEmit`)
- `npm install --legacy-peer-deps` succeeds

## Issue

Resolves BLD-7