### PR TITLE
fix: share human-readable text report instead of JSON (BLD-72)

### DIFF
--- a/__tests__/app/feedback-share.test.ts
+++ b/__tests__/app/feedback-share.test.ts
@@ -1,0 +1,63 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Structural tests for BLD-72: handleShare() must share the human-readable
+ * text report as primary, not the JSON artifact.
+ */
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../../app/feedback.tsx"),
+  "utf-8"
+);
+
+function extractHandler(name: string): string {
+  const pattern = new RegExp(
+    `const ${name} = useCallback\\(async \\(\\) => \\{`
+  );
+  const match = src.match(pattern);
+  if (!match || match.index === undefined) return "";
+  let depth = 0;
+  let start = match.index + match[0].length;
+  for (let i = start; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    if (src[i] === "}") {
+      if (depth === 0) return src.slice(match.index, i + 1);
+      depth--;
+    }
+  }
+  return "";
+}
+
+const handler = extractHandler("handleShare");
+
+describe("handleShare — shares text report as primary (BLD-72)", () => {
+  it("handler exists and is non-empty", () => {
+    expect(handler.length).toBeGreaterThan(0);
+  });
+
+  it("creates fitforge-report.txt", () => {
+    expect(handler).toContain('"fitforge-report.txt"');
+  });
+
+  it("creates fitforge-report.json as secondary artifact", () => {
+    expect(handler).toContain('"fitforge-report.json"');
+  });
+
+  it("creates text file before JSON file", () => {
+    const txt = handler.indexOf('"fitforge-report.txt"');
+    const json = handler.indexOf('"fitforge-report.json"');
+    expect(txt).toBeLessThan(json);
+  });
+
+  it("shares the text report variable, not JSON artifact", () => {
+    const share = handler.match(/Sharing\.shareAsync\((\w+)\.uri/);
+    expect(share).toBeTruthy();
+    expect(share![1]).toBe("report");
+  });
+
+  it("uses text/plain mimeType", () => {
+    expect(handler).toContain('mimeType: "text/plain"');
+    expect(handler).not.toContain('mimeType: "application/json"');
+  });
+});

--- a/app/feedback.tsx
+++ b/app/feedback.tsx
@@ -125,12 +125,12 @@ export default function FeedbackScreen() {
         null,
         2
       );
-      const file = new File(Paths.cache, "fitforge-report.json");
-      await file.write(json);
-      const textFile = new File(Paths.cache, "fitforge-report.txt");
-      await textFile.write(text);
-      await Sharing.shareAsync(file.uri, {
-        mimeType: "application/json",
+      const report = new File(Paths.cache, "fitforge-report.txt");
+      await report.write(text);
+      const artifact = new File(Paths.cache, "fitforge-report.json");
+      await artifact.write(json);
+      await Sharing.shareAsync(report.uri, {
+        mimeType: "text/plain",
         dialogTitle: "Share Report",
       });
       startCooldown();


### PR DESCRIPTION
## Summary

handleShare() in app/feedback.tsx was writing both a .txt and .json report but only sharing the JSON file via Sharing.shareAsync(). Users expect the human-readable text as the primary share artifact.

## Changes

- Share fitforge-report.txt (text/plain) as primary share artifact
- Keep fitforge-report.json written to cache as machine-readable artifact

## Testing

- tsc --noEmit: clean
- 218/218 tests pass

## Issue

Follow-up fix for BLD-70 REVIEWER FUNC-01 finding.
Resolves BLD-72