### PR TITLE
fix: tempo perf and cleanup (BLD-82 follow-up)

### DIFF
--- a/__tests__/components/TrainingModeSelector.test.tsx
+++ b/__tests__/components/TrainingModeSelector.test.tsx
@@ -16,6 +16,7 @@ describe('TrainingModeSelector', () => {
     tempo: '',
     onSelect: jest.fn(),
     onTempoChange: jest.fn(),
+    onTempoBlur: jest.fn(),
   }
 
   beforeEach(() => jest.clearAllMocks())

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -165,12 +165,7 @@ export default function ActiveSession() {
     for (const s of sets) {
       if (!map.has(s.exercise_id)) {
         const ex = exerciseMeta[s.exercise_id];
-        let parsed: TrainingMode[] = [];
-        try {
-          parsed = ex?.training_modes ?? [];
-        } catch {
-          parsed = [];
-        }
+        const parsed: TrainingMode[] = ex?.training_modes ?? [];
         map.set(s.exercise_id, {
           exercise_id: s.exercise_id,
           name: (s.exercise_name ?? "Unknown") + (s.exercise_deleted ? " (removed)" : ""),
@@ -431,6 +426,7 @@ export default function ActiveSession() {
 
   const handleTempoBlur = async (exerciseId: string, val: string) => {
     const clean = val && !/^[\s-]*$/.test(val) ? val : null;
+    setTempoDraft((prev) => ({ ...prev, [exerciseId]: clean ?? "" }));
     const group = groups.find((g) => g.exercise_id === exerciseId);
     if (!group) return;
     for (const set of group.sets) {
@@ -689,8 +685,8 @@ export default function ActiveSession() {
                 onSelect={(m) => handleModeChange(group.exercise_id, m)}
                 onTempoChange={(v) => {
                   setTempoDraft((prev) => ({ ...prev, [group.exercise_id]: v }));
-                  handleTempoBlur(group.exercise_id, v);
                 }}
+                onTempoBlur={() => handleTempoBlur(group.exercise_id, tempoDraft[group.exercise_id] ?? "")}
               />
             )}
 

--- a/components/TrainingModeSelector.tsx
+++ b/components/TrainingModeSelector.tsx
@@ -16,9 +16,10 @@ type Props = {
   tempo: string;
   onSelect: (mode: TrainingMode) => void;
   onTempoChange: (tempo: string) => void;
+  onTempoBlur: () => void;
 };
 
-export default function TrainingModeSelector({ modes, selected, exercise, tempo, onSelect, onTempoChange }: Props) {
+export default function TrainingModeSelector({ modes, selected, exercise, tempo, onSelect, onTempoChange, onTempoBlur }: Props) {
   const theme = useTheme();
   const [tooltip, setTooltip] = useState<string | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -41,11 +42,6 @@ export default function TrainingModeSelector({ modes, selected, exercise, tempo,
       `Switched to ${TRAINING_MODE_LABELS[mode].label} mode`
     );
   }, [onSelect]);
-
-  const sanitize = (val: string) => {
-    if (!val || /^[\s-]*$/.test(val)) return null;
-    return val;
-  };
 
   return (
     <View style={styles.container}>
@@ -98,7 +94,7 @@ export default function TrainingModeSelector({ modes, selected, exercise, tempo,
             placeholder="Tempo (e.g. 3-1-5-1)"
             value={tempo}
             onChangeText={onTempoChange}
-            onBlur={() => onTempoChange(sanitize(tempo) ?? "")}
+            onBlur={onTempoBlur}
             maxLength={15}
             style={styles.tempoInput}
             accessibilityLabel="Tempo notation, for example 3 1 5 1"


### PR DESCRIPTION
Follow-up to PR #49 (merged). Addresses techlead review feedback.

Changes:
- Performance: split onTempoChange into draft-only (onChangeText) and DB-commit (onTempoBlur) to prevent DB writes on every keystroke
- Remove redundant try/catch around training_modes null coalesce
- Remove unused sanitize function from TrainingModeSelector
- Update test defaults for new onTempoBlur prop

Testing: tsc 0 errors, 310 tests pass (23 suites)