### PR TITLE
feat: Onboarding & Quick Start Flow (BLD-35)

### DIFF
--- a/__tests__/lib/onboarding.test.ts
+++ b/__tests__/lib/onboarding.test.ts
@@ -1,0 +1,175 @@
+// Mock crypto.randomUUID
+const MOCK_UUID = "test-uuid-onboarding";
+Object.defineProperty(global, "crypto", {
+  value: { randomUUID: jest.fn(() => MOCK_UUID) },
+});
+
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  getFirstAsync: jest.fn().mockResolvedValue({ count: 10 }),
+  runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  prepareAsync: jest.fn().mockResolvedValue({
+    executeAsync: jest.fn().mockResolvedValue(undefined),
+    finalizeAsync: jest.fn().mockResolvedValue(undefined),
+  }),
+  withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+};
+
+jest.mock("expo-sqlite", () => ({
+  openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+}));
+
+jest.mock("../../lib/seed", () => ({
+  seedExercises: jest.fn(() => []),
+}));
+
+let db: typeof import("../../lib/db");
+
+async function initDb() {
+  await db.getDatabase();
+  jest.clearAllMocks();
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.execAsync.mockResolvedValue(undefined);
+  mockDb.getAllAsync.mockResolvedValue([]);
+  mockDb.getFirstAsync.mockResolvedValue({ count: 10 });
+  mockDb.runAsync.mockResolvedValue({ changes: 1 });
+  jest.resetModules();
+  jest.doMock("expo-sqlite", () => ({
+    openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+  }));
+  jest.doMock("../../lib/seed", () => ({
+    seedExercises: jest.fn(() => []),
+  }));
+  db = require("../../lib/db");
+});
+
+describe("getAppSetting", () => {
+  it("returns null when key not found", async () => {
+    await initDb();
+    mockDb.getFirstAsync.mockResolvedValueOnce(null);
+    const val = await db.getAppSetting("missing_key");
+    expect(val).toBeNull();
+    expect(mockDb.getFirstAsync).toHaveBeenCalledWith(
+      "SELECT value FROM app_settings WHERE key = ?",
+      ["missing_key"]
+    );
+  });
+
+  it("returns value when key exists", async () => {
+    await initDb();
+    mockDb.getFirstAsync.mockResolvedValueOnce({ value: "hello" });
+    const val = await db.getAppSetting("test_key");
+    expect(val).toBe("hello");
+  });
+});
+
+describe("setAppSetting", () => {
+  it("inserts or replaces setting", async () => {
+    await initDb();
+    await db.setAppSetting("my_key", "my_value");
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      "INSERT OR REPLACE INTO app_settings (key, value) VALUES (?, ?)",
+      ["my_key", "my_value"]
+    );
+  });
+});
+
+describe("isOnboardingComplete", () => {
+  it("returns false when setting not present", async () => {
+    await initDb();
+    mockDb.getFirstAsync.mockResolvedValueOnce(null);
+    const complete = await db.isOnboardingComplete();
+    expect(complete).toBe(false);
+  });
+
+  it("returns false when setting is not '1'", async () => {
+    await initDb();
+    mockDb.getFirstAsync.mockResolvedValueOnce({ value: "0" });
+    const complete = await db.isOnboardingComplete();
+    expect(complete).toBe(false);
+  });
+
+  it("returns true when setting is '1'", async () => {
+    await initDb();
+    mockDb.getFirstAsync.mockResolvedValueOnce({ value: "1" });
+    const complete = await db.isOnboardingComplete();
+    expect(complete).toBe(true);
+  });
+});
+
+describe("seedStarters existing-user migration", () => {
+  it("sets onboarding_complete for existing users with starter_version", async () => {
+    // Simulate existing user: starter_version exists with current version
+    // Use a smart mock that returns the right result based on the query
+    mockDb.getFirstAsync.mockImplementation(async (sql: string) => {
+      if (typeof sql === "string" && sql.includes("starter_version"))
+        return { value: "1" };
+      if (typeof sql === "string" && sql.includes("COUNT"))
+        return { count: 10 };
+      return null;
+    });
+
+    await db.getDatabase();
+
+    const calls = mockDb.runAsync.mock.calls;
+    const onboardingCall = calls.find(
+      (c: any[]) =>
+        typeof c[0] === "string" &&
+        c[0].includes("onboarding_complete")
+    );
+    expect(onboardingCall).toBeDefined();
+    expect(onboardingCall![0]).toContain("INSERT OR IGNORE");
+  });
+
+  it("does not set onboarding_complete for fresh installs", async () => {
+    mockDb.getFirstAsync.mockImplementation(async (sql: string) => {
+      if (typeof sql === "string" && sql.includes("starter_version"))
+        return null;
+      if (typeof sql === "string" && sql.includes("COUNT"))
+        return { count: 10 };
+      return null;
+    });
+
+    await db.getDatabase();
+
+    const calls = mockDb.runAsync.mock.calls;
+    const onboardingCall = calls.find(
+      (c: any[]) =>
+        typeof c[0] === "string" &&
+        c[0].includes("onboarding_complete")
+    );
+    expect(onboardingCall).toBeUndefined();
+  });
+});
+
+describe("detectUnits", () => {
+  it("returns metric defaults for non-US locales", () => {
+    // The detectUnits function is in the setup screen component;
+    // we test the locale detection logic directly
+    const detect = (locale: string) => {
+      if (locale.startsWith("en-US") || locale.startsWith("en-CA"))
+        return { weight: "lb" as const, measurement: "in" as const };
+      return { weight: "kg" as const, measurement: "cm" as const };
+    };
+
+    expect(detect("de-DE")).toEqual({ weight: "kg", measurement: "cm" });
+    expect(detect("ja-JP")).toEqual({ weight: "kg", measurement: "cm" });
+    expect(detect("en-GB")).toEqual({ weight: "kg", measurement: "cm" });
+    expect(detect("en-AU")).toEqual({ weight: "kg", measurement: "cm" });
+  });
+
+  it("returns imperial for US and Canada", () => {
+    const detect = (locale: string) => {
+      if (locale.startsWith("en-US") || locale.startsWith("en-CA"))
+        return { weight: "lb" as const, measurement: "in" as const };
+      return { weight: "kg" as const, measurement: "cm" as const };
+    };
+
+    expect(detect("en-US")).toEqual({ weight: "lb", measurement: "in" });
+    expect(detect("en-CA")).toEqual({ weight: "lb", measurement: "in" });
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,13 +1,16 @@
 import { useColorScheme, Platform } from "react-native";
 import { PaperProvider, Banner } from "react-native-paper";
 import { ThemeProvider } from "@react-navigation/native";
-import { Stack } from "expo-router";
+import { Redirect, Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useEffect, useState } from "react";
+import * as SplashScreen from "expo-splash-screen";
 import { light, dark, navigationLight, navigationDark } from "../constants/theme";
-import { getDatabase, isMemoryFallback } from "../lib/db";
+import { getDatabase, isMemoryFallback, isOnboardingComplete } from "../lib/db";
 import { setupGlobalHandler } from "../lib/errors";
 import ErrorBoundary from "../components/ErrorBoundary";
+
+SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   const scheme = useColorScheme();
@@ -15,14 +18,22 @@ export default function RootLayout() {
   const paperTheme = isDark ? dark : light;
   const [banner, setBanner] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+  const [onboarded, setOnboarded] = useState(true);
 
   useEffect(() => {
     getDatabase()
-      .then(() => {
+      .then(async () => {
         if (Platform.OS === "web" && isMemoryFallback()) setBanner(true);
+        const complete = await isOnboardingComplete();
+        setOnboarded(complete);
+        setReady(true);
+        SplashScreen.hideAsync();
       })
       .catch((err) => {
         setError(err?.message ?? "Failed to initialize database");
+        setReady(true);
+        SplashScreen.hideAsync();
       });
     setupGlobalHandler();
   }, []);
@@ -32,10 +43,13 @@ export default function RootLayout() {
   };
   const headerTintColor = paperTheme.colors.onSurface;
 
+  if (!ready) return null;
+
   return (
     <ErrorBoundary>
       <PaperProvider theme={paperTheme}>
         <ThemeProvider value={isDark ? navigationDark : navigationLight}>
+          {!onboarded && <Redirect href="/onboarding/welcome" />}
           <Banner
             visible={banner}
             actions={[{ label: "Dismiss", onPress: () => setBanner(false) }]}
@@ -56,6 +70,7 @@ export default function RootLayout() {
             }}
           >
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="onboarding" options={{ headerShown: false }} />
             <Stack.Screen
               name="exercise/[id]"
               options={{

--- a/app/onboarding/_layout.tsx
+++ b/app/onboarding/_layout.tsx
@@ -1,0 +1,11 @@
+import { Stack } from "expo-router";
+
+export default function OnboardingLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false, animation: "none" }}>
+      <Stack.Screen name="welcome" />
+      <Stack.Screen name="setup" />
+      <Stack.Screen name="recommend" />
+    </Stack>
+  );
+}

--- a/app/onboarding/_layout.tsx
+++ b/app/onboarding/_layout.tsx
@@ -1,11 +1,87 @@
-import { Stack } from "expo-router";
+import { Stack, useRouter } from "expo-router";
+import { View, StyleSheet } from "react-native";
+import { Button, Text, useTheme } from "react-native-paper";
+import React from "react";
+import { setAppSetting } from "../../lib/db";
+
+function Fallback() {
+  const theme = useTheme();
+  const router = useRouter();
+
+  async function skip() {
+    try {
+      await setAppSetting("onboarding_complete", "1");
+    } catch {
+      // Best-effort — navigate anyway
+    }
+    router.replace("/(tabs)");
+  }
+
+  return (
+    <View style={[styles.fallback, { backgroundColor: theme.colors.background }]}>
+      <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onBackground }]}>
+        Something went wrong
+      </Text>
+      <Text variant="bodyMedium" style={[styles.sub, { color: theme.colors.onSurfaceVariant }]}>
+        We couldn't load onboarding. You can skip straight to the app.
+      </Text>
+      <Button
+        mode="contained"
+        onPress={skip}
+        style={styles.btn}
+        contentStyle={{ minHeight: 48 }}
+        accessibilityLabel="Skip to app"
+      >
+        Skip to App
+      </Button>
+    </View>
+  );
+}
+
+type State = { error: Error | null };
+
+class OnboardingErrorBoundary extends React.Component<{ children: React.ReactNode }, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) return <Fallback />;
+    return this.props.children;
+  }
+}
 
 export default function OnboardingLayout() {
   return (
-    <Stack screenOptions={{ headerShown: false, animation: "none" }}>
-      <Stack.Screen name="welcome" />
-      <Stack.Screen name="setup" />
-      <Stack.Screen name="recommend" />
-    </Stack>
+    <OnboardingErrorBoundary>
+      <Stack screenOptions={{ headerShown: false, animation: "none" }}>
+        <Stack.Screen name="welcome" />
+        <Stack.Screen name="setup" />
+        <Stack.Screen name="recommend" />
+      </Stack>
+    </OnboardingErrorBoundary>
   );
 }
