### PR TITLE
feat: Superset & Circuit Training Support (BLD-6)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -20,7 +20,7 @@ import { getErrorCount, clearErrorLog, generateReport } from "../../lib/errors";
 import { csvEscape } from "../../lib/csv";
 
 function workoutCSV(rows: WorkoutCSVRow[]): string {
-  const header = "date,exercise,set_number,weight,reps,duration_seconds,notes,set_rpe,set_notes";
+  const header = "date,exercise,set_number,weight,reps,duration_seconds,notes,set_rpe,set_notes,link_id";
   const lines = rows.map((r) =>
     [
       csvEscape(r.date),
@@ -32,6 +32,7 @@ function workoutCSV(rows: WorkoutCSVRow[]): string {
       csvEscape(r.notes),
       csvEscape(r.set_rpe),
       csvEscape(r.set_notes),
+      csvEscape(r.link_id),
     ].join(",")
   );
   return [header, ...lines].join("\n");

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   AccessibilityInfo,
@@ -88,6 +88,19 @@ export default function ActiveSession() {
   const [halfStep, setHalfStep] = useState<{ setId: string; base: number } | null>(null);
   const [nextHint, setNextHint] = useState<string | null>(null);
   const hintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const linkIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const g of groups) {
+      if (g.link_id && !ids.includes(g.link_id)) ids.push(g.link_id);
+    }
+    return ids;
+  }, [groups]);
+
+  const palette = useMemo(
+    () => [theme.colors.tertiary, theme.colors.secondary, theme.colors.primary, theme.colors.error, theme.colors.inversePrimary],
+    [theme],
+  );
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -284,7 +297,7 @@ export default function ActiveSession() {
           setNextHint(`Next: ${next.name}`);
           AccessibilityInfo.announceForAccessibility(`Next: ${next.name}`);
           if (hintTimer.current) clearTimeout(hintTimer.current);
-          hintTimer.current = setTimeout(() => setNextHint(null), 2000);
+          hintTimer.current = setTimeout(() => setNextHint(null), 1500);
         } else {
           // End of round: start rest timer with MAX(rest_seconds)
           setNextHint(null);
@@ -491,17 +504,19 @@ export default function ActiveSession() {
           const completedRounds = group.link_id
             ? Math.min(...linked.map((g) => g.sets.filter((s) => s.completed).length))
             : 0;
+          const groupColorIdx = group.link_id ? linkIds.indexOf(group.link_id) : -1;
+          const groupColor = groupColorIdx >= 0 ? palette[groupColorIdx % palette.length] : undefined;
 
           return (
           <View key={group.exercise_id} style={styles.group}>
             {/* Linked group header */}
             {isFirstInLink && group.link_id && (
               <View
-                style={[styles.linkGroupHeader, { borderLeftColor: theme.colors.tertiary, borderLeftWidth: 4 }]}
+                style={[styles.linkGroupHeader, { borderLeftColor: groupColor, borderLeftWidth: 4 }]}
                 accessibilityRole="header"
                 accessibilityLabel={`Round ${completedRounds + 1} of ${totalRounds}`}
               >
-                <Text variant="labelMedium" style={{ color: theme.colors.tertiary, fontWeight: "700" }}>
+                <Text variant="labelMedium" style={{ color: groupColor, fontWeight: "700" }}>
                   {linked.length >= 3 ? "Circuit" : "Superset"} — Round {completedRounds + 1}/{totalRounds}
                 </Text>
                 <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant, marginLeft: 8 }}>
@@ -510,7 +525,7 @@ export default function ActiveSession() {
               </View>
             )}
 
-            <View style={group.link_id ? { borderLeftWidth: 4, borderLeftColor: theme.colors.tertiary, paddingLeft: 8 } : undefined}>
+            <View style={group.link_id ? { borderLeftWidth: 4, borderLeftColor: groupColor, paddingLeft: 8 } : undefined}>
             <Text
               variant="titleMedium"
               style={[styles.groupTitle, { color: theme.colors.primary }]}

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -33,6 +33,7 @@ import {
   getTemplateById,
   getPreviousSets,
   getRestSecondsForExercise,
+  getRestSecondsForLink,
   uncompleteSet,
   updateSet,
   updateSetRPE,
@@ -55,6 +56,7 @@ type ExerciseGroup = {
   exercise_id: string;
   name: string;
   sets: SetWithMeta[];
+  link_id: string | null;
 };
 
 const RPE_CHIPS = [6, 7, 8, 9, 10] as const;
@@ -84,6 +86,8 @@ export default function ActiveSession() {
   const [notesOpen, setNotesOpen] = useState<Record<string, boolean>>({});
   const [notesDraft, setNotesDraft] = useState<Record<string, string>>({});
   const [halfStep, setHalfStep] = useState<{ setId: string; base: number } | null>(null);
+  const [nextHint, setNextHint] = useState<string | null>(null);
+  const hintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -121,6 +125,7 @@ export default function ActiveSession() {
           exercise_id: s.exercise_id,
           name: s.exercise_name ?? "Unknown",
           sets: [],
+          link_id: s.link_id ?? null,
         });
       }
       const prev = prevCache[s.exercise_id]?.find(
@@ -153,8 +158,14 @@ export default function ActiveSession() {
         const tpl = await getTemplateById(templateId);
         if (tpl?.exercises) {
           for (const te of tpl.exercises) {
-            for (let i = 1; i <= te.target_sets; i++) {
-              await addSet(id, te.exercise_id, i);
+            if (te.link_id) {
+              for (let i = 1; i <= te.target_sets; i++) {
+                await addSet(id, te.exercise_id, i, te.link_id, i);
+              }
+            } else {
+              for (let i = 1; i <= te.target_sets; i++) {
+                await addSet(id, te.exercise_id, i);
+              }
             }
           }
         }
@@ -220,6 +231,21 @@ export default function ActiveSession() {
     }, 1000);
   }, [id]);
 
+  const startRestWithDuration = useCallback((secs: number) => {
+    if (restRef.current) clearInterval(restRef.current);
+    setRest(secs);
+    restRef.current = setInterval(() => {
+      setRest((prev) => {
+        if (prev <= 1) {
+          if (restRef.current) clearInterval(restRef.current);
+          restRef.current = null;
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, []);
+
   const dismissRest = () => {
     if (restRef.current) clearInterval(restRef.current);
     restRef.current = null;
@@ -237,6 +263,7 @@ export default function ActiveSession() {
   useEffect(() => {
     return () => {
       if (restRef.current) clearInterval(restRef.current);
+      if (hintTimer.current) clearTimeout(hintTimer.current);
     };
   }, []);
 
@@ -245,7 +272,28 @@ export default function ActiveSession() {
       await uncompleteSet(set.id);
     } else {
       await completeSet(set.id);
-      startRest(set.exercise_id);
+
+      if (set.link_id) {
+        // Find linked group exercises
+        const linked = groups.filter((g) => g.link_id === set.link_id);
+        const idx = linked.findIndex((g) => g.exercise_id === set.exercise_id);
+        const next = idx >= 0 && idx < linked.length - 1 ? linked[idx + 1] : null;
+
+        if (next) {
+          // Mid-round: show "Next" hint, no rest timer
+          setNextHint(`Next: ${next.name}`);
+          AccessibilityInfo.announceForAccessibility(`Next: ${next.name}`);
+          if (hintTimer.current) clearTimeout(hintTimer.current);
+          hintTimer.current = setTimeout(() => setNextHint(null), 2000);
+        } else {
+          // End of round: start rest timer with MAX(rest_seconds)
+          setNextHint(null);
+          const secs = await getRestSecondsForLink(id!, set.link_id);
+          startRestWithDuration(secs);
+        }
+      } else {
+        startRest(set.exercise_id);
+      }
     }
     await load();
   };
@@ -426,8 +474,43 @@ export default function ActiveSession() {
           </View>
         )}
 
-        {groups.map((group) => (
+        {/* Next exercise hint for supersets */}
+        {nextHint && (
+          <View style={[styles.nextBanner, { backgroundColor: theme.colors.secondaryContainer }]} accessibilityLiveRegion="polite">
+            <Text variant="titleSmall" style={{ color: theme.colors.onSecondaryContainer, fontWeight: "700" }}>
+              {nextHint}
+            </Text>
+          </View>
+        )}
+
+        {groups.map((group) => {
+          const linked = group.link_id ? groups.filter((g) => g.link_id === group.link_id) : [];
+          const linkIdx = group.link_id ? linked.findIndex((g) => g.exercise_id === group.exercise_id) : -1;
+          const isFirstInLink = linkIdx === 0;
+          const totalRounds = group.link_id ? Math.max(...linked.map((g) => g.sets.length)) : 0;
+          const completedRounds = group.link_id
+            ? Math.min(...linked.map((g) => g.sets.filter((s) => s.completed).length))
+            : 0;
+
+          return (
           <View key={group.exercise_id} style={styles.group}>
+            {/* Linked group header */}
+            {isFirstInLink && group.link_id && (
+              <View
+                style={[styles.linkGroupHeader, { borderLeftColor: theme.colors.tertiary, borderLeftWidth: 4 }]}
+                accessibilityRole="header"
+                accessibilityLabel={`Round ${completedRounds + 1} of ${totalRounds}`}
+              >
+                <Text variant="labelMedium" style={{ color: theme.colors.tertiary, fontWeight: "700" }}>
+                  {linked.length >= 3 ? "Circuit" : "Superset"} — Round {completedRounds + 1}/{totalRounds}
+                </Text>
+                <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant, marginLeft: 8 }}>
+                  Rest after round
+                </Text>
+              </View>
+            )}
+
+            <View style={group.link_id ? { borderLeftWidth: 4, borderLeftColor: theme.colors.tertiary, paddingLeft: 8 } : undefined}>
             <Text
               variant="titleMedium"
               style={[styles.groupTitle, { color: theme.colors.primary }]}
@@ -478,7 +561,7 @@ export default function ActiveSession() {
                     variant="bodyMedium"
                     style={[styles.colSet, { color: theme.colors.onSurface }]}
                   >
-                    {set.set_number}
+                    {set.round ? `R${set.round}` : set.set_number}
                   </Text>
                   <Text
                     variant="bodySmall"
@@ -652,9 +735,11 @@ export default function ActiveSession() {
             >
               Add Set
             </Button>
+            </View>
             <Divider style={styles.divider} />
           </View>
-        ))}
+          );
+        })}
 
         <Button
           mode="outlined"
@@ -779,6 +864,20 @@ const styles = StyleSheet.create({
     padding: 16,
     borderRadius: 12,
     marginBottom: 16,
+  },
+  nextBanner: {
+    alignItems: "center",
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  linkGroupHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    marginBottom: 4,
+    borderRadius: 4,
   },
   rpeRow: {
     flexDirection: "row",

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
 import { Card, Divider, Text, useTheme } from "react-native-paper";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
@@ -22,6 +22,19 @@ export default function SessionDetail() {
   const [session, setSession] = useState<WorkoutSession | null>(null);
   const [groups, setGroups] = useState<ExerciseGroup[]>([]);
   const [prs, setPrs] = useState<{ exercise_id: string; name: string; weight: number; previous_max: number }[]>([]);
+
+  const linkIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const g of groups) {
+      if (g.link_id && !ids.includes(g.link_id)) ids.push(g.link_id);
+    }
+    return ids;
+  }, [groups]);
+
+  const palette = useMemo(
+    () => [theme.colors.tertiary, theme.colors.secondary, theme.colors.primary, theme.colors.error, theme.colors.inversePrimary],
+    [theme],
+  );
 
   useEffect(() => {
     if (!id) return;
@@ -220,20 +233,22 @@ export default function SessionDetail() {
           const label = group.link_id
             ? linked.length >= 3 ? "Circuit" : "Superset"
             : "";
+          const groupColorIdx = group.link_id ? linkIds.indexOf(group.link_id) : -1;
+          const groupColor = groupColorIdx >= 0 ? palette[groupColorIdx % palette.length] : undefined;
 
           return (
           <View key={group.exercise_id} style={styles.group}>
             {isFirst && group.link_id && (
               <View
-                style={[styles.linkHeader, { borderLeftColor: theme.colors.tertiary }]}
+                style={[styles.linkHeader, { borderLeftColor: groupColor }]}
                 accessibilityLabel={`${label}: ${linked.map((g) => g.name).join(" and ")}`}
               >
-                <Text variant="labelMedium" style={{ color: theme.colors.tertiary, fontWeight: "700" }}>
+                <Text variant="labelMedium" style={{ color: groupColor, fontWeight: "700" }}>
                   {label}
                 </Text>
               </View>
             )}
-            <View style={group.link_id ? { borderLeftWidth: 4, borderLeftColor: theme.colors.tertiary, paddingLeft: 8 } : undefined}>
+            <View style={group.link_id ? { borderLeftWidth: 4, borderLeftColor: groupColor, paddingLeft: 8 } : undefined}>
             <Text
               variant="titleMedium"
               style={[styles.groupTitle, { color: theme.colors.primary }]}
@@ -277,7 +292,7 @@ export default function SessionDetail() {
               ))}
             </View>
             {isLast && group.link_id && (
-              <View style={{ height: 4, backgroundColor: theme.colors.tertiary, borderRadius: 2 }} />
+              <View style={{ height: 4, backgroundColor: groupColor, borderRadius: 2 }} />
             )}
             <Divider style={styles.divider} />
           </View>

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -13,6 +13,7 @@ type ExerciseGroup = {
   exercise_id: string;
   name: string;
   sets: SetWithName[];
+  link_id: string | null;
 };
 
 export default function SessionDetail() {
@@ -41,6 +42,7 @@ export default function SessionDetail() {
             exercise_id: s.exercise_id,
             name: s.exercise_name ?? "Unknown",
             sets: [],
+            link_id: s.link_id ?? null,
           });
         }
         map.get(s.exercise_id)!.sets.push(s);
@@ -211,8 +213,27 @@ export default function SessionDetail() {
         )}
 
         {/* Exercise breakdown */}
-        {groups.map((group) => (
+        {groups.map((group) => {
+          const linked = group.link_id ? groups.filter((g) => g.link_id === group.link_id) : [];
+          const isFirst = group.link_id ? linked[0]?.exercise_id === group.exercise_id : false;
+          const isLast = group.link_id ? linked[linked.length - 1]?.exercise_id === group.exercise_id : false;
+          const label = group.link_id
+            ? linked.length >= 3 ? "Circuit" : "Superset"
+            : "";
+
+          return (
           <View key={group.exercise_id} style={styles.group}>
+            {isFirst && group.link_id && (
+              <View
+                style={[styles.linkHeader, { borderLeftColor: theme.colors.tertiary }]}
+                accessibilityLabel={`${label}: ${linked.map((g) => g.name).join(" and ")}`}
+              >
+                <Text variant="labelMedium" style={{ color: theme.colors.tertiary, fontWeight: "700" }}>
+                  {label}
+                </Text>
+              </View>
+            )}
+            <View style={group.link_id ? { borderLeftWidth: 4, borderLeftColor: theme.colors.tertiary, paddingLeft: 8 } : undefined}>
             <Text
               variant="titleMedium"
               style={[styles.groupTitle, { color: theme.colors.primary }]}
@@ -228,7 +249,7 @@ export default function SessionDetail() {
                       variant="bodyMedium"
                       style={[styles.setNum, { color: theme.colors.onSurface }]}
                     >
-                      Set {set.set_number}
+                      {set.round ? `R${set.round}` : `Set ${set.set_number}`}
                     </Text>
                     <Text
                       variant="bodyMedium"
@@ -254,9 +275,14 @@ export default function SessionDetail() {
                   ) : null}
                 </View>
               ))}
+            </View>
+            {isLast && group.link_id && (
+              <View style={{ height: 4, backgroundColor: theme.colors.tertiary, borderRadius: 2 }} />
+            )}
             <Divider style={styles.divider} />
           </View>
-        ))}
+          );
+        })}
 
         {/* Notes */}
         {session.notes ? (
@@ -350,6 +376,12 @@ const styles = StyleSheet.create({
   divider: {
     marginTop: 8,
     marginBottom: 12,
+  },
+  linkHeader: {
+    borderLeftWidth: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    marginBottom: 4,
   },
   notes: {
     marginTop: 8,

--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -1,24 +1,46 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   FlatList,
+  Pressable,
   StyleSheet,
   View,
   type ListRenderItemInfo,
 } from "react-native";
 import {
   Button,
+  Checkbox,
   IconButton,
+  Snackbar,
   Text,
   useTheme,
 } from "react-native-paper";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import {
   addExerciseToTemplate,
+  createExerciseLink,
   getTemplateById,
   removeExerciseFromTemplate,
   reorderTemplateExercises,
+  unlinkExerciseGroup,
+  unlinkSingleExercise,
 } from "../../lib/db";
 import type { TemplateExercise, WorkoutTemplate } from "../../lib/types";
+
+const LINK_COLORS = [
+  "#6750A4", // tertiary
+  "#625B71", // secondary
+  "#7D5260", // pink
+  "#006C4C", // green
+  "#005DB8", // blue
+];
+
+function linkLabel(exercises: TemplateExercise[], linkId: string, idx: number): string {
+  const count = exercises.filter((e) => e.link_id === linkId).length;
+  const custom = exercises.find((e) => e.link_id === linkId && e.link_label)?.link_label;
+  if (custom) return custom;
+  const letter = String.fromCharCode(65 + idx);
+  return count >= 3 ? `Circuit ${letter}` : `Superset ${letter}`;
+}
 
 export default function EditTemplate() {
   const theme = useTheme();
@@ -30,6 +52,19 @@ export default function EditTemplate() {
   const [template, setTemplate] = useState<WorkoutTemplate | null>(null);
   const [exercises, setExercises] = useState<TemplateExercise[]>([]);
   const handled = useRef<string | null>(null);
+  const [selecting, setSelecting] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [snackbar, setSnackbar] = useState("");
+  const [undo, setUndo] = useState<(() => Promise<void>) | null>(null);
+  const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const linkIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const e of exercises) {
+      if (e.link_id && !ids.includes(e.link_id)) ids.push(e.link_id);
+    }
+    return ids;
+  }, [exercises]);
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -41,15 +76,8 @@ export default function EditTemplate() {
   }, [id]);
 
   useEffect(() => {
-    if (id) {
-      getTemplateById(id).then((tpl) => {
-        if (tpl) {
-          setTemplate(tpl);
-          setExercises(tpl.exercises ?? []);
-        }
-      });
-    }
-  }, [id]);
+    if (id) load();
+  }, [id, load]);
 
   useEffect(() => {
     if (!addExerciseId || !id || handled.current === addExerciseId) return;
@@ -58,6 +86,12 @@ export default function EditTemplate() {
       load()
     );
   }, [addExerciseId, id, exercises.length, load]);
+
+  useEffect(() => {
+    return () => {
+      if (undoTimer.current) clearTimeout(undoTimer.current);
+    };
+  }, []);
 
   const remove = useCallback(async (teId: string) => {
     await removeExerciseFromTemplate(teId);
@@ -74,53 +108,181 @@ export default function EditTemplate() {
     await load();
   }, [id, exercises, load]);
 
+  const toggleSelect = (teId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(teId)) next.delete(teId);
+      else next.add(teId);
+      return next;
+    });
+  };
+
+  const startSelection = (preselect?: string) => {
+    setSelecting(true);
+    setSelected(preselect ? new Set([preselect]) : new Set());
+  };
+
+  const cancelSelection = () => {
+    setSelecting(false);
+    setSelected(new Set());
+  };
+
+  const confirmLink = async () => {
+    if (!id || selected.size < 2) return;
+    const linkId = await createExerciseLink(id, [...selected]);
+    setSelecting(false);
+    setSelected(new Set());
+    await load();
+    setSnackbar("Exercises linked as superset");
+    setUndo(() => async () => {
+      await unlinkExerciseGroup(linkId);
+      await load();
+    });
+    if (undoTimer.current) clearTimeout(undoTimer.current);
+    undoTimer.current = setTimeout(() => {
+      setSnackbar("");
+      setUndo(null);
+    }, 5000);
+  };
+
+  const handleUnlink = async (linkId: string) => {
+    await unlinkExerciseGroup(linkId);
+    await load();
+    const prev = exercises.filter((e) => e.link_id === linkId).map((e) => e.id);
+    setSnackbar("Exercises unlinked");
+    setUndo(() => async () => {
+      if (id) {
+        await createExerciseLink(id, prev);
+        await load();
+      }
+    });
+    if (undoTimer.current) clearTimeout(undoTimer.current);
+    undoTimer.current = setTimeout(() => {
+      setSnackbar("");
+      setUndo(null);
+    }, 5000);
+  };
+
+  const handleUnlinkSingle = async (teId: string, linkId: string) => {
+    await unlinkSingleExercise(teId, linkId);
+    await load();
+  };
+
   const renderItem = useCallback(
-    ({ item, index }: ListRenderItemInfo<TemplateExercise>) => (
-      <View
-        style={[
-          styles.row,
-          {
-            backgroundColor: theme.colors.surface,
-            borderBottomColor: theme.colors.outlineVariant,
-          },
-        ]}
-      >
-        <View style={styles.info}>
-          <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>
-            {item.exercise?.name ?? "Unknown"}
-          </Text>
-          <Text
-            variant="bodySmall"
-            style={{ color: theme.colors.onSurfaceVariant }}
+    ({ item, index }: ListRenderItemInfo<TemplateExercise>) => {
+      const linkIdx = item.link_id ? linkIds.indexOf(item.link_id) : -1;
+      const color = linkIdx >= 0 ? LINK_COLORS[linkIdx % LINK_COLORS.length] : undefined;
+      const isFirst = item.link_id ? exercises.findIndex((e) => e.link_id === item.link_id) === index : false;
+      const isLast = item.link_id ? exercises.findLastIndex((e) => e.link_id === item.link_id) === index : false;
+      const groupLabel = item.link_id ? linkLabel(exercises, item.link_id, linkIdx) : "";
+
+      return (
+        <View>
+          {/* Link group header */}
+          {isFirst && item.link_id && (
+            <View
+              style={[styles.linkHeader, { borderLeftColor: color, borderLeftWidth: 4 }]}
+              accessibilityRole="header"
+              accessibilityLabel={`${groupLabel}: ${exercises
+                .filter((e) => e.link_id === item.link_id)
+                .map((e) => e.exercise?.name)
+                .join(" and ")}, ${exercises.filter((e) => e.link_id === item.link_id).length} exercises linked`}
+            >
+              <Text variant="labelMedium" style={{ color, flex: 1, fontWeight: "700" }}>
+                {groupLabel}
+              </Text>
+              <IconButton
+                icon="link-off"
+                size={18}
+                onPress={() => handleUnlink(item.link_id!)}
+                accessibilityLabel={`Unlink ${groupLabel}`}
+              />
+            </View>
+          )}
+
+          <Pressable
+            onLongPress={() => {
+              if (!selecting) startSelection(item.id);
+            }}
+            style={[
+              styles.row,
+              {
+                backgroundColor: theme.colors.surface,
+                borderBottomColor: theme.colors.outlineVariant,
+                borderLeftWidth: color ? 4 : 0,
+                borderLeftColor: color ?? "transparent",
+              },
+            ]}
+            accessibilityRole={selecting ? "checkbox" : "none"}
+            accessibilityState={selecting ? { selected: selected.has(item.id) } : undefined}
+            accessibilityLabel={selecting
+              ? `Select ${item.exercise?.name ?? "exercise"} for superset`
+              : undefined}
           >
-            {item.target_sets} × {item.target_reps} · {item.rest_seconds}s rest
-          </Text>
+            {selecting && (
+              <Checkbox
+                status={selected.has(item.id) ? "checked" : "unchecked"}
+                onPress={() => toggleSelect(item.id)}
+              />
+            )}
+            <View style={styles.info}>
+              <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>
+                {item.exercise?.name ?? "Unknown"}
+              </Text>
+              <Text
+                variant="bodySmall"
+                style={{ color: theme.colors.onSurfaceVariant }}
+              >
+                {item.target_sets} × {item.target_reps} · {item.rest_seconds}s rest
+              </Text>
+              {item.link_id && !selecting && (
+                <Text variant="labelSmall" style={{ color, marginTop: 2 }}>
+                  Linked — rotate in session
+                </Text>
+              )}
+            </View>
+            {!selecting && (
+              <View style={styles.actions}>
+                {item.link_id && (
+                  <IconButton
+                    icon="link-off"
+                    size={16}
+                    onPress={() => handleUnlinkSingle(item.id, item.link_id!)}
+                    accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"} from superset`}
+                  />
+                )}
+                <IconButton
+                  icon="arrow-up"
+                  size={18}
+                  onPress={() => move(index, -1)}
+                  disabled={index === 0}
+                  accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} up`}
+                />
+                <IconButton
+                  icon="arrow-down"
+                  size={18}
+                  onPress={() => move(index, 1)}
+                  disabled={index === exercises.length - 1}
+                  accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} down`}
+                />
+                <IconButton
+                  icon="close"
+                  size={18}
+                  onPress={() => remove(item.id)}
+                  accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"}`}
+                />
+              </View>
+            )}
+          </Pressable>
+
+          {/* Bottom border for link group */}
+          {isLast && item.link_id && (
+            <View style={{ height: 4, backgroundColor: color, borderRadius: 2, marginBottom: 4 }} />
+          )}
         </View>
-        <View style={styles.actions}>
-          <IconButton
-            icon="arrow-up"
-            size={18}
-            onPress={() => move(index, -1)}
-            disabled={index === 0}
-            accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} up`}
-          />
-          <IconButton
-            icon="arrow-down"
-            size={18}
-            onPress={() => move(index, 1)}
-            disabled={index === exercises.length - 1}
-            accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} down`}
-          />
-          <IconButton
-            icon="close"
-            size={18}
-            onPress={() => remove(item.id)}
-            accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"}`}
-          />
-        </View>
-      </View>
-    ),
-    [theme, exercises.length, move, remove]
+      );
+    },
+    [theme, exercises, linkIds, selecting, selected, move, remove]
   );
 
   if (!template) {
@@ -155,10 +317,41 @@ export default function EditTemplate() {
             Exercises ({exercises.length})
           </Text>
         </View>
+
+        {/* Selection mode toolbar */}
+        {selecting && (
+          <View style={[styles.selectionBar, { backgroundColor: theme.colors.primaryContainer }]}>
+            <Text variant="bodyMedium" style={{ color: theme.colors.onPrimaryContainer, flex: 1 }}
+              accessibilityLiveRegion="polite"
+            >
+              {selected.size} selected
+            </Text>
+            <Button
+              mode="contained"
+              compact
+              onPress={confirmLink}
+              disabled={selected.size < 2}
+              style={{ marginRight: 8 }}
+              accessibilityLabel="Link selected exercises"
+            >
+              Link
+            </Button>
+            <Button
+              mode="text"
+              compact
+              onPress={cancelSelection}
+              accessibilityLabel="Cancel selection"
+            >
+              Cancel
+            </Button>
+          </View>
+        )}
+
         <FlatList
           data={exercises}
           renderItem={renderItem}
           keyExtractor={(item) => item.id}
+          extraData={[selecting, selected, linkIds]}
           ListEmptyComponent={
             <View style={styles.empty}>
               <Text
@@ -171,6 +364,20 @@ export default function EditTemplate() {
           }
           style={styles.list}
         />
+
+        {!selecting && exercises.length >= 2 && (
+          <Button
+            mode="outlined"
+            icon="link-variant"
+            onPress={() => startSelection()}
+            style={styles.addBtn}
+            accessibilityLabel="Create superset"
+            accessibilityRole="button"
+          >
+            Create Superset
+          </Button>
+        )}
+
         <Button
           mode="outlined"
           icon="plus"
@@ -186,6 +393,22 @@ export default function EditTemplate() {
           Done
         </Button>
       </View>
+      <Snackbar
+        visible={!!snackbar}
+        onDismiss={() => {
+          setSnackbar("");
+          setUndo(null);
+        }}
+        duration={5000}
+        accessibilityLiveRegion="polite"
+        action={undo ? { label: "Undo", onPress: async () => {
+          if (undo) await undo();
+          setSnackbar("");
+          setUndo(null);
+        }} : undefined}
+      >
+        {snackbar}
+      </Snackbar>
     </>
   );
 }
@@ -212,6 +435,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderBottomWidth: StyleSheet.hairlineWidth,
+    minHeight: 56,
   },
   info: {
     flex: 1,
@@ -229,5 +453,19 @@ const styles = StyleSheet.create({
   empty: {
     alignItems: "center",
     paddingVertical: 24,
+  },
+  selectionBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 8,
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  linkHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    marginTop: 8,
   },
 });

--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -26,14 +26,6 @@ import {
 } from "../../lib/db";
 import type { TemplateExercise, WorkoutTemplate } from "../../lib/types";
 
-const LINK_COLORS = [
-  "#6750A4", // tertiary
-  "#625B71", // secondary
-  "#7D5260", // pink
-  "#006C4C", // green
-  "#005DB8", // blue
-];
-
 function linkLabel(exercises: TemplateExercise[], linkId: string, idx: number): string {
   const count = exercises.filter((e) => e.link_id === linkId).length;
   const custom = exercises.find((e) => e.link_id === linkId && e.link_label)?.link_label;
@@ -65,6 +57,11 @@ export default function EditTemplate() {
     }
     return ids;
   }, [exercises]);
