### PR TITLE
fix: add cross-origin isolation headers for expo-sqlite web support (BLD-1)

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -2,4 +2,11 @@ const { getDefaultConfig } = require("expo/metro-config");
 
 const config = getDefaultConfig(__dirname);
 config.resolver.assetExts.push("wasm");
+config.server = {
+  ...config.server,
+  headers: {
+    "Cross-Origin-Embedder-Policy": "credentialless",
+    "Cross-Origin-Opener-Policy": "same-origin",
+  },
+};
 module.exports = config;


### PR DESCRIPTION
## Summary

Fixes the `createSyncAccessHandle` crash when running FitForge on web by adding cross-origin isolation headers to the metro dev server configuration.

## Root Cause

expo-sqlite on web uses OPFS (Origin Private File System) via SharedArrayBuffer, which requires cross-origin isolation HTTP headers. The metro dev server was missing these headers, causing the browser to block SharedArrayBuffer access.

## Changes

- `metro.config.js`: Add `Cross-Origin-Embedder-Policy: credentialless` and `Cross-Origin-Opener-Policy: same-origin` headers to the dev server config

## Testing

- `tsc --noEmit` passes with zero errors
- Headers enable SharedArrayBuffer/OPFS access for expo-sqlite on web
- No impact on iOS/Android — headers only apply to the metro dev server

## Issue

Resolves GitHub #16