### PR TITLE
feat: 1RM estimation & progressive overload suggestions (BLD-8)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,4 +1,5 @@
 import { Tabs, useRouter } from "expo-router";
+import { View } from "react-native";
 import { IconButton, useTheme } from "react-native-paper";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 
@@ -29,14 +30,24 @@ export default function TabLayout() {
             <MaterialCommunityIcons name="dumbbell" size={size} color={color} />
           ),
           headerRight: () => (
-            <IconButton
-              icon="calculator-variant"
-              size={24}
-              onPress={() => router.push("/tools/plates")}
-              accessibilityLabel="Open plate calculator"
-              accessibilityRole="button"
-              iconColor={theme.colors.onSurface}
-            />
+            <View style={{ flexDirection: "row", alignItems: "center" }}>
+              <IconButton
+                icon="arm-flex"
+                size={24}
+                onPress={() => router.push("/tools/rm")}
+                accessibilityLabel="Open 1RM calculator"
+                accessibilityRole="button"
+                iconColor={theme.colors.onSurface}
+              />
+              <IconButton
+                icon="calculator-variant"
+                size={24}
+                onPress={() => router.push("/tools/plates")}
+                accessibilityLabel="Open plate calculator"
+                accessibilityRole="button"
+                iconColor={theme.colors.onSurface}
+              />
+            </View>
           ),
         }}
       />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -195,6 +195,15 @@ export default function RootLayout() {
                 headerTintColor,
               }}
             />
