### PR TITLE
fix: use theme token for detail border color — dark mode compat (BLD-15)

### DIFF
--- a/app/nutrition/add.tsx
+++ b/app/nutrition/add.tsx
@@ -125,7 +125,7 @@ function DatabaseTab({ meal, saving, onSaving }: { meal: Meal; saving: boolean; 
             {item.calories} cal · {item.protein}p · {item.carbs}c · {item.fat}f · {item.serving}
           </Text>
           {open && (
-            <View style={styles.detail}>
+            <View style={[styles.detail, { borderTopColor: theme.colors.outlineVariant }]}>
               <Text variant="labelMedium" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 8 }}>
                 Serving: {item.serving}
               </Text>
@@ -468,7 +468,7 @@ const styles = StyleSheet.create({
   btn: { marginTop: 8 },
   favCard: { marginBottom: 8, borderRadius: 8 },
   dbCard: { marginBottom: 8, borderRadius: 8 },
-  detail: { marginTop: 12, paddingTop: 12, borderTopWidth: 1, borderTopColor: "rgba(0,0,0,0.1)" },
+  detail: { marginTop: 12, paddingTop: 12, borderTopWidth: 1 },
   multChips: { flexDirection: "row", gap: 6, marginBottom: 8 },
   multInput: { marginBottom: 8 },
   macros: { marginBottom: 12, padding: 8, borderRadius: 8 },


### PR DESCRIPTION
## Summary

Fix hardcoded `borderTopColor: rgba(0,0,0,0.1)` in the Database tab's food detail accordion. Uses `theme.colors.outlineVariant` instead for dark mode compatibility.

## Changes

- `app/nutrition/add.tsx` — Replace static border color with theme-aware inline style

## Testing

- TypeScript compiles with zero errors
- Follow-up from BLD-15 tech lead review

## Issue

Follow-up from BLD-15 (Phase 20)