### PR TITLE
fix: guard getDatabase with promise mutex to prevent workout detail crash (BLD-3)

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -21,13 +21,25 @@ import { seedExercises } from "./seed";
 const DB_NAME = "fitforge.db";
 
 let db: SQLite.SQLiteDatabase | null = null;
+let init: Promise<SQLite.SQLiteDatabase> | null = null;
 
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (db) return db;
-  db = await SQLite.openDatabaseAsync(DB_NAME);
-  await migrate(db);
-  await seed(db);
-  return db;
+  if (!init) {
+    init = (async () => {
+      try {
+        const instance = await SQLite.openDatabaseAsync(DB_NAME);
+        await migrate(instance);
+        await seed(instance);
+        db = instance;
+        return instance;
+      } catch (err) {
+        init = null;
+        throw err;
+      }
+    })();
+  }
+  return init;
 }
 
 async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes the workout detail crash caused by a race condition in `getDatabase()`. The singleton pattern had no concurrency guard — when multiple components called `getDatabase()` concurrently during startup, the database handle was returned before migration completed, causing `NativeDatabase.prepareAsync` NullPointerException on Android.

## Changes

- Added promise-based mutex to `getDatabase()` in `lib/db.ts`
- First caller creates the initialization promise; concurrent callers share it
- `db` handle is only assigned after migration and seeding complete
- On failure, the promise resets to allow retry

## Root Cause

The original code set `db = await openDatabaseAsync()` before running `migrate()`. A second caller entering after the await saw `db` as non-null and returned it immediately — but tables hadn't been created yet. This caused NullPointerException when queries ran against unmigrated tables.

## Testing

- TypeScript compiles with zero errors
- Logic verified: only one initialization promise is created; all callers wait for it

## Issue

Fixes #14
Resolves BLD-3