+            <Stack.Screen
+              name="tools/rm"
+              options={{
+                headerShown: true,
+                title: "1RM Calculator",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
           </Stack>
           <StatusBar style="auto" />
         </ThemeProvider>

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -388,7 +388,7 @@ export default function ExerciseDetail() {
                 ? `Based on: ${toDisplay(best.weight, unit)}${unit} × ${best.reps} reps`
                 : "";
               return (
-                <View style={styles.pctSection}>
+                <View style={[styles.pctSection, { borderTopColor: theme.colors.outlineVariant }]}>
                   <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 4 }}>
                     {tested ? "Tested 1RM" : "Estimated 1RM"}: {orm} {unit}
                   </Text>
@@ -684,7 +684,7 @@ const styles = StyleSheet.create({
     marginTop: 16,
     paddingTop: 12,
     borderTopWidth: StyleSheet.hairlineWidth,
-    borderTopColor: "#e0e0e0",
+
   },
   pctTable: {
     borderRadius: 8,

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -19,6 +19,7 @@ import {
   getExerciseRecords,
   getExerciseChartData,
   getBodySettings,
+  getBestSet,
   type ExerciseSession,
   type ExerciseRecords as Records,
 } from "../../lib/db";
@@ -26,6 +27,7 @@ import { CATEGORY_LABELS, type Exercise } from "../../lib/types";
 import { semantic, difficultyText } from "../../constants/theme";
 import { rpeColor, rpeText } from "../../lib/rpe";
 import { toDisplay } from "../../lib/units";
+import { epley, percentageTable } from "../../lib/rm";
 
 const PAGE_SIZE = 10;
 const MAX_ITEMS = 50;
@@ -57,6 +59,7 @@ export default function ExerciseDetail() {
   const [records, setRecords] = useState<Records | null>(null);
   const [recordsLoading, setRecordsLoading] = useState(true);
   const [recordsError, setRecordsError] = useState(false);
+  const [best, setBest] = useState<{ weight: number; reps: number } | null>(null);
 
   // Chart state
   const [chart, setChart] = useState<{ date: number; value: number }[]>([]);
@@ -74,8 +77,9 @@ export default function ExerciseDetail() {
     setRecordsLoading(true);
     setRecordsError(false);
     try {
-      const r = await getExerciseRecords(eid);
+      const [r, b] = await Promise.all([getExerciseRecords(eid), getBestSet(eid)]);
       setRecords(r);
+      setBest(b);
     } catch {
       setRecordsError(true);
     } finally {
@@ -320,6 +324,7 @@ export default function ExerciseDetail() {
               No workout data yet — start a session to build your history
             </Text>
           ) : records ? (
+            <>
             <View style={styles.statsRow}>
               {bw ? (
                 <>
@@ -360,7 +365,9 @@ export default function ExerciseDetail() {
                     <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
                       {records.est_1rm != null ? toDisplay(records.est_1rm, unit) : "—"}
                     </Text>
-                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>Est 1RM</Text>
+                    <Text variant="labelSmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                      {best && best.reps === 1 ? "Tested 1RM" : "Est 1RM"}
+                    </Text>
                   </View>
                   <View style={styles.stat} accessibilityLabel={`Total sessions: ${records.total_sessions}`}>
                     <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
@@ -371,6 +378,57 @@ export default function ExerciseDetail() {
                 </>
               )}
             </View>
+
+            {/* Strength Profile — % 1RM breakdown table */}
+            {!bw && records.est_1rm != null && (() => {
+              const tested = best != null && best.reps === 1;
+              const orm = toDisplay(records.est_1rm!, unit);
+              const table = percentageTable(orm);
+              const source = best
+                ? `Based on: ${toDisplay(best.weight, unit)}${unit} × ${best.reps} reps`
+                : "";
+              return (
+                <View style={styles.pctSection}>
+                  <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 4 }}>
+                    {tested ? "Tested 1RM" : "Estimated 1RM"}: {orm} {unit}
+                  </Text>
+                  {source ? (
+                    <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 8 }}>
+                      {source} · Epley
+                    </Text>
+                  ) : null}
+                  <View style={styles.pctTable}>
+                    <View style={styles.pctRow}>
+                      <Text variant="labelSmall" style={[styles.pctCol, { color: theme.colors.onSurfaceVariant }]}>% 1RM</Text>
+                      <Text variant="labelSmall" style={[styles.pctCol, { color: theme.colors.onSurfaceVariant }]}>Weight</Text>
+                      <Text variant="labelSmall" style={[styles.pctCol, { color: theme.colors.onSurfaceVariant }]}>Reps</Text>
+                    </View>
+                    {table.map((row) => (
+                      <View
+                        key={row.pct}
+                        style={[styles.pctRow, { borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: theme.colors.outlineVariant }]}
+                        accessibilityLabel={`${row.pct} percent of one rep max, ${row.weight} ${unit === "kg" ? "kilograms" : "pounds"}, ${row.reps} reps`}
+                      >
+                        <Text variant="bodySmall" style={[styles.pctCol, { color: theme.colors.onSurface }]}>{row.pct}%</Text>
+                        <Text variant="bodySmall" style={[styles.pctCol, { color: theme.colors.onSurface }]}>{row.weight} {unit}</Text>
+                        <Text variant="bodySmall" style={[styles.pctCol, { color: theme.colors.onSurface }]}>{row.reps}</Text>
+                      </View>
+                    ))}
+                  </View>
+                  <Button
+                    mode="text"
+                    compact
+                    icon="calculator"
+                    onPress={() => router.push("/tools/rm")}
+                    style={{ alignSelf: "flex-start", marginTop: 4 }}
+                    accessibilityLabel="Open 1RM calculator"
+                  >
+                    1RM Calculator
+                  </Button>
+                </View>
+              );
+            })()}
+            </>
           ) : null}
         </Card.Content>
       </Card>
@@ -621,5 +679,24 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     paddingVertical: 2,
     marginTop: 4,
+  },
+  pctSection: {
+    marginTop: 16,
+    paddingTop: 12,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "#e0e0e0",
+  },
+  pctTable: {
+    borderRadius: 8,
+    overflow: "hidden",
+  },
+  pctRow: {
+    flexDirection: "row",
+    paddingVertical: 6,
+    paddingHorizontal: 4,
+  },
+  pctCol: {
+    flex: 1,
+    textAlign: "center",
   },
 });

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -171,21 +171,22 @@ export default function ActiveSession() {
 
     // Compute progressive overload suggestions
     const weightStep = body.weight_unit === "lb" ? 5 : 2.5;
-    const sugg: Record<string, Suggestion | null> = {};
-    for (const eid of exerciseIds) {
-      try {
-        const recent = await getRecentExerciseSets(eid, 2);
-        if (recent.length === 0) { sugg[eid] = null; continue; }
-        // Check if exercise is time-based (all reps=1, weight=0) — suppress
-        const timeBased = recent.every((r) => r.reps === 1 && (r.weight === 0 || r.weight === null));
-        if (timeBased) { sugg[eid] = null; continue; }
-        const ex = await getExerciseById(eid);
-        const bw = ex ? ex.equipment === "bodyweight" : false;
-        sugg[eid] = suggest(recent, weightStep, bw);
-      } catch {
-        sugg[eid] = null;
-      }
-    }
+    const entries = await Promise.all(
+      exerciseIds.map(async (eid): Promise<[string, Suggestion | null]> => {
+        try {
+          const recent = await getRecentExerciseSets(eid, 2);
+          if (recent.length === 0) return [eid, null];
+          const timeBased = recent.every((r) => r.reps === 1 && (r.weight === 0 || r.weight === null));
+          if (timeBased) return [eid, null];
+          const ex = await getExerciseById(eid);
+          const bw = ex ? ex.equipment === "bodyweight" : false;
+          return [eid, suggest(recent, weightStep, bw)];
+        } catch {
+          return [eid, null];
+        }
+      }),
+    );
+    const sugg: Record<string, Suggestion | null> = Object.fromEntries(entries);
     setSuggestions(sugg);
   }, [id, router]);
 