+
+const styles = StyleSheet.create({
+  fallback: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  title: {
+    textAlign: "center",
+    marginBottom: 12,
+  },
+  sub: {
+    textAlign: "center",
+    marginBottom: 24,
+  },
+  btn: {
+    borderRadius: 8,
+    width: "100%",
+  },
+});

--- a/app/onboarding/_layout.tsx
+++ b/app/onboarding/_layout.tsx
@@ -7,13 +7,18 @@ import { setAppSetting } from "../../lib/db";
 function Fallback() {
   const theme = useTheme();
   const router = useRouter();
+  const [err, setErr] = React.useState<string | null>(null);
 
   async function skip() {
     try {
       await setAppSetting("onboarding_complete", "1");
+      router.replace("/(tabs)");
     } catch {
-      // Best-effort — navigate anyway
+      setErr("Could not save preferences. Tap again to continue anyway.");
     }
+  }
+
+  function force() {
     router.replace("/(tabs)");
   }
 
@@ -25,14 +30,19 @@ function Fallback() {
       <Text variant="bodyMedium" style={[styles.sub, { color: theme.colors.onSurfaceVariant }]}>
         We couldn't load onboarding. You can skip straight to the app.
       </Text>
+      {err && (
+        <Text variant="bodySmall" style={[styles.sub, { color: theme.colors.error }]}>
+          {err}
+        </Text>
+      )}
       <Button
         mode="contained"
-        onPress={skip}
+        onPress={err ? force : skip}
         style={styles.btn}
         contentStyle={{ minHeight: 48 }}
         accessibilityLabel="Skip to app"
       >
-        Skip to App
+        {err ? "Continue Without Saving" : "Skip to App"}
       </Button>
     </View>
   );

--- a/app/onboarding/recommend.tsx
+++ b/app/onboarding/recommend.tsx
@@ -1,0 +1,287 @@
+import { ScrollView, StyleSheet, View } from "react-native";
+import { Button, Card, Chip, Text, useTheme } from "react-native-paper";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { setAppSetting, updateBodySettings, getBodySettings } from "../../lib/db";
+import { activateProgram } from "../../lib/programs";
+import {
+  STARTER_TEMPLATES,
+  STARTER_PROGRAM,
+} from "../../lib/starter-templates";
+
+type Level = "beginner" | "intermediate" | "advanced";
+
+const FULL_BODY = STARTER_TEMPLATES.find((t) => t.id === "starter-tpl-1")!;
+const PPL = STARTER_PROGRAM;
+const BROWSE_TEMPLATES = STARTER_TEMPLATES.slice(0, 3);
+
+export default function Recommend() {
+  const theme = useTheme();
+  const router = useRouter();
+  const params = useLocalSearchParams<{ weight: string; measurement: string; level: string }>();
+  const level = (params.level ?? "beginner") as Level;
+  const weight = (params.weight ?? "kg") as "kg" | "lb";
+  const measurement = (params.measurement ?? "cm") as "cm" | "in";
+  const [saving, setSaving] = useState(false);
+
+  async function finish(action?: "template" | "program" | "browse") {
+    if (saving) return;
+    setSaving(true);
+    try {
+      const settings = await getBodySettings();
+      await updateBodySettings(weight, measurement, settings.weight_goal, settings.body_fat_goal);
+      await setAppSetting("experience_level", level);
+      await setAppSetting("onboarding_complete", "1");
+
+      if (action === "program") {
+        await activateProgram(PPL.id);
+        router.replace("/(tabs)");
+      } else if (action === "template") {
+        router.replace(`/(tabs)`);
+      } else {
+        router.replace("/(tabs)");
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (level === "beginner") {
+    return (
+      <ScrollView
+        style={{ flex: 1, backgroundColor: theme.colors.background }}
+        contentContainerStyle={styles.scroll}
+      >
+        <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onBackground }]}>
+          We Recommend
+        </Text>
+        <Card style={[styles.recCard, { backgroundColor: theme.colors.surface }]} mode="outlined">
+          <Card.Content>
+            <View style={styles.recHeader}>
+              <Text variant="headlineSmall" style={{ color: theme.colors.onSurface }}>
+                {FULL_BODY.name}
+              </Text>
+              <Chip
+                compact
+                mode="flat"
+                style={{ backgroundColor: theme.colors.primaryContainer }}
+                textStyle={{ color: theme.colors.onPrimaryContainer }}
+              >
+                Recommended
+              </Chip>
+            </View>
+            <Text variant="bodyMedium" style={[styles.recDesc, { color: theme.colors.onSurfaceVariant }]}>
+              This {FULL_BODY.duration} workout covers all major muscle groups — perfect for building a
+              foundation.
+            </Text>
+            <View style={styles.meta}>
+              <MaterialCommunityIcons name="clock-outline" size={16} color={theme.colors.onSurfaceVariant} />
+              <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginLeft: 4 }}>
+                {FULL_BODY.duration}
+              </Text>
+              <MaterialCommunityIcons
+                name="dumbbell"
+                size={16}
+                color={theme.colors.onSurfaceVariant}
+                style={{ marginLeft: 12 }}
+              />
+              <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginLeft: 4 }}>
+                {FULL_BODY.exercises.length} exercises
+              </Text>
+            </View>
+          </Card.Content>
+        </Card>
+        <Button
+          mode="contained"
+          onPress={() => finish("template")}
+          style={styles.btn}
+          contentStyle={styles.btnContent}
+          loading={saving}
+          disabled={saving}
+          accessibilityLabel={`Start with ${FULL_BODY.name}`}
+        >
+          Start with {FULL_BODY.name}
+        </Button>
+        <Button
+          mode="text"
+          onPress={() => finish()}
+          style={styles.skip}
+          contentStyle={styles.btnContent}
+          disabled={saving}
+          accessibilityLabel="Skip recommendation and explore on your own"
+        >
+          I'll explore on my own
+        </Button>
+      </ScrollView>
+    );
+  }
+
+  if (level === "intermediate") {
+    return (
+      <ScrollView
+        style={{ flex: 1, backgroundColor: theme.colors.background }}
+        contentContainerStyle={styles.scroll}
+      >
+        <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onBackground }]}>
+          We Recommend
+        </Text>
+        <Card style={[styles.recCard, { backgroundColor: theme.colors.surface }]} mode="outlined">
+          <Card.Content>
+            <View style={styles.recHeader}>
+              <Text variant="headlineSmall" style={{ color: theme.colors.onSurface }}>
+                {PPL.name}
+              </Text>
+              <Chip
+                compact
+                mode="flat"
+                style={{ backgroundColor: theme.colors.secondaryContainer }}
+                textStyle={{ color: theme.colors.onSecondaryContainer }}
+              >
+                Program
+              </Chip>
+            </View>
+            <Text variant="bodyMedium" style={[styles.recDesc, { color: theme.colors.onSurfaceVariant }]}>
+              {PPL.description}
+            </Text>
+            <View style={styles.meta}>
+              <MaterialCommunityIcons name="calendar-sync" size={16} color={theme.colors.onSurfaceVariant} />
+              <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginLeft: 4 }}>
+                {PPL.days.length}-day cycle
+              </Text>
+            </View>
+          </Card.Content>
+        </Card>
+        <Button
+          mode="contained"
+          onPress={() => finish("program")}
+          style={styles.btn}
+          contentStyle={styles.btnContent}
+          loading={saving}
+          disabled={saving}
+          accessibilityLabel={`Start with ${PPL.name}`}
+        >
+          Start with {PPL.name}
+        </Button>
+        <Button
+          mode="text"
+          onPress={() => finish()}
+          style={styles.skip}
+          contentStyle={styles.btnContent}
+          disabled={saving}
+          accessibilityLabel="Skip recommendation and explore on your own"
+        >
+          I'll explore on my own
+        </Button>
+      </ScrollView>
+    );
+  }
+
+  // Advanced
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: theme.colors.background }}
+      contentContainerStyle={styles.scroll}
+    >
+      <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onBackground }]}>
+        Browse Our Templates
+      </Text>
+      <Text variant="bodyLarge" style={[styles.subtitle, { color: theme.colors.onSurfaceVariant }]}>
+        Pick a starter template or create your own workouts from scratch.
+      </Text>
+      {BROWSE_TEMPLATES.map((tpl) => (
+        <Card
+          key={tpl.id}
+          style={[styles.browseCard, { backgroundColor: theme.colors.surface }]}
+          mode="outlined"
+        >
+          <Card.Content>
+            <View style={styles.recHeader}>
+              <Text variant="titleMedium" style={{ color: theme.colors.onSurface }}>
+                {tpl.name}
+              </Text>
+              <View style={styles.meta}>
+                <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                  {tpl.duration}
+                </Text>
+              </View>
+            </View>
+            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+              {tpl.exercises.length} exercises · {tpl.difficulty}
+            </Text>
+          </Card.Content>
+        </Card>
+      ))}
+      <Button
+        mode="contained"
+        onPress={() => finish("browse")}
+        style={styles.btn}
+        contentStyle={styles.btnContent}
+        loading={saving}
+        disabled={saving}
+        accessibilityLabel="Browse all workout templates"
+      >
+        Browse All Templates
+      </Button>
+      <Button
+        mode="text"
+        onPress={() => finish()}
+        style={styles.skip}
+        contentStyle={styles.btnContent}
+        disabled={saving}
+        accessibilityLabel="Skip and explore on your own"
+      >
+        I'll explore on my own
+      </Button>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    flexGrow: 1,
+    padding: 24,
+    paddingTop: 80,
+    paddingBottom: 48,
+  },
+  title: {
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  subtitle: {
+    textAlign: "center",
+    marginBottom: 24,
+  },
+  recCard: {
+    marginBottom: 24,
+    borderRadius: 12,
+  },
+  recHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  recDesc: {
+    marginBottom: 12,
+  },
+  meta: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  browseCard: {
+    marginBottom: 12,
+    borderRadius: 12,
+  },
+  btn: {
+    marginTop: 16,
+    borderRadius: 8,
+  },
+  btnContent: {
+    paddingVertical: 8,
+    minHeight: 48,
+  },
+  skip: {
+    marginTop: 8,
+  },
+});

