### PR TITLE
feat: Per-Set Notes & RPE Tracking (Phase 13) (BLD-14)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -23,6 +23,7 @@ import {
   getAllCompletedSessionWeeks,
   getRecentPRs,
   getRecentSessions,
+  getSessionAvgRPE,
   getSessionSetCount,
   getTemplateExerciseCount,
   getTemplates,
@@ -35,6 +36,7 @@ import {
   softDeleteProgram,
 } from "../../lib/programs";
 import type { Program, ProgramDay, WorkoutSession, WorkoutTemplate } from "../../lib/types";
+import { semantic } from "../../constants/theme";
 
 function mondayOf(date: Date): number {
   const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
@@ -68,6 +70,7 @@ export default function Workouts() {
   const [active, setActive] = useState<WorkoutSession | null>(null);
   const [streak, setStreak] = useState(0);
   const [recentPRs, setRecentPRs] = useState<{ exercise_id: string; name: string; weight: number; session_id: string; date: number }[]>([]);
+  const [avgRPEs, setAvgRPEs] = useState<Record<string, number | null>>({});
   const [nextWorkout, setNextWorkout] = useState<{ program: Program; day: ProgramDay } | null>(null);
   const [snackbar, setSnackbar] = useState("");
 
@@ -102,10 +105,13 @@ export default function Workouts() {
     setCounts(c);
 
     const sc: Record<string, number> = {};
+    const rpeMap: Record<string, number | null> = {};
     for (const s of sess) {
       sc[s.id] = await getSessionSetCount(s.id);
+      rpeMap[s.id] = await getSessionAvgRPE(s.id);
     }
     setSetCounts(sc);
+    setAvgRPEs(rpeMap);
 
     const dc: Record<string, number> = {};
     for (const p of progs) {
@@ -540,13 +546,16 @@ export default function Workouts() {
             data={sessions}
             keyExtractor={(item) => item.id}
             scrollEnabled={false}
-            renderItem={({ item }: ListRenderItemInfo<WorkoutSession>) => (
+            renderItem={({ item }: ListRenderItemInfo<WorkoutSession>) => {
+              const rpe = avgRPEs[item.id];
+              const rpeStr = rpe != null ? ` · RPE ${Math.round(rpe * 10) / 10}` : "";
+              return (
               <Card
                 style={[styles.card, { backgroundColor: theme.colors.surface }]}
                 onPress={() =>
                   router.push(`/session/detail/${item.id}`)
                 }
-                accessibilityLabel={`View workout: ${item.name}, ${dateStr(item.started_at)}, ${duration(item.duration_seconds)}, ${setCounts2[item.id] ?? 0} sets`}
+                accessibilityLabel={`View workout: ${item.name}, ${dateStr(item.started_at)}, ${duration(item.duration_seconds)}, ${setCounts2[item.id] ?? 0} sets${rpeStr}`}
                 accessibilityRole="button"
               >
                 <Card.Content>
@@ -556,16 +565,26 @@ export default function Workouts() {
                   >
                     {item.name}
                   </Text>
-                  <Text
-                    variant="bodySmall"
-                    style={{ color: theme.colors.onSurfaceVariant }}
-                  >
-                    {dateStr(item.started_at)} · {duration(item.duration_seconds)} ·{" "}
-                    {setCounts2[item.id] ?? 0} sets
-                  </Text>
+                  <View style={styles.recentRow}>
+                    <Text
+                      variant="bodySmall"
+                      style={{ color: theme.colors.onSurfaceVariant, flex: 1 }}
+                    >
+                      {dateStr(item.started_at)} · {duration(item.duration_seconds)} ·{" "}
+                      {setCounts2[item.id] ?? 0} sets
+                    </Text>
+                    {rpe != null && (
+                      <View style={[styles.rpeTag, { backgroundColor: rpe <= 7 ? semantic.beginner : rpe <= 8 ? semantic.intermediate : semantic.advanced }]}>
+                        <Text style={{ color: semantic.onSemantic, fontSize: 12, fontWeight: "600" }}>
+                          RPE {Math.round(rpe * 10) / 10}
+                        </Text>
+                      </View>
+                    )}
+                  </View>
                 </Card.Content>
               </Card>
-            )}
+              );
+            }}
           />
         )}
       </View>
@@ -662,6 +681,16 @@ const styles = StyleSheet.create({
   empty: {
     alignItems: "center",
     paddingVertical: 16,
+  },
+  recentRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  rpeTag: {
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    marginLeft: 8,
   },
   emptyBtn: {
     marginTop: 8,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -37,6 +37,7 @@ import {
 } from "../../lib/programs";
 import type { Program, ProgramDay, WorkoutSession, WorkoutTemplate } from "../../lib/types";
 import { semantic } from "../../constants/theme";
+import { rpeColor, rpeText } from "../../lib/rpe";
 
 function mondayOf(date: Date): number {
   const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
@@ -574,8 +575,8 @@ export default function Workouts() {
                       {setCounts2[item.id] ?? 0} sets
                     </Text>
                     {rpe != null && (
-                      <View style={[styles.rpeTag, { backgroundColor: rpe <= 7 ? semantic.beginner : rpe <= 8 ? semantic.intermediate : semantic.advanced }]}>
-                        <Text style={{ color: semantic.onSemantic, fontSize: 12, fontWeight: "600" }}>
+                      <View style={[styles.rpeTag, { backgroundColor: rpeColor(rpe) }]}>
+                        <Text style={{ color: rpeText(rpe), fontSize: 12, fontWeight: "600" }}>
                           RPE {Math.round(rpe * 10) / 10}
                         </Text>
                       </View>

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -20,7 +20,7 @@ import { getErrorCount, clearErrorLog, generateReport } from "../../lib/errors";
 import { csvEscape } from "../../lib/csv";
 
 function workoutCSV(rows: WorkoutCSVRow[]): string {
-  const header = "date,exercise,set_number,weight,reps,duration_seconds,notes";
+  const header = "date,exercise,set_number,weight,reps,duration_seconds,notes,set_rpe,set_notes";
   const lines = rows.map((r) =>
     [
       csvEscape(r.date),
@@ -30,6 +30,8 @@ function workoutCSV(rows: WorkoutCSVRow[]): string {
       csvEscape(r.reps),
       csvEscape(r.duration_seconds),
       csvEscape(r.notes),
+      csvEscape(r.set_rpe),
+      csvEscape(r.set_notes),
     ].join(",")
   );
   return [header, ...lines].join("\n");

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -439,10 +439,17 @@ export default function ExerciseDetail() {
     </View>
   );
 
+  const rpeColor = (val: number): string => {
+    if (val <= 7) return semantic.beginner;
+    if (val <= 8) return semantic.intermediate;
+    return semantic.advanced;
+  };
+
   const renderItem = ({ item }: { item: ExerciseSession }) => {
+    const rpeLabel = item.avg_rpe != null ? `, avg RPE ${Math.round(item.avg_rpe * 10) / 10}` : "";
     const label = bw
-      ? `${exercise.name} session on ${formatDateLong(item.started_at)}, ${item.set_count} sets, max reps ${item.max_reps}`
-      : `${exercise.name} session on ${formatDateLong(item.started_at)}, ${item.set_count} sets, max weight ${toDisplay(item.max_weight, unit)} ${unit}`;
+      ? `${exercise.name} session on ${formatDateLong(item.started_at)}, ${item.set_count} sets, max reps ${item.max_reps}${rpeLabel}`
+      : `${exercise.name} session on ${formatDateLong(item.started_at)}, ${item.set_count} sets, max weight ${toDisplay(item.max_weight, unit)} ${unit}${rpeLabel}`;
     return (
       <Pressable
         onPress={() => router.push(`/session/detail/${item.session_id}`)}
@@ -462,6 +469,13 @@ export default function ExerciseDetail() {
           <Text variant="titleMedium" style={{ color: theme.colors.primary }}>
             {bw ? `${item.max_reps} reps` : `${toDisplay(item.max_weight, unit)} ${unit}`}
           </Text>
+          {item.avg_rpe != null && (
+            <View style={[styles.rpeBadge, { backgroundColor: rpeColor(item.avg_rpe) }]}>
+              <Text style={{ color: semantic.onSemantic, fontSize: 12, fontWeight: "600" }}>
+                RPE {Math.round(item.avg_rpe * 10) / 10}
+              </Text>
+            </View>
+          )}
         </View>
       </Pressable>
     );
@@ -606,5 +620,12 @@ const styles = StyleSheet.create({
   },
   historyRight: {
     marginLeft: 12,
+    alignItems: "flex-end",
+  },
+  rpeBadge: {
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    marginTop: 4,
   },
 });

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -24,6 +24,7 @@ import {
 } from "../../lib/db";
 import { CATEGORY_LABELS, type Exercise } from "../../lib/types";
 import { semantic } from "../../constants/theme";
+import { rpeColor, rpeText } from "../../lib/rpe";
 import { toDisplay } from "../../lib/units";
 
 const PAGE_SIZE = 10;
@@ -439,12 +440,6 @@ export default function ExerciseDetail() {
     </View>
   );
 
-  const rpeColor = (val: number): string => {
-    if (val <= 7) return semantic.beginner;
-    if (val <= 8) return semantic.intermediate;
-    return semantic.advanced;
-  };
-
   const renderItem = ({ item }: { item: ExerciseSession }) => {
     const rpeLabel = item.avg_rpe != null ? `, avg RPE ${Math.round(item.avg_rpe * 10) / 10}` : "";
     const label = bw
@@ -471,7 +466,7 @@ export default function ExerciseDetail() {
           </Text>
           {item.avg_rpe != null && (
             <View style={[styles.rpeBadge, { backgroundColor: rpeColor(item.avg_rpe) }]}>
-              <Text style={{ color: semantic.onSemantic, fontSize: 12, fontWeight: "600" }}>
+              <Text style={{ color: rpeText(item.avg_rpe), fontSize: 12, fontWeight: "600" }}>
                 RPE {Math.round(item.avg_rpe * 10) / 10}
               </Text>
             </View>

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Alert,
   AccessibilityInfo,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   View,
@@ -11,6 +14,7 @@ import {
   Checkbox,
   Chip,
   Divider,
+  IconButton,
   Snackbar,
   Text,
   TextInput,
@@ -31,6 +35,8 @@ import {
   getRestSecondsForExercise,
   uncompleteSet,
   updateSet,
+  updateSetRPE,
+  updateSetNotes,
 } from "../../lib/db";
 import {
   getSessionProgramDayId,
@@ -38,6 +44,7 @@ import {
   advanceProgram,
 } from "../../lib/programs";
 import type { WorkoutSession, WorkoutSet } from "../../lib/types";
+import { semantic } from "../../constants/theme";
 
 type SetWithMeta = WorkoutSet & {
   exercise_name?: string;
@@ -49,6 +56,18 @@ type ExerciseGroup = {
   name: string;
   sets: SetWithMeta[];
 };
+
+const RPE_CHIPS = [6, 7, 8, 9, 10] as const;
+
+const RPE_LABELS: Record<number, string> = {
+  6: "Easy", 7: "Easy", 8: "Mod", 9: "Hard", 10: "Max",
+};
+
+function rpeColor(val: number): string {
+  if (val <= 7) return semantic.beginner;
+  if (val <= 8) return semantic.intermediate;
+  return semantic.advanced;
+}
 
 export default function ActiveSession() {
   const theme = useTheme();
@@ -68,6 +87,8 @@ export default function ActiveSession() {
   const prevExerciseIds = useRef<string>("");
   const prHapticFired = useRef<Set<string>>(new Set());
   const [snackbar, setSnackbar] = useState("");
+  const [notesOpen, setNotesOpen] = useState<Record<string, boolean>>({});
+  const [halfStep, setHalfStep] = useState<{ setId: string; base: number } | null>(null);
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -245,6 +266,29 @@ export default function ActiveSession() {
     router.push(`/template/pick-exercise?sessionId=${id}`);
   };
 
+  const handleRPE = async (set: SetWithMeta, val: number) => {
+    const next = set.rpe === val ? null : val;
+    await updateSetRPE(set.id, next);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    await load();
+  };
+
+  const handleHalfStep = async (setId: string, val: number) => {
+    await updateSetRPE(setId, val);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setHalfStep(null);
+    await load();
+  };
+
+  const handleNotes = async (setId: string, text: string) => {
+    await updateSetNotes(setId, text);
+    await load();
+  };
+
+  const toggleNotes = (setId: string) => {
+    setNotesOpen((prev) => ({ ...prev, [setId]: !prev[setId] }));
+  };
+
   const isPR = (set: SetWithMeta) => {
     if (!set.completed || !set.weight || set.weight <= 0) return false;
     const max = maxes[set.exercise_id];
@@ -360,8 +404,9 @@ export default function ActiveSession() {
           ),
         }}
       />
+      <KeyboardAvoidingView style={styles.container} behavior={Platform.OS === "ios" ? "padding" : undefined} keyboardVerticalOffset={100}>
       <ScrollView
-        style={[styles.container, { backgroundColor: theme.colors.background }]}
+        style={{ backgroundColor: theme.colors.background }}
         contentContainerStyle={styles.content}
       >
         {rest > 0 && (
@@ -424,67 +469,178 @@ export default function ActiveSession() {
             </View>
 
             {group.sets.map((set) => (
-              <View
-                key={set.id}
-                style={[
-                  styles.setRow,
-                  set.completed && {
-                    backgroundColor: theme.colors.primaryContainer + "40",
-                  },
-                ]}
-              >
-                <Text
-                  variant="bodyMedium"
-                  style={[styles.colSet, { color: theme.colors.onSurface }]}
-                >
-                  {set.set_number}
-                </Text>
-                <Text
-                  variant="bodySmall"
+              <View key={set.id}>
+                <View
                   style={[
-                    styles.colPrev,
-                    { color: theme.colors.onSurfaceVariant },
+                    styles.setRow,
+                    set.completed && {
+                      backgroundColor: theme.colors.primaryContainer + "40",
+                    },
                   ]}
                 >
-                  {set.previous}
-                </Text>
-                <TextInput
-                  mode="outlined"
-                  dense
-                  keyboardType="numeric"
-                  style={styles.colInput}
-                  value={set.weight != null ? String(set.weight) : ""}
-                  onChangeText={(v) => handleUpdate(set.id, "weight", v)}
-                  placeholder="-"
-                  accessibilityLabel={`Set ${set.set_number} weight`}
-                />
-                <TextInput
-                  mode="outlined"
-                  dense
-                  keyboardType="numeric"
-                  style={styles.colInput}
-                  value={set.reps != null ? String(set.reps) : ""}
-                  onChangeText={(v) => handleUpdate(set.id, "reps", v)}
-                  placeholder="-"
-                  accessibilityLabel={`Set ${set.set_number} reps`}
-                />
-                <View style={styles.colCheck} accessible accessibilityLabel={`Mark set ${set.set_number} ${set.completed ? "incomplete" : "complete"}`} accessibilityRole="checkbox" accessibilityState={{ checked: set.completed }}>
-                  <Checkbox
-                    status={set.completed ? "checked" : "unchecked"}
-                    onPress={() => handleCheck(set)}
+                  <Text
+                    variant="bodyMedium"
+                    style={[styles.colSet, { color: theme.colors.onSurface }]}
+                  >
+                    {set.set_number}
+                  </Text>
+                  <Text
+                    variant="bodySmall"
+                    style={[
+                      styles.colPrev,
+                      { color: theme.colors.onSurfaceVariant },
+                    ]}
+                  >
+                    {set.previous}
+                  </Text>
+                  <TextInput
+                    mode="outlined"
+                    dense
+                    keyboardType="numeric"
+                    style={styles.colInput}
+                    value={set.weight != null ? String(set.weight) : ""}
+                    onChangeText={(v) => handleUpdate(set.id, "weight", v)}
+                    placeholder="-"
+                    accessibilityLabel={`Set ${set.set_number} weight`}
+                  />
+                  <TextInput
+                    mode="outlined"
+                    dense
+                    keyboardType="numeric"
+                    style={styles.colInput}
+                    value={set.reps != null ? String(set.reps) : ""}
+                    onChangeText={(v) => handleUpdate(set.id, "reps", v)}
+                    placeholder="-"
+                    accessibilityLabel={`Set ${set.set_number} reps`}
+                  />
+                  <View style={styles.colCheck} accessible accessibilityLabel={`Mark set ${set.set_number} ${set.completed ? "incomplete" : "complete"}`} accessibilityRole="checkbox" accessibilityState={{ checked: set.completed }}>
+                    <Checkbox
+                      status={set.completed ? "checked" : "unchecked"}
+                      onPress={() => handleCheck(set)}
+                    />
+                  </View>
+                  {isPR(set) && (
+                    <Chip
+                      compact
+                      icon="trophy"
+                      style={{ backgroundColor: theme.colors.tertiaryContainer }}
+                      textStyle={styles.prChipText}
+                      accessibilityLabel="New personal record"
+                      accessibilityRole="text"
+                    >
+                      PR
+                    </Chip>
+                  )}
+                  <IconButton
+                    icon={set.notes ? "note-text" : "note-text-outline"}
+                    size={18}
+                    onPress={() => toggleNotes(set.id)}
+                    accessibilityLabel="Set notes"
                   />
                 </View>
-                {isPR(set) && (
-                  <Chip
-                    compact
-                    icon="trophy"
-                    style={{ backgroundColor: theme.colors.tertiaryContainer }}
-                    textStyle={styles.prChipText}
-                    accessibilityLabel="New personal record"
-                    accessibilityRole="text"
+
+                {/* RPE chips — visible only for completed sets */}
+                {set.completed && (
+                  <View
+                    style={styles.rpeRow}
+                    accessibilityLabel="Rate of perceived exertion"
+                    accessibilityRole="radiogroup"
                   >
-                    PR
-                  </Chip>
+                    {RPE_CHIPS.map((val) => {
+                      const selected = set.rpe === val;
+                      return (
+                        <Pressable
+                          key={val}
+                          onPress={() => handleRPE(set, val)}
+                          onLongPress={() => setHalfStep({ setId: set.id, base: val })}
+                          style={[
+                            styles.rpeChip,
+                            { borderColor: rpeColor(val) },
+                            selected && { backgroundColor: rpeColor(val) },
+                          ]}
+                          accessibilityRole="radio"
+                          accessibilityState={{ selected }}
+                          accessibilityLabel={`RPE ${val} ${RPE_LABELS[val]}`}
+                        >
+                          <Text style={[
+                            styles.rpeChipText,
+                            { color: selected ? semantic.onSemantic : rpeColor(val) },
+                          ]}>
+                            {val} {RPE_LABELS[val]}
+                          </Text>
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+                )}
+
+                {/* Half-step picker overlay */}
+                {halfStep && halfStep.setId === set.id && (
+                  <View style={[styles.halfStepRow, { backgroundColor: theme.colors.surfaceVariant }]}>
+                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant, marginRight: 8, fontSize: 12 }}>
+                      Half-step:
+                    </Text>
+                    {halfStep.base > 6 && (
+                      <Pressable
+                        onPress={() => handleHalfStep(set.id, halfStep.base - 0.5)}
+                        style={[styles.halfChip, { borderColor: rpeColor(halfStep.base - 0.5) }]}
+                        accessibilityLabel={`RPE ${halfStep.base - 0.5}`}
+                      >
+                        <Text style={[styles.rpeChipText, { color: rpeColor(halfStep.base - 0.5) }]}>
+                          {halfStep.base - 0.5}
+                        </Text>
+                      </Pressable>
+                    )}
+                    {halfStep.base < 10 && (
+                      <Pressable
+                        onPress={() => handleHalfStep(set.id, halfStep.base + 0.5)}
+                        style={[styles.halfChip, { borderColor: rpeColor(halfStep.base + 0.5) }]}
+                        accessibilityLabel={`RPE ${halfStep.base + 0.5}`}
+                      >
+                        <Text style={[styles.rpeChipText, { color: rpeColor(halfStep.base + 0.5) }]}>
+                          {halfStep.base + 0.5}
+                        </Text>
+                      </Pressable>
+                    )}
+                    <Pressable
+                      onPress={() => setHalfStep(null)}
+                      style={[styles.halfChip, { borderColor: theme.colors.outline }]}
+                      accessibilityLabel="Cancel half-step picker"
+                    >
+                      <Text style={[styles.rpeChipText, { color: theme.colors.onSurfaceVariant }]}>✕</Text>
+                    </Pressable>
+                  </View>
+                )}
+
+                {/* RPE badge for half-step values */}
+                {set.completed && set.rpe != null && !Number.isInteger(set.rpe) && (
+                  <View style={styles.rpeBadgeRow}>
+                    <View style={[styles.rpeBadge, { backgroundColor: rpeColor(set.rpe) }]}>
+                      <Text style={{ color: semantic.onSemantic, fontSize: 12, fontWeight: "600" }}>
+                        RPE {set.rpe}
+                      </Text>
+                    </View>
+                  </View>
+                )}
+
+                {/* Notes input */}
+                {notesOpen[set.id] && (
+                  <View style={styles.notesContainer}>
+                    <TextInput
+                      mode="outlined"
+                      dense
+                      placeholder="Add notes..."
+                      value={set.notes}
+                      onChangeText={(v) => handleNotes(set.id, v)}
+                      maxLength={200}
+                      multiline
+                      style={styles.notesInput}
+                      accessibilityLabel="Set notes"
+                    />
+                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant, textAlign: "right", fontSize: 12 }}>
+                      {set.notes.length}/200
+                    </Text>
+                  </View>
                 )}
               </View>
             ))}
@@ -533,6 +689,7 @@ export default function ActiveSession() {
           Cancel Workout
         </Button>
       </ScrollView>
+      </KeyboardAvoidingView>
       <Snackbar
         visible={!!snackbar}
         onDismiss={() => setSnackbar("")}
@@ -625,5 +782,58 @@ const styles = StyleSheet.create({
     padding: 16,
     borderRadius: 12,
     marginBottom: 16,
+  },
+  rpeRow: {
+    flexDirection: "row",
+    gap: 6,
+    paddingHorizontal: 4,
+    paddingVertical: 6,
+    flexWrap: "wrap",
+  },
+  rpeChip: {
+    borderWidth: 1.5,
+    borderRadius: 16,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    minWidth: 56,
+    alignItems: "center",
+  },
+  rpeChipText: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  halfStepRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    borderRadius: 8,
+    marginHorizontal: 4,
+    marginBottom: 4,
+    gap: 8,
+  },
+  halfChip: {
+    borderWidth: 1.5,
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    alignItems: "center",
+  },
+  rpeBadgeRow: {
+    paddingHorizontal: 4,
+    paddingBottom: 4,
+  },
+  rpeBadge: {
+    alignSelf: "flex-start",
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  notesContainer: {
+    paddingHorizontal: 4,
+    paddingBottom: 6,
+  },
+  notesInput: {
+    fontSize: 13,
   },
 });

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -44,7 +44,7 @@ import {
   advanceProgram,
 } from "../../lib/programs";
 import type { WorkoutSession, WorkoutSet } from "../../lib/types";
-import { semantic } from "../../constants/theme";
+import { rpeColor, rpeText } from "../../lib/rpe";
 
 type SetWithMeta = WorkoutSet & {
   exercise_name?: string;
@@ -62,12 +62,6 @@ const RPE_CHIPS = [6, 7, 8, 9, 10] as const;
 const RPE_LABELS: Record<number, string> = {
   6: "Easy", 7: "Easy", 8: "Mod", 9: "Hard", 10: "Max",
 };
-
-function rpeColor(val: number): string {
-  if (val <= 7) return semantic.beginner;
-  if (val <= 8) return semantic.intermediate;
-  return semantic.advanced;
-}
 
 export default function ActiveSession() {
   const theme = useTheme();
@@ -88,6 +82,7 @@ export default function ActiveSession() {
   const prHapticFired = useRef<Set<string>>(new Set());
   const [snackbar, setSnackbar] = useState("");
   const [notesOpen, setNotesOpen] = useState<Record<string, boolean>>({});
+  const [notesDraft, setNotesDraft] = useState<Record<string, string>>({});
   const [halfStep, setHalfStep] = useState<{ setId: string; base: number } | null>(null);
 
   const load = useCallback(async () => {
@@ -282,6 +277,7 @@ export default function ActiveSession() {
 
   const handleNotes = async (setId: string, text: string) => {
     await updateSetNotes(setId, text);
+    setNotesDraft((prev) => { const next = { ...prev }; delete next[setId]; return next; });
     await load();
   };
 
@@ -564,7 +560,7 @@ export default function ActiveSession() {
                         >
                           <Text style={[
                             styles.rpeChipText,
-                            { color: selected ? semantic.onSemantic : rpeColor(val) },
+                            { color: selected ? rpeText(val) : rpeColor(val) },
                           ]}>
                             {val} {RPE_LABELS[val]}
                           </Text>
@@ -616,7 +612,7 @@ export default function ActiveSession() {
                 {set.completed && set.rpe != null && !Number.isInteger(set.rpe) && (
                   <View style={styles.rpeBadgeRow}>
                     <View style={[styles.rpeBadge, { backgroundColor: rpeColor(set.rpe) }]}>
-                      <Text style={{ color: semantic.onSemantic, fontSize: 12, fontWeight: "600" }}>
+                      <Text style={{ color: rpeText(set.rpe), fontSize: 12, fontWeight: "600" }}>
                         RPE {set.rpe}
                       </Text>
                     </View>
@@ -630,15 +626,16 @@ export default function ActiveSession() {
                       mode="outlined"
                       dense
                       placeholder="Add notes..."
-                      value={set.notes}
-                      onChangeText={(v) => handleNotes(set.id, v)}
+                      value={notesDraft[set.id] ?? set.notes}
+                      onChangeText={(v) => setNotesDraft((prev) => ({ ...prev, [set.id]: v }))}
+                      onBlur={() => handleNotes(set.id, notesDraft[set.id] ?? set.notes)}
                       maxLength={200}
                       multiline
                       style={styles.notesInput}
                       accessibilityLabel="Set notes"
                     />
                     <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant, textAlign: "right", fontSize: 12 }}>
-                      {set.notes.length}/200
+                      {(notesDraft[set.id] ?? set.notes).length}/200
                     </Text>
                   </View>
                 )}
@@ -794,7 +791,7 @@ const styles = StyleSheet.create({
     borderWidth: 1.5,
     borderRadius: 16,
     paddingHorizontal: 10,
-    paddingVertical: 6,
+    paddingVertical: 14,
     minWidth: 56,
     alignItems: "center",
   },

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -5,8 +5,15 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { getSessionById, getSessionPRs, getSessionSets } from "../../../lib/db";
 import type { WorkoutSession, WorkoutSet } from "../../../lib/types";
+import { semantic } from "../../../constants/theme";
 
 type SetWithName = WorkoutSet & { exercise_name?: string };
+
+function rpeColor(val: number): string {
+  if (val <= 7) return semantic.beginner;
+  if (val <= 8) return semantic.intermediate;
+  return semantic.advanced;
+}
 
 type ExerciseGroup = {
   exercise_id: string;
@@ -221,19 +228,36 @@ export default function SessionDetail() {
             {group.sets
               .filter((s) => s.completed)
               .map((set) => (
-                <View key={set.id} style={styles.setRow}>
-                  <Text
-                    variant="bodyMedium"
-                    style={[styles.setNum, { color: theme.colors.onSurface }]}
-                  >
-                    Set {set.set_number}
-                  </Text>
-                  <Text
-                    variant="bodyMedium"
-                    style={{ color: theme.colors.onSurface }}
-                  >
-                    {set.weight ?? 0} × {set.reps ?? 0}
-                  </Text>
+                <View key={set.id}>
+                  <View style={styles.setRow}>
+                    <Text
+                      variant="bodyMedium"
+                      style={[styles.setNum, { color: theme.colors.onSurface }]}
+                    >
+                      Set {set.set_number}
+                    </Text>
+                    <Text
+                      variant="bodyMedium"
+                      style={{ color: theme.colors.onSurface }}
+                    >
+                      {set.weight ?? 0} × {set.reps ?? 0}
+                    </Text>
+                    {set.rpe != null && (
+                      <View style={[styles.rpeBadge, { backgroundColor: rpeColor(set.rpe) }]}>
+                        <Text style={{ color: semantic.onSemantic, fontSize: 12, fontWeight: "600" }}>
+                          RPE {set.rpe}
+                        </Text>
+                      </View>
+                    )}
+                  </View>
+                  {set.notes ? (
+                    <Text
+                      variant="bodySmall"
+                      style={[styles.setNote, { color: theme.colors.onSurfaceVariant }]}
+                    >
+                      {set.notes}
+                    </Text>
+                  ) : null}
                 </View>
               ))}
             <Divider style={styles.divider} />
@@ -310,11 +334,24 @@ const styles = StyleSheet.create({
   setRow: {
     flexDirection: "row",
     justifyContent: "space-between",
+    alignItems: "center",
     paddingVertical: 6,
     paddingHorizontal: 8,
   },
   setNum: {
     width: 60,
+  },
+  rpeBadge: {
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    marginLeft: 8,
+  },
+  setNote: {
+    fontStyle: "italic",
+    paddingHorizontal: 8,
+    paddingBottom: 4,
+    fontSize: 12,
   },
   divider: {
     marginTop: 8,

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -5,15 +5,9 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { getSessionById, getSessionPRs, getSessionSets } from "../../../lib/db";
 import type { WorkoutSession, WorkoutSet } from "../../../lib/types";
-import { semantic } from "../../../constants/theme";
+import { rpeColor, rpeText } from "../../../lib/rpe";
 
 type SetWithName = WorkoutSet & { exercise_name?: string };
-
-function rpeColor(val: number): string {
-  if (val <= 7) return semantic.beginner;
-  if (val <= 8) return semantic.intermediate;
-  return semantic.advanced;
-}
 
 type ExerciseGroup = {
   exercise_id: string;
@@ -244,7 +238,7 @@ export default function SessionDetail() {
                     </Text>
                     {set.rpe != null && (
                       <View style={[styles.rpeBadge, { backgroundColor: rpeColor(set.rpe) }]}>
-                        <Text style={{ color: semantic.onSemantic, fontSize: 12, fontWeight: "600" }}>
+                        <Text style={{ color: rpeText(set.rpe), fontSize: 12, fontWeight: "600" }}>
                           RPE {set.rpe}
                         </Text>
                       </View>

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -26,6 +26,9 @@ export const semantic = {
   intermediate: "#FF9800",
   advanced: "#F44336",
   onSemantic: "#ffffff",
+  onBeginner: "#ffffff",
+  onIntermediate: "#000000",
+  onAdvanced: "#ffffff",
 };
 
 export const light = {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -207,6 +207,21 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
     );
   }
 
+  // Migration: add rpe and notes columns to workout_sets
+  const setCols = await database.getAllAsync<{ name: string }>(
+    "PRAGMA table_info(workout_sets)"
+  );
+  if (!setCols.some((c) => c.name === "rpe")) {
+    await database.execAsync(
+      "ALTER TABLE workout_sets ADD COLUMN rpe REAL DEFAULT NULL"
+    );
+  }
+  if (!setCols.some((c) => c.name === "notes")) {
+    await database.execAsync(
+      "ALTER TABLE workout_sets ADD COLUMN notes TEXT DEFAULT ''"
+    );
+  }
+
   // Migration: index for exercise history query performance
   await database.execAsync(
     "CREATE INDEX IF NOT EXISTS idx_workout_sets_exercise ON workout_sets(exercise_id)"
@@ -601,6 +616,8 @@ type SetRow = {
   reps: number | null;
   completed: number;
   completed_at: number | null;
+  rpe: number | null;
+  notes: string;
   exercise_name: string | null;
 };
 
@@ -625,6 +642,8 @@ export async function getSessionSets(
     reps: r.reps,
     completed: r.completed === 1,
     completed_at: r.completed_at,
+    rpe: r.rpe ?? null,
+    notes: r.notes ?? "",
     exercise_name: r.exercise_name ?? undefined,
   }));
 }
@@ -658,6 +677,8 @@ export async function addSet(
     reps: null,
     completed: false,
     completed_at: null,
+    rpe: null,
+    notes: "",
   };
 }
 
@@ -692,6 +713,22 @@ export async function uncompleteSet(id: string): Promise<void> {
 export async function deleteSet(id: string): Promise<void> {
   const database = await getDatabase();
   await database.runAsync("DELETE FROM workout_sets WHERE id = ?", [id]);
+}
+
+export async function updateSetRPE(id: string, rpe: number | null): Promise<void> {
+  const database = await getDatabase();
+  await database.runAsync(
+    "UPDATE workout_sets SET rpe = ? WHERE id = ?",
+    [rpe, id]
+  );
+}
+
+export async function updateSetNotes(id: string, notes: string): Promise<void> {
+  const database = await getDatabase();
+  await database.runAsync(
+    "UPDATE workout_sets SET notes = ? WHERE id = ?",
+    [notes, id]
+  );
 }
 
 export async function getPreviousSets(
@@ -734,6 +771,17 @@ export async function getSessionSetCount(
     [sessionId]
   );
   return row?.count ?? 0;
+}
+
+export async function getSessionAvgRPE(
+  sessionId: string
+): Promise<number | null> {
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{ val: number | null }>(
+    "SELECT AVG(rpe) AS val FROM workout_sets WHERE session_id = ? AND completed = 1 AND rpe IS NOT NULL",
+    [sessionId]
+  );
+  return row?.val ?? null;
 }
 
 // --------------- History & Calendar ---------------
@@ -913,7 +961,7 @@ export async function importData(data: {
   templates?: { id: string; name: string; created_at: number; updated_at: number }[];
   template_exercises?: { id: string; template_id: string; exercise_id: string; position: number; target_sets: number; target_reps: string; rest_seconds: number }[];
   sessions?: { id: string; template_id: string | null; name: string; started_at: number; completed_at: number | null; duration_seconds: number | null; notes: string }[];
-  sets?: { id: string; session_id: string; exercise_id: string; set_number: number; weight: number | null; reps: number | null; completed: number; completed_at: number | null }[];
+  sets?: { id: string; session_id: string; exercise_id: string; set_number: number; weight: number | null; reps: number | null; completed: number; completed_at: number | null; set_rpe?: number | null; set_notes?: string }[];
   food_entries?: { id: string; name: string; calories: number; protein: number; carbs: number; fat: number; serving_size: string; is_favorite: number; created_at: number }[];
   daily_log?: { id: string; food_entry_id: string; date: string; meal: string; servings: number; logged_at: number }[];
   macro_targets?: { id: string; calories: number; protein: number; carbs: number; fat: number; updated_at: number }[];
@@ -968,8 +1016,8 @@ export async function importData(data: {
     if (data.sets) {
       for (const s of data.sets) {
         const r = await database.runAsync(
-          "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-          [s.id, s.session_id, s.exercise_id, s.set_number, s.weight, s.reps, s.completed, s.completed_at]
+          "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          [s.id, s.session_id, s.exercise_id, s.set_number, s.weight, s.reps, s.completed, s.completed_at, s.set_rpe ?? null, s.set_notes ?? ""]
         );
         inserted += r.changes;
       }
@@ -1253,6 +1301,8 @@ export type WorkoutCSVRow = {
   reps: number | null;
   duration_seconds: number | null;
   notes: string;
+  set_rpe: number | null;
+  set_notes: string;
 };
 
 export type NutritionCSVRow = {
@@ -1276,7 +1326,9 @@ export async function getWorkoutCSVData(since: number): Promise<WorkoutCSVRow[]>
        wset.weight,
        wset.reps,
        ws.duration_seconds,
-       ws.notes
+       ws.notes,
+       wset.rpe AS set_rpe,
+       wset.notes AS set_notes
      FROM workout_sessions ws
      JOIN workout_sets wset ON wset.session_id = ws.id
      LEFT JOIN exercises e ON e.id = wset.exercise_id
@@ -1619,6 +1671,7 @@ export type ExerciseSession = {
   total_reps: number;
   set_count: number;
   volume: number;
+  avg_rpe: number | null;
 };
 
 export type ExerciseRecords = {
@@ -1644,7 +1697,8 @@ export async function getExerciseHistory(
             MAX(ws.reps) AS max_reps,
             SUM(ws.reps) AS total_reps,
             COUNT(ws.id) AS set_count,
-            SUM(ws.weight * ws.reps) AS volume
+            SUM(ws.weight * ws.reps) AS volume,
+            AVG(CASE WHEN ws.rpe IS NOT NULL THEN ws.rpe END) AS avg_rpe
      FROM workout_sets ws
      JOIN workout_sessions wss ON ws.session_id = wss.id
      WHERE ws.exercise_id = ?

--- a/lib/rpe.ts
+++ b/lib/rpe.ts
@@ -1,0 +1,13 @@
+import { semantic } from "../constants/theme";
+
+export function rpeColor(val: number): string {
+  if (val <= 7) return semantic.beginner;
+  if (val <= 8) return semantic.intermediate;
+  return semantic.advanced;
+}
+
+export function rpeText(val: number): string {
+  if (val <= 7) return semantic.onBeginner;
+  if (val <= 8) return semantic.onIntermediate;
+  return semantic.onAdvanced;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -165,6 +165,8 @@ export type WorkoutSet = {
   reps: number | null;
   completed: boolean;
   completed_at: number | null;
+  rpe: number | null;
+  notes: string;
 };
 
 // --------------- Nutrition ---------------


### PR DESCRIPTION
## Summary

Add per-set RPE (Rate of Perceived Exertion) tracking and notes to workout sessions. RPE is the industry-standard intensity metric for lifters. Per-set notes capture form cues, injuries, or equipment details.

## Changes

- **Schema migration**: Add `rpe` (REAL, nullable) and `notes` (TEXT) columns to `workout_sets` via idempotent ALTER TABLE
- **DB functions**: Dedicated `updateSetRPE()` and `updateSetNotes()` functions, `getSessionAvgRPE()`, updated `getExerciseHistory()` with avg_rpe
- **Session screen**: 5 whole-number RPE chips (6-10) below completed sets with long-press for half-step values, notes icon per set with expandable TextInput (max 200 chars, character counter)
- **Session detail**: Read-only RPE badges (colored) and italic notes per set
- **Exercise history**: Avg RPE badge per session in history list
- **Home screen**: Avg RPE shown in recent workouts list
- **CSV export**: New `set_rpe` and `set_notes` columns
- **Import**: Backward-compatible handling of new columns

## Accessibility

- RPE chips: `accessibilityRole="radio"`, `accessibilityState`, text label suffixes (Easy/Mod/Hard/Max) for non-color differentiation
- Notes input: `accessibilityLabel="Set notes"`
- All text >= 12px font size
- Semantic color tokens (no hardcoded hex)
- Haptic feedback on RPE selection
- KeyboardAvoidingView for notes input

## Testing

- TypeScript typecheck passes with zero errors
- `npm install --legacy-peer-deps` succeeds
- No regressions in existing functionality

## Issue

Resolves BLD-14