### PR TITLE
fix: correct home stats row data accuracy (BLD-80)

### DIFF
--- a/__tests__/app/visual-polish.test.ts
+++ b/__tests__/app/visual-polish.test.ts
@@ -64,7 +64,7 @@ describe("Home screen stats row (index.tsx)", () => {
   it("has accessibility labels on each stat card", () => {
     expect(indexSrc).toContain("week streak");
     expect(indexSrc).toContain("workouts this week");
-    expect(indexSrc).toContain("personal records this week");
+    expect(indexSrc).toContain("recent personal records");
   });
 
   it("shows 0 with muted styling when streak is zero", () => {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -254,10 +254,7 @@ export default function Workouts() {
   };
 
   const scheduled = adherence.filter((a) => a.scheduled);
-  const weekDone = sessions.filter((s) => {
-    const m = mondayOf(new Date());
-    return s.started_at >= m;
-  }).length;
+  const weekDone = adherence.filter((a) => a.completed).length;
   const weekLabel = scheduled.length > 0
     ? `${weekDone}/${scheduled.length}`
     : `${weekDone}`;
@@ -304,7 +301,7 @@ export default function Workouts() {
         </View>
         <View
           style={[styles.statCard, { backgroundColor: theme.colors.surface }]}
-          accessibilityLabel={`${prCount} personal records this week`}
+          accessibilityLabel={`${prCount} recent personal records`}
         >
           <MaterialCommunityIcons
             name="trophy"
@@ -315,7 +312,7 @@ export default function Workouts() {
             {prCount}
           </Text>
           <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
-            this week
+            recent
           </Text>
         </View>
       </View>


### PR DESCRIPTION
## Summary

Fixes two data accuracy bugs in the home stats row identified during BLD-79 tech lead review.

## Changes

- **DATA-01**: Weekly workout count now uses `adherence` array (from `getWeekAdherence()`) instead of `sessions` (capped at 5 by `getRecentSessions(5)`). This ensures accurate weekly counts even with 6+ workouts.
- **DATA-02**: PR stat card label changed from 'this week' to 'recent' since `getRecentPRs(5)` returns all-time data, not week-filtered. This matches the original spec.

## Testing

- All 294 tests pass
- TypeScript compiles with zero errors
- Updated accessibility label test to match new wording

## Issue

Resolves BLD-80