### PR TITLE
feat: Weekly Muscle Group Volume Analysis (BLD-2)

### DIFF
--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -42,6 +42,7 @@ import {
 import type { BodyWeight, BodySettings, BodyMeasurements } from "../../lib/types";
 import { useLayout } from "../../lib/layout";
 import { KG_TO_LB, LB_TO_KG, toDisplay, toKg } from "../../lib/units";
+import MuscleVolumeSegment from "../../components/MuscleVolumeSegment";
 
 type PR = { exercise_id: string; name: string; max_weight: number };
 type SessionRow = { id: string; name: string; started_at: number; duration_seconds: number | null; set_count: number };
@@ -127,7 +128,7 @@ export default function Progress() {
   useFocusEffect(
     useCallback(() => {
       if (segment === "workouts") loadWorkouts();
-      else loadBody();
+      else if (segment === "body") loadBody();
     }, [segment, loadWorkouts, loadBody])
   );
 
@@ -764,10 +765,15 @@ export default function Progress() {
           buttons={[
             { value: "workouts", label: "Workouts", accessibilityLabel: "Workouts progress" },
             { value: "body", label: "Body", accessibilityLabel: "Body metrics" },
+            { value: "muscles", label: "Muscles", accessibilityLabel: "Muscle volume analysis" },
           ]}
         />
       </View>
-      {segment === "workouts" ? renderWorkouts() : renderBody()}
+      {segment === "workouts"
+        ? renderWorkouts()
+        : segment === "body"
+          ? renderBody()
+          : <MuscleVolumeSegment />}
       {renderModal()}
     </View>
   );

--- a/components/MuscleVolumeSegment.tsx
+++ b/components/MuscleVolumeSegment.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useRef, useState } from "react";
 import {
   AccessibilityInfo,
   ActivityIndicator,
@@ -98,6 +98,7 @@ export default function MuscleVolumeSegment() {
   const [data, setData] = useState<VolumeRow[]>([]);
   const [trend, setTrend] = useState<TrendRow[]>([]);
   const [selected, setSelected] = useState<MuscleGroup | null>(null);
+  const selectedRef = useRef<MuscleGroup | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reduced, setReduced] = useState(false);
@@ -111,13 +112,16 @@ export default function MuscleVolumeSegment() {
       const rows = await getMuscleVolumeForWeek(monday.getTime());
       setData(rows);
       if (rows.length > 0) {
-        const muscle = selected && rows.some((r) => r.muscle === selected)
-          ? selected
+        const cur = selectedRef.current;
+        const muscle = cur && rows.some((r) => r.muscle === cur)
+          ? cur
           : rows[0].muscle;
+        selectedRef.current = muscle;
         setSelected(muscle);
         const t = await getMuscleVolumeTrend(muscle, TREND_WEEKS);
         setTrend(t);
       } else {
+        selectedRef.current = null;
         setSelected(null);
         setTrend([]);
       }
@@ -126,7 +130,7 @@ export default function MuscleVolumeSegment() {
     } finally {
       setLoading(false);
     }
-  }, [monday, selected]);
+  }, [monday]);
 
   useFocusEffect(
     useCallback(() => {
@@ -136,6 +140,7 @@ export default function MuscleVolumeSegment() {
   );
 
   const selectMuscle = useCallback(async (muscle: MuscleGroup) => {
+    selectedRef.current = muscle;
     setSelected(muscle);
     try {
       const t = await getMuscleVolumeTrend(muscle, TREND_WEEKS);

--- a/components/MuscleVolumeSegment.tsx
+++ b/components/MuscleVolumeSegment.tsx
@@ -1,0 +1,487 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  AccessibilityInfo,
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
+import {
+  Button,
+  Card,
+  IconButton,
+  Text,
+  useTheme,
+} from "react-native-paper";
+import { useFocusEffect } from "expo-router";
+import { LineChart } from "react-native-chart-kit";
+import { getMuscleVolumeForWeek, getMuscleVolumeTrend } from "../lib/db";
+import type { MuscleGroup } from "../lib/types";
+import { MUSCLE_LABELS } from "../lib/types";
+import { useLayout } from "../lib/layout";
+
+type VolumeRow = { muscle: MuscleGroup; sets: number; exercises: number };
+type TrendRow = { week: string; sets: number };
+
+const MEV = 10;
+const MRV = 20;
+const TREND_WEEKS = 8;
+
+function mondayOfWeek(offset: number): Date {
+  const now = new Date();
+  const day = now.getDay();
+  const diff = day === 0 ? 6 : day - 1;
+  const monday = new Date(now);
+  monday.setHours(0, 0, 0, 0);
+  monday.setDate(monday.getDate() - diff + offset * 7);
+  return monday;
+}
+
+function formatRange(start: Date): string {
+  const end = new Date(start);
+  end.setDate(end.getDate() + 6);
+  const fmt = (d: Date) =>
+    d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return `${fmt(start)} – ${fmt(end)}`;
+}
+
+const MuscleRow = React.memo(function MuscleRow({
+  item,
+  selected,
+  onPress,
+  color,
+  text,
+  muted,
+}: {
+  item: VolumeRow;
+  selected: boolean;
+  onPress: () => void;
+  color: string;
+  text: string;
+  muted: string;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.row,
+        { borderBottomColor: muted },
+        selected && { backgroundColor: color + "18" },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={`${MUSCLE_LABELS[item.muscle]}: ${item.sets} sets from ${item.exercises} exercises`}
+      accessibilityHint="Double tap to see weekly trend"
+      accessibilityState={{ selected }}
+    >
+      <Text
+        variant="bodyMedium"
+        style={{ color: text, flex: 1 }}
+        numberOfLines={1}
+      >
+        {MUSCLE_LABELS[item.muscle]}
+      </Text>
+      <Text variant="bodySmall" style={{ color: muted, marginRight: 8 }}>
+        {item.exercises} ex
+      </Text>
+      <Text variant="titleSmall" style={{ color: text, width: 40, textAlign: "right" }}>
+        {item.sets}
+      </Text>
+    </Pressable>
+  );
+});
+
+export default function MuscleVolumeSegment() {
+  const theme = useTheme();
+  const layout = useLayout();
+  const [offset, setOffset] = useState(0);
+  const [data, setData] = useState<VolumeRow[]>([]);
+  const [trend, setTrend] = useState<TrendRow[]>([]);
+  const [selected, setSelected] = useState<MuscleGroup | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reduced, setReduced] = useState(false);
+
+  const monday = useMemo(() => mondayOfWeek(offset), [offset]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await getMuscleVolumeForWeek(monday.getTime());
+      setData(rows);
+      if (rows.length > 0) {
+        const muscle = selected && rows.some((r) => r.muscle === selected)
+          ? selected
+          : rows[0].muscle;
+        setSelected(muscle);
+        const t = await getMuscleVolumeTrend(muscle, TREND_WEEKS);
+        setTrend(t);
+      } else {
+        setSelected(null);
+        setTrend([]);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load data");
+    } finally {
+      setLoading(false);
+    }
+  }, [monday, selected]);
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+      AccessibilityInfo.isReduceMotionEnabled().then(setReduced);
+    }, [load])
+  );
+
+  const selectMuscle = useCallback(async (muscle: MuscleGroup) => {
+    setSelected(muscle);
+    try {
+      const t = await getMuscleVolumeTrend(muscle, TREND_WEEKS);
+      setTrend(t);
+    } catch {
+      // trend load failure is non-critical
+    }
+  }, []);
+
+  const maxSets = useMemo(
+    () => Math.max(...data.map((d) => d.sets), MRV),
+    [data]
+  );
+
+  const chartWidth = layout.wide
+    ? (layout.width - 64) / 2 - 32
+    : layout.width - 48;
+
+  const chartConfig = useMemo(() => ({
+    backgroundGradientFrom: theme.colors.surface,
+    backgroundGradientTo: theme.colors.surface,
+    color: () => theme.colors.primary,
+    labelColor: () => theme.colors.onSurfaceVariant,
+    decimalPlaces: 0,
+    propsForBackgroundLines: { stroke: theme.colors.outlineVariant },
+  }), [theme]);
+
+  const hasEnoughTrend = useMemo(
+    () => trend.filter((t) => t.sets > 0).length >= 2,
+    [trend]
+  );
+
+  const trendData = useMemo(() => ({
+    labels: trend.map((t) => t.week),
+    datasets: [{ data: trend.length > 0 ? trend.map((t) => t.sets) : [0] }],
+  }), [trend]);
+
+  // ---- Render ----
+
+  if (loading) {
+    return (
+      <View style={styles.center} accessibilityRole="progressbar" accessibilityLabel="Loading muscle volume data">
+        <ActivityIndicator size="large" color={theme.colors.primary} />
+        <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant, marginTop: 12 }}>
+          Loading…
+        </Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text variant="bodyLarge" style={{ color: theme.colors.error, marginBottom: 12 }}>
+          {error}
+        </Text>
+        <Button mode="contained" onPress={load} accessibilityLabel="Retry loading muscle volume data">
+          Retry
+        </Button>
+      </View>
+    );
+  }
+
+  const mevPos = (MEV / maxSets) * 100;
+  const mrvPos = (MRV / maxSets) * 100;
+
+  return (
+    <View>
+      {/* Week Selector */}
+      <View style={styles.weekRow}>
+        <IconButton
+          icon="chevron-left"
+          onPress={() => setOffset(offset - 1)}
+          size={24}
+          accessibilityLabel="Previous week"
+          style={styles.chevron}
+        />
+        <View
+          style={{ flex: 1, alignItems: "center" }}
+          accessibilityRole="header"
+          accessibilityLiveRegion="polite"
+        >
+          <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>
+            {offset === 0 ? "This Week" : formatRange(monday)}
+          </Text>
+          <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+            {formatRange(monday)}
+          </Text>
+        </View>
+        {offset < 0 ? (
+          <IconButton
+            icon="chevron-right"
+            onPress={() => setOffset(offset + 1)}
+            size={24}
+            accessibilityLabel="Next week"
+            style={styles.chevron}
+          />
+        ) : (
+          <View style={{ width: 48 }} />
+        )}
+      </View>
+
+      {offset !== 0 && (
+        <View style={{ alignItems: "center", marginBottom: 8 }}>
+          <Button
+            mode="contained-tonal"
+            compact
+            onPress={() => setOffset(0)}
+            accessibilityLabel="Go to current week"
+          >
+            Today
+          </Button>
+        </View>
+      )}
+
+      {data.length === 0 ? (
+        <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+          <Card.Content>
+            <Text
+              variant="bodyLarge"
+              style={{ color: theme.colors.onSurfaceVariant, textAlign: "center", padding: 32 }}
+            >
+              No workouts this week. Complete a session to see muscle volume.
+            </Text>
+          </Card.Content>
+        </Card>
+      ) : (
+        <>
+          {/* Volume Bars */}
+          <Card style={[styles.card, layout.wide && styles.wide, { backgroundColor: theme.colors.surface }]}>
+            <Card.Content>
+              <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
+                Sets per Muscle Group
+              </Text>
+              <View style={styles.bars}>
+                {/* Landmark labels */}
+                <View style={styles.landmarks}>
+                  {mevPos < 95 && (
+                    <View style={[styles.landmark, { left: `${mevPos}%` }]}>
+                      <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                        MEV
+                      </Text>
+                      <View style={[styles.dottedLine, { borderColor: theme.colors.outlineVariant }]} />
+                    </View>
+                  )}
+                  {mrvPos < 95 && (
+                    <View style={[styles.landmark, { left: `${mrvPos}%` }]}>
+                      <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                        MRV
+                      </Text>
+                      <View style={[styles.dottedLine, { borderColor: theme.colors.outlineVariant }]} />
+                    </View>
+                  )}
+                </View>
+
+                {data.map((item) => {
+                  const pct = (item.sets / maxSets) * 100;
+                  const active = item.muscle === selected;
+                  return (
+                    <Pressable
+                      key={item.muscle}
+                      onPress={() => selectMuscle(item.muscle)}
+                      style={[
+                        styles.barRow,
+                        active && { backgroundColor: theme.colors.primary + "18" },
+                      ]}
+                      accessibilityRole="button"
+                      accessibilityLabel={`${MUSCLE_LABELS[item.muscle]}: ${item.sets} sets`}
+                      accessibilityHint="Double tap to see weekly trend"
+                      accessibilityState={{ selected: active }}
+                    >
+                      <Text
+                        variant="bodySmall"
+                        style={[styles.barLabel, { color: theme.colors.onSurface }]}
+                        numberOfLines={1}
+                      >
+                        {MUSCLE_LABELS[item.muscle]}
+                      </Text>
+                      <View style={styles.barTrack}>
+                        <View
+                          style={[
+                            styles.barFill,
+                            {
+                              width: `${pct}%`,
+                              backgroundColor: active
+                                ? theme.colors.primary
+                                : theme.colors.primary + "99",
+                              borderRadius: 4,
+                            },
+                          ]}
+                        />
+                      </View>
+                      <Text
+                        variant="labelMedium"
+                        style={{ color: theme.colors.onSurface, width: 28, textAlign: "right" }}
+                      >
+                        {item.sets}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </Card.Content>
+          </Card>
+
+          {/* Trend Chart */}
+          <Card style={[styles.card, layout.wide && styles.wide, { backgroundColor: theme.colors.surface }]}>
+            <Card.Content>
+              <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 4 }}>
+                {selected ? `${MUSCLE_LABELS[selected]} — 8 Week Trend` : "Weekly Trend"}
+              </Text>
+              {hasEnoughTrend ? (
+                <LineChart
+                  data={trendData}
+                  width={chartWidth}
+                  height={180}
+                  chartConfig={chartConfig}
+                  bezier={!reduced}
+                  withDots
+                  style={styles.chart}
+                  fromZero
+                />
+              ) : (
+                <Text
+                  variant="bodyMedium"
+                  style={{
+                    color: theme.colors.onSurfaceVariant,
+                    textAlign: "center",
+                    padding: 24,
+                  }}
+                >
+                  Keep training to see your trends
+                </Text>
+              )}
+            </Card.Content>
+          </Card>
+
+          {/* Muscle Detail List */}
+          <Card style={[styles.card, layout.wide && styles.wide, { backgroundColor: theme.colors.surface }]}>
+            <Card.Content>
+              <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 8 }}>
+                Muscle Group Details
+              </Text>
+              <FlatList
+                data={data}
+                keyExtractor={(item) => item.muscle}
+                scrollEnabled={false}
+                renderItem={({ item }) => (
+                  <MuscleRow
+                    item={item}
+                    selected={item.muscle === selected}
+                    onPress={() => selectMuscle(item.muscle)}
+                    color={theme.colors.primary}
+                    text={theme.colors.onSurface}
+                    muted={theme.colors.outlineVariant}
+                  />
+                )}
+              />
+            </Card.Content>
+          </Card>
+        </>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 32,
+  },
+  weekRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 8,
+    paddingHorizontal: 4,
+  },
+  chevron: {
+    minWidth: 48,
+    minHeight: 48,
+  },
+  card: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+  },
+  wide: {
+    maxWidth: 600,
+    alignSelf: "center",
+    width: "100%" as unknown as number,
+  },
+  bars: {
+    position: "relative",
+  },
+  landmarks: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 72,
+    right: 36,
+  },
+  landmark: {
+    position: "absolute",
+    top: -4,
+    bottom: 0,
+    alignItems: "center",
+    width: 1,
+  },
+  dottedLine: {
+    flex: 1,
+    width: 0,
+    borderLeftWidth: 1,
+    borderStyle: "dashed",
+  },
+  barRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 6,
+    paddingHorizontal: 4,
+    borderRadius: 4,
+    minHeight: 48,
+  },
+  barLabel: {
+    width: 64,
+    marginRight: 8,
+  },
+  barTrack: {
+    flex: 1,
+    height: 16,
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+  barFill: {
+    height: "100%",
+  },
+  chart: {
+    marginVertical: 8,
+    borderRadius: 8,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    minHeight: 48,
+  },
+});

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -15,6 +15,7 @@ import type {
   Program,
   ProgramDay,
   ProgramLog,
+  MuscleGroup,
 } from "./types";
 import { seedExercises } from "./seed";
 
