### PR TITLE
feat: Muscle Illustration for Exercises (BLD-65)

### DIFF
--- a/__tests__/lib/muscle-paths.test.ts
+++ b/__tests__/lib/muscle-paths.test.ts
@@ -1,0 +1,89 @@
+import {
+  FRONT_PATHS,
+  REAR_PATHS,
+  BODY_OUTLINE_FRONT,
+  BODY_OUTLINE_REAR,
+  ALL_FRONT_MUSCLES,
+  ALL_REAR_MUSCLES,
+  ALL_MUSCLES,
+} from "../../components/muscle-paths";
+import type { MuscleGroup } from "../../lib/types";
+
+describe("muscle-paths", () => {
+  describe("body outlines", () => {
+    it("defines front outline", () => {
+      expect(BODY_OUTLINE_FRONT.length).toBeGreaterThan(0);
+      expect(BODY_OUTLINE_FRONT).toContain("M");
+    });
+
+    it("defines rear outline", () => {
+      expect(BODY_OUTLINE_REAR.length).toBeGreaterThan(0);
+      expect(BODY_OUTLINE_REAR).toContain("M");
+    });
+  });
+
+  describe("front paths", () => {
+    it("has paths for expected front muscles", () => {
+      const expected: MuscleGroup[] = ["chest", "shoulders", "biceps", "forearms", "core", "quads", "calves"];
+      for (const m of expected) {
+        expect(FRONT_PATHS[m]).toBeDefined();
+        expect(FRONT_PATHS[m]!.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("does not have back-only muscles", () => {
+      expect(FRONT_PATHS.back).toBeUndefined();
+      expect(FRONT_PATHS.lats).toBeUndefined();
+      expect(FRONT_PATHS.traps).toBeUndefined();
+      expect(FRONT_PATHS.glutes).toBeUndefined();
+      expect(FRONT_PATHS.hamstrings).toBeUndefined();
+    });
+
+    it("all paths are valid SVG d strings", () => {
+      for (const [, ds] of Object.entries(FRONT_PATHS)) {
+        for (const d of ds!) {
+          expect(d).toMatch(/^[MLCQZmlcqz0-9., -]+$/);
+        }
+      }
+    });
+
+    it("bilateral muscles have two paths", () => {
+      expect(FRONT_PATHS.chest!.length).toBe(2);
+      expect(FRONT_PATHS.shoulders!.length).toBe(2);
+      expect(FRONT_PATHS.biceps!.length).toBe(2);
+    });
+  });
+
+  describe("rear paths", () => {
+    it("has paths for expected rear muscles", () => {
+      const expected: MuscleGroup[] = ["shoulders", "triceps", "forearms", "traps", "back", "lats", "glutes", "hamstrings", "calves"];
+      for (const m of expected) {
+        expect(REAR_PATHS[m]).toBeDefined();
+        expect(REAR_PATHS[m]!.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("does not have front-only muscles", () => {
+      expect(REAR_PATHS.chest).toBeUndefined();
+      expect(REAR_PATHS.biceps).toBeUndefined();
+      expect(REAR_PATHS.core).toBeUndefined();
+      expect(REAR_PATHS.quads).toBeUndefined();
+    });
+  });
+
+  describe("muscle lists", () => {
+    it("ALL_FRONT_MUSCLES matches FRONT_PATHS keys", () => {
+      expect(ALL_FRONT_MUSCLES.sort()).toEqual(Object.keys(FRONT_PATHS).sort());
+    });
+
+    it("ALL_REAR_MUSCLES matches REAR_PATHS keys", () => {
+      expect(ALL_REAR_MUSCLES.sort()).toEqual(Object.keys(REAR_PATHS).sort());
+    });
+
+    it("ALL_MUSCLES contains all 14 groups", () => {
+      expect(ALL_MUSCLES.length).toBe(14);
+      expect(ALL_MUSCLES).toContain("chest");
+      expect(ALL_MUSCLES).toContain("full_body");
+    });
+  });
+});

--- a/__tests__/lib/muscle-theme.test.ts
+++ b/__tests__/lib/muscle-theme.test.ts
@@ -1,0 +1,30 @@
+import { muscle } from "../../constants/theme";
+
+describe("muscle theme colors", () => {
+  it("defines light mode colors", () => {
+    expect(muscle.light.primary).toBeDefined();
+    expect(muscle.light.secondary).toBeDefined();
+    expect(muscle.light.inactive).toBeDefined();
+    expect(muscle.light.outline).toBeDefined();
+  });
+
+  it("defines dark mode colors", () => {
+    expect(muscle.dark.primary).toBeDefined();
+    expect(muscle.dark.secondary).toBeDefined();
+    expect(muscle.dark.inactive).toBeDefined();
+    expect(muscle.dark.outline).toBeDefined();
+  });
+
+  it("light and dark colors differ for contrast", () => {
+    expect(muscle.light.primary).not.toBe(muscle.dark.primary);
+    expect(muscle.light.secondary).not.toBe(muscle.dark.secondary);
+    expect(muscle.light.inactive).not.toBe(muscle.dark.inactive);
+  });
+
+  it("primary is red-family and secondary is orange-family", () => {
+    // Light primary should be red (#D...)
+    expect(muscle.light.primary.toLowerCase()).toMatch(/^#[d-f]/);
+    // Light secondary should be orange (#F5...)
+    expect(muscle.light.secondary.toLowerCase()).toMatch(/^#f/);
+  });
+});

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -25,6 +25,7 @@ import {
 } from "../../lib/db";
 import { CATEGORY_LABELS, MOUNT_POSITION_LABELS, ATTACHMENT_LABELS, type Exercise } from "../../lib/types";
 import { semantic, difficultyText } from "../../constants/theme";
+import { MuscleMap } from "../../components/MuscleMap";
 import { rpeColor, rpeText } from "../../lib/rpe";
 import { toDisplay } from "../../lib/units";
 import { epley, percentageTable } from "../../lib/rm";
@@ -291,43 +292,17 @@ export default function ExerciseDetail() {
         </View>
       )}
 
-      {/* Primary Muscles */}
+      {/* Muscle Diagram */}
       <View style={styles.section}>
         <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
-          Primary Muscles
+          Muscles Involved
         </Text>
-        <View style={styles.chipRow}>
-          {exercise.primary_muscles.map((m) => (
-            <Chip
-              key={m}
-              compact
-              style={[styles.muscleChip, { backgroundColor: theme.colors.secondaryContainer }]}
-            >
-              {m}
-            </Chip>
-          ))}
-        </View>
+        <MuscleMap
+          primary={exercise.primary_muscles}
+          secondary={exercise.secondary_muscles}
+          width={screenWidth - 32}
+        />
       </View>
-
-      {/* Secondary Muscles */}
-      {exercise.secondary_muscles.length > 0 && (
-        <View style={styles.section}>
-          <Text variant="labelLarge" style={{ color: theme.colors.onSurfaceVariant }}>
-            Secondary Muscles
-          </Text>
-          <View style={styles.chipRow}>
-            {exercise.secondary_muscles.map((m) => (
-              <Chip
-                key={m}
-                compact
-                style={[styles.muscleChip, { backgroundColor: theme.colors.tertiaryContainer }]}
-              >
-                {m}
-              </Chip>
-            ))}
-          </View>
-        </View>
-      )}
 
       {/* Instructions */}
       {steps.length > 0 && (

--- a/components/MuscleMap.tsx
+++ b/components/MuscleMap.tsx
@@ -1,0 +1,250 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Text, useTheme } from "react-native-paper";
+import Svg, { Path } from "react-native-svg";
+import type { MuscleGroup } from "../lib/types";
+import { MUSCLE_LABELS } from "../lib/types";
+import { muscle } from "../constants/theme";
+import {
+  BODY_OUTLINE_FRONT,
+  BODY_OUTLINE_REAR,
+  FRONT_PATHS,
+  REAR_PATHS,
+  ALL_MUSCLES,
+} from "./muscle-paths";
+
+type Props = {
+  primary: MuscleGroup[];
+  secondary: MuscleGroup[];
+  width?: number;
+};
+
+function colors(isDark: boolean) {
+  return isDark ? muscle.dark : muscle.light;
+}
+
+function role(
+  group: MuscleGroup,
+  primary: MuscleGroup[],
+  secondary: MuscleGroup[]
+): "primary" | "secondary" | "inactive" {
+  const expanded = primary.includes("full_body") ? ALL_MUSCLES : primary;
+  if (expanded.includes(group)) return "primary";
+  if (secondary.includes(group)) return "secondary";
+  return "inactive";
+}
+
+function fill(r: "primary" | "secondary" | "inactive", c: ReturnType<typeof colors>) {
+  if (r === "primary") return c.primary;
+  if (r === "secondary") return c.secondary;
+  return c.inactive;
+}
+
+function opacity(r: "primary" | "secondary" | "inactive") {
+  if (r === "primary") return 0.7;
+  if (r === "secondary") return 0.5;
+  return 0.15;
+}
+
+function stroke(r: "primary" | "secondary" | "inactive", c: ReturnType<typeof colors>) {
+  if (r === "primary") return { width: 2, dash: "" };
+  if (r === "secondary") return { width: 1, dash: "4,3" };
+  return { width: 1, dash: "" };
+}
+
+function BodyView({
+  paths,
+  outline,
+  primary,
+  secondary,
+  size,
+  label,
+  isDark,
+}: {
+  paths: Partial<Record<MuscleGroup, string[]>>;
+  outline: string;
+  primary: MuscleGroup[];
+  secondary: MuscleGroup[];
+  size: number;
+  label: string;
+  isDark: boolean;
+}) {
+  const c = colors(isDark);
+  const height = size * 2.5;
+
+  return (
+    <View
+      accessible
+      accessibilityRole="image"
+      accessibilityLabel={label}
+      style={{ width: size, height }}
+    >
+      <Svg width={size} height={height} viewBox="0 0 200 500">
+        <Path
+          d={outline}
+          fill="none"
+          stroke={c.outline}
+          strokeWidth={1.5}
+          fillRule="evenodd"
+        />
+        {(Object.entries(paths) as [MuscleGroup, string[]][]).map(([group, ds]) => {
+          const r = role(group, primary, secondary);
+          const s = stroke(r, c);
+          return ds.map((d, i) => (
+            <Path
+              key={`${group}-${i}`}
+              d={d}
+              fill={fill(r, c)}
+              fillOpacity={opacity(r)}
+              stroke={fill(r, c)}
+              strokeWidth={s.width}
+              strokeDasharray={s.dash || undefined}
+              accessibilityLabel={
+                r !== "inactive"
+                  ? `${r === "primary" ? "Primary" : "Secondary"} muscle: ${MUSCLE_LABELS[group]}`
+                  : undefined
+              }
+            />
+          ));
+        })}
+      </Svg>
+    </View>
+  );
+}
+
+function Legend({
+  primary,
+  secondary,
+  isDark,
+}: {
+  primary: MuscleGroup[];
+  secondary: MuscleGroup[];
+  isDark: boolean;
+}) {
+  const theme = useTheme();
+  const c = colors(isDark);
+  const names = (list: MuscleGroup[]) =>
+    list.filter((m) => m !== "full_body").map((m) => MUSCLE_LABELS[m]).join(", ");
+
+  if (primary.length === 0) {
+    return (
+      <Text
+        variant="bodySmall"
+        style={{ color: theme.colors.onSurfaceVariant, textAlign: "center", marginTop: 8 }}
+      >
+        No muscle data
+      </Text>
+    );
+  }
+
+  const label = primary.includes("full_body") ? "Full Body" : names(primary);
+
+  return (
+    <View style={styles.legend}>
+      <View style={styles.row}>
+        <View style={[styles.dot, { backgroundColor: c.primary }]} />
+        <Text variant="bodySmall" style={{ color: theme.colors.onSurface }}>
+          <Text style={{ fontWeight: "700" }}>Primary: </Text>
+          {label}
+        </Text>
+      </View>
+      {secondary.length > 0 && (
+        <View style={styles.row}>
+          <View style={[styles.dot, { backgroundColor: c.secondary, borderStyle: "dashed", borderWidth: 1, borderColor: c.secondary }]} />
+          <Text variant="bodySmall" style={{ color: theme.colors.onSurface }}>
+            <Text style={{ fontWeight: "700" }}>Secondary: </Text>
+            {names(secondary)}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function MuscleMapInner({ primary, secondary, width: w }: Props) {
+  const theme = useTheme();
+  const isDark = theme.dark;
+  const total = w ?? 280;
+  const narrow = total < 300;
+  const size = narrow ? Math.min(total - 16, 160) : Math.floor((total - 24) / 2);
+
+  const labels = (list: MuscleGroup[]) =>
+    list.map((m) => MUSCLE_LABELS[m]).join(", ");
+
+  const summary = [
+    primary.length > 0 ? `primary muscles: ${labels(primary)}` : "",
+    secondary.length > 0 ? `secondary muscles: ${labels(secondary)}` : "",
+  ]
+    .filter(Boolean)
+    .join("; ");
+
+  const acc = summary
+    ? `Muscle diagram showing ${summary}`
+    : "Muscle diagram with no muscle data";
+
+  return (
+    <View
+      accessible
+      accessibilityRole="image"
+      accessibilityLabel={acc}
+      style={styles.container}
+    >
+      <View style={narrow ? styles.vertical : styles.horizontal}>
+        <BodyView
+          paths={FRONT_PATHS}
+          outline={BODY_OUTLINE_FRONT}
+          primary={primary}
+          secondary={secondary}
+          size={size}
+          label="Front view"
+          isDark={isDark}
+        />
+        <BodyView
+          paths={REAR_PATHS}
+          outline={BODY_OUTLINE_REAR}
+          primary={primary}
+          secondary={secondary}
+          size={size}
+          label="Rear view"
+          isDark={isDark}
+        />
+      </View>
+      <Legend primary={primary} secondary={secondary} isDark={isDark} />
+    </View>
+  );
+}
+
+export const MuscleMap = React.memo(MuscleMapInner);
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    paddingVertical: 8,
+  },
+  horizontal: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 12,
+  },
+  vertical: {
+    flexDirection: "column",
+    alignItems: "center",
+    gap: 12,
+  },
+  legend: {
+    marginTop: 12,
+    gap: 6,
+    alignSelf: "stretch",
+    paddingHorizontal: 8,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  dot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+});

--- a/components/muscle-paths.ts
+++ b/components/muscle-paths.ts
@@ -1,0 +1,152 @@
+import type { MuscleGroup } from "../lib/types";
+
+// ViewBox: 0 0 200 500 for both front and rear views
+// Minimalistic silhouette style with simplified anatomical shapes
+
+export const BODY_OUTLINE_FRONT =
+  // Head
+  "M100,10 C115,10 125,22 125,35 C125,48 115,58 100,58 C85,58 75,48 75,35 C75,22 85,10 100,10 Z " +
+  // Neck
+  "M90,58 L90,72 L110,72 L110,58 " +
+  // Torso
+  "M60,72 L55,85 L50,130 L48,180 L55,195 L70,200 L100,205 L130,200 L145,195 L152,180 L150,130 L145,85 L140,72 Z " +
+  // Left arm
+  "M60,72 L48,78 L35,110 L30,145 L28,170 L35,172 L40,145 L48,115 L55,85 " +
+  // Right arm
+  "M140,72 L152,78 L165,110 L170,145 L172,170 L165,172 L160,145 L152,115 L145,85 " +
+  // Left hand
+  "M28,170 L24,185 L30,187 L35,172 " +
+  // Right hand
+  "M172,170 L176,185 L170,187 L165,172 " +
+  // Left leg
+  "M70,200 L65,260 L62,320 L58,400 L55,460 L50,485 L65,490 L70,465 L72,400 L75,320 L78,260 L85,210 L100,205 " +
+  // Right leg
+  "M130,200 L135,260 L138,320 L142,400 L145,460 L150,485 L135,490 L130,465 L128,400 L125,320 L122,260 L115,210 L100,205";
+
+export const BODY_OUTLINE_REAR =
+  // Head
+  "M100,10 C115,10 125,22 125,35 C125,48 115,58 100,58 C85,58 75,48 75,35 C75,22 85,10 100,10 Z " +
+  // Neck
+  "M90,58 L90,72 L110,72 L110,58 " +
+  // Torso
+  "M60,72 L55,85 L50,130 L48,180 L55,195 L70,200 L100,205 L130,200 L145,195 L152,180 L150,130 L145,85 L140,72 Z " +
+  // Left arm
+  "M60,72 L48,78 L35,110 L30,145 L28,170 L35,172 L40,145 L48,115 L55,85 " +
+  // Right arm
+  "M140,72 L152,78 L165,110 L170,145 L172,170 L165,172 L160,145 L152,115 L145,85 " +
+  // Left hand
+  "M28,170 L24,185 L30,187 L35,172 " +
+  // Right hand
+  "M172,170 L176,185 L170,187 L165,172 " +
+  // Left leg
+  "M70,200 L65,260 L62,320 L58,400 L55,460 L50,485 L65,490 L70,465 L72,400 L75,320 L78,260 L85,210 L100,205 " +
+  // Right leg
+  "M130,200 L135,260 L138,320 L142,400 L145,460 L150,485 L135,490 L130,465 L128,400 L125,320 L122,260 L115,210 L100,205";
+
+// Front view muscle regions
+// Each value is an array of SVG path `d` strings (some muscles have left+right)
+export const FRONT_PATHS: Partial<Record<MuscleGroup, string[]>> = {
+  chest: [
+    // Left pec
+    "M65,85 L60,90 L58,110 L65,120 L80,125 L98,120 L98,95 L90,82 L75,80 Z",
+    // Right pec
+    "M135,85 L140,90 L142,110 L135,120 L120,125 L102,120 L102,95 L110,82 L125,80 Z",
+  ],
+  shoulders: [
+    // Left front deltoid
+    "M55,72 L48,78 L50,95 L58,90 L65,85 L65,75 Z",
+    // Right front deltoid
+    "M145,72 L152,78 L150,95 L142,90 L135,85 L135,75 Z",
+  ],
+  biceps: [
+    // Left bicep
+    "M48,95 L42,115 L38,135 L45,135 L50,118 L55,100 Z",
+    // Right bicep
+    "M152,95 L158,115 L162,135 L155,135 L150,118 L145,100 Z",
+  ],
+  forearms: [
+    // Left forearm
+    "M38,135 L33,155 L30,170 L37,170 L42,155 L45,135 Z",
+    // Right forearm
+    "M162,135 L167,155 L170,170 L163,170 L158,155 L155,135 Z",
+  ],
+  core: [
+    // Abdominals + obliques
+    "M78,120 L70,130 L65,155 L63,180 L70,195 L80,200 L100,205 L120,200 L130,195 L137,180 L135,155 L130,130 L122,120 L100,118 Z",
+  ],
+  quads: [
+    // Left quad
+    "M70,200 L65,230 L63,270 L62,310 L66,320 L76,318 L80,280 L82,240 L85,210 Z",
+    // Right quad
+    "M130,200 L135,230 L137,270 L138,310 L134,320 L124,318 L120,280 L118,240 L115,210 Z",
+  ],
+  calves: [
+    // Left calf (front)
+    "M62,340 L60,380 L58,410 L60,420 L68,418 L72,390 L73,360 L70,340 Z",
+    // Right calf (front)
+    "M138,340 L140,380 L142,410 L140,420 L132,418 L128,390 L127,360 L130,340 Z",
+  ],
+};
+
+// Rear view muscle regions
+export const REAR_PATHS: Partial<Record<MuscleGroup, string[]>> = {
+  shoulders: [
+    // Left rear deltoid
+    "M55,72 L48,78 L50,95 L58,90 L65,85 L65,75 Z",
+    // Right rear deltoid
+    "M145,72 L152,78 L150,95 L142,90 L135,85 L135,75 Z",
+  ],
+  triceps: [
+    // Left tricep
+    "M48,95 L42,115 L38,135 L45,135 L50,118 L55,100 Z",
+    // Right tricep
+    "M152,95 L158,115 L162,135 L155,135 L150,118 L145,100 Z",
+  ],
+  forearms: [
+    // Left forearm (rear)
+    "M38,135 L33,155 L30,170 L37,170 L42,155 L45,135 Z",
+    // Right forearm (rear)
+    "M162,135 L167,155 L170,170 L163,170 L158,155 L155,135 Z",
+  ],
+  traps: [
+    // Trapezius
+    "M75,65 L65,72 L70,90 L85,95 L100,97 L115,95 L130,90 L135,72 L125,65 L110,62 L100,60 L90,62 Z",
+  ],
+  back: [
+    // Mid-back
+    "M80,100 L72,120 L70,150 L75,165 L85,170 L100,172 L115,170 L125,165 L130,150 L128,120 L120,100 L100,97 Z",
+  ],
+  lats: [
+    // Left lat
+    "M60,95 L55,110 L52,140 L55,170 L62,180 L70,175 L72,145 L70,115 L68,95 Z",
+    // Right lat
+    "M140,95 L145,110 L148,140 L145,170 L138,180 L130,175 L128,145 L130,115 L132,95 Z",
+  ],
+  glutes: [
+    // Left glute
+    "M70,190 L65,200 L68,215 L80,225 L100,222 L100,200 L85,195 Z",
+    // Right glute
+    "M130,190 L135,200 L132,215 L120,225 L100,222 L100,200 L115,195 Z",
+  ],
+  hamstrings: [
+    // Left hamstring
+    "M68,225 L65,260 L63,300 L66,320 L76,318 L78,290 L80,255 L80,230 Z",
+    // Right hamstring
+    "M132,225 L135,260 L137,300 L134,320 L124,318 L122,290 L120,255 L120,230 Z",
+  ],
+  calves: [
+    // Left calf (rear)
+    "M62,340 L60,380 L58,410 L60,420 L68,418 L72,390 L73,360 L70,340 Z",
+    // Right calf (rear)
+    "M138,340 L140,380 L142,410 L140,420 L132,418 L128,390 L127,360 L130,340 Z",
+  ],
+};
+
+// All muscle groups that appear on each view
+export const ALL_FRONT_MUSCLES: MuscleGroup[] = Object.keys(FRONT_PATHS) as MuscleGroup[];
+export const ALL_REAR_MUSCLES: MuscleGroup[] = Object.keys(REAR_PATHS) as MuscleGroup[];
+export const ALL_MUSCLES: MuscleGroup[] = [
+  "chest", "shoulders", "biceps", "triceps", "forearms",
+  "core", "quads", "hamstrings", "glutes", "calves",
+  "back", "lats", "traps", "full_body",
+];

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -91,6 +91,22 @@ export const semantic = {
   onAdvanced: "#ffffff",
 };
 
+// Muscle diagram colors — separate light/dark for WCAG contrast
+export const muscle = {
+  light: {
+    primary: "#D32F2F",
+    secondary: "#F57C00",
+    inactive: "#E0E0E0",
+    outline: "#9E9E9E",
+  },
+  dark: {
+    primary: "#EF5350",
+    secondary: "#FFB74D",
+    inactive: "#424242",
+    outline: "#616161",
+  },
+};
+
 export function difficultyText(level: string): string {
   if (level === "intermediate") return semantic.onIntermediate;
   if (level === "advanced") return semantic.onAdvanced;


### PR DESCRIPTION
## Summary

Add a reusable MuscleMap SVG component that displays front and rear human body silhouettes with highlighted muscle regions for each exercise, replacing the plain-text chip display.

## Changes

- **`components/MuscleMap.tsx`** — Main component with front/rear SVG body views, color-coded muscle highlights (primary=red, secondary=orange, inactive=grey), legend with grouped muscle names
- **`components/muscle-paths.ts`** — SVG path data for all 14 MuscleGroup values, body outline shapes
- **`constants/theme.ts`** — Semantic muscle color tokens with separate light/dark values
- **`app/exercise/[id].tsx`** — Replace primary/secondary muscle chip sections with MuscleMap component

## Key Decisions

- Dual visual channels for color-blind accessibility: solid stroke (primary) vs dashed stroke (secondary)
- All colors via semantic tokens — no hardcoded hex in component
- Responsive: stacks vertically on narrow screens (<300px)
- `full_body` highlights all regions on both views
- React.memo for performance
- `accessibilityRole="image"` on diagram container

## Testing

- 15 new tests for muscle paths validation and theme colors
- All 188 tests pass
- TypeScript compiles with zero errors

## Issue

Resolves BLD-65