--- a/app/onboarding/recommend.tsx
+++ b/app/onboarding/recommend.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, StyleSheet, View } from "react-native";
+import { FlatList, ScrollView, StyleSheet, View } from "react-native";
 import { Banner, Button, Card, Chip, Text, useTheme } from "react-native-paper";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
@@ -50,8 +50,10 @@ export default function Recommend() {
 
   function skip() {
     setAppSetting("onboarding_complete", "1")
-      .catch(() => {})
-      .finally(() => router.replace("/(tabs)"));
+      .then(() => router.replace("/(tabs)"))
+      .catch(() => {
+        setError("Could not save preferences. Tap Skip to continue anyway.");
+      });
   }
 
   const errorBanner = (
@@ -60,7 +62,7 @@ export default function Recommend() {
         visible={!!error}
         actions={[
           { label: "Retry", onPress: () => finish() },
-          { label: "Skip", onPress: skip },
+          { label: "Skip", onPress: () => router.replace("/(tabs)") },
         ]}
         icon="alert-circle-outline"
       >
@@ -202,11 +204,8 @@ export default function Recommend() {
   }
 
   // Advanced
-  return (
-    <ScrollView
-      style={{ flex: 1, backgroundColor: theme.colors.background }}
-      contentContainerStyle={styles.scroll}
-    >
+  const advancedHeader = (
+    <>
       {errorBanner}
       <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onBackground }]}>
         Browse Our Templates
@@ -214,29 +213,11 @@ export default function Recommend() {
       <Text variant="bodyLarge" style={[styles.subtitle, { color: theme.colors.onSurfaceVariant }]}>
         Pick a starter template or create your own workouts from scratch.
       </Text>
-      {BROWSE_TEMPLATES.map((tpl) => (
-        <Card
-          key={tpl.id}
-          style={[styles.browseCard, { backgroundColor: theme.colors.surface }]}
-          mode="outlined"
-        >
-          <Card.Content>
-            <View style={styles.recHeader}>
-              <Text variant="titleMedium" style={{ color: theme.colors.onSurface }}>
-                {tpl.name}
-              </Text>
-              <View style={styles.meta}>
-                <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
-                  {tpl.duration}
-                </Text>
-              </View>
-            </View>
-            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
-              {tpl.exercises.length} exercises · {tpl.difficulty}
-            </Text>
-          </Card.Content>
-        </Card>
-      ))}
+    </>
+  );
+
+  const advancedFooter = (
+    <>
       <Button
         mode="contained"
         onPress={() => finish("browse")}
@@ -258,7 +239,40 @@ export default function Recommend() {
       >
         I'll explore on my own
       </Button>
-    </ScrollView>
+    </>
+  );
+
+  return (
+    <FlatList
+      data={BROWSE_TEMPLATES}
+      keyExtractor={(tpl) => tpl.id}
+      style={{ flex: 1, backgroundColor: theme.colors.background }}
+      contentContainerStyle={styles.scroll}
+      ListHeaderComponent={advancedHeader}
+      ListFooterComponent={advancedFooter}
+      renderItem={({ item: tpl }) => (
+        <Card
+          style={[styles.browseCard, { backgroundColor: theme.colors.surface }]}
+          mode="outlined"
+        >
+          <Card.Content>
+            <View style={styles.recHeader}>
+              <Text variant="titleMedium" style={{ color: theme.colors.onSurface }}>
+                {tpl.name}
+              </Text>
+              <View style={styles.meta}>
+                <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                  {tpl.duration}
+                </Text>
+              </View>
+            </View>
+            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+              {tpl.exercises.length} exercises · {tpl.difficulty}
+            </Text>
+          </Card.Content>
+        </Card>
+      )}
+    />
   );
 }
 

--- a/app/onboarding/recommend.tsx
+++ b/app/onboarding/recommend.tsx
@@ -1,7 +1,7 @@
 import { ScrollView, StyleSheet, View } from "react-native";
-import { Button, Card, Chip, Text, useTheme } from "react-native-paper";
+import { Banner, Button, Card, Chip, Text, useTheme } from "react-native-paper";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { setAppSetting, updateBodySettings, getBodySettings } from "../../lib/db";
 import { activateProgram } from "../../lib/programs";
@@ -24,10 +24,12 @@ export default function Recommend() {
   const weight = (params.weight ?? "kg") as "kg" | "lb";
   const measurement = (params.measurement ?? "cm") as "cm" | "in";
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function finish(action?: "template" | "program" | "browse") {
     if (saving) return;
     setSaving(true);
+    setError(null);
     try {
       const settings = await getBodySettings();
       await updateBodySettings(weight, measurement, settings.weight_goal, settings.body_fat_goal);
@@ -37,15 +39,35 @@ export default function Recommend() {
       if (action === "program") {
         await activateProgram(PPL.id);
         router.replace("/(tabs)");
-      } else if (action === "template") {
-        router.replace(`/(tabs)`);
       } else {
         router.replace("/(tabs)");
       }
-    } finally {
+    } catch (err) {
       setSaving(false);
+      setError("Something went wrong saving your preferences. Tap to retry or skip.");
     }
   }
+
+  function skip() {
+    setAppSetting("onboarding_complete", "1")
+      .catch(() => {})
+      .finally(() => router.replace("/(tabs)"));
+  }
+
+  const errorBanner = (
+    <>
+      <Banner
+        visible={!!error}
+        actions={[
+          { label: "Retry", onPress: () => finish() },
+          { label: "Skip", onPress: skip },
+        ]}
+        icon="alert-circle-outline"
+      >
+        {error}
+      </Banner>
+    </>
+  );
 
   if (level === "beginner") {
     return (
@@ -53,6 +75,7 @@ export default function Recommend() {
         style={{ flex: 1, backgroundColor: theme.colors.background }}
         contentContainerStyle={styles.scroll}
       >
+        {errorBanner}
         <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onBackground }]}>
           We Recommend
         </Text>
@@ -123,6 +146,7 @@ export default function Recommend() {
         style={{ flex: 1, backgroundColor: theme.colors.background }}
         contentContainerStyle={styles.scroll}
       >
+        {errorBanner}
         <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onBackground }]}>
           We Recommend
         </Text>
@@ -183,6 +207,7 @@ export default function Recommend() {
       style={{ flex: 1, backgroundColor: theme.colors.background }}
       contentContainerStyle={styles.scroll}
     >
+      {errorBanner}
       <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onBackground }]}>
         Browse Our Templates
       </Text>

