### PR TITLE
feat: Starter Workout Templates & Program (BLD-32)

### DIFF
--- a/__tests__/lib/db.test.ts
+++ b/__tests__/lib/db.test.ts
@@ -261,12 +261,14 @@ describe("templates CRUD", () => {
   it("getTemplates returns all templates", async () => {
     await initDb();
     const templates = [
-      { id: "t1", name: "Push", created_at: 100, updated_at: 200 },
+      { id: "t1", name: "Push", created_at: 100, updated_at: 200, is_starter: 0 },
     ];
     mockDb.getAllAsync.mockResolvedValueOnce(templates);
 
     const result = await db.getTemplates();
-    expect(result).toEqual(templates);
+    expect(result).toEqual([
+      { id: "t1", name: "Push", created_at: 100, updated_at: 200, is_starter: false },
+    ]);
   });
 
   it("deleteTemplate removes template and related data", async () => {

--- a/__tests__/lib/starter-templates.test.ts
+++ b/__tests__/lib/starter-templates.test.ts
@@ -1,0 +1,115 @@
+import { STARTER_TEMPLATES, STARTER_PROGRAM, STARTER_VERSION } from "../../lib/starter-templates";
+import { DIFFICULTY_LABELS } from "../../lib/types";
+
+describe("starter-templates data", () => {
+  it("has 6 starter templates", () => {
+    expect(STARTER_TEMPLATES).toHaveLength(6);
+  });
+
+  it("has unique template IDs", () => {
+    const ids = STARTER_TEMPLATES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("each template has 6 exercises", () => {
+    for (const tpl of STARTER_TEMPLATES) {
+      expect(tpl.exercises).toHaveLength(6);
+    }
+  });
+
+  it("each exercise has a unique ID within its template", () => {
+    for (const tpl of STARTER_TEMPLATES) {
+      const ids = tpl.exercises.map((e) => e.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    }
+  });
+
+  it("all exercise IDs are globally unique", () => {
+    const ids = STARTER_TEMPLATES.flatMap((t) => t.exercises.map((e) => e.id));
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("all exercise_ids reference voltra exercises", () => {
+    for (const tpl of STARTER_TEMPLATES) {
+      for (const ex of tpl.exercises) {
+        expect(ex.exercise_id).toMatch(/^voltra-\d{3}$/);
+      }
+    }
+  });
+
+  it("template 1 (Full Body) is marked recommended", () => {
+    const full = STARTER_TEMPLATES.find((t) => t.id === "starter-tpl-1");
+    expect(full).toBeDefined();
+    expect(full!.recommended).toBe(true);
+  });
+
+  it("non-recommended templates have no recommended flag", () => {
+    const others = STARTER_TEMPLATES.filter((t) => t.id !== "starter-tpl-1");
+    for (const tpl of others) {
+      expect(tpl.recommended).toBeFalsy();
+    }
+  });
+
+  it("each template has valid difficulty", () => {
+    for (const tpl of STARTER_TEMPLATES) {
+      expect(DIFFICULTY_LABELS[tpl.difficulty]).toBeDefined();
+    }
+  });
+
+  it("each template has a duration string", () => {
+    for (const tpl of STARTER_TEMPLATES) {
+      expect(tpl.duration).toMatch(/^~\d+ min$/);
+    }
+  });
+
+  it("each exercise has valid sets, reps, rest", () => {
+    for (const tpl of STARTER_TEMPLATES) {
+      for (const ex of tpl.exercises) {
+        expect(ex.target_sets).toBeGreaterThanOrEqual(1);
+        expect(ex.target_reps).toMatch(/^\d+-\d+$/);
+        expect(ex.rest_seconds).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("STARTER_VERSION is a positive integer", () => {
+    expect(STARTER_VERSION).toBeGreaterThanOrEqual(1);
+    expect(Number.isInteger(STARTER_VERSION)).toBe(true);
+  });
+});
+
+describe("starter program data", () => {
+  it("has a valid program", () => {
+    expect(STARTER_PROGRAM.id).toBe("starter-prog-1");
+    expect(STARTER_PROGRAM.name).toBeTruthy();
+    expect(STARTER_PROGRAM.description).toBeTruthy();
+  });
+
+  it("has 3 days", () => {
+    expect(STARTER_PROGRAM.days).toHaveLength(3);
+  });
+
+  it("each day references a valid starter template", () => {
+    const tplIds = new Set(STARTER_TEMPLATES.map((t) => t.id));
+    for (const day of STARTER_PROGRAM.days) {
+      expect(tplIds.has(day.template_id)).toBe(true);
+    }
+  });
+
+  it("days have unique IDs", () => {
+    const ids = STARTER_PROGRAM.days.map((d) => d.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("days have labels", () => {
+    for (const day of STARTER_PROGRAM.days) {
+      expect(day.label).toBeTruthy();
+    }
+  });
+
+  it("PPL program references Push, Pull, Legs templates", () => {
+    expect(STARTER_PROGRAM.days[0].template_id).toBe("starter-tpl-2");
+    expect(STARTER_PROGRAM.days[1].template_id).toBe("starter-tpl-3");
+    expect(STARTER_PROGRAM.days[2].template_id).toBe("starter-tpl-4");
+  });
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -9,7 +9,9 @@ import {
 import {
   Button,
   Card,
+  Chip,
   IconButton,
+  Menu,
   SegmentedButtons,
   Snackbar,
   Text,
@@ -18,7 +20,15 @@ import {
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useFocusEffect, useRouter } from "expo-router";
 import {
+  getNextWorkout,
+  getPrograms,
+  getProgramDayCount,
+  softDeleteProgram,
+} from "../../lib/programs";
+import {
   deleteTemplate,
+  duplicateTemplate,
+  duplicateProgram,
   getActiveSession,
   getAllCompletedSessionWeeks,
   getRecentPRs,
@@ -29,15 +39,11 @@ import {
   getTemplates,
   startSession,
 } from "../../lib/db";
-import {
-  getNextWorkout,
-  getPrograms,
-  getProgramDayCount,
-  softDeleteProgram,
-} from "../../lib/programs";
 import type { Program, ProgramDay, WorkoutSession, WorkoutTemplate } from "../../lib/types";
 import { semantic } from "../../constants/theme";
 import { rpeColor, rpeText } from "../../lib/rpe";
+import { STARTER_TEMPLATES } from "../../lib/starter-templates";
+import { DIFFICULTY_LABELS } from "../../lib/types";
 
 function mondayOf(date: Date): number {
   const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
@@ -74,6 +80,7 @@ export default function Workouts() {
   const [avgRPEs, setAvgRPEs] = useState<Record<string, number | null>>({});
   const [nextWorkout, setNextWorkout] = useState<{ program: Program; day: ProgramDay } | null>(null);
   const [snackbar, setSnackbar] = useState("");
+  const [menu, setMenu] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     const [tpls, sess, act, timestamps, prData, progs, nw] = await Promise.all([
@@ -152,6 +159,7 @@ export default function Workouts() {
   };
 
   const confirmDeleteProgram = (prog: Program) => {
+    if (prog.is_starter) return;
     Alert.alert(
       "Delete Program",
       `Delete "${prog.name}"? Past workout data will be preserved.`,
@@ -170,6 +178,7 @@ export default function Workouts() {
   };
 
   const confirmDelete = (tpl: WorkoutTemplate) => {
+    if (tpl.is_starter) return;
     Alert.alert(
       "Delete Template",
       `Delete "${tpl.name}"? Past workout data will be preserved.`,
@@ -186,6 +195,28 @@ export default function Workouts() {
       ]
     );
   };
+
+  const handleDuplicateTemplate = async (tpl: WorkoutTemplate) => {
+    setMenu(null);
+    const newId = await duplicateTemplate(tpl.id);
+    await load();
+    router.push(`/template/${newId}`);
+  };
+
+  const handleDuplicateProgram = async (prog: Program) => {
+    setMenu(null);
+    const newId = await duplicateProgram(prog.id);
+    await load();
+    router.push(`/program/${newId}`);
+  };
+
+  const starterMeta = (id: string) =>
+    STARTER_TEMPLATES.find((s) => s.id === id);
+
+  const userTemplates = templates.filter((t) => !t.is_starter);
+  const starters = templates.filter((t) => t.is_starter);
+  const userPrograms = programs.filter((p) => !p.is_starter);
+  const starterPrograms = programs.filter((p) => p.is_starter);
 
   const duration = (seconds: number | null) => {
     if (!seconds) return "-";
@@ -281,7 +312,7 @@ export default function Workouts() {
 
       {segment === "templates" ? (
         <>
-          {/* Templates */}
+          {/* User Templates */}
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
               <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
@@ -297,7 +328,7 @@ export default function Workouts() {
                 Create
               </Button>
             </View>
-            {templates.length === 0 ? (
+            {userTemplates.length === 0 && starters.length === 0 ? (
               <View style={styles.empty}>
                 <Text
                   variant="bodyMedium"
@@ -315,49 +346,139 @@ export default function Workouts() {
                 </Button>
               </View>
             ) : (
-              <FlatList
-                data={templates}
-                keyExtractor={(item) => item.id}
-                scrollEnabled={false}
-                renderItem={({ item }: ListRenderItemInfo<WorkoutTemplate>) => (
-                  <Card
-                    style={[styles.card, { backgroundColor: theme.colors.surface }]}
-                    onPress={() => startFromTemplate(item)}
-                    onLongPress={() => confirmDelete(item)}
-                    accessibilityLabel={`Start workout from template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
-                    accessibilityRole="button"
-                  >
-                    <Card.Content style={styles.cardContent}>
-                      <View style={styles.cardInfo}>
-                        <Text
-                          variant="titleSmall"
-                          style={{ color: theme.colors.onSurface }}
-                        >
-                          {item.name}
-                        </Text>
-                        <Text
-                          variant="bodySmall"
-                          style={{ color: theme.colors.onSurfaceVariant }}
-                        >
-                          {counts[item.id] ?? 0} exercises
-                        </Text>
-                      </View>
-                      <IconButton
-                        icon="pencil"
-                        size={20}
-                        onPress={() => router.push(`/template/${item.id}`)}
-                        accessibilityLabel={`Edit template ${item.name}`}
-                      />
-                    </Card.Content>
-                  </Card>
+              <>
+                {userTemplates.length > 0 && (
+                  <FlatList
+                    data={userTemplates}
+                    keyExtractor={(item) => item.id}
+                    scrollEnabled={false}
+                    renderItem={({ item }: ListRenderItemInfo<WorkoutTemplate>) => (
+                      <Card
+                        style={[styles.card, { backgroundColor: theme.colors.surface }]}
+                        onPress={() => startFromTemplate(item)}
+                        onLongPress={() => confirmDelete(item)}
+                        accessibilityLabel={`Start workout from template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
+                        accessibilityRole="button"
+                      >
+                        <Card.Content style={styles.cardContent}>
+                          <View style={styles.cardInfo}>
+                            <Text
+                              variant="titleSmall"
+                              style={{ color: theme.colors.onSurface }}
+                            >
+                              {item.name}
+                            </Text>
+                            <Text
+                              variant="bodySmall"
+                              style={{ color: theme.colors.onSurfaceVariant }}
+                            >
+                              {counts[item.id] ?? 0} exercises
+                            </Text>
+                          </View>
+                          <IconButton
+                            icon="pencil"
+                            size={20}
+                            onPress={() => router.push(`/template/${item.id}`)}
+                            accessibilityLabel={`Edit template ${item.name}`}
+                          />
+                        </Card.Content>
+                      </Card>
+                    )}
+                  />
                 )}
-              />
+
+                {/* Starter Workouts */}
+                {starters.length > 0 && (
+                  <>
+                    <View style={styles.starterHeader} accessibilityRole="header">
+                      <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
+                        Starter Workouts
+                      </Text>
+                    </View>
+                    <FlatList
+                      data={starters}
+                      keyExtractor={(item) => item.id}
+                      scrollEnabled={false}
+                      renderItem={({ item }: ListRenderItemInfo<WorkoutTemplate>) => {
+                        const meta = starterMeta(item.id);
+                        return (
+                          <Card
+                            style={[styles.card, { backgroundColor: theme.colors.surface }]}
+                            onPress={() => startFromTemplate(item)}
+                            accessibilityLabel={`Starter template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
+                            accessibilityHint="Double-tap to start workout"
+                            accessibilityRole="button"
+                          >
+                            <Card.Content style={styles.cardContent}>
+                              <View style={styles.cardInfo}>
+                                <View style={styles.chipRow}>
+                                  <Text
+                                    variant="titleSmall"
+                                    style={{ color: theme.colors.onSurface }}
+                                  >
+                                    {item.name}
+                                  </Text>
+                                  <Chip
+                                    mode="flat"
+                                    compact
+                                    style={styles.starterChip}
+                                    textStyle={styles.starterChipText}
+                                    accessibilityLabel="Starter template"
+                                  >
+                                    STARTER
+                                  </Chip>
+                                  {meta?.recommended && (
+                                    <Chip
+                                      mode="flat"
+                                      compact
+                                      style={[styles.starterChip, { backgroundColor: theme.colors.primaryContainer }]}
+                                      textStyle={[styles.starterChipText, { color: theme.colors.onPrimaryContainer }]}
+                                      accessibilityLabel="Recommended"
+                                    >
+                                      Recommended
+                                    </Chip>
+                                  )}
+                                </View>
+                                <Text
+                                  variant="bodySmall"
+                                  style={{ color: theme.colors.onSurfaceVariant }}
+                                >
+                                  {meta ? `${DIFFICULTY_LABELS[meta.difficulty]} · ${meta.duration} · ${meta.exercises.length} exercises` : `${counts[item.id] ?? 0} exercises`}
+                                </Text>
+                              </View>
+                              <Menu
+                                visible={menu === item.id}
+                                onDismiss={() => setMenu(null)}
+                                anchor={
+                                  <IconButton
+                                    icon="dots-vertical"
+                                    size={20}
+                                    onPress={() => setMenu(item.id)}
+                                    accessibilityLabel={`Options for ${item.name}`}
+                                  />
+                                }
+                              >
+                                <Menu.Item
+                                  onPress={() => handleDuplicateTemplate(item)}
+                                  title="Duplicate"
+                                  leadingIcon="content-copy"
+                                  accessibilityLabel="Duplicate template for editing"
+                                />
+                              </Menu>
+                            </Card.Content>
+                          </Card>
+                        );
+                      }}
+                    />
+                  </>
+                )}
+              </>
             )}
           </View>
         </>
       ) : (
         <>
-          {/* Programs */}
+          {/* User Programs */}
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
               <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
@@ -373,7 +494,7 @@ export default function Workouts() {
                 Create
               </Button>
             </View>
-            {programs.length === 0 ? (
+            {userPrograms.length === 0 && starterPrograms.length === 0 ? (
               <View style={styles.empty}>
                 <Text
                   variant="bodyMedium"
@@ -393,45 +514,121 @@ export default function Workouts() {
                 </Button>
               </View>
             ) : (
-              <FlatList
-                data={programs}
-                keyExtractor={(item) => item.id}
-                scrollEnabled={false}
-                renderItem={({ item }: ListRenderItemInfo<Program>) => (
-                  <Card
-                    style={[styles.card, { backgroundColor: theme.colors.surface }]}
-                    onPress={() => router.push(`/program/${item.id}`)}
-                    onLongPress={() => confirmDeleteProgram(item)}
-                    accessibilityLabel={`Program: ${item.name}, ${dayCounts[item.id] ?? 0} days${item.is_active ? ", active" : ""}`}
-                    accessibilityRole="button"
-                  >
-                    <Card.Content style={styles.cardContent}>
-                      <View style={styles.cardInfo}>
-                        <Text
-                          variant="titleSmall"
-                          style={{ color: theme.colors.onSurface }}
-                        >
-                          {item.name}
-                        </Text>
-                        <Text
-                          variant="bodySmall"
-                          style={{ color: theme.colors.onSurfaceVariant }}
-                        >
-                          {dayCounts[item.id] ?? 0} days{item.is_active ? " · Active" : ""}
-                        </Text>
-                      </View>
-                      {item.is_active && (
-                        <MaterialCommunityIcons
-                          name="check-circle"
-                          size={20}
-                          color={theme.colors.primary}
-                          accessibilityLabel="Active program"
-                        />
-                      )}
-                    </Card.Content>
-                  </Card>
+              <>
+                {userPrograms.length > 0 && (
+                  <FlatList
+                    data={userPrograms}
+                    keyExtractor={(item) => item.id}
+                    scrollEnabled={false}
+                    renderItem={({ item }: ListRenderItemInfo<Program>) => (
+                      <Card
+                        style={[styles.card, { backgroundColor: theme.colors.surface }]}
+                        onPress={() => router.push(`/program/${item.id}`)}
+                        onLongPress={() => confirmDeleteProgram(item)}
+                        accessibilityLabel={`Program: ${item.name}, ${dayCounts[item.id] ?? 0} days${item.is_active ? ", active" : ""}`}
+                        accessibilityRole="button"
+                      >
+                        <Card.Content style={styles.cardContent}>
+                          <View style={styles.cardInfo}>
+                            <Text
+                              variant="titleSmall"
+                              style={{ color: theme.colors.onSurface }}
+                            >
+                              {item.name}
+                            </Text>
+                            <Text
+                              variant="bodySmall"
+                              style={{ color: theme.colors.onSurfaceVariant }}
+                            >
+                              {dayCounts[item.id] ?? 0} days{item.is_active ? " · Active" : ""}
+                            </Text>
+                          </View>
+                          {item.is_active && (
+                            <MaterialCommunityIcons
+                              name="check-circle"
+                              size={20}
+                              color={theme.colors.primary}
+                              accessibilityLabel="Active program"
+                            />
+                          )}
+                        </Card.Content>
+                      </Card>
+                    )}
+                  />
                 )}
-              />
+
+                {/* Starter Programs */}
+                {starterPrograms.length > 0 && (
+                  <>
+                    <View style={styles.starterHeader} accessibilityRole="header">
+                      <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
+                        Starter Programs
+                      </Text>
+                    </View>
+                    <FlatList
+                      data={starterPrograms}
+                      keyExtractor={(item) => item.id}
+                      scrollEnabled={false}
+                      renderItem={({ item }: ListRenderItemInfo<Program>) => (
+                        <Card
+                          style={[styles.card, { backgroundColor: theme.colors.surface }]}
+                          onPress={() => router.push(`/program/${item.id}`)}
+                          accessibilityLabel={`Starter program: ${item.name}, ${dayCounts[item.id] ?? 0} days`}
+                          accessibilityHint="Double-tap to view program"
+                          accessibilityRole="button"
+                        >
+                          <Card.Content style={styles.cardContent}>
+                            <View style={styles.cardInfo}>
+                              <View style={styles.chipRow}>
+                                <Text
+                                  variant="titleSmall"
+                                  style={{ color: theme.colors.onSurface }}
+                                >
+                                  {item.name}
+                                </Text>
+                                <Chip
+                                  mode="flat"
+                                  compact
+                                  style={styles.starterChip}
+                                  textStyle={styles.starterChipText}
+                                  accessibilityLabel="Starter template"
+                                >
+                                  STARTER
+                                </Chip>
+                              </View>
+                              <Text
+                                variant="bodySmall"
+                                style={{ color: theme.colors.onSurfaceVariant }}
+                              >
+                                {dayCounts[item.id] ?? 0} days · Intermediate
+                              </Text>
+                            </View>
+                            <Menu
+                              visible={menu === `prog-${item.id}`}
+                              onDismiss={() => setMenu(null)}
+                              anchor={
+                                <IconButton
+                                  icon="dots-vertical"
+                                  size={20}
+                                  onPress={() => setMenu(`prog-${item.id}`)}
+                                  accessibilityLabel={`Options for ${item.name}`}
+                                />
+                              }
+                            >
+                              <Menu.Item
+                                onPress={() => handleDuplicateProgram(item)}
+                                title="Duplicate"
+                                leadingIcon="content-copy"
+                                accessibilityLabel="Duplicate program for editing"
+                              />
+                            </Menu>
+                          </Card.Content>
+                        </Card>
+                      )}
+                    />
+                  </>
+                )}
+              </>
             )}
           </View>
         </>
@@ -695,5 +892,22 @@ const styles = StyleSheet.create({
   },
   emptyBtn: {
     marginTop: 8,
+  },
+  starterHeader: {
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  chipRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    flexWrap: "wrap",
+  },
+  starterChip: {
+    height: 24,
+  },
+  starterChipText: {
+    fontSize: 10,
+    lineHeight: 14,
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -907,7 +907,7 @@ const styles = StyleSheet.create({
     height: 24,
   },
   starterChipText: {
-    fontSize: 10,
-    lineHeight: 14,
+    fontSize: 12,
+    lineHeight: 16,
   },
 });

--- a/app/program/[id].tsx
+++ b/app/program/[id].tsx
@@ -10,6 +10,7 @@ import {
 import {
   Button,
   Card,
+  Chip,
   IconButton,
   Text,
   useTheme,
@@ -28,6 +29,7 @@ import {
   removeProgramDay,
   reorderProgramDays,
 } from "../../lib/programs";
+import { duplicateProgram } from "../../lib/db";
 import type { Program, ProgramDay } from "../../lib/types";
 
 export default function ProgramDetail() {
@@ -141,6 +143,12 @@ export default function ProgramDetail() {
   }
 
   const currentIdx = days.findIndex((d) => d.id === program.current_day_id);
+  const starter = program.is_starter;
+
+  const handleDuplicate = async () => {
+    const newId = await duplicateProgram(program.id);
+    router.replace(`/program/${newId}`);
+  };
 
   return (
     <>
@@ -152,6 +160,17 @@ export default function ProgramDetail() {
         keyExtractor={(item) => item.id}
         ListHeaderComponent={
           <>
+            {starter && (
+              <Chip
+                mode="flat"
+                compact
+                style={styles.starterChip}
+                accessibilityLabel="Starter program, read-only. Duplicate to edit."
+              >
+                STARTER
+              </Chip>
+            )}
+
             {program.description ? (
               <Text
                 variant="bodyMedium"
@@ -176,44 +195,69 @@ export default function ProgramDetail() {
               )}
             </View>
 
-            <View style={styles.actions}>
-              <Button
-                mode={program.is_active ? "outlined" : "contained"}
-                onPress={toggle}
-                disabled={loading}
-                style={styles.actionBtn}
-                accessibilityLabel={program.is_active ? "Deactivate program" : "Set program as active"}
-              >
-                {program.is_active ? "Deactivate" : "Set Active"}
-              </Button>
-              <Button
-                mode="outlined"
-                onPress={() => router.push(`/program/create?programId=${program.id}`)}
-                style={styles.actionBtn}
-                accessibilityLabel="Edit program"
-              >
-                Edit
-              </Button>
-              <IconButton
-                icon="delete"
-                onPress={confirmDelete}
-                accessibilityLabel="Delete program"
-              />
-            </View>
+            {starter ? (
+              <View style={styles.actions}>
+                <Button
+                  mode={program.is_active ? "outlined" : "contained"}
+                  onPress={toggle}
+                  disabled={loading}
+                  style={styles.actionBtn}
+                  accessibilityLabel={program.is_active ? "Deactivate program" : "Set program as active"}
+                >
+                  {program.is_active ? "Deactivate" : "Set Active"}
+                </Button>
+                <Button
+                  mode="outlined"
+                  icon="content-copy"
+                  onPress={handleDuplicate}
+                  style={styles.actionBtn}
+                  accessibilityLabel="Duplicate to edit"
+                >
+                  Duplicate to Edit
+                </Button>
+              </View>
+            ) : (
+              <View style={styles.actions}>
+                <Button
+                  mode={program.is_active ? "outlined" : "contained"}
+                  onPress={toggle}
+                  disabled={loading}
+                  style={styles.actionBtn}
+                  accessibilityLabel={program.is_active ? "Deactivate program" : "Set program as active"}
+                >
+                  {program.is_active ? "Deactivate" : "Set Active"}
+                </Button>
+                <Button
+                  mode="outlined"
+                  onPress={() => router.push(`/program/create?programId=${program.id}`)}
+                  style={styles.actionBtn}
+                  accessibilityLabel="Edit program"
+                >
+                  Edit
+                </Button>
+                <IconButton
+                  icon="delete"
+                  onPress={confirmDelete}
+                  accessibilityLabel="Delete program"
+                />
+              </View>
+            )}
 
             <View style={styles.sectionHeader}>
               <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
                 Workout Days ({days.length})
               </Text>
-              <Button
-                mode="text"
-                icon="plus"
-                compact
-                onPress={() => router.push(`/program/pick-template?programId=${program.id}`)}
-                accessibilityLabel="Add workout day"
-              >
-                Add Day
-              </Button>
+              {!starter && (
+                <Button
+                  mode="text"
+                  icon="plus"
+                  compact
+                  onPress={() => router.push(`/program/pick-template?programId=${program.id}`)}
+                  accessibilityLabel="Add workout day"
+                >
+                  Add Day
+                </Button>
+              )}
             </View>
           </>
         }
@@ -245,30 +289,32 @@ export default function ProgramDetail() {
                   </Text>
                 )}
               </View>
-              <View style={styles.cardActions}>
-                <IconButton
-                  icon="arrow-up"
-                  size={18}
-                  onPress={() => move(index, -1)}
-                  disabled={index === 0}
-                  accessibilityLabel={`Move ${dayName(item)} up`}
-                  accessibilityHint="Reorders workout day"
-                />
-                <IconButton
-                  icon="arrow-down"
-                  size={18}
-                  onPress={() => move(index, 1)}
-                  disabled={index === days.length - 1}
-                  accessibilityLabel={`Move ${dayName(item)} down`}
-                  accessibilityHint="Reorders workout day"
-                />
-                <IconButton
-                  icon="close"
+              {!starter && (
+                <View style={styles.cardActions}>
+                  <IconButton
+                    icon="arrow-up"
+                    size={18}
+                    onPress={() => move(index, -1)}
+                    disabled={index === 0}
+                    accessibilityLabel={`Move ${dayName(item)} up`}
+                    accessibilityHint="Reorders workout day"
+                  />
+                  <IconButton
+                    icon="arrow-down"
+                    size={18}
+                    onPress={() => move(index, 1)}
+                    disabled={index === days.length - 1}
+                    accessibilityLabel={`Move ${dayName(item)} down`}
+                    accessibilityHint="Reorders workout day"
+                  />
+                  <IconButton
+                    icon="close"
                   size={18}
                   onPress={() => remove(item.id)}
                   accessibilityLabel={`Remove ${dayName(item)}`}
                 />
               </View>
+              )}
             </Card.Content>
           </Card>
         )}
@@ -330,6 +376,10 @@ const styles = StyleSheet.create({
     paddingBottom: 48,
   },
   desc: {
+    marginBottom: 12,
+  },
+  starterChip: {
+    alignSelf: "flex-start",
     marginBottom: 12,
   },
   meta: {

--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -9,6 +9,7 @@ import {
 import {
   Button,
   Checkbox,
+  Chip,
   IconButton,
   Snackbar,
   Text,
@@ -18,6 +19,7 @@ import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import {
   addExerciseToTemplate,
   createExerciseLink,
+  duplicateTemplate,
   getTemplateById,
   removeExerciseFromTemplate,
   reorderTemplateExercises,
@@ -318,6 +320,13 @@ export default function EditTemplate() {
     );
   }
 
+  const starter = template.is_starter;
+
+  const handleDuplicate = async () => {
+    const newId = await duplicateTemplate(template.id);
+    router.replace(`/template/${newId}`);
+  };
+
   return (
     <>
       <Stack.Screen options={{ title: template.name }} />
@@ -325,16 +334,27 @@ export default function EditTemplate() {
         style={[styles.container, { backgroundColor: theme.colors.background }]}
       >
         <View style={styles.section}>
-          <Text
-            variant="titleMedium"
-            style={{ color: theme.colors.onBackground }}
-          >
-            Exercises ({exercises.length})
-          </Text>
+          <View style={styles.headerRow}>
+            <Text
+              variant="titleMedium"
+              style={{ color: theme.colors.onBackground }}
+            >
+              Exercises ({exercises.length})
+            </Text>
+            {starter && (
+              <Chip
+                mode="flat"
+                compact
+                accessibilityLabel="Starter template, read-only. Duplicate to edit."
+              >
+                STARTER
+              </Chip>
+            )}
+          </View>
         </View>
 
         {/* Selection mode toolbar */}
-        {selecting && (
+        {selecting && !starter && (
           <View style={[styles.selectionBar, { backgroundColor: theme.colors.primaryContainer }]}>
             <Text variant="bodyMedium" style={{ color: theme.colors.onPrimaryContainer, flex: 1 }}
               accessibilityLiveRegion="polite"
@@ -364,7 +384,42 @@ export default function EditTemplate() {
 
         <FlatList
           data={exercises}
-          renderItem={renderItem}
+          renderItem={starter ? ({ item, index }: ListRenderItemInfo<TemplateExercise>) => {
+            const linkIdx = item.link_id ? linkIds.indexOf(item.link_id) : -1;
+            const color = linkIdx >= 0 ? palette[linkIdx % palette.length] : undefined;
+            return (
+              <Pressable
+                style={[
+                  styles.row,
+                  {
+                    backgroundColor: theme.colors.surface,
+                    borderBottomColor: theme.colors.outlineVariant,
+                    borderLeftWidth: color ? 4 : 0,
+                    borderLeftColor: color ?? "transparent",
+                  },
+                ]}
+                accessibilityRole="none"
+              >
+                <View style={styles.info}>
+                  <Text
+                    variant="titleSmall"
+                    style={{
+                      color: item.exercise?.deleted_at ? theme.colors.onSurfaceVariant : theme.colors.onSurface,
+                      fontStyle: item.exercise?.deleted_at ? "italic" : "normal",
+                    }}
+                  >
+                    {item.exercise?.name ?? "Unknown"}{item.exercise?.deleted_at ? " (removed)" : ""}
+                  </Text>
+                  <Text
+                    variant="bodySmall"
+                    style={{ color: theme.colors.onSurfaceVariant }}
+                  >
+                    {item.target_sets} × {item.target_reps} · {item.rest_seconds}s rest
+                  </Text>
+                </View>
+              </Pressable>
+            );
+          } : renderItem}
           keyExtractor={(item) => item.id}
           extraData={[selecting, selected, linkIds]}
           ListEmptyComponent={
@@ -380,33 +435,47 @@ export default function EditTemplate() {
           style={styles.list}
         />
 
-        {!selecting && exercises.length >= 2 && (
+        {starter ? (
           <Button
-            mode="outlined"
-            icon="link-variant"
-            onPress={() => startSelection()}
-            style={styles.addBtn}
-            accessibilityLabel="Create superset"
-            accessibilityRole="button"
+            mode="contained"
+            icon="content-copy"
+            onPress={handleDuplicate}
+            style={styles.doneBtn}
+            accessibilityLabel="Duplicate to edit"
           >
-            Create Superset
+            Duplicate to Edit
           </Button>
-        )}
+        ) : (
+          <>
+            {!selecting && exercises.length >= 2 && (
+              <Button
+                mode="outlined"
+                icon="link-variant"
+                onPress={() => startSelection()}
+                style={styles.addBtn}
+                accessibilityLabel="Create superset"
+                accessibilityRole="button"
+              >
+                Create Superset
+              </Button>
+            )}
 
-        <Button
-          mode="outlined"
-          icon="plus"
-          onPress={() =>
-            router.push(`/template/pick-exercise?templateId=${id}&editId=${id}`)
-          }
-          style={styles.addBtn}
-          accessibilityLabel="Add exercise to template"
-        >
-          Add Exercise
-        </Button>
-        <Button mode="contained" onPress={() => router.back()} style={styles.doneBtn} accessibilityLabel="Done editing template">
-          Done
-        </Button>
+            <Button
+              mode="outlined"
+              icon="plus"
+              onPress={() =>
+                router.push(`/template/pick-exercise?templateId=${id}&editId=${id}`)
+              }
+              style={styles.addBtn}
+              accessibilityLabel="Add exercise to template"
+            >
+              Add Exercise
+            </Button>
+            <Button mode="contained" onPress={() => router.back()} style={styles.doneBtn} accessibilityLabel="Done editing template">
+              Done
+            </Button>
+          </>
+        )}
       </View>
       <Snackbar
         visible={!!snackbar}
@@ -440,6 +509,11 @@ const styles = StyleSheet.create({
   },
   section: {
     marginBottom: 8,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
   list: {
     flex: 1,

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -19,6 +19,11 @@ import type {
   MuscleGroup,
 } from "./types";
 import { seedExercises } from "./seed";
+import {
+  STARTER_TEMPLATES,
+  STARTER_PROGRAM,
+  STARTER_VERSION,
+} from "./starter-templates";
 
 const DB_NAME = "fitforge.db";
 
@@ -336,6 +341,31 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
       );
     });
   }
+
+  // Migration: add is_starter column to workout_templates
+  const tplCols = await database.getAllAsync<{ name: string }>(
+    "PRAGMA table_info(workout_templates)"
+  );
+  if (!tplCols.some((c) => c.name === "is_starter")) {
+    await database.execAsync(
+      "ALTER TABLE workout_templates ADD COLUMN is_starter INTEGER DEFAULT 0"
+    );
+  }
+
+  // Migration: add is_starter column to programs
+  const progCols = await database.getAllAsync<{ name: string }>(
+    "PRAGMA table_info(programs)"
+  );
+  if (!progCols.some((c) => c.name === "is_starter")) {
+    await database.execAsync(
+      "ALTER TABLE programs ADD COLUMN is_starter INTEGER DEFAULT 0"
+    );
+  }
+
+  // Migration: create app_settings table
+  await database.execAsync(
+    "CREATE TABLE IF NOT EXISTS app_settings (key TEXT PRIMARY KEY, value TEXT)"
+  );
 }
 
 async function seed(database: SQLite.SQLiteDatabase): Promise<void> {
@@ -370,6 +400,48 @@ async function seed(database: SQLite.SQLiteDatabase): Promise<void> {
   } finally {
     await stmt.finalizeAsync();
   }
+
+  await seedStarters(database);
+}
+
+async function seedStarters(database: SQLite.SQLiteDatabase): Promise<void> {
+  const row = await database.getFirstAsync<{ value: string }>(
+    "SELECT value FROM app_settings WHERE key = 'starter_version'"
+  );
+  if (row && Number(row.value) >= STARTER_VERSION) return;
+
+  await database.withTransactionAsync(async () => {
+    for (const tpl of STARTER_TEMPLATES) {
+      await database.runAsync(
+        "INSERT OR IGNORE INTO workout_templates (id, name, created_at, updated_at, is_starter) VALUES (?, ?, 0, 0, 1)",
+        [tpl.id, tpl.name]
+      );
+      for (let i = 0; i < tpl.exercises.length; i++) {
+        const ex = tpl.exercises[i];
+        await database.runAsync(
+          "INSERT OR IGNORE INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds) VALUES (?, ?, ?, ?, ?, ?, ?)",
+          [ex.id, tpl.id, ex.exercise_id, i, ex.target_sets, ex.target_reps, ex.rest_seconds]
+        );
+      }
+    }
+
+    await database.runAsync(
+      "INSERT OR IGNORE INTO programs (id, name, description, is_active, current_day_id, created_at, updated_at, is_starter) VALUES (?, ?, ?, 0, NULL, 0, 0, 1)",
+      [STARTER_PROGRAM.id, STARTER_PROGRAM.name, STARTER_PROGRAM.description]
+    );
+    for (let i = 0; i < STARTER_PROGRAM.days.length; i++) {
+      const day = STARTER_PROGRAM.days[i];
+      await database.runAsync(
+        "INSERT OR IGNORE INTO program_days (id, program_id, template_id, position, label) VALUES (?, ?, ?, ?, ?)",
+        [day.id, STARTER_PROGRAM.id, day.template_id, i, day.label]
+      );
+    }
+
+    await database.runAsync(
+      "INSERT OR REPLACE INTO app_settings (key, value) VALUES ('starter_version', ?)",
+      [String(STARTER_VERSION)]
+    );
+  });
 }
 
 type ExerciseRow = {
@@ -512,10 +584,16 @@ export async function createTemplate(name: string): Promise<WorkoutTemplate> {
 
 export async function getTemplates(): Promise<WorkoutTemplate[]> {
   const database = await getDatabase();
-  const rows = await database.getAllAsync<WorkoutTemplate>(
-    "SELECT * FROM workout_templates ORDER BY updated_at DESC"
+  const rows = await database.getAllAsync<{
+    id: string;
+    name: string;
+    created_at: number;
+    updated_at: number;
+    is_starter: number;
+  }>(
+    "SELECT * FROM workout_templates ORDER BY is_starter ASC, created_at DESC"
   );
-  return rows;
+  return rows.map((r) => ({ ...r, is_starter: r.is_starter === 1 }));
 }
 
 type TemplateExerciseRow = {
@@ -543,11 +621,18 @@ export async function getTemplateById(
   id: string
 ): Promise<WorkoutTemplate | null> {
   const database = await getDatabase();
-  const tpl = await database.getFirstAsync<WorkoutTemplate>(
+  const raw = await database.getFirstAsync<{
+    id: string;
+    name: string;
+    created_at: number;
+    updated_at: number;
+    is_starter: number;
+  }>(
     "SELECT * FROM workout_templates WHERE id = ?",
     [id]
   );
-  if (!tpl) return null;
+  if (!raw) return null;
+  const tpl: WorkoutTemplate = { ...raw, is_starter: raw.is_starter === 1 };
   const rows = await database.getAllAsync<TemplateExerciseRow>(
     `SELECT te.*, e.name AS exercise_name, e.category AS exercise_category,
        e.primary_muscles AS exercise_primary_muscles, e.secondary_muscles AS exercise_secondary_muscles,
@@ -594,9 +679,91 @@ export async function getTemplateById(
 
 export async function deleteTemplate(id: string): Promise<void> {
   const database = await getDatabase();
+  const tpl = await database.getFirstAsync<{ is_starter: number }>(
+    "SELECT is_starter FROM workout_templates WHERE id = ?",
+    [id]
+  );
+  if (tpl?.is_starter === 1) return;
   await database.runAsync("DELETE FROM template_exercises WHERE template_id = ?", [id]);
   await database.runAsync("UPDATE program_days SET template_id = NULL WHERE template_id = ?", [id]);
-  await database.runAsync("DELETE FROM workout_templates WHERE id = ?", [id]);
+  await database.runAsync("DELETE FROM workout_templates WHERE id = ? AND is_starter = 0", [id]);
+}
+
+export async function duplicateTemplate(id: string): Promise<string> {
+  const database = await getDatabase();
+  const tpl = await getTemplateById(id);
+  if (!tpl) throw new Error("Template not found");
+
+  const newId = crypto.randomUUID();
+  const now = Date.now();
+  const name = tpl.is_starter ? `${tpl.name} (Copy)` : `${tpl.name} (Copy)`;
+
+  await database.withTransactionAsync(async () => {
+    await database.runAsync(
+      "INSERT INTO workout_templates (id, name, created_at, updated_at, is_starter) VALUES (?, ?, ?, ?, 0)",
+      [newId, name, now, now]
+    );
+
+    const linkMap = new Map<string, string>();
+    for (const ex of tpl.exercises ?? []) {
+      const teId = crypto.randomUUID();
+      let linkId = ex.link_id;
+      if (linkId) {
+        if (!linkMap.has(linkId)) linkMap.set(linkId, crypto.randomUUID());
+        linkId = linkMap.get(linkId)!;
+      }
+      await database.runAsync(
+        "INSERT INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds, link_id, link_label) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [teId, newId, ex.exercise_id, ex.position, ex.target_sets, ex.target_reps, ex.rest_seconds, linkId, ex.link_label]
+      );
+    }
+  });
+
+  return newId;
+}
+
+export async function duplicateProgram(id: string): Promise<string> {
+  const database = await getDatabase();
+  const prog = await database.getFirstAsync<{ id: string; name: string; description: string; is_starter: number }>(
+    "SELECT id, name, description, is_starter FROM programs WHERE id = ? AND deleted_at IS NULL",
+    [id]
+  );
+  if (!prog) throw new Error("Program not found");
+
+  const newId = crypto.randomUUID();
+  const now = Date.now();
+  const name = `${prog.name} (Copy)`;
+
+  const days = await database.getAllAsync<{ id: string; template_id: string | null; position: number; label: string }>(
+    "SELECT id, template_id, position, label FROM program_days WHERE program_id = ? ORDER BY position ASC",
+    [id]
+  );
+
+  await database.withTransactionAsync(async () => {
+    await database.runAsync(
+      "INSERT INTO programs (id, name, description, is_active, current_day_id, created_at, updated_at, is_starter) VALUES (?, ?, ?, 0, NULL, ?, ?, 0)",
+      [newId, name, prog.description, now, now]
+    );
+
+    for (const day of days) {
+      let tplId = day.template_id;
+      if (tplId) {
+        const tpl = await database.getFirstAsync<{ is_starter: number }>(
+          "SELECT is_starter FROM workout_templates WHERE id = ?",
+          [tplId]
+        );
+        if (tpl?.is_starter === 1) {
+          tplId = await duplicateTemplate(tplId);
+        }
+      }
+      await database.runAsync(
+        "INSERT INTO program_days (id, program_id, template_id, position, label) VALUES (?, ?, ?, ?, ?)",
+        [crypto.randomUUID(), newId, tplId, day.position, day.label]
+      );
+    }
+  });
+
+  return newId;
 }
 
 export async function addExerciseToTemplate(

--- a/lib/programs.ts
+++ b/lib/programs.ts
@@ -33,14 +33,15 @@ export async function getPrograms(): Promise<Program[]> {
     name: string;
     description: string;
     is_active: number;
+    is_starter: number;
     current_day_id: string | null;
     created_at: number;
     updated_at: number;
     deleted_at: number | null;
   }>(
-    "SELECT * FROM programs WHERE deleted_at IS NULL ORDER BY is_active DESC, updated_at DESC"
+    "SELECT * FROM programs WHERE deleted_at IS NULL ORDER BY is_active DESC, is_starter ASC, updated_at DESC"
   );
-  return rows.map((r) => ({ ...r, is_active: r.is_active === 1 }));
+  return rows.map((r) => ({ ...r, is_active: r.is_active === 1, is_starter: r.is_starter === 1 }));
 }
 
 export async function getProgramById(id: string): Promise<Program | null> {
@@ -50,13 +51,14 @@ export async function getProgramById(id: string): Promise<Program | null> {
     name: string;
     description: string;
     is_active: number;
+    is_starter: number;
     current_day_id: string | null;
     created_at: number;
     updated_at: number;
     deleted_at: number | null;
   }>("SELECT * FROM programs WHERE id = ? AND deleted_at IS NULL", [id]);
   if (!row) return null;
-  return { ...row, is_active: row.is_active === 1 };
+  return { ...row, is_active: row.is_active === 1, is_starter: row.is_starter === 1 };
 }
 
 export async function updateProgram(
@@ -73,8 +75,13 @@ export async function updateProgram(
 
 export async function softDeleteProgram(id: string): Promise<void> {
   const database = await getDatabase();
+  const prog = await database.getFirstAsync<{ is_starter: number }>(
+    "SELECT is_starter FROM programs WHERE id = ?",
+    [id]
+  );
+  if (prog?.is_starter === 1) return;
   await database.runAsync(
-    "UPDATE programs SET deleted_at = ?, is_active = 0, updated_at = ? WHERE id = ?",
+    "UPDATE programs SET deleted_at = ?, is_active = 0, updated_at = ? WHERE id = ? AND is_starter = 0",
     [Date.now(), Date.now(), id]
   );
 }

--- a/lib/starter-templates.ts
+++ b/lib/starter-templates.ts
@@ -1,0 +1,126 @@
+import type { Difficulty } from "./types";
+
+export type StarterExercise = {
+  id: string;
+  exercise_id: string;
+  target_sets: number;
+  target_reps: string;
+  rest_seconds: number;
+};
+
+export type StarterTemplate = {
+  id: string;
+  name: string;
+  difficulty: Difficulty;
+  duration: string;
+  recommended?: boolean;
+  exercises: StarterExercise[];
+};
+
+export type StarterProgram = {
+  id: string;
+  name: string;
+  description: string;
+  days: { id: string; label: string; template_id: string }[];
+};
+
+export const STARTER_VERSION = 1;
+
+export const STARTER_TEMPLATES: StarterTemplate[] = [
+  {
+    id: "starter-tpl-1",
+    name: "Full Body",
+    difficulty: "beginner",
+    duration: "~35 min",
+    recommended: true,
+    exercises: [
+      { id: "starter-te-1-goblet-squat", exercise_id: "voltra-039", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+      { id: "starter-te-1-chest-press-handle", exercise_id: "voltra-035", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+      { id: "starter-te-1-seated-row", exercise_id: "voltra-021", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+      { id: "starter-te-1-lateral-raises", exercise_id: "voltra-049", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+      { id: "starter-te-1-biceps-curls", exercise_id: "voltra-011", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+      { id: "starter-te-1-ab-crunches", exercise_id: "voltra-001", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+    ],
+  },
+  {
+    id: "starter-tpl-2",
+    name: "Upper Push",
+    difficulty: "intermediate",
+    duration: "~30 min",
+    exercises: [
+      { id: "starter-te-2-incline-chest", exercise_id: "voltra-031", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+      { id: "starter-te-2-chest-press-bar", exercise_id: "voltra-034", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+      { id: "starter-te-2-crossover-fly", exercise_id: "voltra-029", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+      { id: "starter-te-2-front-raise", exercise_id: "voltra-048", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+      { id: "starter-te-2-lateral-one-arm", exercise_id: "voltra-050", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+      { id: "starter-te-2-triceps-pushdown", exercise_id: "voltra-017", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+    ],
+  },
+  {
+    id: "starter-tpl-3",
+    name: "Upper Pull",
+    difficulty: "intermediate",
+    duration: "~30 min",
+    exercises: [
+      { id: "starter-te-3-lat-pulldown", exercise_id: "voltra-019", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+      { id: "starter-te-3-seated-row", exercise_id: "voltra-021", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+      { id: "starter-te-3-face-pulls", exercise_id: "voltra-046", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+      { id: "starter-te-3-straight-arm", exercise_id: "voltra-026", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+      { id: "starter-te-3-biceps-low", exercise_id: "voltra-010", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+      { id: "starter-te-3-hammer-curl", exercise_id: "voltra-012", target_sets: 3, target_reps: "8-12", rest_seconds: 90 },
+    ],
+  },
+  {
+    id: "starter-tpl-4",
+    name: "Lower & Core",
+    difficulty: "intermediate",
+    duration: "~35 min",
+    exercises: [
+      { id: "starter-te-4-goblet-squat", exercise_id: "voltra-039", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+      { id: "starter-te-4-deadlift", exercise_id: "voltra-038", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+      { id: "starter-te-4-reverse-lunges", exercise_id: "voltra-043", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+      { id: "starter-te-4-hip-extension", exercise_id: "voltra-040", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+      { id: "starter-te-4-half-kneel-chop", exercise_id: "voltra-003", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+      { id: "starter-te-4-trunk-rotations", exercise_id: "voltra-009", target_sets: 3, target_reps: "10-12", rest_seconds: 60 },
+    ],
+  },
+  {
+    id: "starter-tpl-5",
+    name: "Arms & Shoulders",
+    difficulty: "beginner",
+    duration: "~25 min",
+    exercises: [
+      { id: "starter-te-5-biceps-curls", exercise_id: "voltra-011", target_sets: 3, target_reps: "10-15", rest_seconds: 60 },
+      { id: "starter-te-5-triceps-pushdown", exercise_id: "voltra-017", target_sets: 3, target_reps: "10-15", rest_seconds: 60 },
+      { id: "starter-te-5-hammer-curl", exercise_id: "voltra-012", target_sets: 3, target_reps: "10-15", rest_seconds: 60 },
+      { id: "starter-te-5-overhead-triceps", exercise_id: "voltra-013", target_sets: 3, target_reps: "10-15", rest_seconds: 60 },
+      { id: "starter-te-5-lateral-raises", exercise_id: "voltra-049", target_sets: 3, target_reps: "10-15", rest_seconds: 60 },
+      { id: "starter-te-5-upright-rows", exercise_id: "voltra-053", target_sets: 3, target_reps: "10-15", rest_seconds: 60 },
+    ],
+  },
+  {
+    id: "starter-tpl-6",
+    name: "Core Strength",
+    difficulty: "intermediate",
+    duration: "~20 min",
+    exercises: [
+      { id: "starter-te-6-ab-crunches", exercise_id: "voltra-001", target_sets: 3, target_reps: "12-15", rest_seconds: 45 },
+      { id: "starter-te-6-half-kneel-chop", exercise_id: "voltra-003", target_sets: 3, target_reps: "12-15", rest_seconds: 45 },
+      { id: "starter-te-6-supine-bicycle", exercise_id: "voltra-002", target_sets: 3, target_reps: "12-15", rest_seconds: 45 },
+      { id: "starter-te-6-trunk-rotations", exercise_id: "voltra-009", target_sets: 3, target_reps: "12-15", rest_seconds: 45 },
+      { id: "starter-te-6-squat-rotation", exercise_id: "voltra-008", target_sets: 3, target_reps: "12-15", rest_seconds: 45 },
+      { id: "starter-te-6-high-row", exercise_id: "voltra-004", target_sets: 3, target_reps: "12-15", rest_seconds: 45 },
+    ],
+  },
+];
+
+export const STARTER_PROGRAM: StarterProgram = {
+  id: "starter-prog-1",
+  name: "Push / Pull / Legs",
+  description: "3-day training split. Push muscles on day 1, pull muscles on day 2, legs and core on day 3. Repeat the cycle.",
+  days: [
+    { id: "starter-day-1-push", label: "Push", template_id: "starter-tpl-2" },
+    { id: "starter-day-2-pull", label: "Pull", template_id: "starter-tpl-3" },
+    { id: "starter-day-3-legs", label: "Legs & Core", template_id: "starter-tpl-4" },
+  ],
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -166,6 +166,7 @@ export type WorkoutTemplate = {
   name: string;
   created_at: number;
   updated_at: number;
+  is_starter?: boolean;
   exercises?: TemplateExercise[];
 };
 
@@ -326,6 +327,7 @@ export type Program = {
   name: string;
   description: string;
   is_active: boolean;
+  is_starter?: boolean;
   current_day_id: string | null;
   created_at: number;
   updated_at: number;


### PR DESCRIPTION
## Summary

Add 6 curated starter workout templates and 1 starter program (Push/Pull/Legs) to help new users start training immediately after the Phase 22 Voltra pivot.

## Changes

- **Schema**: `is_starter` column on `workout_templates` and `programs` tables; `app_settings` table for version-based seeding
- **Data**: 6 starter templates (Full Body, Upper Push, Upper Pull, Lower & Core, Arms & Shoulders, Core Strength) + PPL program referencing explicit voltra exercise IDs
- **Seeding**: Version-based idempotent seeding in `initDatabase()` via `app_settings.starter_version`
- **Queries**: Templates/programs ordered user-first (`is_starter ASC`); `is_starter` returned in query results
- **Defense**: `is_starter` guard on `deleteTemplate()` and `softDeleteProgram()` prevents deletion
- **Duplicate**: `duplicateTemplate()` and `duplicateProgram()` create editable copies (with link_id remapping)
- **UI (index.tsx)**: Separate "My Templates" and "Starter Workouts" sections; STARTER chip, difficulty tag, duration, Recommended chip, overflow menu with Duplicate
- **UI (template detail)**: Read-only mode for starters, "Duplicate to Edit" button
- **UI (program detail)**: Read-only mode for starters, "Duplicate to Edit" button, hide edit/delete/reorder
- **Accessibility**: `accessibilityHint`, `accessibilityLabel`, `accessibilityRole='header'` per spec
- **Tests**: 18 new tests validating starter template data integrity

## Testing

- `npx tsc --noEmit` — 0 errors
- `npm test` — 149/149 tests pass (131 existing + 18 new)

## Issue

Resolves BLD-32