### PR TITLE
fix: resolve expo-sqlite web crash with OPFS fallback (BLD-28)

### DIFF
--- a/.plans/PLAN-BLD-PHASE22.md
+++ b/.plans/PLAN-BLD-PHASE22.md
@@ -3,7 +3,7 @@
 **Issue**: BLD-27
 **Author**: CEO
 **Date**: 2026-04-13
-**Status**: DRAFT
+**Status**: DRAFT → Rev 2 (addressing Tech Lead feedback)
 
 ## Problem Statement
 

--- a/__tests__/lib/db.test.ts
+++ b/__tests__/lib/db.test.ts
@@ -60,6 +60,58 @@ describe("getDatabase", () => {
   });
 });
 
+describe("getDatabase web fallback", () => {
+  const originalPlatform = jest.requireActual("react-native").Platform;
+
+  it("falls back to :memory: on web when OPFS fails", async () => {
+    jest.resetModules();
+
+    const failOnce = jest.fn()
+      .mockRejectedValueOnce(new Error("cannot create file"))
+      .mockResolvedValue(mockDb);
+
+    jest.doMock("expo-sqlite", () => ({
+      openDatabaseAsync: failOnce,
+    }));
+    jest.doMock("react-native", () => ({
+      Platform: { OS: "web" },
+    }));
+    jest.doMock("../../lib/seed", () => ({
+      seedExercises: jest.fn(() => []),
+    }));
+
+    const dbMod = require("../../lib/db");
+    const result = await dbMod.getDatabase();
+
+    expect(result).toBe(mockDb);
+    expect(failOnce).toHaveBeenCalledTimes(2);
+    expect(failOnce).toHaveBeenNthCalledWith(1, "fitforge.db");
+    expect(failOnce).toHaveBeenNthCalledWith(2, ":memory:");
+    expect(dbMod.isMemoryFallback()).toBe(true);
+  });
+
+  it("throws on non-web platform when open fails", async () => {
+    jest.resetModules();
+
+    const fail = jest.fn().mockRejectedValue(new Error("native crash"));
+
+    jest.doMock("expo-sqlite", () => ({
+      openDatabaseAsync: fail,
+    }));
+    jest.doMock("react-native", () => ({
+      Platform: { OS: "android" },
+    }));
+    jest.doMock("../../lib/seed", () => ({
+      seedExercises: jest.fn(() => []),
+    }));
+
+    const dbMod = require("../../lib/db");
+    await expect(dbMod.getDatabase()).rejects.toThrow("native crash");
+    expect(fail).toHaveBeenCalledTimes(1);
+    expect(dbMod.isMemoryFallback()).toBe(false);
+  });
+});
+
 describe("exercises CRUD", () => {
   it("getAllExercises returns mapped exercises", async () => {
     await initDb();

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,6 +14,7 @@ export default function RootLayout() {
   const isDark = scheme === "dark";
   const paperTheme = isDark ? dark : light;
   const [banner, setBanner] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     getDatabase()
@@ -21,7 +22,7 @@ export default function RootLayout() {
         if (Platform.OS === "web" && isMemoryFallback()) setBanner(true);
       })
       .catch((err) => {
-        console.error("Database initialization failed:", err);
+        setError(err?.message ?? "Failed to initialize database");
       });
     setupGlobalHandler();
   }, []);
@@ -41,6 +42,13 @@ export default function RootLayout() {
             icon="alert-circle-outline"
           >
             Web storage unavailable — using in-memory database. Your data will not persist across page reloads.
+          </Banner>
+          <Banner
+            visible={!!error}
+            actions={[{ label: "Retry", onPress: () => { setError(null); getDatabase().catch(() => {}); } }]}
+            icon="alert"
+          >
+            Database error: {error}. Try reloading the app.
           </Banner>
           <Stack
             screenOptions={{

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,11 @@
-import { useColorScheme } from "react-native";
-import { PaperProvider } from "react-native-paper";
+import { useColorScheme, Platform } from "react-native";
+import { PaperProvider, Banner } from "react-native-paper";
 import { ThemeProvider } from "@react-navigation/native";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { light, dark, navigationLight, navigationDark } from "../constants/theme";
-import { getDatabase } from "../lib/db";
+import { getDatabase, isMemoryFallback } from "../lib/db";
 import { setupGlobalHandler } from "../lib/errors";
 import ErrorBoundary from "../components/ErrorBoundary";
 
@@ -13,9 +13,12 @@ export default function RootLayout() {
   const scheme = useColorScheme();
   const isDark = scheme === "dark";
   const paperTheme = isDark ? dark : light;
+  const [banner, setBanner] = useState(false);
 
   useEffect(() => {
-    getDatabase();
+    getDatabase().then(() => {
+      if (Platform.OS === "web" && isMemoryFallback()) setBanner(true);
+    });
     setupGlobalHandler();
   }, []);
 
@@ -28,6 +31,13 @@ export default function RootLayout() {
     <ErrorBoundary>
       <PaperProvider theme={paperTheme}>
         <ThemeProvider value={isDark ? navigationDark : navigationLight}>
+          <Banner
+            visible={banner}
+            actions={[{ label: "Dismiss", onPress: () => setBanner(false) }]}
+            icon="alert-circle-outline"
+          >
+            Web storage unavailable — using in-memory database. Your data will not persist across page reloads.
+          </Banner>
           <Stack
             screenOptions={{
               headerShown: false,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,9 +16,13 @@ export default function RootLayout() {
   const [banner, setBanner] = useState(false);
 
   useEffect(() => {
-    getDatabase().then(() => {
-      if (Platform.OS === "web" && isMemoryFallback()) setBanner(true);
-    });
+    getDatabase()
+      .then(() => {
+        if (Platform.OS === "web" && isMemoryFallback()) setBanner(true);
+      })
+      .catch((err) => {
+        console.error("Database initialization failed:", err);
+      });
     setupGlobalHandler();
   }, []);
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -45,7 +45,7 @@ export default function RootLayout() {
           </Banner>
           <Banner
             visible={!!error}
-            actions={[{ label: "Retry", onPress: () => { setError(null); getDatabase().catch(() => {}); } }]}
+            actions={[{ label: "Retry", onPress: () => { setError(null); getDatabase().catch((e) => setError(e?.message ?? "Retry failed")); } }]}
             icon="alert"
           >
             Database error: {error}. Try reloading the app.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,5 @@
 import * as SQLite from "expo-sqlite";
+import { Platform } from "react-native";
 import type {
   Exercise,
   WorkoutTemplate,
@@ -23,6 +24,11 @@ const DB_NAME = "fitforge.db";
 
 let db: SQLite.SQLiteDatabase | null = null;
 let init: Promise<SQLite.SQLiteDatabase> | null = null;
+let memoryFallback = false;
+
+export function isMemoryFallback(): boolean {
+  return memoryFallback;
+}
 
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   if (db) return db;
@@ -35,6 +41,23 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
         db = instance;
         return instance;
       } catch (err) {
+        if (Platform.OS === "web") {
+          console.warn(
+            "expo-sqlite: OPFS unavailable, using in-memory database. Data will not persist across reloads.",
+            err,
+          );
+          try {
+            const instance = await SQLite.openDatabaseAsync(":memory:");
+            await migrate(instance);
+            await seed(instance);
+            memoryFallback = true;
+            db = instance;
+            return instance;
+          } catch (fallbackErr) {
+            init = null;
+            throw fallbackErr;
+          }
+        }
         init = null;
         throw err;
       }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -42,12 +42,6 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
         return instance;
       } catch (err) {
         if (Platform.OS === "web") {
-          if (__DEV__) {
-            console.warn(
-              "expo-sqlite: OPFS unavailable, using in-memory database. Data will not persist across reloads.",
-              err,
-            );
-          }
           try {
             const instance = await SQLite.openDatabaseAsync(":memory:");
             await migrate(instance);

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -42,10 +42,12 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
         return instance;
       } catch (err) {
         if (Platform.OS === "web") {
-          console.warn(
-            "expo-sqlite: OPFS unavailable, using in-memory database. Data will not persist across reloads.",
-            err,
-          );
+          if (__DEV__) {
+            console.warn(
+              "expo-sqlite: OPFS unavailable, using in-memory database. Data will not persist across reloads.",
+              err,
+            );
+          }
           try {
             const instance = await SQLite.openDatabaseAsync(":memory:");
             await migrate(instance);

--- a/metro.config.js
+++ b/metro.config.js
@@ -4,9 +4,12 @@ const config = getDefaultConfig(__dirname);
 config.resolver.assetExts.push("wasm");
 config.server = {
   ...config.server,
-  headers: {
-    "Cross-Origin-Embedder-Policy": "credentialless",
-    "Cross-Origin-Opener-Policy": "same-origin",
+  enhanceMiddleware: (middleware) => {
+    return (req, res, next) => {
+      res.setHeader("Cross-Origin-Embedder-Policy", "credentialless");
+      res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+      return middleware(req, res, next);
+    };
   },
 };
 module.exports = config;


### PR DESCRIPTION
## Summary

Fixes the expo-sqlite web crash reported in GitHub #36 — the app crashed with `cannot create file` / `sqlite3_open_v2` errors when running on web (localhost:8081).

## Root Cause

Two issues combined:
1. **Unreliable header injection** — `metro.config.js` used `config.server.headers` which doesn't reliably apply COOP/COEP headers to all responses (worker.js, .wasm files). Without these headers, `SharedArrayBuffer` is unavailable and the OPFS-backed VFS fails.
2. **No web fallback** — when OPFS failed, the entire app crashed with no recovery path.

## Changes

- **metro.config.js**: Switch from `config.server.headers` to `config.server.enhanceMiddleware` for reliable header injection on all responses (per [Expo docs](https://docs.expo.dev/versions/latest/sdk/sqlite/#web-setup) and [expo/expo#39903](https://github.com/expo/expo/issues/39903))
- **lib/db.ts**: Add web-specific `:memory:` database fallback when OPFS fails, with `isMemoryFallback()` export
- **app/_layout.tsx**: Show a dismissable Banner warning users when data won't persist
- **\_\_tests\_\_/lib/db.test.ts**: Add tests for web fallback and non-web error propagation

## Testing

- All 121 tests pass (`npx jest`)
- TypeScript type-check passes (`tsc --noEmit`)
- npm install succeeds

## Issue

Fixes GitHub #36
Resolves BLD-28