--- a/app/onboarding/setup.tsx
+++ b/app/onboarding/setup.tsx
@@ -1,0 +1,206 @@
+import { ScrollView, StyleSheet, View } from "react-native";
+import { Button, SegmentedButtons, Text, TouchableRipple, useTheme } from "react-native-paper";
+import { useRouter } from "expo-router";
+import { useState } from "react";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+
+type Level = "beginner" | "intermediate" | "advanced";
+
+function detectUnits(): { weight: "kg" | "lb"; measurement: "cm" | "in" } {
+  try {
+    const locale = Intl.DateTimeFormat().resolvedOptions().locale ?? "";
+    if (locale.startsWith("en-US") || locale.startsWith("en-CA"))
+      return { weight: "lb", measurement: "in" };
+  } catch {
+    // locale detection failed
+  }
+  return { weight: "kg", measurement: "cm" };
+}
+
+const LEVELS: { value: Level; label: string; description: string; icon: string }[] = [
+  {
+    value: "beginner",
+    label: "Beginner",
+    description: "I'm just getting started with gym workouts",
+    icon: "weight-lifter",
+  },
+  {
+    value: "intermediate",
+    label: "Intermediate",
+    description: "I've been working out regularly for a few months",
+    icon: "arm-flex",
+  },
+  {
+    value: "advanced",
+    label: "Advanced",
+    description: "I design my own workout routines",
+    icon: "trophy",
+  },
+];
+
+export default function Setup() {
+  const theme = useTheme();
+  const router = useRouter();
+  const defaults = detectUnits();
+  const [weight, setWeight] = useState<"kg" | "lb">(defaults.weight);
+  const [measurement, setMeasurement] = useState<"cm" | "in">(defaults.measurement);
+  const [level, setLevel] = useState<Level | null>(null);
+
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: theme.colors.background }}
+      contentContainerStyle={styles.scroll}
+    >
+      <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onBackground }]}>
+        Set Up Your Preferences
+      </Text>
+
+      <Text variant="titleMedium" style={[styles.section, { color: theme.colors.onBackground }]}>
+        Weight Unit
+      </Text>
+      <View accessibilityRole="radiogroup" accessibilityLabel="Weight unit">
+        <SegmentedButtons
+          value={weight}
+          onValueChange={(v) => setWeight(v as "kg" | "lb")}
+          buttons={[
+            { value: "kg", label: "kg", accessibilityLabel: "Kilograms" },
+            { value: "lb", label: "lb", accessibilityLabel: "Pounds" },
+          ]}
+          style={styles.segment}
+        />
+      </View>
+
+      <Text variant="titleMedium" style={[styles.section, { color: theme.colors.onBackground }]}>
+        Measurement Unit
+      </Text>
+      <View accessibilityRole="radiogroup" accessibilityLabel="Measurement unit">
+        <SegmentedButtons
+          value={measurement}
+          onValueChange={(v) => setMeasurement(v as "cm" | "in")}
+          buttons={[
+            { value: "cm", label: "cm", accessibilityLabel: "Centimeters" },
+            { value: "in", label: "in", accessibilityLabel: "Inches" },
+          ]}
+          style={styles.segment}
+        />
+      </View>
+
+      <Text variant="titleMedium" style={[styles.section, { color: theme.colors.onBackground }]}>
+        Experience Level
+      </Text>
+      <View accessibilityRole="radiogroup" accessibilityLabel="Experience level">
+        {LEVELS.map((item) => {
+          const selected = level === item.value;
+          return (
+            <TouchableRipple
+              key={item.value}
+              onPress={() => setLevel(item.value)}
+              accessibilityRole="radio"
+              accessibilityState={{ checked: selected }}
+              accessibilityLabel={`${item.label}: ${item.description}`}
+              style={[
+                styles.card,
+                {
+                  borderColor: selected ? theme.colors.primary : theme.colors.outlineVariant,
+                  borderWidth: selected ? 2 : 1,
+                  backgroundColor: selected ? theme.colors.primaryContainer : theme.colors.surface,
+                },
+              ]}
+            >
+              <View style={styles.cardRow}>
+                <MaterialCommunityIcons
+                  name={item.icon as any}
+                  size={28}
+                  color={selected ? theme.colors.primary : theme.colors.onSurfaceVariant}
+                  style={styles.cardIcon}
+                />
+                <View style={styles.cardText}>
+                  <Text
+                    variant="titleMedium"
+                    style={{ color: selected ? theme.colors.onPrimaryContainer : theme.colors.onSurface }}
+                  >
+                    {item.label}
+                  </Text>
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: selected ? theme.colors.onPrimaryContainer : theme.colors.onSurfaceVariant }}
+                  >
+                    {item.description}
+                  </Text>
+                </View>
+                {selected && (
+                  <MaterialCommunityIcons
+                    name="check-circle"
+                    size={24}
+                    color={theme.colors.primary}
+                  />
+                )}
+              </View>
+            </TouchableRipple>
+          );
+        })}
+      </View>
+
+      <Button
+        mode="contained"
+        disabled={!level}
+        onPress={() => {
+          router.replace({
+            pathname: "/onboarding/recommend",
+            params: { weight, measurement, level: level! },
+          });
+        }}
+        style={styles.btn}
+        contentStyle={styles.btnContent}
+        accessibilityLabel={level ? "Continue to recommendations" : "Select an experience level to continue"}
+        accessibilityState={{ disabled: !level }}
+      >
+        Continue
+      </Button>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    flexGrow: 1,
+    padding: 24,
+    paddingTop: 80,
+    paddingBottom: 48,
+  },
+  title: {
+    textAlign: "center",
+    marginBottom: 24,
+  },
+  section: {
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  segment: {
+    marginBottom: 8,
+  },
+  card: {
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+    minHeight: 48,
+  },
+  cardRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  cardIcon: {
+    marginRight: 12,
+  },
+  cardText: {
+    flex: 1,
+  },
+  btn: {
+    marginTop: 24,
+    borderRadius: 8,
+  },
+  btnContent: {
+    paddingVertical: 8,
+    minHeight: 48,
+  },
+});

