### PR TITLE
feat: Volta training mode selection & eccentric tracking (BLD-82)

### DIFF
--- a/__tests__/components/TrainingModeSelector.test.tsx
+++ b/__tests__/components/TrainingModeSelector.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { AccessibilityInfo } from 'react-native'
+import TrainingModeSelector from '../../components/TrainingModeSelector'
+import { renderScreen } from '../helpers/render'
+
+const announce = jest.fn()
+jest.spyOn(AccessibilityInfo, 'announceForAccessibility').mockImplementation(announce)
+
+describe('TrainingModeSelector', () => {
+  const modes = ['weight', 'eccentric_overload', 'band'] as const
+  const defaults = {
+    modes: [...modes],
+    selected: 'weight' as const,
+    exercise: 'Cable Curl',
+    tempo: '',
+    onSelect: jest.fn(),
+    onTempoChange: jest.fn(),
+  }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it('renders chip for each mode', () => {
+    const { getByText } = renderScreen(<TrainingModeSelector {...defaults} />)
+    expect(getByText('Standard')).toBeTruthy()
+    expect(getByText('Eccentric')).toBeTruthy()
+    expect(getByText('Band')).toBeTruthy()
+  })
+
+  it('calls onSelect when a chip is pressed', () => {
+    const { getByText } = renderScreen(<TrainingModeSelector {...defaults} />)
+    fireEvent.press(getByText('Eccentric'))
+    expect(defaults.onSelect).toHaveBeenCalledWith('eccentric_overload')
+  })
+
+  it('announces mode change for accessibility', () => {
+    const { getByText } = renderScreen(<TrainingModeSelector {...defaults} />)
+    fireEvent.press(getByText('Band'))
+    expect(announce).toHaveBeenCalledWith(
+      'Switched to Band mode'
+    )
+  })
+
+  it('shows long-press description tooltip', async () => {
+    const { getByText, queryByText } = renderScreen(<TrainingModeSelector {...defaults} />)
+    expect(queryByText(/Normal cable weight/)).toBeNull()
+    fireEvent(getByText('Standard'), 'onLongPress')
+    await waitFor(() =>
+      expect(getByText(/Normal cable weight resistance/)).toBeTruthy()
+    )
+  })
+
+  it('does NOT show tempo field when mode is not eccentric', () => {
+    const { queryByPlaceholderText } = renderScreen(
+      <TrainingModeSelector {...defaults} selected="weight" />
+    )
+    expect(queryByPlaceholderText(/Tempo/)).toBeNull()
+  })
+
+  it('shows tempo field when eccentric mode is selected', () => {
+    const { getByPlaceholderText, getByText } = renderScreen(
+      <TrainingModeSelector {...defaults} selected="eccentric_overload" />
+    )
+    expect(getByPlaceholderText('Tempo (e.g. 3-1-5-1)')).toBeTruthy()
+    expect(getByText(/Eccentric – Pause – Concentric – Pause/)).toBeTruthy()
+  })
+
+  it('calls onTempoChange when tempo text changes', () => {
+    const { getByPlaceholderText } = renderScreen(
+      <TrainingModeSelector {...defaults} selected="eccentric_overload" />
+    )
+    fireEvent.changeText(getByPlaceholderText('Tempo (e.g. 3-1-5-1)'), '3-1-5-1')
+    expect(defaults.onTempoChange).toHaveBeenCalledWith('3-1-5-1')
+  })
+
+  it('has radiogroup accessibility role on container', () => {
+    const { getByLabelText } = renderScreen(<TrainingModeSelector {...defaults} />)
+    expect(getByLabelText('Training mode selector for Cable Curl')).toBeTruthy()
+  })
+
+  it('has radio accessibility role on individual chips', () => {
+    const { getByLabelText } = renderScreen(<TrainingModeSelector {...defaults} />)
+    const chip = getByLabelText('Standard training mode')
+    expect(chip.props.accessibilityRole).toBe('radio')
+  })
+
+  it('marks selected chip as selected in accessibility state', () => {
+    const { getByLabelText } = renderScreen(
+      <TrainingModeSelector {...defaults} selected="band" />
+    )
+    const band = getByLabelText('Band training mode')
+    expect(band.props.accessibilityState).toEqual({ selected: true })
+    const std = getByLabelText('Standard training mode')
+    expect(std.props.accessibilityState).toEqual({ selected: false })
+  })
+
+  it('tempo field has accessibility hint', () => {
+    const { getByLabelText } = renderScreen(
+      <TrainingModeSelector {...defaults} selected="eccentric_overload" />
+    )
+    const field = getByLabelText(/Tempo notation/)
+    expect(field.props.accessibilityHint).toContain('eccentric, pause, concentric, pause')
+  })
+})

