### PR TITLE
fix: show friendly fallback on web instead of expo-sqlite crash (BLD-1)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { useColorScheme } from "react-native";
+import { Platform, useColorScheme } from "react-native";
 import { PaperProvider } from "react-native-paper";
 import { ThemeProvider } from "@react-navigation/native";
 import { Stack } from "expo-router";
@@ -8,6 +8,7 @@ import { light, dark, navigationLight, navigationDark } from "../constants/theme
 import { getDatabase } from "../lib/db";
 import { setupGlobalHandler } from "../lib/errors";
 import ErrorBoundary from "../components/ErrorBoundary";
+import WebUnsupported from "../components/WebUnsupported";
 
 export default function RootLayout() {
   const scheme = useColorScheme();
@@ -15,9 +16,19 @@ export default function RootLayout() {
   const paperTheme = isDark ? dark : light;
 
   useEffect(() => {
-    getDatabase();
-    setupGlobalHandler();
+    if (Platform.OS !== "web") {
+      getDatabase();
+      setupGlobalHandler();
+    }
   }, []);
+
+  if (Platform.OS === "web") {
+    return (
+      <PaperProvider theme={paperTheme}>
+        <WebUnsupported />
+      </PaperProvider>
+    );
+  }
 
   const headerStyle = {
     backgroundColor: paperTheme.colors.surface,

--- a/components/WebUnsupported.tsx
+++ b/components/WebUnsupported.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { Appearance, Linking, StyleSheet, View } from "react-native";
+import { Button, Text } from "react-native-paper";
+import { light, dark } from "../constants/theme";
+
+function theme() {
+  return Appearance.getColorScheme() === "dark" ? dark : light;
+}
+
+export default function WebUnsupported() {
+  const t = theme();
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: t.colors.background }]}
+      accessibilityRole="summary"
+    >
+      <Text
+        variant="displaySmall"
+        style={[styles.icon]}
+        accessibilityElementsHidden
+      >
+        📱
+      </Text>
+      <Text
+        variant="headlineMedium"
+        style={[styles.heading, { color: t.colors.onBackground }]}
+      >
+        Mobile App Only
+      </Text>
+      <Text
+        variant="bodyLarge"
+        style={[styles.body, { color: t.colors.onSurfaceVariant }]}
+      >
+        FitForge is designed for iOS and Android. Web browsers are not currently
+        supported due to database limitations.
+      </Text>
+      <Text
+        variant="bodyMedium"
+        style={[styles.hint, { color: t.colors.onSurfaceVariant }]}
+      >
+        To use FitForge, install it on your phone or run it in an iOS/Android
+        simulator.
+      </Text>
+      <Button
+        mode="contained"
+        icon="github"
+        style={styles.btn}
+        onPress={() =>
+          Linking.openURL("https://github.com/alankyshum/fitforge")
+        }
+        accessibilityLabel="View FitForge on GitHub"
+      >
+        View on GitHub
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 32,
+  },
+  icon: {
+    fontSize: 64,
+    marginBottom: 16,
+  },
+  heading: {
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  body: {
+    marginBottom: 12,
+    textAlign: "center",
+    maxWidth: 400,
+  },
+  hint: {
+    marginBottom: 24,
+    textAlign: "center",
+    maxWidth: 400,
+  },
+  btn: {
+    minWidth: 200,
+  },
+});


### PR DESCRIPTION
## Summary

Fixes the web crash caused by expo-sqlite's OPFS `createSyncAccessHandle` error by detecting the web platform and showing a friendly "Mobile App Only" fallback screen instead of crashing.

## Changes

- Add `WebUnsupported` component with clear messaging that FitForge is designed for iOS/Android
- Guard `getDatabase()` and `setupGlobalHandler()` from running on web in root layout
- Web users see an informative screen with a link to the GitHub repo instead of a cryptic OPFS error

## Testing

- `tsc --noEmit` passes with zero errors
- On web: renders WebUnsupported component instead of crashing
- On iOS/Android: behavior unchanged — database initializes normally

## Issue

Resolves GitHub #16