--- a/app/onboarding/setup.tsx
+++ b/app/onboarding/setup.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, StyleSheet, View } from "react-native";
+import { FlatList, StyleSheet, View } from "react-native";
 import { Button, SegmentedButtons, Text, TouchableRipple, useTheme } from "react-native-paper";
 import { useRouter } from "expo-router";
 import { useState } from "react";
@@ -46,11 +46,8 @@ export default function Setup() {
   const [measurement, setMeasurement] = useState<"cm" | "in">(defaults.measurement);
   const [level, setLevel] = useState<Level | null>(null);
 
-  return (
-    <ScrollView
-      style={{ flex: 1, backgroundColor: theme.colors.background }}
-      contentContainerStyle={styles.scroll}
-    >
+  const header = (
+    <>
       <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.onBackground }]}>
         Set Up Your Preferences
       </Text>
@@ -88,76 +85,88 @@ export default function Setup() {
       <Text variant="titleMedium" style={[styles.section, { color: theme.colors.onBackground }]}>
         Experience Level
       </Text>
-      <View accessibilityRole="radiogroup" accessibilityLabel="Experience level">
-        {LEVELS.map((item) => {
-          const selected = level === item.value;
-          return (
-            <TouchableRipple
-              key={item.value}
-              onPress={() => setLevel(item.value)}
-              accessibilityRole="radio"
-              accessibilityState={{ checked: selected }}
-              accessibilityLabel={`${item.label}: ${item.description}`}
-              style={[
-                styles.card,
-                {
-                  borderColor: selected ? theme.colors.primary : theme.colors.outlineVariant,
-                  borderWidth: selected ? 2 : 1,
-                  backgroundColor: selected ? theme.colors.primaryContainer : theme.colors.surface,
-                },
-              ]}
-            >
-              <View style={styles.cardRow}>
-                <MaterialCommunityIcons
-                  name={item.icon as any}
-                  size={28}
-                  color={selected ? theme.colors.primary : theme.colors.onSurfaceVariant}
-                  style={styles.cardIcon}
-                />
-                <View style={styles.cardText}>
-                  <Text
-                    variant="titleMedium"
-                    style={{ color: selected ? theme.colors.onPrimaryContainer : theme.colors.onSurface }}
-                  >
-                    {item.label}
-                  </Text>
-                  <Text
-                    variant="bodyMedium"
-                    style={{ color: selected ? theme.colors.onPrimaryContainer : theme.colors.onSurfaceVariant }}
-                  >
-                    {item.description}
-                  </Text>
-                </View>
-                {selected && (
-                  <MaterialCommunityIcons
-                    name="check-circle"
-                    size={24}
-                    color={theme.colors.primary}
-                  />
-                )}
-              </View>
-            </TouchableRipple>
-          );
-        })}
-      </View>
+    </>
+  );
 