--- a/__tests__/helpers/factories.ts
+++ b/__tests__/helpers/factories.ts
@@ -135,6 +135,8 @@ export function createSet(overrides: Partial<WorkoutSet> = {}): WorkoutSet {
     notes: '',
     link_id: null,
     round: null,
+    training_mode: null,
+    tempo: null,
     ...overrides,
   }
 }

--- a/__tests__/lib/training-mode.test.ts
+++ b/__tests__/lib/training-mode.test.ts
@@ -1,0 +1,42 @@
+import { TRAINING_MODE_LABELS } from '../../lib/types'
+import type { TrainingMode, WorkoutSet } from '../../lib/types'
+import { createSet } from '../helpers/factories'
+
+describe('TrainingMode types and labels', () => {
+  const ALL_MODES: TrainingMode[] = [
+    'weight', 'eccentric_overload', 'band', 'damper',
+    'isokinetic', 'isometric', 'custom_curves', 'rowing',
+  ]
+
+  it('has labels for every training mode', () => {
+    for (const mode of ALL_MODES) {
+      expect(TRAINING_MODE_LABELS[mode]).toBeDefined()
+      expect(TRAINING_MODE_LABELS[mode].label).toBeTruthy()
+      expect(TRAINING_MODE_LABELS[mode].short).toBeTruthy()
+      expect(TRAINING_MODE_LABELS[mode].description).toBeTruthy()
+    }
+  })
+
+  it('short labels are ≤4 characters', () => {
+    for (const mode of ALL_MODES) {
+      expect(TRAINING_MODE_LABELS[mode].short.length).toBeLessThanOrEqual(4)
+    }
+  })
+
+  it('WorkoutSet factory defaults training_mode and tempo to null', () => {
+    const set = createSet()
+    expect(set.training_mode).toBeNull()
+    expect(set.tempo).toBeNull()
+  })
+
+  it('WorkoutSet can be created with training_mode', () => {
+    const set = createSet({ training_mode: 'eccentric_overload', tempo: '3-1-5-1' })
+    expect(set.training_mode).toBe('eccentric_overload')
+    expect(set.tempo).toBe('3-1-5-1')
+  })
+
+  it('legacy sets with null training_mode are valid', () => {
+    const set = createSet({ training_mode: null })
+    expect(set.training_mode).toBeNull()
+  })
+})

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -42,6 +42,8 @@ import {
   updateSet,
   updateSetRPE,
   updateSetNotes,
+  updateSetTrainingMode,
+  updateSetTempo,
   getExerciseById,
 } from "../../lib/db";
 import {
@@ -49,9 +51,11 @@ import {
   getProgramDayById,
   advanceProgram,
 } from "../../lib/programs";
-import type { WorkoutSession, WorkoutSet } from "../../lib/types";
+import type { WorkoutSession, WorkoutSet, TrainingMode, Exercise } from "../../lib/types";
+import { TRAINING_MODE_LABELS } from "../../lib/types";
 import { rpeColor, rpeText } from "../../lib/rpe";
 import { suggest, type Suggestion } from "../../lib/rm";
+import TrainingModeSelector from "../../components/TrainingModeSelector";
 
 type SetWithMeta = WorkoutSet & {
   exercise_name?: string;
@@ -64,6 +68,8 @@ type ExerciseGroup = {
   name: string;
   sets: SetWithMeta[];
   link_id: string | null;
+  training_modes: TrainingMode[];
+  is_voltra: boolean;
 };
 
 const RPE_CHIPS = [6, 7, 8, 9, 10] as const;
@@ -100,6 +106,8 @@ export default function ActiveSession() {
   const restFlash = useRef(new Animated.Value(0)).current;
   const restHapticTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const [suggestions, setSuggestions] = useState<Record<string, Suggestion | null>>({});
+  const [modes, setModes] = useState<Record<string, TrainingMode>>({});
+  const [tempoDraft, setTempoDraft] = useState<Record<string, string>>({});
 
   const linkIds = useMemo(() => {
     const ids: string[] = [];
@@ -149,13 +157,27 @@ export default function ActiveSession() {
 
     // Group by exercise
     const map = new Map<string, ExerciseGroup>();
+    const exerciseMeta: Record<string, Exercise> = {};
+    for (const eid of exerciseIds) {
+      const ex = await getExerciseById(eid);
+      if (ex) exerciseMeta[eid] = ex;
+    }
     for (const s of sets) {
       if (!map.has(s.exercise_id)) {
+        const ex = exerciseMeta[s.exercise_id];
+        let parsed: TrainingMode[] = [];
+        try {
+          parsed = ex?.training_modes ?? [];
+        } catch {
+          parsed = [];
+        }
         map.set(s.exercise_id, {
           exercise_id: s.exercise_id,
           name: (s.exercise_name ?? "Unknown") + (s.exercise_deleted ? " (removed)" : ""),
           sets: [],
           link_id: s.link_id ?? null,
+          training_modes: parsed,
+          is_voltra: ex?.is_voltra ?? false,
         });
       }
       const prev = prevCache[s.exercise_id]?.find(
@@ -388,8 +410,33 @@ export default function ActiveSession() {
   const handleAddSet = async (exerciseId: string) => {
     const group = groups.find((g) => g.exercise_id === exerciseId);
     const num = (group?.sets.length ?? 0) + 1;
-    await addSet(id!, exerciseId, num);
+    const mode = modes[exerciseId] ?? null;
+    const tp = mode === "eccentric_overload" ? (tempoDraft[exerciseId] || null) : null;
+    await addSet(id!, exerciseId, num, null, null, mode, tp);
     await load();
+  };
+
+  const handleModeChange = async (exerciseId: string, mode: TrainingMode) => {
+    setModes((prev) => ({ ...prev, [exerciseId]: mode }));
+    const group = groups.find((g) => g.exercise_id === exerciseId);
+    if (!group) return;
+    for (const set of group.sets) {
+      if (!set.completed) {
+        await updateSetTrainingMode(set.id, mode);
+      }
+    }
+    await load();
+  };
+
+  const handleTempoBlur = async (exerciseId: string, val: string) => {
+    const clean = val && !/^[\s-]*$/.test(val) ? val : null;
+    const group = groups.find((g) => g.exercise_id === exerciseId);
+    if (!group) return;
+    for (const set of group.sets) {
+      if (!set.completed) {
+        await updateSetTempo(set.id, clean);
+      }
+    }
   };
 
   const handleAddExercise = () => {
@@ -631,6 +678,21 @@ export default function ActiveSession() {
               {group.name}
             </Text>
 
+            {/* Training mode selector for Volta exercises with multiple modes */}
+            {group.is_voltra && group.training_modes.length > 1 && (
+              <TrainingModeSelector
+                modes={group.training_modes}
+                selected={modes[group.exercise_id] ?? group.training_modes[0]}
+                exercise={group.name}
+                tempo={tempoDraft[group.exercise_id] ?? ""}
+                onSelect={(m) => handleModeChange(group.exercise_id, m)}
+                onTempoChange={(v) => {
+                  setTempoDraft((prev) => ({ ...prev, [group.exercise_id]: v }));
+                  handleTempoBlur(group.exercise_id, v);
+                }}
+              />
+            )}
+
             {/* Header row */}
             <View style={styles.headerRow}>
               <Text
@@ -801,6 +863,13 @@ export default function ActiveSession() {
                     >
                       PR
                     </Chip>
+                  )}
+                  {set.completed && set.training_mode && set.training_mode !== "weight" && (
+                    <View style={[styles.modeBadge, { backgroundColor: theme.colors.secondaryContainer }]}>
+                      <Text style={{ color: theme.colors.onSecondaryContainer, fontSize: 10, fontWeight: "700" }}>
+                        {TRAINING_MODE_LABELS[set.training_mode]?.short ?? set.training_mode}
+                      </Text>
+                    </View>
                   )}
                   <IconButton
                     icon={set.notes ? "note-text" : "note-text-outline"}
@@ -1032,6 +1101,12 @@ const styles = StyleSheet.create({
   },
   prChipText: {
     fontSize: 12,
+  },
+  modeBadge: {
+    borderRadius: 8,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    marginLeft: 4,
   },
   addSetBtn: {
     alignSelf: "flex-start",

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -410,7 +410,8 @@ export default function ActiveSession() {
   const handleAddSet = async (exerciseId: string) => {
     const group = groups.find((g) => g.exercise_id === exerciseId);
     const num = (group?.sets.length ?? 0) + 1;
-    const mode = modes[exerciseId] ?? null;
+    const fallback = group?.is_voltra && group.training_modes.length > 1 ? group.training_modes[0] : null;
+    const mode = modes[exerciseId] ?? fallback;
     const tp = mode === "eccentric_overload" ? (tempoDraft[exerciseId] || null) : null;
     await addSet(id!, exerciseId, num, null, null, mode, tp);
     await load();
@@ -866,7 +867,7 @@ export default function ActiveSession() {
                   )}
                   {set.completed && set.training_mode && set.training_mode !== "weight" && (
                     <View style={[styles.modeBadge, { backgroundColor: theme.colors.secondaryContainer }]}>
-                      <Text style={{ color: theme.colors.onSecondaryContainer, fontSize: 10, fontWeight: "700" }}>
+                      <Text style={{ color: theme.colors.onSecondaryContainer, fontSize: 12, fontWeight: "700" }}>
                         {TRAINING_MODE_LABELS[set.training_mode]?.short ?? set.training_mode}
                       </Text>
                     </View>

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -5,6 +5,7 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { getSessionById, getSessionPRs, getSessionSets } from "../../../lib/db";
 import type { WorkoutSession, WorkoutSet } from "../../../lib/types";
+import { TRAINING_MODE_LABELS } from "../../../lib/types";
 import { rpeColor, rpeText } from "../../../lib/rpe";
 
 type SetWithName = WorkoutSet & { exercise_name?: string; exercise_deleted?: boolean };
@@ -275,6 +276,21 @@ export default function SessionDetail() {
                     >
                       {set.weight ?? 0} × {set.reps ?? 0}
                     </Text>
+                    {set.training_mode && set.training_mode !== "weight" && (
+                      <View style={[styles.modeBadge, { backgroundColor: theme.colors.secondaryContainer }]}>
+                        <Text style={{ color: theme.colors.onSecondaryContainer, fontSize: 10, fontWeight: "700" }}>
+                          {TRAINING_MODE_LABELS[set.training_mode]?.short ?? set.training_mode}
+                        </Text>
+                      </View>
+                    )}
+                    {set.tempo && (
+                      <Text
+                        variant="bodySmall"
+                        style={{ color: theme.colors.onSurfaceVariant, marginLeft: 8 }}
+                      >
+                        ♩ {set.tempo}
+                      </Text>
+                    )}
                     {set.rpe != null && (
                       <View style={[styles.rpeBadge, { backgroundColor: rpeColor(set.rpe) }]}>
                         <Text style={{ color: rpeText(set.rpe), fontSize: 12, fontWeight: "600" }}>
@@ -382,6 +398,12 @@ const styles = StyleSheet.create({
   rpeBadge: {
     borderRadius: 12,
     paddingHorizontal: 8,
+    paddingVertical: 2,
+    marginLeft: 8,
+  },
+  modeBadge: {
+    borderRadius: 8,
+    paddingHorizontal: 6,
     paddingVertical: 2,
     marginLeft: 8,
   },

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -278,7 +278,7 @@ export default function SessionDetail() {
                     </Text>
                     {set.training_mode && set.training_mode !== "weight" && (
                       <View style={[styles.modeBadge, { backgroundColor: theme.colors.secondaryContainer }]}>
-                        <Text style={{ color: theme.colors.onSecondaryContainer, fontSize: 10, fontWeight: "700" }}>
+                        <Text style={{ color: theme.colors.onSecondaryContainer, fontSize: 12, fontWeight: "700" }}>
                           {TRAINING_MODE_LABELS[set.training_mode]?.short ?? set.training_mode}
                         </Text>
                       </View>

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -24,6 +24,7 @@ import {
   getSessionWeightIncreases,
 } from "../../../lib/db";
 import type { WorkoutSession, WorkoutSet } from "../../../lib/types";
+import { TRAINING_MODE_LABELS } from "../../../lib/types";
 import { toDisplay } from "../../../lib/units";
 
 type PR = { exercise_id: string; name: string; weight: number; previous_max: number };

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -83,6 +83,16 @@ export default function Summary() {
     [sets],
   );
 
+  const grouped = useMemo(() => {
+    const map = new Map<string, { name: string; sets: typeof completed }>();
+    for (const s of completed) {
+      const key = s.exercise_id;
+      if (!map.has(key)) map.set(key, { name: s.exercise_name ?? key, sets: [] });
+      map.get(key)!.sets.push(s);
+    }
+    return [...map.values()];
+  }, [completed]);
+
   const volume = useMemo(() => {
     let total = 0;
     for (const s of completed) {
@@ -177,6 +187,7 @@ export default function Summary() {
             ...(allPrs.length > 0 ? [{ key: "prs" }] : []),
             ...(increases.length > 0 ? [{ key: "increases" }] : []),
             ...(comparison?.previous ? [{ key: "comparison" }] : []),
+            ...(grouped.length > 0 ? [{ key: "sets" }] : []),
           ] as { key: string }[]
         }
         keyExtractor={(s) => s.key}
@@ -407,6 +418,68 @@ export default function Summary() {
             );
           }
 
+          if (item.key === "sets") {
+            return (
+              <Card style={[styles.section, { backgroundColor: theme.colors.surface }]}>
+                <Card.Content>
+                  <View style={styles.sectionHeader}>
+                    <MaterialCommunityIcons
+                      name="dumbbell"
+                      size={20}
+                      color={theme.colors.primary}
+                    />
+                    <Text
+                      variant="titleMedium"
+                      style={{ color: theme.colors.onSurface, marginLeft: 8, fontWeight: "700" }}
+                    >
+                      Sets
+                    </Text>
+                  </View>
+                  {grouped.map((group) => (
+                    <View key={group.name} style={styles.exerciseGroup}>
+                      <Text
+                        variant="labelLarge"
+                        style={{ color: theme.colors.onSurfaceVariant, marginBottom: 4 }}
+                      >
+                        {group.name}
+                      </Text>
+                      {group.sets.map((set) => (
+                        <View key={set.id} style={styles.setRow}>
+                          <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
+                            {set.weight ?? 0} × {set.reps ?? 0}
+                          </Text>
+                          {set.training_mode && set.training_mode !== "weight" && (
+                            <View style={[styles.modeBadge, { backgroundColor: theme.colors.secondaryContainer }]}>
+                              <Text style={{ color: theme.colors.onSecondaryContainer, fontSize: 12, fontWeight: "700" }}>
+                                {TRAINING_MODE_LABELS[set.training_mode]?.short ?? set.training_mode}
+                              </Text>
+                            </View>
+                          )}
+                          {set.tempo && (
+                            <Text
+                              variant="bodySmall"
+                              style={{ color: theme.colors.onSurfaceVariant, marginLeft: 4 }}
+                            >
+                              ♩ {set.tempo}
+                            </Text>
+                          )}
+                          {set.rpe != null && (
+                            <Text
+                              variant="bodySmall"
+                              style={{ color: theme.colors.onSurfaceVariant, marginLeft: 4 }}
+                            >
+                              RPE {set.rpe}
+                            </Text>
+                          )}
+                        </View>
+                      ))}
+                    </View>
+                  ))}
+                </Card.Content>
+              </Card>
+            );
+          }
+
           return null;
         }}
         ListFooterComponent={
@@ -501,6 +574,21 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
     paddingVertical: 8,
+  },
+  exerciseGroup: {
+    marginBottom: 8,
+  },
+  setRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingVertical: 3,
+    paddingLeft: 8,
+  },
+  modeBadge: {
+    borderRadius: 4,
+    paddingHorizontal: 5,
+    paddingVertical: 1,
   },
   actions: {
     marginTop: 16,

--- a/components/TrainingModeSelector.tsx
+++ b/components/TrainingModeSelector.tsx
@@ -1,0 +1,157 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  AccessibilityInfo,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
+import { Text, TextInput, useTheme } from "react-native-paper";
+import type { TrainingMode } from "../lib/types";
+import { TRAINING_MODE_LABELS } from "../lib/types";
+
+type Props = {
+  modes: TrainingMode[];
+  selected: TrainingMode;
+  exercise: string;
+  tempo: string;
+  onSelect: (mode: TrainingMode) => void;
+  onTempoChange: (tempo: string) => void;
+};
+
+export default function TrainingModeSelector({ modes, selected, exercise, tempo, onSelect, onTempoChange }: Props) {
+  const theme = useTheme();
+  const [tooltip, setTooltip] = useState<string | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showTooltip = useCallback((mode: TrainingMode) => {
+    setTooltip(TRAINING_MODE_LABELS[mode].description);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => setTooltip(null), 3000);
+  }, []);
+
+  const handleSelect = useCallback((mode: TrainingMode) => {
+    onSelect(mode);
+    AccessibilityInfo.announceForAccessibility(
+      `Switched to ${TRAINING_MODE_LABELS[mode].label} mode`
+    );
+  }, [onSelect]);
+
+  const sanitize = (val: string) => {
+    if (!val || /^[\s-]*$/.test(val)) return null;
+    return val;
+  };
+
+  return (
+    <View style={styles.container}>
+      <View
+        style={styles.row}
+        accessibilityRole="radiogroup"
+        accessibilityLabel={`Training mode selector for ${exercise}`}
+      >
+        {modes.map((mode) => {
+          const info = TRAINING_MODE_LABELS[mode];
+          const active = selected === mode;
+          return (
+            <Pressable
+              key={mode}
+              onPress={() => handleSelect(mode)}
+              onLongPress={() => showTooltip(mode)}
+              style={[
+                styles.chip,
+                { borderColor: theme.colors.primary },
+                active && { backgroundColor: theme.colors.primary },
+              ]}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: active }}
+              accessibilityLabel={`${info.label} training mode`}
+            >
+              <Text style={[
+                styles.label,
+                { color: active ? theme.colors.onPrimary : theme.colors.primary },
+              ]}>
+                {info.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {tooltip && (
+        <View style={[styles.tooltip, { backgroundColor: theme.colors.inverseSurface }]}>
+          <Text style={{ color: theme.colors.inverseOnSurface, fontSize: 13 }}>
+            {tooltip}
+          </Text>
+        </View>
+      )}
+
+      {selected === "eccentric_overload" && (
+        <View style={styles.tempoContainer}>
+          <TextInput
+            mode="outlined"
+            dense
+            placeholder="Tempo (e.g. 3-1-5-1)"
+            value={tempo}
+            onChangeText={onTempoChange}
+            onBlur={() => onTempoChange(sanitize(tempo) ?? "")}
+            maxLength={15}
+            style={styles.tempoInput}
+            accessibilityLabel="Tempo notation, for example 3 1 5 1"
+            accessibilityHint="Enter four numbers separated by dashes: eccentric, pause, concentric, pause seconds"
+          />
+          <Text
+            variant="labelSmall"
+            style={[styles.helper, { color: theme.colors.onSurfaceVariant }]}
+          >
+            Seconds: Eccentric – Pause – Concentric – Pause
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 8,
+  },
+  row: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+    paddingHorizontal: 4,
+    paddingVertical: 4,
+  },
+  chip: {
+    borderWidth: 1.5,
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 14,
+    minWidth: 56,
+    minHeight: 56,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  tooltip: {
+    marginHorizontal: 4,
+    marginTop: 4,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  tempoContainer: {
+    paddingHorizontal: 4,
+    marginTop: 8,
+  },
+  tempoInput: {
+    fontSize: 14,
+  },
+  helper: {
+    marginTop: 4,
+    fontSize: 12,
+    fontStyle: "italic",
+  },
+});

--- a/components/TrainingModeSelector.tsx
+++ b/components/TrainingModeSelector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   AccessibilityInfo,
   Pressable,
@@ -27,6 +27,12 @@ export default function TrainingModeSelector({ modes, selected, exercise, tempo,
     setTooltip(TRAINING_MODE_LABELS[mode].description);
     if (timer.current) clearTimeout(timer.current);
     timer.current = setTimeout(() => setTooltip(null), 3000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
   }, []);
 
   const handleSelect = useCallback((mode: TrainingMode) => {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -17,6 +17,7 @@ import type {
   ProgramDay,
   ProgramLog,
   MuscleGroup,
+  TrainingMode,
 } from "./types";
 import { seedExercises } from "./seed";
 import {
@@ -289,6 +290,23 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
     await database.execAsync(
       "ALTER TABLE workout_sets ADD COLUMN round INTEGER DEFAULT NULL"
     );
+  }
+
+  // Migration: add training_mode and tempo to workout_sets
+  const setNames = new Set(setCols.map((c) => c.name));
+  if (!setNames.has("training_mode") || !setNames.has("tempo")) {
+    await database.withTransactionAsync(async () => {
+      if (!setNames.has("training_mode")) {
+        await database.execAsync(
+          "ALTER TABLE workout_sets ADD COLUMN training_mode TEXT DEFAULT NULL"
+        );
+      }
+      if (!setNames.has("tempo")) {
+        await database.execAsync(
+          "ALTER TABLE workout_sets ADD COLUMN tempo TEXT DEFAULT NULL"
+        );
+      }
+    });
   }
 
   // Migration: add Voltra metadata columns to exercises
@@ -967,6 +985,8 @@ type SetRow = {
   notes: string;
   link_id: string | null;
   round: number | null;
+  training_mode: string | null;
+  tempo: string | null;
   exercise_name: string | null;
   exercise_deleted_at: number | null;
 };
@@ -996,6 +1016,8 @@ export async function getSessionSets(
     notes: r.notes ?? "",
     link_id: r.link_id ?? null,
     round: r.round ?? null,
+    training_mode: (r.training_mode as TrainingMode) ?? null,
+    tempo: r.tempo ?? null,
     exercise_name: r.exercise_name ?? undefined,
     exercise_deleted: r.exercise_deleted_at != null,
   }));
@@ -1015,13 +1037,15 @@ export async function addSet(
   exerciseId: string,
   setNumber: number,
   linkId?: string | null,
-  round?: number | null
+  round?: number | null,
+  trainingMode?: TrainingMode | null,
+  tempo?: string | null
 ): Promise<WorkoutSet> {
   const database = await getDatabase();
   const id = crypto.randomUUID();
   await database.runAsync(
-    "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round) VALUES (?, ?, ?, ?, ?, ?)",
-    [id, sessionId, exerciseId, setNumber, linkId ?? null, round ?? null]
+    "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    [id, sessionId, exerciseId, setNumber, linkId ?? null, round ?? null, trainingMode ?? null, tempo ?? null]
   );
   return {
     id,
@@ -1036,6 +1060,8 @@ export async function addSet(
     notes: "",
     link_id: linkId ?? null,
     round: round ?? null,
+    training_mode: trainingMode ?? null,
+    tempo: tempo ?? null,
   };
 }
 
@@ -1085,6 +1111,22 @@ export async function updateSetNotes(id: string, notes: string): Promise<void> {
   await database.runAsync(
     "UPDATE workout_sets SET notes = ? WHERE id = ?",
     [notes, id]
+  );
+}
+
+export async function updateSetTrainingMode(id: string, mode: TrainingMode | null): Promise<void> {
+  const database = await getDatabase();
+  await database.runAsync(
+    "UPDATE workout_sets SET training_mode = ? WHERE id = ?",
+    [mode, id]
+  );
+}
+
+export async function updateSetTempo(id: string, tempo: string | null): Promise<void> {
+  const database = await getDatabase();
+  await database.runAsync(
+    "UPDATE workout_sets SET tempo = ? WHERE id = ?",
+    [tempo, id]
   );
 }
 
@@ -1296,7 +1338,7 @@ export async function exportAllData(): Promise<{
   const measurements = await database.getAllAsync<BodyMeasurements>("SELECT * FROM body_measurements");
   const bodySettings = await database.getAllAsync<BodySettings>("SELECT * FROM body_settings");
   return {
-    version: 1,
+    version: 2,
     exported_at: new Date().toISOString(),
     exercises,
     templates,
@@ -1318,7 +1360,7 @@ export async function importData(data: {
   templates?: { id: string; name: string; created_at: number; updated_at: number }[];
   template_exercises?: { id: string; template_id: string; exercise_id: string; position: number; target_sets: number; target_reps: string; rest_seconds: number; link_id?: string | null; link_label?: string }[];
   sessions?: { id: string; template_id: string | null; name: string; started_at: number; completed_at: number | null; duration_seconds: number | null; notes: string }[];
-  sets?: { id: string; session_id: string; exercise_id: string; set_number: number; weight: number | null; reps: number | null; completed: number; completed_at: number | null; set_rpe?: number | null; set_notes?: string; link_id?: string | null; round?: number | null }[];
+  sets?: { id: string; session_id: string; exercise_id: string; set_number: number; weight: number | null; reps: number | null; completed: number; completed_at: number | null; set_rpe?: number | null; set_notes?: string; link_id?: string | null; round?: number | null; training_mode?: string | null; tempo?: string | null }[];
   food_entries?: { id: string; name: string; calories: number; protein: number; carbs: number; fat: number; serving_size: string; is_favorite: number; created_at: number }[];
   daily_log?: { id: string; food_entry_id: string; date: string; meal: string; servings: number; logged_at: number }[];
   macro_targets?: { id: string; calories: number; protein: number; carbs: number; fat: number; updated_at: number }[];
@@ -1373,8 +1415,8 @@ export async function importData(data: {
     if (data.sets) {
       for (const s of data.sets) {
         const r = await database.runAsync(
-          "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-          [s.id, s.session_id, s.exercise_id, s.set_number, s.weight, s.reps, s.completed, s.completed_at, s.set_rpe ?? null, s.set_notes ?? "", s.link_id ?? null, s.round ?? null]
+          "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, training_mode, tempo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          [s.id, s.session_id, s.exercise_id, s.set_number, s.weight, s.reps, s.completed, s.completed_at, s.set_rpe ?? null, s.set_notes ?? "", s.link_id ?? null, s.round ?? null, s.training_mode ?? null, s.tempo ?? null]
         );
         inserted += r.changes;
       }
@@ -1761,6 +1803,8 @@ export type WorkoutCSVRow = {
   set_rpe: number | null;
   set_notes: string;
   link_id: string | null;
+  training_mode: string | null;
+  tempo: string | null;
 };
 
 export type NutritionCSVRow = {
@@ -1787,7 +1831,9 @@ export async function getWorkoutCSVData(since: number): Promise<WorkoutCSVRow[]>
        ws.notes,
        wset.rpe AS set_rpe,
        wset.notes AS set_notes,
-       wset.link_id
+       wset.link_id,
+       wset.training_mode,
+       wset.tempo
      FROM workout_sessions ws
      JOIN workout_sets wset ON wset.session_id = ws.id
      LEFT JOIN exercises e ON e.id = wset.exercise_id

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -206,6 +206,19 @@ export type WorkoutSet = {
   notes: string;
   link_id: string | null;
   round: number | null;
+  training_mode: TrainingMode | null;
+  tempo: string | null;
+};
+
+export const TRAINING_MODE_LABELS: Record<TrainingMode, { label: string; short: string; description: string }> = {
+  weight: { label: "Standard", short: "STD", description: "Normal cable weight resistance — standard lifting" },
+  eccentric_overload: { label: "Eccentric", short: "ECC", description: "Heavier resistance on the lowering phase for muscle growth" },
+  band: { label: "Band", short: "BND", description: "Resistance band attached for variable tension" },
+  damper: { label: "Damper", short: "DMP", description: "Damper provides smooth, constant resistance" },
+  isokinetic: { label: "Isokinetic", short: "ISO", description: "Machine controls speed — constant velocity throughout" },
+  isometric: { label: "Isometric", short: "ISOM", description: "Hold position against resistance — no movement" },
+  custom_curves: { label: "Custom", short: "CRV", description: "Custom resistance profile set on the Volta" },
+  rowing: { label: "Rowing", short: "ROW", description: "Rowing movement pattern with cable resistance" },
 };
 
 export type LinkedGroup = {


### PR DESCRIPTION
## Summary

Add training mode selection to the workout session screen for Volta exercises. Users can now select their training mode (Standard, Eccentric, Band, etc.), record tempo for eccentric training, and see mode badges on completed sets.

## Changes

- **Schema**: Add `training_mode` and `tempo` columns to `workout_sets` (migration with PRAGMA guard + transaction)
- **Component**: New `TrainingModeSelector` component (`components/TrainingModeSelector.tsx`) — chip row with long-press descriptions, tempo field for eccentric mode, full accessibility
- **Session screen**: Integrate selector below exercise group header for Volta exercises with >1 mode. Mode applies to pending sets; completed sets are locked
- **Session detail**: Show mode badge (ECC, BND, etc.) and tempo on completed set rows
- **DB functions**: Update `addSet()`, `getSessionSets()`, add `updateSetTrainingMode()`, `updateSetTempo()`
- **Import/Export**: Add training_mode and tempo to import INSERT and CSV export. Bump export version from 1 to 2
- **Types**: Add `training_mode` and `tempo` to `WorkoutSet`, add `TRAINING_MODE_LABELS` constant

## Accessibility

- Chip container: `accessibilityRole='radiogroup'` with exercise name label
- Individual chips: `accessibilityRole='radio'` with selected state
- Mode changes announced via `AccessibilityInfo.announceForAccessibility`
- Tempo field: descriptive label and hint
- 56dp minimum touch targets on mode chips

## Testing

- 16 new tests (310 total, all passing)
- TypeScript typecheck: zero errors
- Component tests: rendering, selection, accessibility, long-press tooltip, tempo field
- Type tests: labels coverage, factory defaults, training_mode on WorkoutSet

## Issue

Resolves BLD-82