@@ -673,10 +674,17 @@ export default function ActiveSession() {
               return (
                 <Pressable
                   onPress={() => {
-                    if (s.type === "rep_increase") return;
-                    for (const set of group.sets) {
-                      if (!set.completed && (set.weight == null || set.weight === 0)) {
-                        handleUpdate(set.id, "weight", String(s.weight));
+                    if (s.type === "rep_increase") {
+                      for (const set of group.sets) {
+                        if (!set.completed && (set.reps == null || set.reps === 0)) {
+                          handleUpdate(set.id, "reps", String(s.reps));
+                        }
+                      }
+                    } else {
+                      for (const set of group.sets) {
+                        if (!set.completed && (set.weight == null || set.weight === 0)) {
+                          handleUpdate(set.id, "weight", String(s.weight));
+                        }
                       }
                     }
                     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -691,7 +699,7 @@ export default function ActiveSession() {
                   ]}
                   accessibilityRole="button"
                   accessibilityLabel={hint}
-                  accessibilityHint="Double tap to fill suggested weight"
+                  accessibilityHint={s.type === "rep_increase" ? "Double tap to fill suggested reps" : "Double tap to fill suggested weight"}
                 >
                   <Text
                     variant="labelSmall"

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -31,6 +31,7 @@ import {
   completeSet,
   getBodySettings,
   getMaxWeightByExercise,
+  getRecentExerciseSets,
   getSessionById,
   getSessionSets,
   getTemplateById,
@@ -41,6 +42,7 @@ import {
   updateSet,
   updateSetRPE,
   updateSetNotes,
+  getExerciseById,
 } from "../../lib/db";
 import {
   getSessionProgramDayId,
@@ -49,6 +51,7 @@ import {
 } from "../../lib/programs";
 import type { WorkoutSession, WorkoutSet } from "../../lib/types";
 import { rpeColor, rpeText } from "../../lib/rpe";
+import { suggest, type Suggestion } from "../../lib/rm";
 
 type SetWithMeta = WorkoutSet & {
   exercise_name?: string;
@@ -95,6 +98,7 @@ export default function ActiveSession() {
   const [step, setStep] = useState(2.5);
   const restFlash = useRef(new Animated.Value(0)).current;
   const restHapticTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const [suggestions, setSuggestions] = useState<Record<string, Suggestion | null>>({});
 
   const linkIds = useMemo(() => {
     const ids: string[] = [];
@@ -164,6 +168,25 @@ export default function ActiveSession() {
       });
     }
     setGroups([...map.values()]);
+
+    // Compute progressive overload suggestions
+    const weightStep = body.weight_unit === "lb" ? 5 : 2.5;
+    const sugg: Record<string, Suggestion | null> = {};
+    for (const eid of exerciseIds) {
+      try {
+        const recent = await getRecentExerciseSets(eid, 2);
+        if (recent.length === 0) { sugg[eid] = null; continue; }
+        // Check if exercise is time-based (all reps=1, weight=0) — suppress
+        const timeBased = recent.every((r) => r.reps === 1 && (r.weight === 0 || r.weight === null));
+        if (timeBased) { sugg[eid] = null; continue; }
+        const ex = await getExerciseById(eid);
+        const bw = ex ? ex.equipment === "bodyweight" : false;
+        sugg[eid] = suggest(recent, weightStep, bw);
+      } catch {
+        sugg[eid] = null;
+      }
+    }
+    setSuggestions(sugg);
   }, [id, router]);
 
   // Initialize session from template
@@ -633,6 +656,58 @@ export default function ActiveSession() {
               <View style={styles.colCheck} />
             </View>
 
+            {/* Suggestion chip */}
+            {suggestions[group.exercise_id] && (() => {
+              const s = suggestions[group.exercise_id]!;
+              const isIncrease = s.type === "increase" || s.type === "rep_increase";
+              const label = s.type === "rep_increase"
+                ? `${s.reps} reps ▲`
+                : s.type === "increase"
+                  ? `${s.weight} ▲`
+                  : `${s.weight} =`;
+              const hint = s.type === "rep_increase"
+                ? `Suggested reps: ${s.reps}, ${s.reason}`
+                : s.type === "increase"
+                  ? `Suggested weight: ${s.weight}, increase by ${step}`
+                  : `Suggested weight: ${s.weight}, maintain`;
+              return (
+                <Pressable
+                  onPress={() => {
+                    if (s.type === "rep_increase") return;
+                    for (const set of group.sets) {
+                      if (!set.completed && (set.weight == null || set.weight === 0)) {
+                        handleUpdate(set.id, "weight", String(s.weight));
+                      }
+                    }
+                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                  }}
+                  style={[
+                    styles.suggestionChip,
+                    {
+                      backgroundColor: isIncrease
+                        ? theme.colors.primaryContainer
+                        : theme.colors.surfaceVariant,
+                    },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={hint}
+                  accessibilityHint="Double tap to fill suggested weight"
+                >
+                  <Text
+                    variant="labelSmall"
+                    style={{
+                      color: isIncrease
+                        ? theme.colors.onPrimaryContainer
+                        : theme.colors.onSurfaceVariant,
+                      fontWeight: "600",
+                    }}
+                  >
+                    Suggested: {label}
+                  </Text>
+                </Pressable>
+              );
+            })()}
+
             {group.sets.map((set) => (
               <View key={set.id}>
                 <View
@@ -1052,5 +1127,15 @@ const styles = StyleSheet.create({
   stepBtn: {
     margin: 0,
     padding: 0,
+  },
+  suggestionChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 16,
+    alignSelf: "flex-start",
+    marginLeft: 4,
+    marginBottom: 6,
+    minHeight: 48,
+    justifyContent: "center",
   },
 });

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -128,7 +128,8 @@ export default function ActiveSession() {
 
     // Fetch weight step from body settings
     const body = await getBodySettings();
-    setStep(body.weight_unit === "lb" ? 5 : 2.5);
+    const derived = body.weight_unit === "lb" ? 5 : 2.5;
+    setStep(derived);
 
     // Build previous data
     const prevCache: Record<string, { set_number: number; weight: number | null; reps: number | null }[]> = {};
@@ -169,8 +170,7 @@ export default function ActiveSession() {
     }
     setGroups([...map.values()]);
 
-    // Compute progressive overload suggestions
-    const weightStep = body.weight_unit === "lb" ? 5 : 2.5;
+    // Compute progressive overload suggestions (uses derived step from body settings)
     const entries = await Promise.all(
       exerciseIds.map(async (eid): Promise<[string, Suggestion | null]> => {
         try {
@@ -180,7 +180,7 @@ export default function ActiveSession() {
           if (timeBased) return [eid, null];
           const ex = await getExerciseById(eid);
           const bw = ex ? ex.equipment === "bodyweight" : false;
-          return [eid, suggest(recent, weightStep, bw)];
+          return [eid, suggest(recent, derived, bw)];
         } catch {
           return [eid, null];
         }

--- a/app/tools/rm.tsx
+++ b/app/tools/rm.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
+import {
+  DataTable,
+  Text,
+  TextInput,
+  useTheme,
+} from "react-native-paper";
+import { Stack } from "expo-router";
+import { useFocusEffect } from "expo-router";
+import { getBodySettings } from "../../lib/db";
+import { epley, brzycki, lombardi, average, percentageTable } from "../../lib/rm";
+
+export default function RMCalculator() {
+  const theme = useTheme();
+  const [unit, setUnit] = useState<"kg" | "lb">("kg");
+  const [weight, setWeight] = useState("");
+  const [reps, setReps] = useState("");
+
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        const body = await getBodySettings();
+        setUnit(body.weight_unit);
+      })();
+    }, []),
+  );
+
+  const parsed = parseFloat(weight);
+  const parsedReps = parseInt(reps, 10);
+  const valid = !isNaN(parsed) && parsed > 0 && !isNaN(parsedReps) && parsedReps > 0;
+  const warn = valid && parsedReps > 12;
+
+  const results = useMemo(() => {
+    if (!valid) return null;
+    const e = Math.round(epley(parsed, parsedReps) * 10) / 10;
+    const b = Math.round(brzycki(parsed, parsedReps) * 10) / 10;
+    const l = Math.round(lombardi(parsed, parsedReps) * 10) / 10;
+    const avg = Math.round(average(parsed, parsedReps) * 10) / 10;
+    return { epley: e, brzycki: b, lombardi: l, average: avg };
+  }, [valid, parsed, parsedReps]);
+
+  const table = useMemo(() => {
+    if (!results) return [];
+    return percentageTable(results.average);
+  }, [results]);
+
+  const label = unit === "kg" ? "kilograms" : "pounds";
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "1RM Calculator" }} />
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={100}
+      >
+        <ScrollView
+          style={{ backgroundColor: theme.colors.background }}
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+        >
+          <Text variant="titleMedium" style={{ color: theme.colors.onBackground, marginBottom: 8 }}>
+            Weight
+          </Text>
+          <TextInput
+            mode="outlined"
+            keyboardType="numeric"
+            value={weight}
+            onChangeText={setWeight}
+            placeholder="0"
+            right={<TextInput.Affix text={unit} />}
+            style={styles.input}
+            accessibilityLabel={`Weight in ${label}`}
+          />
+
+          <Text variant="titleMedium" style={{ color: theme.colors.onBackground, marginTop: 16, marginBottom: 8 }}>
+            Reps
+          </Text>
+          <TextInput
+            mode="outlined"
+            keyboardType="numeric"
+            value={reps}
+            onChangeText={setReps}
+            placeholder="0"
+            style={styles.input}
+            accessibilityLabel="Number of repetitions"
+          />
+
+          {valid && !results && (
+            <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant, marginTop: 16 }}>
+              Enter weight and reps to calculate
+            </Text>
+          )}
+
+          {!valid && weight !== "" && (
+            <Text variant="bodyMedium" style={{ color: theme.colors.error, marginTop: 12, textAlign: "center" }}>
+              {parsed <= 0 || isNaN(parsed) ? "Enter a weight" : "Enter reps"}
+            </Text>
+          )}
+
+          {warn && (
+            <Text variant="bodySmall" style={{ color: theme.colors.error, marginTop: 8, textAlign: "center" }}>
+              ⚠ Estimates become less accurate above 12 reps
+            </Text>
+          )}
+
+          {results && (
+            <View style={styles.results}>
+              <Text variant="titleMedium" style={{ color: theme.colors.onBackground, marginBottom: 12 }}>
+                Estimated 1RM
+              </Text>
+              <DataTable>
+                <DataTable.Header>
+                  <DataTable.Title>Formula</DataTable.Title>
+                  <DataTable.Title numeric>Est 1RM</DataTable.Title>
+                </DataTable.Header>
+                <DataTable.Row accessibilityLabel={`Epley formula, ${results.epley} ${label}`}>
+                  <DataTable.Cell>Epley</DataTable.Cell>
+                  <DataTable.Cell numeric>{results.epley} {unit}</DataTable.Cell>
+                </DataTable.Row>
+                <DataTable.Row accessibilityLabel={`Brzycki formula, ${results.brzycki} ${label}`}>
+                  <DataTable.Cell>Brzycki</DataTable.Cell>
+                  <DataTable.Cell numeric>{results.brzycki} {unit}</DataTable.Cell>
+                </DataTable.Row>
+                <DataTable.Row accessibilityLabel={`Lombardi formula, ${results.lombardi} ${label}`}>
+                  <DataTable.Cell>Lombardi</DataTable.Cell>
+                  <DataTable.Cell numeric>{results.lombardi} {unit}</DataTable.Cell>
+                </DataTable.Row>
+                <DataTable.Row style={{ backgroundColor: theme.colors.primaryContainer }}>
+                  <DataTable.Cell textStyle={{ fontWeight: "700" }}
+                    accessibilityLabel={`Average of all formulas, ${results.average} ${label}`}
+                  >Average</DataTable.Cell>
+                  <DataTable.Cell numeric textStyle={{ fontWeight: "700" }}>{results.average} {unit}</DataTable.Cell>
+                </DataTable.Row>
+              </DataTable>
+
+              <Text variant="titleMedium" style={{ color: theme.colors.onBackground, marginTop: 24, marginBottom: 12 }}>
+                % 1RM Table
+              </Text>
+              <DataTable>
+                <DataTable.Header>
+                  <DataTable.Title>% 1RM</DataTable.Title>
+                  <DataTable.Title numeric>Weight</DataTable.Title>
+                  <DataTable.Title numeric>Rep Range</DataTable.Title>
+                </DataTable.Header>
+                {table.map((row) => (
+                  <DataTable.Row
+                    key={row.pct}
+                    accessibilityLabel={`${row.pct} percent of one rep max, ${row.weight} ${label}, ${row.reps} reps`}
+                  >
+                    <DataTable.Cell>{row.pct}%</DataTable.Cell>
+                    <DataTable.Cell numeric>{row.weight} {unit}</DataTable.Cell>
+                    <DataTable.Cell numeric>{row.reps}</DataTable.Cell>
+                  </DataTable.Row>
+                ))}
+              </DataTable>
+
+              <Text variant="bodySmall" style={[styles.disclaimer, { color: theme.colors.onSurfaceVariant }]}>
+                Estimates based on submaximal performance. Actual 1RM may vary. Estimates become less accurate above 12 reps.
+              </Text>
+            </View>
+          )}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 40,
+  },
+  input: {
+    fontSize: 18,
+  },
+  results: {
+    marginTop: 24,
+  },
+  disclaimer: {
+    marginTop: 16,
+    textAlign: "center",
+    fontStyle: "italic",
+  },
+});

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1986,6 +1986,70 @@ export async function getExerciseChartData(
   );
 }
 
+// ---- Recent Exercise Sets (for progressive overload) ----
+
+export async function getRecentExerciseSets(
+  exerciseId: string,
+  count: number,
+): Promise<{
+  session_id: string;
+  set_number: number;
+  weight: number | null;
+  reps: number | null;
+  rpe: number | null;
+  completed: number;
+  started_at: number;
+}[]> {
+  const database = await getDatabase();
+  return database.getAllAsync<{
+    session_id: string;
+    set_number: number;
+    weight: number | null;
+    reps: number | null;
+    rpe: number | null;
+    completed: number;
+    started_at: number;
+  }>(
+    `SELECT ws.session_id, ws.set_number, ws.weight, ws.reps, ws.rpe,
+            ws.completed, wss.started_at
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.exercise_id = ?
+       AND wss.completed_at IS NOT NULL
+       AND wss.id IN (
+         SELECT DISTINCT wss2.id
+         FROM workout_sessions wss2
+         JOIN workout_sets ws2 ON ws2.session_id = wss2.id
+         WHERE ws2.exercise_id = ?
+           AND wss2.completed_at IS NOT NULL
+         ORDER BY wss2.started_at DESC
+         LIMIT ?
+       )
+     ORDER BY wss.started_at ASC, ws.set_number ASC`,
+    [exerciseId, exerciseId, count],
+  );
+}
+
+export async function getBestSet(
+  exerciseId: string,
+): Promise<{ weight: number; reps: number } | null> {
+  const database = await getDatabase();
+  return database.getFirstAsync<{ weight: number; reps: number }>(
+    `SELECT ws.weight, ws.reps
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.exercise_id = ?
+       AND ws.completed = 1
+       AND ws.weight > 0
+       AND ws.reps > 0
+       AND ws.reps <= 12
+       AND wss.completed_at IS NOT NULL
+     ORDER BY ws.weight * (1.0 + ws.reps / 30.0) DESC
+     LIMIT 1`,
+    [exerciseId],
+  );
+}
+
 // ---- Muscle Volume Analysis ----
 
 export async function getMuscleVolumeForWeek(

--- a/lib/rm.ts
+++ b/lib/rm.ts
@@ -1,0 +1,135 @@
+// 1RM estimation formulas and progressive overload suggestion logic
+
+export function epley(weight: number, reps: number): number {
+  if (reps === 1) return weight;
+  return weight * (1 + reps / 30);
+}
+
+export function brzycki(weight: number, reps: number): number {
+  if (reps === 1) return weight;
+  if (reps >= 37) return weight;
+  return weight * (36 / (37 - reps));
+}
+
+export function lombardi(weight: number, reps: number): number {
+  if (reps === 1) return weight;
+  return weight * Math.pow(reps, 0.1);
+}
+
+export function average(weight: number, reps: number): number {
+  return (epley(weight, reps) + brzycki(weight, reps) + lombardi(weight, reps)) / 3;
+}
+
+const PCT_TIERS = [
+  { pct: 100, reps: "1" },
+  { pct: 95, reps: "2" },
+  { pct: 90, reps: "3–4" },
+  { pct: 85, reps: "5–6" },
+  { pct: 80, reps: "7–8" },
+  { pct: 75, reps: "9–10" },
+  { pct: 70, reps: "10–12" },
+  { pct: 65, reps: "12–15" },
+  { pct: 60, reps: "15–18" },
+  { pct: 50, reps: "20–25" },
+] as const;
+
+export function percentageTable(orm: number): { pct: number; weight: number; reps: string }[] {
+  return PCT_TIERS.map((t) => ({
+    pct: t.pct,
+    weight: Math.round((orm * t.pct) / 100 * 10) / 10,
+    reps: t.reps,
+  }));
+}
+
+export type HistorySet = {
+  session_id: string;
+  weight: number | null;
+  reps: number | null;
+  rpe: number | null;
+  completed: number;
+  started_at: number;
+};
+
+export type Suggestion = {
+  type: "increase" | "maintain" | "rep_increase";
+  weight: number;
+  reps: number | null;
+  reason: string;
+};
+
+export function suggest(
+  sets: HistorySet[],
+  step: number,
+  bodyweight: boolean,
+): Suggestion | null {
+  // Group sets by session
+  const sessions = new Map<string, HistorySet[]>();
+  for (const s of sets) {
+    const arr = sessions.get(s.session_id) ?? [];
+    arr.push(s);
+    sessions.set(s.session_id, arr);
+  }
+
+  // Sort sessions by started_at descending
+  const sorted = [...sessions.entries()]
+    .sort((a, b) => b[1][0].started_at - a[1][0].started_at);
+
+  if (sorted.length < 2) return null;
+
+  const [, last] = sorted[0];
+  const [, prior] = sorted[1];
+
+  // Filter to "attempted" sets (weight > 0 AND reps > 0)
+  const attempted = last.filter(
+    (s) => s.weight != null && s.weight > 0 && s.reps != null && s.reps > 0,
+  );
+  if (attempted.length === 0) return null;
+
+  const priorAttempted = prior.filter(
+    (s) => s.weight != null && s.weight > 0 && s.reps != null && s.reps > 0,
+  );
+  if (priorAttempted.length === 0) return null;
+
+  // Check if all attempted sets completed
+  const allCompleted = attempted.every((s) => s.completed === 1);
+
+  // Check RPE — only suppress when at least one set has RPE ≥ 9.5
+  const hasRPE = attempted.some((s) => s.rpe != null);
+  if (hasRPE && attempted.some((s) => s.rpe != null && s.rpe >= 9.5)) {
+    const w = attempted[0].weight!;
+    return { type: "maintain", weight: w, reps: null, reason: "RPE ≥ 9.5 last session — maintain" };
+  }
+
+  const lastWeight = Math.max(...attempted.map((s) => s.weight!));
+  const priorWeight = Math.max(...priorAttempted.map((s) => s.weight!));
+
+  // Check if user decreased weight (deload)
+  if (lastWeight < priorWeight) {
+    return { type: "maintain", weight: lastWeight, reps: null, reason: "Weight decreased — respect deload" };
+  }
+
+  // Bodyweight exercises — rep progression
+  if (bodyweight) {
+    if (!allCompleted) {
+      const avg = Math.round(attempted.reduce((a, s) => a + s.reps!, 0) / attempted.length);
+      return { type: "maintain", weight: 0, reps: avg, reason: "Not all sets completed — maintain reps" };
+    }
+    const maxReps = Math.max(...attempted.map((s) => s.reps!));
+    return { type: "rep_increase", weight: 0, reps: maxReps + 1, reason: "Bodyweight — increase reps" };
+  }
+
+  // Weight progression
+  if (!allCompleted) {
+    return { type: "maintain", weight: lastWeight, reps: null, reason: "Not all sets completed — maintain weight" };
+  }
+
+  // Check reps haven't dropped vs prior session
+  const lastMinReps = Math.min(...attempted.map((s) => s.reps!));
+  const priorMinReps = Math.min(...priorAttempted.map((s) => s.reps!));
+  if (lastMinReps < priorMinReps) {
+    return { type: "maintain", weight: lastWeight, reps: null, reason: "Reps dropped — maintain weight" };
+  }
+
+  const next = Math.round((lastWeight + step) * 100) / 100;
+  return { type: "increase", weight: next, reps: null, reason: `All sets completed — increase by ${step}` };
+}


### PR DESCRIPTION
## Summary

Adds 1RM estimation formulas, a strength profile display, progressive overload suggestion chips in active workout sessions, and a standalone 1RM calculator screen.

## Changes

### Core Logic (`lib/rm.ts`)
- Epley, Brzycki, Lombardi 1RM formulas with average calculator
- Percentage table generator for strength training zones (95% → 50%)
- `suggest()` function implementing progressive overload detection:
  - Requires ≥2 session history for reliable suggestions
  - Detects completed vs incomplete sessions
  - RPE-aware: suppresses increase at RPE ≥ 9.5
  - Handles bodyweight exercises (rep-increase instead of weight)
  - Handles deload detection (weight decrease → maintain)
  - Time-based exercises excluded

### Database (`lib/db.ts`)
- `getRecentExerciseSets()` — fetch sets from N most recent completed sessions
- `getBestSet()` — find the set producing the highest Epley 1RM estimate

### Exercise Detail (`app/exercise/[id].tsx`)
- Strength Profile merged into Personal Records card
- Shows Estimated or Tested 1RM with source set info
- Percentage breakdown table for all training zones
- Link to standalone 1RM Calculator

### Active Session (`app/session/[id].tsx`)
- Suggestion chip rendered per exercise group
- Three variants: )), maintain (=), rep-increaseincrease (
- Tap to auto-fill weight for all unfilled sets with haptic feedback
- Lazy computation during session load

### 1RM Calculator (`app/tools/rm.tsx`)
- Standalone screen with weight/reps inputs
- DataTable showing all 3 formulas + average
- Percentage breakdown table for training zones
- Unit-aware, accessible, keyboard-avoiding layout

### Navigation (`app/(tabs)/_layout.tsx`)
- Added 1RM calculator icon to Workouts tab header

## Testing

- TypeScript typecheck passes with zero errors (`tsc --noEmit`)
- No new dependencies introduced
- All theme tokens used (no hardcoded colors)
- Accessibility labels on all interactive elements

## Issue

Resolves BLD-8