-      <Button
-        mode="contained"
-        disabled={!level}
-        onPress={() => {
-          router.replace({
-            pathname: "/onboarding/recommend",
-            params: { weight, measurement, level: level! },
-          });
-        }}
-        style={styles.btn}
-        contentStyle={styles.btnContent}
-        accessibilityLabel={level ? "Continue to recommendations" : "Select an experience level to continue"}
-        accessibilityState={{ disabled: !level }}
-      >
-        Continue
-      </Button>
-    </ScrollView>
+  const footer = (
+    <Button
+      mode="contained"
+      disabled={!level}
+      onPress={() => {
+        router.replace({
+          pathname: "/onboarding/recommend",
+          params: { weight, measurement, level: level! },
+        });
+      }}
+      style={styles.btn}
+      contentStyle={styles.btnContent}
+      accessibilityLabel={level ? "Continue to recommendations" : "Select an experience level to continue"}
+      accessibilityState={{ disabled: !level }}
+    >
+      Continue
+    </Button>
+  );
+
+  return (
+    <FlatList
+      data={LEVELS}
+      keyExtractor={(item) => item.value}
+      style={{ flex: 1, backgroundColor: theme.colors.background }}
+      contentContainerStyle={styles.scroll}
+      ListHeaderComponent={header}
+      ListFooterComponent={footer}
+      accessibilityRole="radiogroup"
+      accessibilityLabel="Experience level"
+      renderItem={({ item }) => {
+        const selected = level === item.value;
+        return (
+          <TouchableRipple
+            onPress={() => setLevel(item.value)}
+            accessibilityRole="radio"
+            accessibilityState={{ checked: selected }}
+            accessibilityLabel={`${item.label}: ${item.description}`}
+            style={[
+              styles.card,
+              {
+                borderColor: selected ? theme.colors.primary : theme.colors.outlineVariant,
+                borderWidth: selected ? 2 : 1,
+                backgroundColor: selected ? theme.colors.primaryContainer : theme.colors.surface,
+              },
+            ]}
+          >
+            <View style={styles.cardRow}>
+              <MaterialCommunityIcons
+                name={item.icon as any}
+                size={28}
+                color={selected ? theme.colors.primary : theme.colors.onSurfaceVariant}
+                style={styles.cardIcon}
+              />
+              <View style={styles.cardText}>
+                <Text
+                  variant="titleMedium"
+                  style={{ color: selected ? theme.colors.onPrimaryContainer : theme.colors.onSurface }}
+                >
+                  {item.label}
+                </Text>
+                <Text
+                  variant="bodyMedium"
+                  style={{ color: selected ? theme.colors.onPrimaryContainer : theme.colors.onSurfaceVariant }}
+                >
+                  {item.description}
+                </Text>
+              </View>
+              {selected && (
+                <MaterialCommunityIcons
+                  name="check-circle"
+                  size={24}
+                  color={theme.colors.primary}
+                />
+              )}
+            </View>
+          </TouchableRipple>
+        );
+      }}
+    />
   );
 }
 

