### PR TITLE
fix: nested button hydration error on web (BLD-69)

### DIFF
--- a/__tests__/app/home-nested-buttons.test.ts
+++ b/__tests__/app/home-nested-buttons.test.ts
@@ -1,0 +1,118 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Structural tests for BLD-69: no nested <button> elements on web.
+ *
+ * react-native-paper Chip renders as <button> on web even without onPress.
+ * Cards with onPress render as <button>. Nesting causes hydration errors.
+ *
+ * Verifies: Chip replaced with View+Text badges, Cards with interactive
+ * children use Pressable instead of Card onPress.
+ */
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../../app/(tabs)/index.tsx"),
+  "utf-8"
+);
+
+describe("Home screen — no nested buttons (BLD-69)", () => {
+  it("does not import Chip from react-native-paper", () => {
+    const imports = src.match(/import\s*\{[^}]+\}\s*from\s*["']react-native-paper["']/s);
+    expect(imports).toBeTruthy();
+    expect(imports![0]).not.toContain("Chip");
+  });
+
+  it("imports Pressable from react-native", () => {
+    const imports = src.match(/import\s*\{[^}]+\}\s*from\s*["']react-native["']/s);
+    expect(imports).toBeTruthy();
+    expect(imports![0]).toContain("Pressable");
+  });
+
+  it("does not use Chip component anywhere", () => {
+    const body = src.replace(/import\s*\{[^}]+\}\s*from\s*["'][^"']+["']/gs, "");
+    expect(body).not.toMatch(/<Chip[\s>]/);
+  });
+
+  it("Cards with IconButton children do not have onPress", () => {
+    const lines = src.split("\n");
+    let depth = 0;
+    let start = -1;
+    let props = "";
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.match(/<Card\b/) && !line.match(/<Card\./)) {
+        start = i;
+        props = "";
+        depth = 1;
+      }
+      if (start >= 0 && depth > 0) {
+        props += line + "\n";
+        const opens = (line.match(/<Card\b/g) || []).length;
+        const closes = (line.match(/<\/Card>/g) || []).length;
+        depth += opens - closes;
+        if (i === start) depth -= opens - 1;
+
+        if (depth <= 0) {
+          if (props.includes("IconButton") || props.includes("Menu")) {
+            const tag = props.match(/<Card\b[^>]*>/s);
+            if (tag) {
+              expect(tag[0]).not.toMatch(/onPress/);
+            }
+          }
+          start = -1;
+          props = "";
+        }
+      }
+    }
+  });
+
+  it("uses badge styles instead of starterChip", () => {
+    expect(src).toContain("styles.badge");
+    expect(src).toContain("styles.badgeText");
+    expect(src).not.toContain("styles.starterChip");
+    expect(src).not.toContain("styles.starterChipText");
+  });
+
+  it("badge style has no hardcoded hex colors", () => {
+    const match = src.match(/badge:\s*\{[^}]+\}/);
+    if (match) {
+      expect(match[0]).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+    }
+  });
+
+  it("Pressable wrappers have accessibilityRole button", () => {
+    const lines = src.split("\n");
+    let count = 0;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].match(/<Pressable\b/)) {
+        count++;
+        let block = "";
+        for (let j = i; j < Math.min(i + 15, lines.length); j++) {
+          block += lines[j] + "\n";
+          if (lines[j].trim() === ">" || lines[j].match(/\w>\s*$/)) break;
+        }
+        expect(block).toContain('accessibilityRole="button"');
+      }
+    }
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it("Pressable wrappers have accessibilityLabel", () => {
+    const lines = src.split("\n");
+    let count = 0;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].match(/<Pressable\b/)) {
+        count++;
+        let block = "";
+        for (let j = i; j < Math.min(i + 15, lines.length); j++) {
+          block += lines[j] + "\n";
+          if (lines[j].trim() === ">" || lines[j].match(/\w>\s*$/)) break;
+        }
+        expect(block).toContain("accessibilityLabel");
+      }
+    }
+    expect(count).toBeGreaterThan(0);
+  });
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import {
   Alert,
   FlatList,
+  Pressable,
   StyleSheet,
   View,
   type ListRenderItemInfo,
@@ -9,7 +10,6 @@ import {
 import {
   Button,
   Card,
-  Chip,
   IconButton,
   Menu,
   SegmentedButtons,
@@ -502,13 +502,15 @@ export default function Workouts() {
                     renderItem={({ item }: ListRenderItemInfo<WorkoutTemplate>) => (
                       <Card
                         style={[styles.card, { backgroundColor: theme.colors.surface }]}
-                        onPress={() => startFromTemplate(item)}
-                        onLongPress={() => confirmDelete(item)}
-                        accessibilityLabel={`Start workout from template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
-                        accessibilityRole="button"
                       >
                         <Card.Content style={styles.cardContent}>
-                          <View style={styles.cardInfo}>
+                          <Pressable
+                            onPress={() => startFromTemplate(item)}
+                            onLongPress={() => confirmDelete(item)}
+                            style={styles.cardInfo}
+                            accessibilityLabel={`Start workout from template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
+                            accessibilityRole="button"
+                          >
                             <Text
                               variant="titleSmall"
                               style={{ color: theme.colors.onSurface }}
@@ -521,7 +523,7 @@ export default function Workouts() {
                             >
                               {counts[item.id] ?? 0} exercises
                             </Text>
-                          </View>
+                          </Pressable>
                           <IconButton
                             icon="pencil"
                             size={20}
@@ -551,13 +553,15 @@ export default function Workouts() {
                         return (
                           <Card
                             style={[styles.card, { backgroundColor: theme.colors.surface }]}
-                            onPress={() => startFromTemplate(item)}
-                            accessibilityLabel={`Starter template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
-                            accessibilityHint="Double-tap to start workout"
-                            accessibilityRole="button"
                           >
                             <Card.Content style={styles.cardContent}>
-                              <View style={styles.cardInfo}>
+                              <Pressable
+                                onPress={() => startFromTemplate(item)}
+                                style={styles.cardInfo}
+                                accessibilityLabel={`Starter template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
+                                accessibilityHint="Double-tap to start workout"
+                                accessibilityRole="button"
+                              >
                                 <View style={styles.chipRow}>
                                   <Text
                                     variant="titleSmall"
@@ -565,25 +569,18 @@ export default function Workouts() {
                                   >
                                     {item.name}
                                   </Text>
-                                  <Chip
-                                    mode="flat"
-                                    compact
-                                    style={styles.starterChip}
-                                    textStyle={styles.starterChipText}
-                                    accessibilityLabel="Starter template"
-                                  >
-                                    STARTER
-                                  </Chip>
+                                  <View style={[styles.badge, { backgroundColor: theme.colors.surfaceVariant }]} accessibilityLabel="Starter template">
+                                    <Text style={[styles.badgeText, { color: theme.colors.onSurfaceVariant }]}>STARTER</Text>
+                                  </View>
                                   {meta?.recommended && (
-                                    <Chip
-                                      mode="flat"
-                                      compact
-                                      style={[styles.starterChip, { backgroundColor: theme.colors.primaryContainer }]}
-                                      textStyle={[styles.starterChipText, { color: theme.colors.onPrimaryContainer }]}
+                                    <View
+                                      style={[styles.badge, { backgroundColor: theme.colors.primaryContainer }]}
                                       accessibilityLabel="Recommended"
                                     >
-                                      Recommended
-                                    </Chip>
+                                      <Text style={[styles.badgeText, { color: theme.colors.onPrimaryContainer }]}>
+                                        Recommended
+                                      </Text>
+                                    </View>
                                   )}
                                 </View>
                                 <Text
@@ -592,7 +589,7 @@ export default function Workouts() {
                                 >
                                   {meta ? `${DIFFICULTY_LABELS[meta.difficulty]} · ${meta.duration} · ${meta.exercises.length} exercises` : `${counts[item.id] ?? 0} exercises`}
                                 </Text>
-                              </View>
+                              </Pressable>
                               <Menu
                                 visible={menu === item.id}
                                 onDismiss={() => setMenu(null)}
@@ -719,13 +716,15 @@ export default function Workouts() {
                       renderItem={({ item }: ListRenderItemInfo<Program>) => (
                         <Card
                           style={[styles.card, { backgroundColor: theme.colors.surface }]}
-                          onPress={() => router.push(`/program/${item.id}`)}
-                          accessibilityLabel={`Starter program: ${item.name}, ${dayCounts[item.id] ?? 0} days`}
-                          accessibilityHint="Double-tap to view program"
-                          accessibilityRole="button"
                         >
                           <Card.Content style={styles.cardContent}>
-                            <View style={styles.cardInfo}>
+                            <Pressable
+                              onPress={() => router.push(`/program/${item.id}`)}
+                              style={styles.cardInfo}
+                              accessibilityLabel={`Starter program: ${item.name}, ${dayCounts[item.id] ?? 0} days`}
+                              accessibilityHint="Double-tap to view program"
+                              accessibilityRole="button"
+                            >
                               <View style={styles.chipRow}>
                                 <Text
                                   variant="titleSmall"
@@ -733,15 +732,9 @@ export default function Workouts() {
                                 >
                                   {item.name}
                                 </Text>
-                                <Chip
-                                  mode="flat"
-                                  compact
-                                  style={styles.starterChip}
-                                  textStyle={styles.starterChipText}
-                                  accessibilityLabel="Starter template"
-                                >
-                                  STARTER
-                                </Chip>
+                                <View style={[styles.badge, { backgroundColor: theme.colors.surfaceVariant }]} accessibilityLabel="Starter template">
+                                  <Text style={[styles.badgeText, { color: theme.colors.onSurfaceVariant }]}>STARTER</Text>
+                                </View>
                               </View>
                               <Text
                                 variant="bodySmall"
@@ -749,7 +742,7 @@ export default function Workouts() {
                               >
                                 {dayCounts[item.id] ?? 0} days · Intermediate
                               </Text>
-                            </View>
+                            </Pressable>
                             <Menu
                               visible={menu === `prog-${item.id}`}
                               onDismiss={() => setMenu(null)}
@@ -1050,10 +1043,13 @@ const styles = StyleSheet.create({
     gap: 6,
     flexWrap: "wrap",
   },
-  starterChip: {
+  badge: {
     height: 24,
+    paddingHorizontal: 8,
+    borderRadius: 8,
+    justifyContent: "center",
   },
-  starterChipText: {
+  badgeText: {
     fontSize: 12,
     lineHeight: 16,
   },


### PR DESCRIPTION
## Summary

Fixes nested `<button>` hydration errors on web caused by react-native-paper's `Card` (with `onPress`) containing `Chip` and `IconButton` children that also render as `<button>` elements.

## Changes

- **Replace non-interactive `Chip` with styled badges**: `Chip` uses `TouchableRipple` internally which renders as `<button>` on web even without `onPress`. Replaced with `View`+`Text` styled badges that visually match but don't create button elements.
- **Move `onPress`/`onLongPress` from `Card` to `Pressable`**: For cards with interactive children (`IconButton`, `Menu`), removed `onPress` from the `Card` and wrapped the content info area in a `Pressable`. This makes the Card a visual container only, with the content area and IconButton as sibling buttons — no nesting.
- **Three card types fixed**:
  - User template cards: tap content → starts workout, long press → confirm delete, tap pencil → edit
  - Starter template cards: tap content → starts workout, tap dots → menu
  - Starter program cards: tap content → opens program, tap dots → menu
- **User program cards unchanged** — no nested button issue (only has a non-interactive icon)
- All `accessibilityLabel`, `accessibilityHint`, and `accessibilityRole` moved to `Pressable`
- No hardcoded hex colors — uses `theme.colors.surfaceVariant` and `theme.colors.primaryContainer`

## Testing

- `npx tsc --noEmit` passes (no new errors)
- All 189 existing tests pass
- Badge styling uses theme colors for light/dark mode support

## Issue

Resolves BLD-69