+
+  const palette = useMemo(
+    () => [theme.colors.tertiary, theme.colors.secondary, theme.colors.primary, theme.colors.error, theme.colors.inversePrimary],
+    [theme],
+  );
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -171,7 +168,7 @@ export default function EditTemplate() {
   const renderItem = useCallback(
     ({ item, index }: ListRenderItemInfo<TemplateExercise>) => {
       const linkIdx = item.link_id ? linkIds.indexOf(item.link_id) : -1;
-      const color = linkIdx >= 0 ? LINK_COLORS[linkIdx % LINK_COLORS.length] : undefined;
+      const color = linkIdx >= 0 ? palette[linkIdx % palette.length] : undefined;
       const isFirst = item.link_id ? exercises.findIndex((e) => e.link_id === item.link_id) === index : false;
       const isLast = item.link_id ? exercises.findLastIndex((e) => e.link_id === item.link_id) === index : false;
       const groupLabel = item.link_id ? linkLabel(exercises, item.link_id, linkIdx) : "";
@@ -282,7 +279,7 @@ export default function EditTemplate() {
         </View>
       );
     },
-    [theme, exercises, linkIds, selecting, selected, move, remove]
+    [theme, exercises, linkIds, palette, selecting, selected, move, remove]
   );
 
   if (!template) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1241,6 +1241,8 @@ export async function updateLinkLabel(
   );
 }
 