@@ -1971,4 +1972,113 @@ export async function getExerciseChartData(
      ) ORDER BY date ASC`,
     [exerciseId, limit]
   );
+}
+
+// ---- Muscle Volume Analysis ----
+
+export async function getMuscleVolumeForWeek(
+  weekStart: number
+): Promise<{ muscle: MuscleGroup; sets: number; exercises: number }[]> {
+  const database = await getDatabase();
+  const end = weekStart + 7 * 24 * 60 * 60 * 1000;
+
+  const rows = await database.getAllAsync<{
+    exercise_id: string;
+    primary_muscles: string | null;
+    sets: number;
+  }>(
+    `SELECT ws.exercise_id,
+            e.primary_muscles,
+            COUNT(*) AS sets
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     LEFT JOIN exercises e ON ws.exercise_id = e.id
+     WHERE wss.completed_at IS NOT NULL
+       AND wss.completed_at >= ?
+       AND wss.completed_at < ?
+       AND ws.completed = 1
+     GROUP BY ws.exercise_id`,
+    [weekStart, end]
+  );
+
+  const map = new Map<MuscleGroup, { sets: number; exercises: Set<string> }>();
+
+  for (const row of rows) {
+    if (!row.primary_muscles) continue;
+    let muscles: MuscleGroup[];
+    try {
+      muscles = JSON.parse(row.primary_muscles);
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(muscles) || muscles.length === 0) continue;
+
+    for (const m of muscles) {
+      const entry = map.get(m) ?? { sets: 0, exercises: new Set<string>() };
+      entry.sets += row.sets;
+      entry.exercises.add(row.exercise_id);
+      map.set(m, entry);
+    }
+  }
+
+  return Array.from(map.entries())
+    .map(([muscle, data]) => ({
+      muscle,
+      sets: data.sets,
+      exercises: data.exercises.size,
+    }))
+    .sort((a, b) => b.sets - a.sets);
+}
+
+export async function getMuscleVolumeTrend(
+  muscle: MuscleGroup,
+  weeks: number
+): Promise<{ week: string; sets: number }[]> {
+  const database = await getDatabase();
+  const now = new Date();
+  const day = now.getDay();
+  const diff = day === 0 ? 6 : day - 1;
+  const monday = new Date(now);
+  monday.setHours(0, 0, 0, 0);
+  monday.setDate(monday.getDate() - diff);
+
+  const result: { week: string; sets: number }[] = [];
+
+  for (let i = weeks - 1; i >= 0; i--) {
+    const start = new Date(monday);
+    start.setDate(start.getDate() - i * 7);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 7);
+
+    const rows = await database.getAllAsync<{
+      primary_muscles: string | null;
+      sets: number;
+    }>(
+      `SELECT e.primary_muscles, COUNT(*) AS sets
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       LEFT JOIN exercises e ON ws.exercise_id = e.id
+       WHERE wss.completed_at IS NOT NULL
+         AND wss.completed_at >= ?
+         AND wss.completed_at < ?
+         AND ws.completed = 1
+       GROUP BY ws.exercise_id`,
+      [start.getTime(), end.getTime()]
+    );
+
+    let total = 0;
+    for (const row of rows) {
+      if (!row.primary_muscles) continue;
+      try {
+        const muscles: MuscleGroup[] = JSON.parse(row.primary_muscles);
+        if (muscles.includes(muscle)) total += row.sets;
+      } catch {
+        continue;
+      }
+    }
+
+    result.push({ week: `W${weeks - i}`, sets: total });
+  }
+
+  return result;
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -2042,43 +2042,43 @@ export async function getMuscleVolumeTrend(
   monday.setHours(0, 0, 0, 0);
   monday.setDate(monday.getDate() - diff);
 
-  const result: { week: string; sets: number }[] = [];
+  const oldest = new Date(monday);
+  oldest.setDate(oldest.getDate() - (weeks - 1) * 7);
+  const end = new Date(monday);
+  end.setDate(end.getDate() + 7);
 
-  for (let i = weeks - 1; i >= 0; i--) {
-    const start = new Date(monday);
-    start.setDate(start.getDate() - i * 7);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 7);
+  const rows = await database.getAllAsync<{
+    primary_muscles: string | null;
+    completed_at: number;
+    sets: number;
+  }>(
+    `SELECT e.primary_muscles, wss.completed_at, COUNT(*) AS sets
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     LEFT JOIN exercises e ON ws.exercise_id = e.id
+     WHERE wss.completed_at IS NOT NULL
+       AND wss.completed_at >= ?
+       AND wss.completed_at < ?
+       AND ws.completed = 1
+     GROUP BY ws.exercise_id, wss.id`,
+    [oldest.getTime(), end.getTime()]
+  );
 
-    const rows = await database.getAllAsync<{
-      primary_muscles: string | null;
-      sets: number;
-    }>(
-      `SELECT e.primary_muscles, COUNT(*) AS sets
-       FROM workout_sets ws
-       JOIN workout_sessions wss ON ws.session_id = wss.id
-       LEFT JOIN exercises e ON ws.exercise_id = e.id
-       WHERE wss.completed_at IS NOT NULL
-         AND wss.completed_at >= ?
-         AND wss.completed_at < ?
-         AND ws.completed = 1
-       GROUP BY ws.exercise_id`,
-      [start.getTime(), end.getTime()]
-    );
+  // Bucket by week index
+  const buckets = new Array<number>(weeks).fill(0);
+  const oldestMs = oldest.getTime();
 
-    let total = 0;
-    for (const row of rows) {
-      if (!row.primary_muscles) continue;
-      try {
-        const muscles: MuscleGroup[] = JSON.parse(row.primary_muscles);
-        if (muscles.includes(muscle)) total += row.sets;
-      } catch {
-        continue;
-      }
+  for (const row of rows) {
+    if (!row.primary_muscles) continue;
+    try {
+      const muscles: MuscleGroup[] = JSON.parse(row.primary_muscles);
+      if (!muscles.includes(muscle)) continue;
+    } catch {
+      continue;
     }
-
-    result.push({ week: `W${weeks - i}`, sets: total });
+    const idx = Math.floor((row.completed_at - oldestMs) / (7 * 24 * 60 * 60 * 1000));
+    if (idx >= 0 && idx < weeks) buckets[idx] += row.sets;
   }
 
-  return result;
+  return buckets.map((sets, i) => ({ week: `W${i + 1}`, sets }));
 }


### PR DESCRIPTION
## Summary

Adds a "Muscles" segment to the Progress tab showing weekly set volume broken down by muscle group, with custom horizontal bars, volume landmarks (MEV/MRV), 8-week trend line chart, and muscle group detail list.

## Changes

- **lib/db.ts**: Add `getMuscleVolumeForWeek()` and `getMuscleVolumeTrend()` — query workout_sets joined with sessions and exercises, filter by completed_at within Mon–Sun week and `completed=1`, parse primary_muscles JSON, aggregate in JS
- **components/MuscleVolumeSegment.tsx**: New extracted component with week selector (chevrons + Today pill), custom View-based horizontal bars with MEV/MRV vertical reference lines, react-native-chart-kit LineChart for 8-week trend, FlatList detail list
- **app/(tabs)/progress.tsx**: Add "Muscles" as third segment, render MuscleVolumeSegment component (file stays at 872 lines, under 900 limit)

## Key Design Decisions

- Custom View-based horizontal bars (NOT chart-kit BarChart) per techlead M2
- Mon–Sun week boundaries (correct alignment) per techlead M1
- Today pill button (not tap-to-reset) per QD M1
- `useReducedMotion` respected for chart animations per QD m4
- Only count `workout_sets.completed=1` per QD M5

## Accessibility

- `accessibilityLabel` on all bars and interactive elements
- `accessibilityHint` on tappable bars ("Double tap to see weekly trend")
- `accessibilityLiveRegion="polite"` on week label
- Touch targets minimum 48dp
- `useReducedMotion()` for chart animations

## Performance

- `useMemo` for data processing, chart config, trend data
- `React.memo` on FlatList renderItem
- `keyExtractor` with stable muscle group name IDs

## Testing

- TypeScript compiles with zero errors
- Expo export succeeds
- All colors use theme tokens (no hardcoded hex)

## Issue

Resolves BLD-2