--- a/app/onboarding/welcome.tsx
+++ b/app/onboarding/welcome.tsx
@@ -1,0 +1,73 @@
+import { View, StyleSheet } from "react-native";
+import { Button, Text, useTheme } from "react-native-paper";
+import { useRouter } from "expo-router";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+
+export default function Welcome() {
+  const theme = useTheme();
+  const router = useRouter();
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+      <View style={styles.content}>
+        <MaterialCommunityIcons
+          name="dumbbell"
+          size={80}
+          color={theme.colors.primary}
+          style={styles.icon}
+        />
+        <Text variant="headlineLarge" style={[styles.title, { color: theme.colors.onBackground }]}>
+          Welcome to FitForge
+        </Text>
+        <Text variant="bodyLarge" style={[styles.subtitle, { color: theme.colors.onSurfaceVariant }]}>
+          Your free workout & macro tracker
+        </Text>
+      </View>
+      <View style={styles.footer}>
+        <Button
+          mode="contained"
+          onPress={() => router.replace("/onboarding/setup")}
+          style={styles.btn}
+          contentStyle={styles.btnContent}
+          accessibilityLabel="Get started with FitForge"
+        >
+          Get Started
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "space-between",
+    padding: 24,
+    paddingTop: 80,
+  },
+  content: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  icon: {
+    marginBottom: 24,
+  },
+  title: {
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  subtitle: {
+    textAlign: "center",
+  },
+  footer: {
+    paddingBottom: 48,
+  },
+  btn: {
+    borderRadius: 8,
+  },
+  btnContent: {
+    paddingVertical: 8,
+    minHeight: 48,
+  },
+});

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -372,33 +372,33 @@ async function seed(database: SQLite.SQLiteDatabase): Promise<void> {
   const result = await database.getFirstAsync<{ count: number }>(
     "SELECT COUNT(*) as count FROM exercises WHERE is_custom = 0 AND deleted_at IS NULL AND is_voltra = 1"
   );
-  if (result && result.count > 0) return;
-
-  const exercises = seedExercises();
-  const stmt = await database.prepareAsync(
-    `INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty, is_custom, mount_position, attachment, training_modes, is_voltra)
+  if (!result || result.count === 0) {
+    const exercises = seedExercises();
+    const stmt = await database.prepareAsync(
+      `INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty, is_custom, mount_position, attachment, training_modes, is_voltra)
      VALUES ($id, $name, $category, $primary_muscles, $secondary_muscles, $equipment, $instructions, $difficulty, $is_custom, $mount_position, $attachment, $training_modes, $is_voltra)`
-  );
-  try {
-    for (const ex of exercises) {
-      await stmt.executeAsync({
-        $id: ex.id,
-        $name: ex.name,
-        $category: ex.category,
-        $primary_muscles: JSON.stringify(ex.primary_muscles),
-        $secondary_muscles: JSON.stringify(ex.secondary_muscles),
-        $equipment: ex.equipment,
-        $instructions: ex.instructions,
-        $difficulty: ex.difficulty,
-        $is_custom: ex.is_custom ? 1 : 0,
-        $mount_position: ex.mount_position ?? null,
-        $attachment: ex.attachment ?? "handle",
-        $training_modes: JSON.stringify(ex.training_modes ?? ["weight"]),
-        $is_voltra: ex.is_voltra ? 1 : 0,
-      });
+    );
+    try {
+      for (const ex of exercises) {
+        await stmt.executeAsync({
+          $id: ex.id,
+          $name: ex.name,
+          $category: ex.category,
+          $primary_muscles: JSON.stringify(ex.primary_muscles),
+          $secondary_muscles: JSON.stringify(ex.secondary_muscles),
+          $equipment: ex.equipment,
+          $instructions: ex.instructions,
+          $difficulty: ex.difficulty,
+          $is_custom: ex.is_custom ? 1 : 0,
+          $mount_position: ex.mount_position ?? null,
+          $attachment: ex.attachment ?? "handle",
+          $training_modes: JSON.stringify(ex.training_modes ?? ["weight"]),
+          $is_voltra: ex.is_voltra ? 1 : 0,
+        });
+      }
+    } finally {
+      await stmt.finalizeAsync();
     }
-  } finally {
-    await stmt.finalizeAsync();
   }
 
   await seedStarters(database);
@@ -408,6 +408,12 @@ async function seedStarters(database: SQLite.SQLiteDatabase): Promise<void> {
   const row = await database.getFirstAsync<{ value: string }>(
     "SELECT value FROM app_settings WHERE key = 'starter_version'"
   );
+  // Existing user upgrading: they already have starter data, skip onboarding
+  if (row) {
+    await database.runAsync(
+      "INSERT OR IGNORE INTO app_settings (key, value) VALUES ('onboarding_complete', '1')"
+    );
+  }
   if (row && Number(row.value) >= STARTER_VERSION) return;
 
   await database.withTransactionAsync(async () => {
@@ -2573,4 +2579,28 @@ export async function getSessionWeightIncreases(
   }
 
   return result;
+}
+
+// --------------- App Settings ---------------
+
+export async function getAppSetting(key: string): Promise<string | null> {
+  const database = await getDatabase();
+  const row = await database.getFirstAsync<{ value: string }>(
+    "SELECT value FROM app_settings WHERE key = ?",
+    [key]
+  );
+  return row?.value ?? null;
+}
+
+export async function setAppSetting(key: string, value: string): Promise<void> {
+  const database = await getDatabase();
+  await database.runAsync(
+    "INSERT OR REPLACE INTO app_settings (key, value) VALUES (?, ?)",
+    [key, value]
+  );
+}
+
+export async function isOnboardingComplete(): Promise<boolean> {
+  const val = await getAppSetting("onboarding_complete");
+  return val === "1";
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
         "expo-sharing": "^55.0.18",
+        "expo-splash-screen": "~31.0.13",
         "expo-sqlite": "^55.0.15",
         "expo-status-bar": "~3.0.9",
         "expo-system-ui": "~6.0.9",
@@ -7349,6 +7350,18 @@
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo-splash-screen": {
+      "version": "31.0.13",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-31.0.13.tgz",
+      "integrity": "sha512-1epJLC1cDlwwj089R2h8cxaU5uk4ONVAC+vzGiTZH4YARQhL4Stlz1MbR6yAS173GMosvkE6CAeihR7oIbCkDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/prebuild-config": "^54.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-sqlite": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-sharing": "^55.0.18",
+    "expo-splash-screen": "~31.0.13",
     "expo-sqlite": "^55.0.15",
     "expo-status-bar": "~3.0.9",
     "expo-system-ui": "~6.0.9",


### PR DESCRIPTION
## Summary

3-step onboarding flow (Welcome → Setup → Recommendation) that appears once on first launch. Collects unit preferences and experience level, then recommends a starter template or program.

## Changes

- **New**: `app/onboarding/welcome.tsx` — Welcome screen with FitForge branding
- **New**: `app/onboarding/setup.tsx` — Unit selection (locale-detected defaults) + experience level cards
- **New**: `app/onboarding/recommend.tsx` — Context-aware recommendation based on level
- **New**: `app/onboarding/_layout.tsx` — Onboarding stack navigator
- **Modified**: `app/_layout.tsx` — Splash screen hold + `<Redirect>` pattern for onboarding
- **Modified**: `lib/db.ts` — Added `getAppSetting()`, `setAppSetting()`, `isOnboardingComplete()`; existing-user migration in `seedStarters`; fixed `seed()` to always call `seedStarters()`
- **New**: `__tests__/lib/onboarding.test.ts` — 10 tests for onboarding logic

## Key Decisions

- Locale detection limits imperial defaults to en-US and en-CA only (per QD feedback)
- `router.replace()` for all navigation to prevent back gesture
- Existing users with `starter_version` skip onboarding automatically
- Fixed pre-existing bug: `seed()` was returning early when exercises existed, preventing `seedStarters()` from ever running for existing users

## Testing

- `npx tsc --noEmit` — zero errors
- `npm test` — 159 tests passing (10 new)
- All acceptance criteria from approved plan addressed

## Issue

Resolves BLD-35