### PR TITLE
feat: Exercise History & Performance Trends (Phase 12) (BLD-1)

### DIFF
--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -41,21 +41,12 @@ import {
 } from "../../lib/db";
 import type { BodyWeight, BodySettings, BodyMeasurements } from "../../lib/types";
 import { useLayout } from "../../lib/layout";
+import { KG_TO_LB, LB_TO_KG, toDisplay, toKg } from "../../lib/units";
 
 type PR = { exercise_id: string; name: string; max_weight: number };
 type SessionRow = { id: string; name: string; started_at: number; duration_seconds: number | null; set_count: number };
 
-const KG_TO_LB = 2.20462;
-const LB_TO_KG = 0.453592;
 const PAGE_SIZE = 20;
-
-function toDisplay(kg: number, unit: "kg" | "lb"): number {
-  return unit === "lb" ? Math.round(kg * KG_TO_LB * 10) / 10 : Math.round(kg * 10) / 10;
-}
-
-function toKg(val: number, unit: "kg" | "lb"): number {
-  return unit === "lb" ? val * LB_TO_KG : val;
-}
 
 function today(): string {
   return new Date().toISOString().slice(0, 10);

--- a/app/body/goals.tsx
+++ b/app/body/goals.tsx
@@ -3,9 +3,7 @@ import { ScrollView, StyleSheet, View } from "react-native";
 import { Button, Text, TextInput, useTheme } from "react-native-paper";
 import { useFocusEffect, useRouter } from "expo-router";
 import { getBodySettings, updateBodySettings } from "../../lib/db";
-
-const KG_TO_LB = 2.20462;
-const LB_TO_KG = 0.453592;
+import { KG_TO_LB, LB_TO_KG } from "../../lib/units";
 
 export default function Goals() {
   const theme = useTheme();

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -1,14 +1,33 @@
-import { useCallback, useEffect, useState } from "react";
-import { Alert, ScrollView, StyleSheet, View } from "react-native";
-import { Chip, IconButton, Snackbar, Text, useTheme } from "react-native-paper";
-import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { useCallback, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from "react-native";
+import { Button, Card, Chip, IconButton, Snackbar, Text, useTheme } from "react-native-paper";
+import { Stack, useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
+import { LineChart } from "react-native-chart-kit";
 import {
   getExerciseById,
   softDeleteCustomExercise,
   getTemplatesUsingExercise,
+  getExerciseHistory,
+  getExerciseRecords,
+  getExerciseChartData,
+  getBodySettings,
+  type ExerciseSession,
+  type ExerciseRecords as Records,
 } from "../../lib/db";
 import { CATEGORY_LABELS, type Exercise } from "../../lib/types";
 import { semantic } from "../../constants/theme";
+import { toDisplay } from "../../lib/units";
+
+const PAGE_SIZE = 10;
+const MAX_ITEMS = 50;
 
 const DIFFICULTY_COLORS: Record<string, string> = {
   beginner: semantic.beginner,
@@ -16,16 +35,104 @@ const DIFFICULTY_COLORS: Record<string, string> = {
   advanced: semantic.advanced,
 };
 
+function formatDate(ts: number): string {
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(new Date(ts));
+}
+
+function formatDateLong(ts: number): string {
+  return new Intl.DateTimeFormat(undefined, { year: "numeric", month: "short", day: "numeric" }).format(new Date(ts));
+}
+
 export default function ExerciseDetail() {
   const theme = useTheme();
   const router = useRouter();
+  const { width: screenWidth } = useWindowDimensions();
   const { id } = useLocalSearchParams<{ id: string }>();
   const [exercise, setExercise] = useState<Exercise | null>(null);
   const [toast, setToast] = useState("");
+  const [unit, setUnit] = useState<"kg" | "lb">("kg");
 
-  useEffect(() => {
-    if (id) getExerciseById(id).then(setExercise);
-  }, [id]);
+  // Records state
+  const [records, setRecords] = useState<Records | null>(null);
+  const [recordsLoading, setRecordsLoading] = useState(true);
+  const [recordsError, setRecordsError] = useState(false);
+
+  // Chart state
+  const [chart, setChart] = useState<{ date: number; value: number }[]>([]);
+  const [chartLoading, setChartLoading] = useState(true);
+  const [chartError, setChartError] = useState(false);
+
+  // History state
+  const [history, setHistory] = useState<ExerciseSession[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(true);
+  const [historyError, setHistoryError] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  const loadRecords = useCallback(async (eid: string) => {
+    setRecordsLoading(true);
+    setRecordsError(false);
+    try {
+      const r = await getExerciseRecords(eid);
+      setRecords(r);
+    } catch {
+      setRecordsError(true);
+    } finally {
+      setRecordsLoading(false);
+    }
+  }, []);
+
+  const loadChart = useCallback(async (eid: string) => {
+    setChartLoading(true);
+    setChartError(false);
+    try {
+      const c = await getExerciseChartData(eid);
+      setChart(c);
+    } catch {
+      setChartError(true);
+    } finally {
+      setChartLoading(false);
+    }
+  }, []);
+
+  const loadHistory = useCallback(async (eid: string) => {
+    setHistoryLoading(true);
+    setHistoryError(false);
+    try {
+      const h = await getExerciseHistory(eid, PAGE_SIZE, 0);
+      setHistory(h);
+      setHasMore(h.length >= PAGE_SIZE);
+    } catch {
+      setHistoryError(true);
+    } finally {
+      setHistoryLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!id) return;
+      getExerciseById(id).then(setExercise);
+      getBodySettings().then((s) => setUnit(s.weight_unit));
+      loadRecords(id);
+      loadChart(id);
+      loadHistory(id);
+    }, [id, loadRecords, loadChart, loadHistory])
+  );
+
+  const loadMore = useCallback(async () => {
+    if (!id || loadingMore || !hasMore || history.length >= MAX_ITEMS) return;
+    setLoadingMore(true);
+    try {
+      const more = await getExerciseHistory(id, PAGE_SIZE, history.length);
+      setHistory((prev) => [...prev, ...more]);
+      setHasMore(more.length >= PAGE_SIZE && history.length + more.length < MAX_ITEMS);
+    } catch {
+      // silent — footer indicator disappears
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [id, loadingMore, hasMore, history.length]);
 
   const edit = useCallback(() => {
     if (id) router.push(`/exercise/edit/${id}`);
@@ -71,6 +178,307 @@ export default function ExerciseDetail() {
     .map((s) => s.trim())
     .filter(Boolean);
 
+  const bw = records?.is_bodyweight ?? false;
+  const chartWidth = screenWidth - 48;
+
+  const chartConfig = {
+    backgroundGradientFrom: theme.colors.surface,
+    backgroundGradientTo: theme.colors.surface,
+    color: () => theme.colors.primary,
+    labelColor: () => theme.colors.onSurfaceVariant,
+    decimalPlaces: bw ? 0 : 1,
+    propsForBackgroundLines: { stroke: theme.colors.outlineVariant },
+  };
+
+  // Chart accessibility summary
+  const chartSummary = chart.length >= 2
+    ? (() => {
+        const start = chart[0].value;
+        const end = chart[chart.length - 1].value;
+        const pct = start > 0 ? Math.round(((end - start) / start) * 100) : 0;
+        const label = bw ? "reps" : unit;
+        const sv = bw ? start : toDisplay(start, unit);
+        const ev = bw ? end : toDisplay(end, unit);
+        const dir = pct >= 0 ? "+" : "";
+        return `Your ${exercise.name} progressed from ${sv}${label} to ${ev}${label} over ${chart.length} sessions (${dir}${pct}%)`;
+      })()
+    : null;
+
+  const renderHeader = () => (
+    <View style={styles.content}>
+      {/* Custom badge */}
+      {exercise.is_custom && (
+        <Chip
+          compact
+          style={[styles.badge, { backgroundColor: theme.colors.tertiaryContainer }]}
+          textStyle={{ fontSize: 12 }}
+        >
+          Custom
+        </Chip>
+      )}
+
+      {/* Category & Difficulty */}
+      <View style={styles.row}>
+        <Chip
+          compact
+          style={{ backgroundColor: theme.colors.primaryContainer }}
+          textStyle={{ color: theme.colors.onPrimaryContainer }}
+        >
+          {CATEGORY_LABELS[exercise.category]}
+        </Chip>
+        <Chip
+          compact
+          style={[styles.difficultyChip, { backgroundColor: DIFFICULTY_COLORS[exercise.difficulty] }]}
+          textStyle={styles.difficultyText}
+        >
+          {exercise.difficulty}
+        </Chip>
+      </View>
+
+      {/* Equipment */}
+      <View style={styles.section}>
+        <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
+          Equipment
+        </Text>
+        <Text variant="bodyLarge" style={[styles.value, { color: theme.colors.onSurface }]}>
+          {exercise.equipment}
+        </Text>
+      </View>
+
+      {/* Primary Muscles */}
+      <View style={styles.section}>
+        <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
+          Primary Muscles
+        </Text>
+        <View style={styles.chipRow}>
+          {exercise.primary_muscles.map((m) => (
+            <Chip
+              key={m}
+              compact
+              style={[styles.muscleChip, { backgroundColor: theme.colors.secondaryContainer }]}
+            >
+              {m}
+            </Chip>
+          ))}
+        </View>
+      </View>
+
+      {/* Secondary Muscles */}
+      {exercise.secondary_muscles.length > 0 && (
+        <View style={styles.section}>
+          <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
+            Secondary Muscles
+          </Text>
+          <View style={styles.chipRow}>
+            {exercise.secondary_muscles.map((m) => (
+              <Chip
+                key={m}
+                compact
+                style={[styles.muscleChip, { backgroundColor: theme.colors.tertiaryContainer }]}
+              >
+                {m}
+              </Chip>
+            ))}
+          </View>
+        </View>
+      )}
+
+      {/* Instructions */}
+      {steps.length > 0 && (
+        <View style={styles.section}>
+          <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
+            Instructions
+          </Text>
+          {steps.map((step, i) => (
+            <Text
+              key={i}
+              variant="bodyMedium"
+              style={[styles.step, { color: theme.colors.onSurface }]}
+            >
+              {step}
+            </Text>
+          ))}
+        </View>
+      )}
+
+      {/* Personal Records Card */}
+      <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+        <Card.Content>
+          <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
+            Personal Records
+          </Text>
+          {recordsLoading ? (
+            <ActivityIndicator style={styles.loader} />
+          ) : recordsError ? (
+            <View style={styles.errorBox}>
+              <Text style={{ color: theme.colors.error }}>Failed to load records</Text>
+              <Button mode="text" onPress={() => id && loadRecords(id)}>Retry</Button>
+            </View>
+          ) : records && records.total_sessions === 0 ? (
+            <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant }}>
+              No workout data yet — start a session to build your history
+            </Text>
+          ) : records ? (
+            <View style={styles.statsRow}>
+              {bw ? (
+                <>
+                  <View style={styles.stat} accessibilityLabel={`Maximum reps: ${records.max_reps ?? 0}`}>
+                    <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
+                      {records.max_reps ?? "—"}
+                    </Text>
+                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>Max Reps</Text>
+                  </View>
+                  <View style={styles.stat} accessibilityLabel={`Total sessions: ${records.total_sessions}`}>
+                    <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
+                      {records.total_sessions}
+                    </Text>
+                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>Sessions</Text>
+                  </View>
+                  <View style={styles.stat} accessibilityLabel={`Best volume: ${records.max_volume ?? 0}`}>
+                    <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
+                      {records.max_volume != null ? Math.round(records.max_volume) : "—"}
+                    </Text>
+                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>Best Vol</Text>
+                  </View>
+                </>
+              ) : (
+                <>
+                  <View style={styles.stat} accessibilityLabel={`Maximum weight: ${records.max_weight != null ? toDisplay(records.max_weight, unit) : 0} ${unit}`}>
+                    <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
+                      {records.max_weight != null ? toDisplay(records.max_weight, unit) : "—"}
+                    </Text>
+                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>Max {unit}</Text>
+                  </View>
+                  <View style={styles.stat} accessibilityLabel={`Maximum reps: ${records.max_reps ?? 0}`}>
+                    <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
+                      {records.max_reps ?? "—"}
+                    </Text>
+                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>Max Reps</Text>
+                  </View>
+                  <View style={styles.stat} accessibilityLabel={`Estimated one rep max: ${records.est_1rm != null ? toDisplay(records.est_1rm, unit) : 0} ${unit}`}>
+                    <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
+                      {records.est_1rm != null ? toDisplay(records.est_1rm, unit) : "—"}
+                    </Text>
+                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>Est 1RM</Text>
+                  </View>
+                  <View style={styles.stat} accessibilityLabel={`Total sessions: ${records.total_sessions}`}>
+                    <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
+                      {records.total_sessions}
+                    </Text>
+                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>Sessions</Text>
+                  </View>
+                </>
+              )}
+            </View>
+          ) : null}
+        </Card.Content>
+      </Card>
+
+      {/* Performance Chart */}
+      <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+        <Card.Content>
+          <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
+            {bw ? "Reps Progression" : "Weight Progression"}
+          </Text>
+          {chartLoading ? (
+            <ActivityIndicator style={styles.loader} />
+          ) : chartError ? (
+            <View style={styles.errorBox}>
+              <Text style={{ color: theme.colors.error }}>Failed to load chart</Text>
+              <Button mode="text" onPress={() => id && loadChart(id)}>Retry</Button>
+            </View>
+          ) : chart.length < 2 ? (
+            <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant }}>
+              {chart.length === 0
+                ? "No data to chart yet"
+                : "Log more sessions to see a trend chart"}
+            </Text>
+          ) : (
+            <View accessibilityLabel={chartSummary ?? undefined}>
+              <LineChart
+                data={{
+                  labels: chart.map((d) => formatDate(d.date)),
+                  datasets: [{
+                    data: bw ? chart.map((d) => d.value) : chart.map((d) => toDisplay(d.value, unit)),
+                  }],
+                }}
+                width={chartWidth}
+                height={200}
+                chartConfig={chartConfig}
+                bezier
+                style={styles.chartStyle}
+                withDots={chart.length <= 30}
+              />
+              {chartSummary && (
+                <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginTop: 8 }}>
+                  {chartSummary}
+                </Text>
+              )}
+            </View>
+          )}
+        </Card.Content>
+      </Card>
+
+      {/* History section header */}
+      <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginTop: 8, marginBottom: 8 }}>
+        Session History
+      </Text>
+
+      {historyLoading ? (
+        <ActivityIndicator style={styles.loader} />
+      ) : historyError ? (
+        <View style={styles.errorBox}>
+          <Text style={{ color: theme.colors.error }}>Failed to load history</Text>
+          <Button mode="text" onPress={() => id && loadHistory(id)}>Retry</Button>
+        </View>
+      ) : history.length === 0 ? (
+        <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 16 }}>
+          No sessions recorded for this exercise
+        </Text>
+      ) : null}
+    </View>
+  );
+
+  const renderItem = ({ item }: { item: ExerciseSession }) => {
+    const label = bw
+      ? `${exercise.name} session on ${formatDateLong(item.started_at)}, ${item.set_count} sets, max reps ${item.max_reps}`
+      : `${exercise.name} session on ${formatDateLong(item.started_at)}, ${item.set_count} sets, max weight ${toDisplay(item.max_weight, unit)} ${unit}`;
+    return (
+      <Pressable
+        onPress={() => router.push(`/session/detail/${item.session_id}`)}
+        style={[styles.historyRow, { borderBottomColor: theme.colors.outlineVariant }]}
+        accessibilityLabel={label}
+        accessibilityRole="button"
+      >
+        <View style={styles.historyLeft}>
+          <Text variant="bodyLarge" style={{ color: theme.colors.onSurface }}>
+            {formatDateLong(item.started_at)}
+          </Text>
+          <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+            {item.session_name} · {item.set_count} sets · {item.total_reps} reps
+          </Text>
+        </View>
+        <View style={styles.historyRight}>
+          <Text variant="titleMedium" style={{ color: theme.colors.primary }}>
+            {bw ? `${item.max_reps} reps` : `${toDisplay(item.max_weight, unit)} ${unit}`}
+          </Text>
+        </View>
+      </Pressable>
+    );
+  };
+
+  const renderFooter = () => {
+    if (loadingMore) return <ActivityIndicator style={{ padding: 16 }} />;
+    if (!hasMore && history.length >= MAX_ITEMS) {
+      return (
+        <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
+          Showing last {history.length} sessions
+        </Text>
+      );
+    }
+    return null;
+  };
+
   return (
     <>
       <Stack.Screen
@@ -96,104 +504,17 @@ export default function ExerciseDetail() {
             : undefined,
         }}
       />
-      <ScrollView style={[styles.scrollContainer, { backgroundColor: theme.colors.background }]}>
-        <View style={styles.content}>
-          {/* Custom badge */}
-          {exercise.is_custom && (
-            <Chip
-              compact
-              style={[styles.customBadge, { backgroundColor: theme.colors.tertiaryContainer }]}
-              textStyle={{ fontSize: 12 }}
-            >
-              Custom
-            </Chip>
-          )}
-
-          {/* Category & Difficulty */}
-          <View style={styles.row}>
-            <Chip
-              compact
-              style={{ backgroundColor: theme.colors.primaryContainer }}
-              textStyle={{ color: theme.colors.onPrimaryContainer }}
-            >
-              {CATEGORY_LABELS[exercise.category]}
-            </Chip>
-            <Chip
-              compact
-              style={[styles.difficultyChip, { backgroundColor: DIFFICULTY_COLORS[exercise.difficulty] }]}
-              textStyle={styles.difficultyText}
-            >
-              {exercise.difficulty}
-            </Chip>
-          </View>
-
-          {/* Equipment */}
-          <View style={styles.section}>
-            <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
-              Equipment
-            </Text>
-            <Text variant="bodyLarge" style={[styles.value, { color: theme.colors.onSurface }]}>
-              {exercise.equipment}
-            </Text>
-          </View>
-
-          {/* Primary Muscles */}
-          <View style={styles.section}>
-            <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
-              Primary Muscles
-            </Text>
-            <View style={styles.chipRow}>
-              {exercise.primary_muscles.map((m) => (
-                <Chip
-                  key={m}
-                  compact
-                  style={[styles.muscleChip, { backgroundColor: theme.colors.secondaryContainer }]}
-                >
-                  {m}
-                </Chip>
-              ))}
-            </View>
-          </View>
-
-          {/* Secondary Muscles */}
-          {exercise.secondary_muscles.length > 0 && (
-            <View style={styles.section}>
-              <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
-                Secondary Muscles
-              </Text>
-              <View style={styles.chipRow}>
-                {exercise.secondary_muscles.map((m) => (
-                  <Chip
-                    key={m}
-                    compact
-                    style={[styles.muscleChip, { backgroundColor: theme.colors.tertiaryContainer }]}
-                  >
-                    {m}
-                  </Chip>
-                ))}
-              </View>
-            </View>
-          )}
-
-          {/* Instructions */}
-          {steps.length > 0 && (
-            <View style={styles.section}>
-              <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
-                Instructions
-              </Text>
-              {steps.map((step, i) => (
-                <Text
-                  key={i}
-                  variant="bodyMedium"
-                  style={[styles.step, { color: theme.colors.onSurface }]}
-                >
-                  {step}
-                </Text>
-              ))}
-            </View>
-          )}
-        </View>
-      </ScrollView>
+      <FlatList
+        style={{ flex: 1, backgroundColor: theme.colors.background }}
+        data={historyLoading || historyError || history.length === 0 ? [] : history}
+        keyExtractor={(item) => item.session_id}
+        renderItem={renderItem}
+        ListHeaderComponent={renderHeader}
+        ListFooterComponent={renderFooter}
+        onEndReached={loadMore}
+        onEndReachedThreshold={0.3}
+        contentContainerStyle={{ paddingBottom: 32 }}
+      />
 
       <Snackbar visible={!!toast} onDismiss={() => setToast("")} duration={3000}>
         {toast}
@@ -203,9 +524,6 @@ export default function ExerciseDetail() {
 }
 
 const styles = StyleSheet.create({
-  scrollContainer: {
-    flex: 1,
-  },
   center: {
     flex: 1,
     alignItems: "center",
@@ -213,12 +531,11 @@ const styles = StyleSheet.create({
   },
   content: {
     padding: 16,
-    paddingBottom: 32,
   },
   headerActions: {
     flexDirection: "row",
   },
-  customBadge: {
+  badge: {
     alignSelf: "flex-start",
     marginBottom: 8,
   },
@@ -252,5 +569,42 @@ const styles = StyleSheet.create({
   step: {
     marginTop: 6,
     lineHeight: 22,
+  },
+  card: {
+    marginBottom: 16,
+    borderRadius: 12,
+  },
+  loader: {
+    paddingVertical: 24,
+  },
+  errorBox: {
+    alignItems: "center",
+    paddingVertical: 12,
+  },
+  statsRow: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+  },
+  stat: {
+    alignItems: "center",
+  },
+  chartStyle: {
+    borderRadius: 12,
+    marginLeft: -16,
+  },
+  historyRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    minHeight: 48,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  historyLeft: {
+    flex: 1,
+  },
+  historyRight: {
+    marginLeft: 12,
   },
 });

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -206,6 +206,11 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
       "ALTER TABLE workout_sessions ADD COLUMN program_day_id TEXT DEFAULT NULL"
     );
   }
+
+  // Migration: index for exercise history query performance
+  await database.execAsync(
+    "CREATE INDEX IF NOT EXISTS idx_workout_sets_exercise ON workout_sets(exercise_id)"
+  );
 }
 
 async function seed(database: SQLite.SQLiteDatabase): Promise<void> {
@@ -1600,5 +1605,160 @@ export async function getRecentPRs(
      ORDER BY wss.started_at DESC
      LIMIT ?`,
     [limit]
+  );
+}
+
+// --- Exercise History & Performance ---
+
+export type ExerciseSession = {
+  session_id: string;
+  session_name: string;
+  started_at: number;
+  max_weight: number;
+  max_reps: number;
+  total_reps: number;
+  set_count: number;
+  volume: number;
+};
+
+export type ExerciseRecords = {
+  max_weight: number | null;
+  max_reps: number | null;
+  max_volume: number | null;
+  est_1rm: number | null;
+  total_sessions: number;
+  is_bodyweight: boolean;
+};
+
+export async function getExerciseHistory(
+  exerciseId: string,
+  limit: number = 10,
+  offset: number = 0
+): Promise<ExerciseSession[]> {
+  const database = await getDatabase();
+  return database.getAllAsync<ExerciseSession>(
+    `SELECT wss.id AS session_id,
+            wss.name AS session_name,
+            wss.started_at,
+            MAX(ws.weight) AS max_weight,
+            MAX(ws.reps) AS max_reps,
+            SUM(ws.reps) AS total_reps,
+            COUNT(ws.id) AS set_count,
+            SUM(ws.weight * ws.reps) AS volume
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.exercise_id = ?
+       AND ws.completed = 1
+       AND wss.completed_at IS NOT NULL
+     GROUP BY wss.id
+     ORDER BY wss.started_at DESC
+     LIMIT ? OFFSET ?`,
+    [exerciseId, limit, offset]
+  );
+}
+
+export async function getExerciseRecords(exerciseId: string): Promise<ExerciseRecords> {
+  const database = await getDatabase();
+
+  const weight = await database.getFirstAsync<{ val: number | null }>(
+    `SELECT MAX(ws.weight) AS val
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.weight > 0 AND wss.completed_at IS NOT NULL`,
+    [exerciseId]
+  );
+
+  const reps = await database.getFirstAsync<{ val: number | null }>(
+    `SELECT MAX(ws.reps) AS val
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.exercise_id = ? AND ws.completed = 1 AND wss.completed_at IS NOT NULL`,
+    [exerciseId]
+  );
+
+  const vol = await database.getFirstAsync<{ val: number | null }>(
+    `SELECT MAX(sv) AS val FROM (
+       SELECT SUM(ws.weight * ws.reps) AS sv
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.exercise_id = ? AND ws.completed = 1 AND wss.completed_at IS NOT NULL
+       GROUP BY wss.id
+     )`,
+    [exerciseId]
+  );
+
+  const rm = await database.getFirstAsync<{ val: number | null }>(
+    `SELECT MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS val
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.weight > 0 AND ws.reps > 0 AND ws.reps <= 12 AND wss.completed_at IS NOT NULL`,
+    [exerciseId]
+  );
+
+  const count = await database.getFirstAsync<{ val: number }>(
+    `SELECT COUNT(DISTINCT wss.id) AS val
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.exercise_id = ? AND ws.completed = 1 AND wss.completed_at IS NOT NULL`,
+    [exerciseId]
+  );
+
+  const weighted = await database.getFirstAsync<{ val: number }>(
+    `SELECT EXISTS(SELECT 1 FROM workout_sets WHERE exercise_id = ? AND completed = 1 AND weight > 0) AS val`,
+    [exerciseId]
+  );
+
+  return {
+    max_weight: weight?.val ?? null,
+    max_reps: reps?.val ?? null,
+    max_volume: vol?.val ?? null,
+    est_1rm: rm?.val ? Math.round(rm.val * 10) / 10 : null,
+    total_sessions: count?.val ?? 0,
+    is_bodyweight: !(weighted?.val),
+  };
+}
+
+export async function getExerciseChartData(
+  exerciseId: string,
+  limit: number = 20
+): Promise<{ date: number; value: number }[]> {
+  const database = await getDatabase();
+
+  // Try weight chart first
+  const rows = await database.getAllAsync<{ date: number; value: number }>(
+    `SELECT * FROM (
+       SELECT wss.started_at AS date,
+              MAX(ws.weight) AS value
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.exercise_id = ?
+         AND ws.completed = 1
+         AND ws.weight IS NOT NULL
+         AND ws.weight > 0
+         AND wss.completed_at IS NOT NULL
+       GROUP BY wss.id
+       ORDER BY wss.started_at DESC
+       LIMIT ?
+     ) ORDER BY date ASC`,
+    [exerciseId, limit]
+  );
+
+  if (rows.length > 0) return rows;
+
+  // Fallback: reps chart for bodyweight exercises
+  return database.getAllAsync<{ date: number; value: number }>(
+    `SELECT * FROM (
+       SELECT wss.started_at AS date,
+              MAX(ws.reps) AS value
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.exercise_id = ?
+         AND ws.completed = 1
+         AND wss.completed_at IS NOT NULL
+       GROUP BY wss.id
+       ORDER BY wss.started_at DESC
+       LIMIT ?
+     ) ORDER BY date ASC`,
+    [exerciseId, limit]
   );
 }

--- a/lib/units.ts
+++ b/lib/units.ts
@@ -1,0 +1,10 @@
+export const KG_TO_LB = 2.20462;
+export const LB_TO_KG = 0.453592;
+
+export function toDisplay(kg: number, unit: "kg" | "lb"): number {
+  return unit === "lb" ? Math.round(kg * KG_TO_LB * 10) / 10 : Math.round(kg * 10) / 10;
+}
+
+export function toKg(val: number, unit: "kg" | "lb"): number {
+  return unit === "lb" ? val * LB_TO_KG : val;
+}


### PR DESCRIPTION
## Summary

Add exercise history, personal records, and performance charts to the exercise detail page. Users can now see their progression for any exercise over time.

## Changes

- **lib/units.ts** (NEW): Extract `toDisplay`, `KG_TO_LB`, `LB_TO_KG`, `toKg` from progress.tsx into shared utility
- **app/(tabs)/progress.tsx**: Import from lib/units.ts (dedup)
- **app/body/goals.tsx**: Import from lib/units.ts (dedup)
- **lib/db.ts**: Add `getExerciseHistory`, `getExerciseRecords`, `getExerciseChartData` query functions + exercise_id index migration
- **app/exercise/[id].tsx**: Complete overhaul — ScrollView → FlatList, personal records card, performance chart, paginated session history

## Key Details

- Server-side pagination: 10 items/page, max 50 items (5 pages)
- Bodyweight exercise support: shows reps instead of weight throughout
- Per-section loading states + error handling with retry buttons
- Full accessibility labels on all elements
- Locale-aware date formatting via Intl.DateTimeFormat
- Chart accessibility summary text for screen readers
- Weight unit respects user preference (kg/lb)
- No new dependencies — uses existing react-native-chart-kit

## Testing

- TypeScript typecheck passes (tsc --noEmit: 0 errors)
- Exercises with 0, 1, 2+ sessions handled (empty states, single entry, chart)

## Issue

Resolves BLD-1