+// Queries live template for rest seconds — if template links change mid-session,
+// the query may return NULL and falls back to 90s default.
 export async function getRestSecondsForLink(
   sessionId: string,
   linkId: string

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -529,12 +529,25 @@ export async function addExerciseToTemplate(
 
 export async function removeExerciseFromTemplate(id: string): Promise<void> {
   const database = await getDatabase();
-  const row = await database.getFirstAsync<{ template_id: string }>(
-    "SELECT template_id FROM template_exercises WHERE id = ?",
+  const row = await database.getFirstAsync<{ template_id: string; link_id: string | null }>(
+    "SELECT template_id, link_id FROM template_exercises WHERE id = ?",
     [id]
   );
   await database.runAsync("DELETE FROM template_exercises WHERE id = ?", [id]);
   if (row) {
+    // If the removed exercise was in a link group, check if group needs dissolving
+    if (row.link_id) {
+      const remaining = await database.getFirstAsync<{ count: number }>(
+        "SELECT COUNT(*) as count FROM template_exercises WHERE link_id = ?",
+        [row.link_id]
+      );
+      if (remaining && remaining.count < 2) {
+        await database.runAsync(
+          "UPDATE template_exercises SET link_id = NULL, link_label = '' WHERE link_id = ?",
+          [row.link_id]
+        );
+      }
+    }
     await database.runAsync(
       "UPDATE workout_templates SET updated_at = ? WHERE id = ?",
       [Date.now(), row.template_id]

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -226,6 +226,33 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   await database.execAsync(
     "CREATE INDEX IF NOT EXISTS idx_workout_sets_exercise ON workout_sets(exercise_id)"
   );
+
+  // Migration: add link_id and link_label to template_exercises
+  const teCols = await database.getAllAsync<{ name: string }>(
+    "PRAGMA table_info(template_exercises)"
+  );
+  if (!teCols.some((c) => c.name === "link_id")) {
+    await database.execAsync(
+      "ALTER TABLE template_exercises ADD COLUMN link_id TEXT DEFAULT NULL"
+    );
+  }
+  if (!teCols.some((c) => c.name === "link_label")) {
+    await database.execAsync(
+      "ALTER TABLE template_exercises ADD COLUMN link_label TEXT DEFAULT ''"
+    );
+  }
+
+  // Migration: add link_id and round to workout_sets
+  if (!setCols.some((c) => c.name === "link_id")) {
+    await database.execAsync(
+      "ALTER TABLE workout_sets ADD COLUMN link_id TEXT DEFAULT NULL"
+    );
+  }
+  if (!setCols.some((c) => c.name === "round")) {
+    await database.execAsync(
+      "ALTER TABLE workout_sets ADD COLUMN round INTEGER DEFAULT NULL"
+    );
+  }
 }
 
 async function seed(database: SQLite.SQLiteDatabase): Promise<void> {
@@ -402,6 +429,8 @@ type TemplateExerciseRow = {
   target_sets: number;
   target_reps: string;
   rest_seconds: number;
+  link_id: string | null;
+  link_label: string;
   exercise_name: string | null;
   exercise_category: string | null;
   exercise_primary_muscles: string | null;
@@ -440,6 +469,8 @@ export async function getTemplateById(
     target_sets: r.target_sets,
     target_reps: r.target_reps,
     rest_seconds: r.rest_seconds,
+    link_id: r.link_id ?? null,
+    link_label: r.link_label ?? "",
     exercise: r.exercise_name
       ? mapRow({
           id: r.exercise_id,
@@ -491,6 +522,8 @@ export async function addExerciseToTemplate(
     target_sets: targetSets,
     target_reps: targetReps,
     rest_seconds: restSeconds,
+    link_id: null,
+    link_label: "",
   };
 }
 
@@ -618,6 +651,8 @@ type SetRow = {
   completed_at: number | null;
   rpe: number | null;
   notes: string;
+  link_id: string | null;
+  round: number | null;
   exercise_name: string | null;
 };
 
@@ -644,6 +679,8 @@ export async function getSessionSets(
     completed_at: r.completed_at,
     rpe: r.rpe ?? null,
     notes: r.notes ?? "",
+    link_id: r.link_id ?? null,
+    round: r.round ?? null,
     exercise_name: r.exercise_name ?? undefined,
   }));
 }
@@ -660,13 +697,15 @@ export async function getActiveSession(): Promise<WorkoutSession | null> {
 export async function addSet(
   sessionId: string,
   exerciseId: string,
-  setNumber: number
+  setNumber: number,
+  linkId?: string | null,
+  round?: number | null
 ): Promise<WorkoutSet> {
   const database = await getDatabase();
   const id = crypto.randomUUID();
   await database.runAsync(
-    "INSERT INTO workout_sets (id, session_id, exercise_id, set_number) VALUES (?, ?, ?, ?)",
-    [id, sessionId, exerciseId, setNumber]
+    "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round) VALUES (?, ?, ?, ?, ?, ?)",
+    [id, sessionId, exerciseId, setNumber, linkId ?? null, round ?? null]
   );
   return {
     id,
@@ -679,6 +718,8 @@ export async function addSet(
     completed_at: null,
     rpe: null,
     notes: "",
+    link_id: linkId ?? null,
+    round: round ?? null,
   };
 }
 
@@ -959,9 +1000,9 @@ export async function importData(data: {
   version: number;
   exercises?: { id: string; name: string; category: string; primary_muscles: string; secondary_muscles: string; equipment: string; instructions: string; difficulty: string; is_custom: number }[];
   templates?: { id: string; name: string; created_at: number; updated_at: number }[];
-  template_exercises?: { id: string; template_id: string; exercise_id: string; position: number; target_sets: number; target_reps: string; rest_seconds: number }[];
+  template_exercises?: { id: string; template_id: string; exercise_id: string; position: number; target_sets: number; target_reps: string; rest_seconds: number; link_id?: string | null; link_label?: string }[];
   sessions?: { id: string; template_id: string | null; name: string; started_at: number; completed_at: number | null; duration_seconds: number | null; notes: string }[];
-  sets?: { id: string; session_id: string; exercise_id: string; set_number: number; weight: number | null; reps: number | null; completed: number; completed_at: number | null; set_rpe?: number | null; set_notes?: string }[];
+  sets?: { id: string; session_id: string; exercise_id: string; set_number: number; weight: number | null; reps: number | null; completed: number; completed_at: number | null; set_rpe?: number | null; set_notes?: string; link_id?: string | null; round?: number | null }[];
   food_entries?: { id: string; name: string; calories: number; protein: number; carbs: number; fat: number; serving_size: string; is_favorite: number; created_at: number }[];
   daily_log?: { id: string; food_entry_id: string; date: string; meal: string; servings: number; logged_at: number }[];
   macro_targets?: { id: string; calories: number; protein: number; carbs: number; fat: number; updated_at: number }[];
@@ -996,8 +1037,8 @@ export async function importData(data: {
     if (data.template_exercises) {
       for (const te of data.template_exercises) {
         const r = await database.runAsync(
-          "INSERT OR IGNORE INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds) VALUES (?, ?, ?, ?, ?, ?, ?)",
-          [te.id, te.template_id, te.exercise_id, te.position, te.target_sets, te.target_reps, te.rest_seconds]
+          "INSERT OR IGNORE INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds, link_id, link_label) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          [te.id, te.template_id, te.exercise_id, te.position, te.target_sets, te.target_reps, te.rest_seconds, te.link_id ?? null, te.link_label ?? ""]
         );
         inserted += r.changes;
       }
@@ -1016,8 +1057,8 @@ export async function importData(data: {
     if (data.sets) {
       for (const s of data.sets) {
         const r = await database.runAsync(
-          "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-          [s.id, s.session_id, s.exercise_id, s.set_number, s.weight, s.reps, s.completed, s.completed_at, s.set_rpe ?? null, s.set_notes ?? ""]
+          "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          [s.id, s.session_id, s.exercise_id, s.set_number, s.weight, s.reps, s.completed, s.completed_at, s.set_rpe ?? null, s.set_notes ?? "", s.link_id ?? null, s.round ?? null]
         );
         inserted += r.changes;
       }
@@ -1102,6 +1143,104 @@ export async function getRestSecondsForExercise(
     [exerciseId, sessionId]
   );
   return row?.rest_seconds ?? 90;
+}
+
+// --------------- Superset / Circuit Linking ---------------
+
+export async function createExerciseLink(
+  templateId: string,
+  exerciseIds: string[]
+): Promise<string> {
+  const database = await getDatabase();
+  const linkId = crypto.randomUUID();
+  await database.withTransactionAsync(async () => {
+    for (const eid of exerciseIds) {
+      await database.runAsync(
+        "UPDATE template_exercises SET link_id = ? WHERE id = ? AND template_id = ?",
+        [linkId, eid, templateId]
+      );
+    }
+  });
+  await database.runAsync(
+    "UPDATE workout_templates SET updated_at = ? WHERE id = ?",
+    [Date.now(), templateId]
+  );
+  return linkId;
+}
+
+export async function unlinkExerciseGroup(linkId: string): Promise<void> {
+  const database = await getDatabase();
+  await database.withTransactionAsync(async () => {
+    await database.runAsync(
+      "UPDATE template_exercises SET link_id = NULL, link_label = '' WHERE link_id = ?",
+      [linkId]
+    );
+  });
+}
+
+export async function addToExerciseLink(
+  linkId: string,
+  exerciseIds: string[]
+): Promise<void> {
+  const database = await getDatabase();
+  await database.withTransactionAsync(async () => {
+    for (const eid of exerciseIds) {
+      await database.runAsync(
+        "UPDATE template_exercises SET link_id = ? WHERE id = ?",
+        [linkId, eid]
+      );
+    }
+  });
+}
+
+export async function unlinkSingleExercise(
+  teId: string,
+  linkId: string
+): Promise<void> {
+  const database = await getDatabase();
+  await database.withTransactionAsync(async () => {
+    await database.runAsync(
+      "UPDATE template_exercises SET link_id = NULL, link_label = '' WHERE id = ?",
+      [teId]
+    );
+    // If only 1 exercise remains in the group, dissolve it
+    const remaining = await database.getFirstAsync<{ count: number }>(
+      "SELECT COUNT(*) as count FROM template_exercises WHERE link_id = ?",
+      [linkId]
+    );
+    if (remaining && remaining.count < 2) {
+      await database.runAsync(
+        "UPDATE template_exercises SET link_id = NULL, link_label = '' WHERE link_id = ?",
+        [linkId]
+      );
+    }
+  });
+}
+
+export async function updateLinkLabel(
+  linkId: string,
+  label: string
+): Promise<void> {
+  const database = await getDatabase();
+  await database.runAsync(
+    "UPDATE template_exercises SET link_label = ? WHERE link_id = ?",
+    [label, linkId]
+  );
+}
+
+export async function getRestSecondsForLink(
+  sessionId: string,
+  linkId: string
+): Promise<number> {
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{ rest: number }>(
+    `SELECT MAX(te.rest_seconds) AS rest
+     FROM workout_sessions wss
+     JOIN template_exercises te ON te.template_id = wss.template_id
+     WHERE wss.id = ? AND te.link_id = ?`,
+    [sessionId, linkId]
+  );
+  return row?.rest ?? 90;
 }
 
 // --------------- Nutrition ---------------

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1442,6 +1442,7 @@ export type WorkoutCSVRow = {
   notes: string;
   set_rpe: number | null;
   set_notes: string;
+  link_id: string | null;
 };
 
 export type NutritionCSVRow = {
@@ -1467,7 +1468,8 @@ export async function getWorkoutCSVData(since: number): Promise<WorkoutCSVRow[]>
        ws.duration_seconds,
        ws.notes,
        wset.rpe AS set_rpe,
-       wset.notes AS set_notes
+       wset.notes AS set_notes,
+       wset.link_id
      FROM workout_sessions ws
      JOIN workout_sets wset ON wset.session_id = ws.id
      LEFT JOIN exercises e ON e.id = wset.exercise_id

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -143,6 +143,8 @@ export type TemplateExercise = {
   target_sets: number;
   target_reps: string;
   rest_seconds: number;
+  link_id: string | null;
+  link_label: string;
   exercise?: Exercise;
 };
 
@@ -167,6 +169,14 @@ export type WorkoutSet = {
   completed_at: number | null;
   rpe: number | null;
   notes: string;
+  link_id: string | null;
+  round: number | null;
+};
+
+export type LinkedGroup = {
+  link_id: string;
+  label: string;
+  exercises: TemplateExercise[];
 };
 
 // --------------- Nutrition ---------------


### PR DESCRIPTION
## Summary

Add exercise linking (supersets/circuits) at the template level, with rotation-based set flow during sessions and visual grouping throughout the app.

## Changes

### Schema (lib/db.ts)
- Add `link_id TEXT` and `link_label TEXT` columns to `template_exercises`
- Add `link_id TEXT` and `round INTEGER` columns to `workout_sets`
- All migrations use PRAGMA table_info guard pattern, backward compatible (NULL = standalone)

### DB Functions (lib/db.ts)
- `createExerciseLink()` — generate UUID, link exercises in transaction
- `unlinkExerciseGroup()` — dissolve all links in group
- `unlinkSingleExercise()` — remove one exercise, auto-dissolve if <2 remain
- `addToExerciseLink()` — add exercises to existing group
- `updateLinkLabel()` — custom label for groups
- `getRestSecondsForLink()` — MAX(rest_seconds) across linked exercises
- `addSet()` updated with optional `linkId` and `round` params
- `removeExerciseFromTemplate()` auto-dissolves groups when member count drops below 2

### Template Editor (app/template/[id].tsx)
- "Create Superset" button opens selection mode with checkboxes
- Long-press exercise as secondary entry point for selection
- Visual brackets with colored left border for linked exercises
- Link group header with "Linked — rotate in session" badge
- Unlink single exercise or dissolve entire group
- Undo snackbar for link/unlink with 5s timeout
- Full accessibility: labels, roles, states, live regions

### Session Screen (app/session/[id].tsx)
- Rotation flow: after completing a set, show "Next: [Exercise B]" banner
- Rest timer only starts after full round for linked groups
- Uses MAX(rest_seconds) from linked group
- Round labels (R1, R2...) replace set numbers for linked sets
- Link group header shows "Superset — Round 1/3"
- "Rest after round" indicator

### Session Detail (app/session/detail/[id].tsx)
- Linked exercises display with colored bracket border
- Superset/Circuit label header
- Round labels in set display

### Import/Export
- Template exercises export/import includes `link_id`, `link_label`
- Workout sets export/import includes `link_id`, `round`
- CSV export includes `link_id` column
- Old exports without link columns import gracefully (NULL defaults)

### Types (lib/types.ts)
- `TemplateExercise` gets `link_id` and `link_label`
- `WorkoutSet` gets `link_id` and `round`
- New `LinkedGroup` type (distinct from existing `ExerciseGroup`)

## Testing

- TypeScript compiles with zero errors (`tsc --noEmit`)
- Expo web build succeeds (`expo export --platform web`)
- Existing solo-exercise workflow unchanged (link columns default to NULL)

## Issue

Resolves BLD-6