### PR TITLE
feat: Interval Workout Timers — Tabata, EMOM, AMRAP (BLD-88)

### DIFF
--- a/__tests__/lib/timer.test.ts
+++ b/__tests__/lib/timer.test.ts
@@ -102,10 +102,12 @@ describe("timer", () => {
       expect(s2.startedAt).toBe(1000)
     })
 
-    it("does not start if completed", () => {
+    it("starts from completed state", () => {
       const s = { ...init("tabata"), status: "completed" as const }
       const s2 = start(s, 1000)
-      expect(s2.status).toBe("completed")
+      expect(s2.status).toBe("running")
+      expect(s2.phase).toBe("work")
+      expect(s2.round).toBe(1)
     })
 
     it("starts emom at round 1", () => {

--- a/__tests__/lib/timer.test.ts
+++ b/__tests__/lib/timer.test.ts
@@ -1,0 +1,436 @@
+import {
+  init,
+  start,
+  pause,
+  resume,
+  reset,
+  addRound,
+  tick,
+  format,
+  roundLabel,
+  phaseLabel,
+  pauseDuration,
+  clamp,
+  progress,
+  duration,
+  totalDuration,
+  DEFAULTS,
+  type TabataConfig,
+  type EmomConfig,
+  type AmrapConfig,
+} from "../../lib/timer"
+
+describe("timer", () => {
+  describe("init", () => {
+    it("creates idle tabata state with defaults", () => {
+      const s = init("tabata")
+      expect(s.mode).toBe("tabata")
+      expect(s.status).toBe("idle")
+      expect(s.phase).toBe("idle")
+      expect(s.round).toBe(0)
+      expect(s.remaining).toBe(20)
+      expect((s.config as TabataConfig).work).toBe(20)
+      expect((s.config as TabataConfig).rest).toBe(10)
+      expect((s.config as TabataConfig).rounds).toBe(8)
+    })
+
+    it("creates idle emom state with defaults", () => {
+      const s = init("emom")
+      expect(s.mode).toBe("emom")
+      expect(s.status).toBe("idle")
+      expect((s.config as EmomConfig).minutes).toBe(10)
+      expect(s.remaining).toBe(60)
+    })
+
+    it("creates idle amrap state with defaults", () => {
+      const s = init("amrap")
+      expect(s.mode).toBe("amrap")
+      expect(s.status).toBe("idle")
+      expect((s.config as AmrapConfig).minutes).toBe(10)
+      expect(s.remaining).toBe(600)
+    })
+
+    it("accepts custom config", () => {
+      const s = init("tabata", { work: 30, rest: 15, rounds: 5 })
+      expect((s.config as TabataConfig).work).toBe(30)
+      expect((s.config as TabataConfig).rest).toBe(15)
+      expect((s.config as TabataConfig).rounds).toBe(5)
+      expect(s.remaining).toBe(30)
+    })
+  })
+
+  describe("duration", () => {
+    it("returns work duration for tabata", () => {
+      expect(duration("tabata", { work: 20, rest: 10, rounds: 8 })).toBe(20)
+    })
+
+    it("returns 60 for emom (per minute)", () => {
+      expect(duration("emom", { minutes: 10 })).toBe(60)
+    })
+
+    it("returns total seconds for amrap", () => {
+      expect(duration("amrap", { minutes: 15 })).toBe(900)
+    })
+  })
+
+  describe("totalDuration", () => {
+    it("computes tabata total", () => {
+      expect(totalDuration("tabata", { work: 20, rest: 10, rounds: 8 })).toBe(240)
+    })
+
+    it("computes emom total", () => {
+      expect(totalDuration("emom", { minutes: 10 })).toBe(600)
+    })
+
+    it("computes amrap total", () => {
+      expect(totalDuration("amrap", { minutes: 5 })).toBe(300)
+    })
+  })
+
+  describe("start", () => {
+    it("transitions from idle to running", () => {
+      const s = start(init("tabata"), 1000)
+      expect(s.status).toBe("running")
+      expect(s.phase).toBe("work")
+      expect(s.round).toBe(1)
+      expect(s.startedAt).toBe(1000)
+    })
+
+    it("does not restart if already running", () => {
+      const s1 = start(init("tabata"), 1000)
+      const s2 = start(s1, 2000)
+      expect(s2.startedAt).toBe(1000)
+    })
+
+    it("does not start if completed", () => {
+      const s = { ...init("tabata"), status: "completed" as const }
+      const s2 = start(s, 1000)
+      expect(s2.status).toBe("completed")
+    })
+
+    it("starts emom at round 1", () => {
+      const s = start(init("emom"), 1000)
+      expect(s.round).toBe(1)
+      expect(s.phase).toBe("work")
+    })
+
+    it("starts amrap at round 0", () => {
+      const s = start(init("amrap"), 1000)
+      expect(s.round).toBe(0)
+      expect(s.amrapRounds).toBe(0)
+    })
+  })
+
+  describe("pause", () => {
+    it("pauses a running timer", () => {
+      const s = pause(start(init("tabata"), 1000), 5000)
+      expect(s.status).toBe("paused")
+      expect(s.pausedAt).toBe(5000)
+      expect(s.elapsed).toBe(4000)
+    })
+
+    it("does nothing if not running", () => {
+      const s = pause(init("tabata"), 1000)
+      expect(s.status).toBe("idle")
+    })
+  })
+
+  describe("resume", () => {
+    it("resumes a paused timer", () => {
+      const running = start(init("tabata"), 1000)
+      const paused = pause(running, 5000)
+      const resumed = resume(paused, 8000)
+      expect(resumed.status).toBe("running")
+      expect(resumed.startedAt).toBe(8000)
+      expect(resumed.pausedAt).toBeNull()
+    })
+
+    it("does nothing if not paused", () => {
+      const s = resume(init("tabata"), 1000)
+      expect(s.status).toBe("idle")
+    })
+  })
+
+  describe("reset", () => {
+    it("resets to initial state preserving config", () => {
+      const running = start(init("tabata", { work: 30, rest: 15, rounds: 5 }), 1000)
+      const s = reset(running)
+      expect(s.status).toBe("idle")
+      expect(s.round).toBe(0)
+      expect((s.config as TabataConfig).work).toBe(30)
+    })
+  })
+
+  describe("addRound", () => {
+    it("increments amrap rounds when running", () => {
+      const s = addRound(start(init("amrap"), 1000))
+      expect(s.amrapRounds).toBe(1)
+      const s2 = addRound(s)
+      expect(s2.amrapRounds).toBe(2)
+    })
+
+    it("does nothing for tabata", () => {
+      const s = addRound(start(init("tabata"), 1000))
+      expect(s.amrapRounds).toBe(0)
+    })
+
+    it("does nothing if not running", () => {
+      const s = addRound(init("amrap"))
+      expect(s.amrapRounds).toBe(0)
+    })
+  })
+
+  describe("tick — tabata", () => {
+    it("counts down during work phase", () => {
+      const s = start(init("tabata"), 1000)
+      const result = tick(s, 6000)
+      expect(result.state.remaining).toBe(15)
+      expect(result.state.phase).toBe("work")
+      expect(result.state.round).toBe(1)
+    })
+
+    it("transitions to rest after work", () => {
+      const s = start(init("tabata"), 1000)
+      const result = tick(s, 21000)
+      expect(result.state.phase).toBe("rest")
+      expect(result.state.round).toBe(1)
+      expect(result.transition).toBe("rest")
+    })
+
+    it("transitions to work on new round", () => {
+      const s = { ...start(init("tabata"), 1000), phase: "rest" as const }
+      const result = tick(s, 31000)
+      expect(result.state.phase).toBe("work")
+      expect(result.state.round).toBe(2)
+      expect(result.transition).toBe("work")
+    })
+
+    it("completes after all rounds", () => {
+      const cfg = { work: 5, rest: 5, rounds: 2 }
+      const s = start(init("tabata", cfg), 1000)
+      // total = (5+5)*2 = 20 seconds
+      const result = tick(s, 21000)
+      expect(result.state.status).toBe("completed")
+      expect(result.state.phase).toBe("completed")
+      expect(result.transition).toBe("completed")
+    })
+
+    it("stays on last round before completion", () => {
+      const cfg = { work: 5, rest: 5, rounds: 2 }
+      const s = start(init("tabata", cfg), 1000)
+      const result = tick(s, 18000)
+      expect(result.state.round).toBe(2)
+      expect(result.state.phase).toBe("rest")
+      expect(result.state.status).toBe("running")
+    })
+  })
+
+  describe("tick — emom", () => {
+    it("counts down within a minute", () => {
+      const s = start(init("emom"), 1000)
+      const result = tick(s, 31000)
+      expect(result.state.remaining).toBe(30)
+      expect(result.state.round).toBe(1)
+    })
+
+    it("transitions at minute boundary", () => {
+      const s = { ...start(init("emom"), 1000), round: 1 }
+      const result = tick(s, 62000)
+      expect(result.state.round).toBe(2)
+      expect(result.transition).toBe("minute")
+    })
+
+    it("completes after total minutes", () => {
+      const cfg = { minutes: 1 }
+      const s = start(init("emom", cfg), 1000)
+      const result = tick(s, 62000)
+      expect(result.state.status).toBe("completed")
+      expect(result.transition).toBe("completed")
+    })
+  })
+
+  describe("tick — amrap", () => {
+    it("counts down total time", () => {
+      const cfg = { minutes: 1 }
+      const s = start(init("amrap", cfg), 1000)
+      const result = tick(s, 31000)
+      expect(result.state.remaining).toBe(30)
+    })
+
+    it("triggers warning at 30s", () => {
+      const cfg = { minutes: 1 }
+      const s = { ...start(init("amrap", cfg), 1000), remaining: 31 }
+      const result = tick(s, 31000)
+      expect(result.transition).toBe("warning30")
+    })
+
+    it("triggers warning at 10s", () => {
+      const cfg = { minutes: 1 }
+      const s = { ...start(init("amrap", cfg), 1000), remaining: 11 }
+      const result = tick(s, 51000)
+      expect(result.transition).toBe("warning10")
+    })
+
+    it("completes after total time", () => {
+      const cfg = { minutes: 1 }
+      const s = start(init("amrap", cfg), 1000)
+      const result = tick(s, 62000)
+      expect(result.state.status).toBe("completed")
+      expect(result.transition).toBe("completed")
+    })
+  })
+
+  describe("tick — paused/idle", () => {
+    it("returns unchanged for idle", () => {
+      const s = init("tabata")
+      const result = tick(s, 1000)
+      expect(result.state).toBe(s)
+      expect(result.transition).toBe("none")
+    })
+
+    it("returns unchanged for paused", () => {
+      const s = pause(start(init("tabata"), 1000), 5000)
+      const result = tick(s, 10000)
+      expect(result.transition).toBe("none")
+    })
+  })
+
+  describe("tick — pause/resume preserves elapsed", () => {
+    it("accumulates elapsed across pause/resume", () => {
+      const s1 = start(init("tabata", { work: 20, rest: 10, rounds: 8 }), 1000)
+      // run for 5 seconds
+      const s2 = pause(s1, 6000)
+      expect(s2.elapsed).toBe(5000)
+      // resume at 10000, run for 10 more seconds
+      const s3 = resume(s2, 10000)
+      const result = tick(s3, 20000)
+      // total elapsed = 5s + 10s = 15s → in work phase (15 < 20)
+      expect(result.state.phase).toBe("work")
+      expect(result.state.remaining).toBe(5)
+    })
+  })
+
+  describe("format", () => {
+    it("formats seconds as M:SS", () => {
+      expect(format(0)).toBe("0:00")
+      expect(format(5)).toBe("0:05")
+      expect(format(60)).toBe("1:00")
+      expect(format(90)).toBe("1:30")
+      expect(format(600)).toBe("10:00")
+      expect(format(3599)).toBe("59:59")
+    })
+  })
+
+  describe("roundLabel", () => {
+    it("shows round/total for tabata", () => {
+      const s = { ...start(init("tabata"), 1000), round: 3 }
+      expect(roundLabel(s)).toBe("3 / 8")
+    })
+
+    it("shows minute for emom", () => {
+      const s = { ...start(init("emom"), 1000), round: 5 }
+      expect(roundLabel(s)).toBe("Minute 5 / 10")
+    })
+
+    it("shows amrap rounds", () => {
+      const s = { ...start(init("amrap"), 1000), amrapRounds: 7 }
+      expect(roundLabel(s)).toBe("7 rounds")
+    })
+  })
+
+  describe("phaseLabel", () => {
+    it("returns WORK for work", () => {
+      expect(phaseLabel({ ...init("tabata"), phase: "work" })).toBe("WORK")
+    })
+
+    it("returns REST for rest", () => {
+      expect(phaseLabel({ ...init("tabata"), phase: "rest" })).toBe("REST")
+    })
+
+    it("returns DONE for completed", () => {
+      expect(phaseLabel({ ...init("tabata"), phase: "completed" })).toBe("DONE")
+    })
+
+    it("returns empty for idle", () => {
+      expect(phaseLabel(init("tabata"))).toBe("")
+    })
+  })
+
+  describe("pauseDuration", () => {
+    it("computes pause duration in seconds", () => {
+      const s = { ...init("tabata"), status: "paused" as const, pausedAt: 1000 }
+      expect(pauseDuration(s, 6000)).toBe(5)
+    })
+
+    it("returns 0 if not paused", () => {
+      expect(pauseDuration(init("tabata"), 1000)).toBe(0)
+    })
+  })
+
+  describe("clamp", () => {
+    it("clamps within range", () => {
+      expect(clamp(5, 1, 10)).toBe(5)
+      expect(clamp(-1, 1, 10)).toBe(1)
+      expect(clamp(15, 1, 10)).toBe(10)
+    })
+  })
+
+  describe("progress", () => {
+    it("returns 0 when remaining equals total", () => {
+      const s = init("tabata")
+      expect(progress(s)).toBe(0)
+    })
+
+    it("returns 0.5 at halfway", () => {
+      const s = { ...init("tabata"), remaining: 10, total: 20 }
+      expect(progress(s)).toBe(0.5)
+    })
+
+    it("returns 0 when total is 0", () => {
+      const s = { ...init("tabata"), remaining: 0, total: 0 }
+      expect(progress(s)).toBe(0)
+    })
+  })
+
+  describe("edge cases", () => {
+    it("handles single round tabata", () => {
+      const cfg = { work: 10, rest: 5, rounds: 1 }
+      const s = start(init("tabata", cfg), 0)
+      const r1 = tick(s, 10000)
+      expect(r1.state.phase).toBe("rest")
+      const r2 = tick(r1.state, 15000)
+      expect(r2.state.status).toBe("completed")
+    })
+
+    it("handles 1 minute emom", () => {
+      const cfg = { minutes: 1 }
+      const s = start(init("emom", cfg), 0)
+      const r = tick(s, 59000)
+      expect(r.state.remaining).toBe(1)
+      expect(r.state.status).toBe("running")
+    })
+
+    it("handles rapid tick calls", () => {
+      const s = start(init("tabata"), 0)
+      const r1 = tick(s, 100)
+      const r2 = tick(r1.state, 200)
+      expect(r2.state.status).toBe("running")
+      expect(r2.state.remaining).toBe(20)
+    })
+
+    it("handles very long amrap (60 min)", () => {
+      const cfg = { minutes: 60 }
+      const s = start(init("amrap", cfg), 0)
+      expect(s.remaining).toBe(3600)
+      const r = tick(s, 1800000) // 30 min
+      expect(r.state.remaining).toBe(1800)
+    })
+
+    it("mode switching resets state", () => {
+      const s1 = start(init("tabata"), 1000)
+      const s2 = init("emom")
+      expect(s2.status).toBe("idle")
+      expect(s2.mode).toBe("emom")
+    })
+  })
+})

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -911,6 +911,30 @@ export default function Workouts() {
         )}
       </View>
 
+      {/* Tools */}
+      <View style={styles.section}>
+        <View style={styles.sectionHeader}>
+          <Text variant="titleMedium" style={{ color: theme.colors.onBackground }}>
+            Tools
+          </Text>
+        </View>
+        <Card
+          style={styles.card}
+          onPress={() => router.push("/tools/timer")}
+          accessibilityLabel="Open interval timer"
+        >
+          <Card.Content style={styles.cardContent}>
+            <View style={styles.cardInfo}>
+              <Text variant="titleSmall">Interval Timer</Text>
+              <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+                Tabata · EMOM · AMRAP
+              </Text>
+            </View>
+            <IconButton icon="timer-outline" size={24} iconColor={theme.colors.onSurfaceVariant} />
+          </Card.Content>
+        </Card>
+      </View>
+
       <Snackbar
         visible={!!snackbar}
         onDismiss={() => setSnackbar("")}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -279,6 +279,15 @@ export default function RootLayout() {
                 headerTintColor,
               }}
             />
+            <Stack.Screen
+              name="tools/timer"
+              options={{
+                headerShown: true,
+                title: "Interval Timer",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
           </Stack>
           <StatusBar style="auto" />
         </ThemeProvider>

--- a/app/tools/timer.tsx
+++ b/app/tools/timer.tsx
@@ -1,0 +1,655 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  AccessibilityInfo,
+  AppState,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native"
+import {
+  Button,
+  IconButton,
+  SegmentedButtons,
+  Text,
+  useTheme,
+} from "react-native-paper"
+import { Stack } from "expo-router"
+import { useFocusEffect } from "expo-router"
+import * as Haptics from "expo-haptics"
+import { useKeepAwake } from "expo-keep-awake"
+import Svg, { Circle } from "react-native-svg"
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  useReducedMotion,
+  useAnimatedProps,
+} from "react-native-reanimated"
+import {
+  init,
+  start,
+  pause,
+  resume,
+  reset,
+  addRound,
+  tick,
+  format,
+  roundLabel,
+  phaseLabel,
+  pauseDuration,
+  clamp,
+  progress,
+  DEFAULTS,
+  type Mode,
+  type State,
+  type TabataConfig,
+  type EmomConfig,
+  type AmrapConfig,
+  type Config,
+} from "../../lib/timer"
+import { getAppSetting, setAppSetting } from "../../lib/db"
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle)
+
+const DEBOUNCE = 300
+const RING_SIZE = 220
+const RING_STROKE = 8
+const RING_RADIUS = (RING_SIZE - RING_STROKE) / 2
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS
+
+const STORAGE_KEYS: Record<Mode, string> = {
+  tabata: "timer_tabata_config",
+  emom: "timer_emom_config",
+  amrap: "timer_amrap_config",
+}
+
+export default function TimerScreen() {
+  const theme = useTheme()
+  const reduced = useReducedMotion()
+  const [mode, setMode] = useState<Mode>("tabata")
+  const [state, setState] = useState<State>(init("tabata"))
+  const [pauseMsg, setPauseMsg] = useState("")
+  const lastTap = useRef(0)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const appRef = useRef(state)
+  appRef.current = state
+
+  const active = state.status === "running" || state.status === "paused"
+  useKeepAwake()
+
+  // Animated values
+  const bgOpacity = useSharedValue(0)
+  const isWork = useSharedValue(true)
+  const ringProgress = useSharedValue(0)
+
+  // Load saved config
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        const raw = await getAppSetting(STORAGE_KEYS[mode])
+        if (raw) {
+          try {
+            const cfg = JSON.parse(raw) as Config
+            setState(init(mode, cfg))
+          } catch { /* use defaults */ }
+        }
+      })()
+    }, [mode])
+  )
+
+  // Save config on start
+  const save = useCallback(async (m: Mode, cfg: Config) => {
+    await setAppSetting(STORAGE_KEYS[m], JSON.stringify(cfg))
+  }, [])
+
+  // Tick interval
+  useEffect(() => {
+    if (state.status !== "running") {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+      return
+    }
+
+    intervalRef.current = setInterval(() => {
+      setState(prev => {
+        const result = tick(prev, Date.now())
+        if (result.transition === "work") {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+          setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 150)
+        } else if (result.transition === "rest") {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
+        } else if (result.transition === "minute") {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+        } else if (result.transition === "warning30" || result.transition === "warning10") {
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning)
+        } else if (result.transition === "completed") {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+          setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 150)
+          setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 300)
+        }
+        return result.state
+      })
+    }, 200)
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+  }, [state.status])
+
+  // Update animated values
+  useEffect(() => {
+    const p = progress(state)
+    const dur = reduced ? 0 : 300
+    bgOpacity.value = withTiming(state.status === "running" ? 0.15 : 0, { duration: dur })
+    isWork.value = state.phase === "work"
+    ringProgress.value = withTiming(p, { duration: dur })
+  }, [state.remaining, state.phase, state.status])
+
+  // AppState handling
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", next => {
+      if (next === "background" || next === "inactive") {
+        if (appRef.current.status === "running") {
+          setState(prev => pause(prev, Date.now()))
+        }
+      } else if (next === "active") {
+        if (appRef.current.status === "paused" && appRef.current.pausedAt) {
+          const secs = pauseDuration(appRef.current, Date.now())
+          setPauseMsg(`Paused for ${format(secs)}`)
+        }
+      }
+    })
+    return () => sub.remove()
+  }, [])
+
+  // Focus handling
+  useFocusEffect(
+    useCallback(() => {
+      return () => {
+        if (appRef.current.status === "running") {
+          setState(prev => pause(prev, Date.now()))
+        }
+      }
+    }, [])
+  )
+
+  // Screen reader announcements
+  useEffect(() => {
+    if (state.status !== "running") return
+    const r = state.remaining
+    if ([10, 5, 3, 2, 1].includes(r)) {
+      const label = `${r} second${r === 1 ? "" : "s"} remaining`
+      AccessibilityInfo.announceForAccessibility(label)
+    }
+  }, [state.remaining, state.status])
+
+  const debounced = useCallback((fn: () => void) => {
+    const now = Date.now()
+    if (now - lastTap.current < DEBOUNCE) return
+    lastTap.current = now
+    fn()
+  }, [])
+
+  const handleStart = useCallback(() => {
+    debounced(() => {
+      if (state.status === "idle" || state.status === "completed") {
+        save(mode, state.config)
+        setState(prev => start(prev, Date.now()))
+        setPauseMsg("")
+      } else if (state.status === "running") {
+        setState(prev => pause(prev, Date.now()))
+      } else if (state.status === "paused") {
+        setState(prev => resume(prev, Date.now()))
+        setPauseMsg("")
+      }
+    })
+  }, [state.status, mode, state.config])
+
+  const handleReset = useCallback(() => {
+    debounced(() => {
+      setState(prev => reset(prev))
+      setPauseMsg("")
+    })
+  }, [])
+
+  const handleAddRound = useCallback(() => {
+    debounced(() => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
+      setState(prev => addRound(prev))
+    })
+  }, [])
+
+  const handleMode = useCallback((m: string) => {
+    const next = m as Mode
+    setMode(next)
+    setState(init(next))
+    setPauseMsg("")
+  }, [])
+
+  // Config steppers
+  const adjust = useCallback((field: string, delta: number) => {
+    setState(prev => {
+      const cfg = { ...prev.config }
+      if (prev.mode === "tabata") {
+        const tc = cfg as TabataConfig
+        if (field === "work") tc.work = clamp(tc.work + delta, 5, 60)
+        if (field === "rest") tc.rest = clamp(tc.rest + delta, 5, 60)
+        if (field === "rounds") tc.rounds = clamp(tc.rounds + delta, 1, 20)
+      } else if (prev.mode === "emom") {
+        const ec = cfg as EmomConfig
+        if (field === "minutes") ec.minutes = clamp(ec.minutes + delta, 1, 60)
+      } else {
+        const ac = cfg as AmrapConfig
+        if (field === "minutes") ac.minutes = clamp(ac.minutes + delta, 1, 60)
+      }
+      return init(prev.mode, cfg)
+    })
+  }, [])
+
+  const bgColor = state.phase === "work"
+    ? theme.colors.primary
+    : state.phase === "rest"
+    ? theme.colors.error
+    : "transparent"
+
+  const bgStyle = useAnimatedStyle(() => ({
+    backgroundColor: isWork.value
+      ? `rgba(${hexToRgb(theme.colors.primary)}, ${bgOpacity.value})`
+      : `rgba(${hexToRgb(theme.colors.error)}, ${bgOpacity.value})`,
+  }))
+
+  const ringAnimated = useAnimatedProps(() => ({
+    strokeDashoffset: RING_CIRCUMFERENCE * (1 - ringProgress.value),
+  }))
+
+  const startLabel = state.status === "idle" || state.status === "completed"
+    ? "Start"
+    : state.status === "running"
+    ? "Pause"
+    : "Resume"
+
+  const startA11y = state.status === "idle" || state.status === "completed"
+    ? "Start timer"
+    : state.status === "running"
+    ? "Pause timer"
+    : "Resume timer"
+
+  const phaseIcon = state.phase === "work" ? "play" : state.phase === "rest" ? "pause" : undefined
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: true, title: "Interval Timer" }} />
+      <Animated.View style={[styles.container, bgStyle]}>
+        <ScrollView contentContainerStyle={styles.scroll} keyboardShouldPersistTaps="handled">
+          {/* Mode selector */}
+          {!active && (
+            <SegmentedButtons
+              value={mode}
+              onValueChange={handleMode}
+              buttons={[
+                { value: "tabata", label: "Tabata", accessibilityLabel: "Tabata mode" },
+                { value: "emom", label: "EMOM", accessibilityLabel: "EMOM mode" },
+                { value: "amrap", label: "AMRAP", accessibilityLabel: "AMRAP mode" },
+              ]}
+              style={styles.modes}
+            />
+          )}
+
+          {/* Config steppers */}
+          {state.status === "idle" && (
+            <View style={styles.config}>
+              {mode === "tabata" && (
+                <>
+                  <Stepper
+                    label="Work"
+                    value={(state.config as TabataConfig).work}
+                    suffix="s"
+                    min={5}
+                    max={60}
+                    onUp={() => adjust("work", 5)}
+                    onDown={() => adjust("work", -5)}
+                  />
+                  <Stepper
+                    label="Rest"
+                    value={(state.config as TabataConfig).rest}
+                    suffix="s"
+                    min={5}
+                    max={60}
+                    onUp={() => adjust("rest", 5)}
+                    onDown={() => adjust("rest", -5)}
+                  />
+                  <Stepper
+                    label="Rounds"
+                    value={(state.config as TabataConfig).rounds}
+                    suffix=""
+                    min={1}
+                    max={20}
+                    onUp={() => adjust("rounds", 1)}
+                    onDown={() => adjust("rounds", -1)}
+                  />
+                </>
+              )}
+              {mode === "emom" && (
+                <Stepper
+                  label="Minutes"
+                  value={(state.config as EmomConfig).minutes}
+                  suffix="min"
+                  min={1}
+                  max={60}
+                  onUp={() => adjust("minutes", 1)}
+                  onDown={() => adjust("minutes", -1)}
+                />
+              )}
+              {mode === "amrap" && (
+                <Stepper
+                  label="Minutes"
+                  value={(state.config as AmrapConfig).minutes}
+                  suffix="min"
+                  min={1}
+                  max={60}
+                  onUp={() => adjust("minutes", 1)}
+                  onDown={() => adjust("minutes", -1)}
+                />
+              )}
+            </View>
+          )}
+
+          {/* Phase label */}
+          {active && (
+            <View style={styles.phaseRow}>
+              {phaseIcon && (
+                <IconButton
+                  icon={phaseIcon}
+                  size={20}
+                  iconColor={bgColor}
+                  style={{ margin: 0 }}
+                />
+              )}
+              <Text
+                variant="titleMedium"
+                style={[styles.phaseText, { color: bgColor }]}
+                accessibilityRole="text"
+              >
+                {phaseLabel(state)}
+              </Text>
+            </View>
+          )}
+
+          {/* Pause message */}
+          {pauseMsg !== "" && state.status === "paused" && (
+            <Text variant="bodyMedium" style={styles.pauseMsg}>
+              {pauseMsg}
+            </Text>
+          )}
+
+          {/* Timer display with progress ring */}
+          <View style={styles.ringWrap} accessibilityLabel={`${format(state.remaining)} remaining`}>
+            <Svg width={RING_SIZE} height={RING_SIZE} style={styles.ringSvg}>
+              <Circle
+                cx={RING_SIZE / 2}
+                cy={RING_SIZE / 2}
+                r={RING_RADIUS}
+                stroke={theme.colors.surfaceVariant}
+                strokeWidth={RING_STROKE}
+                fill="none"
+              />
+              <AnimatedCircle
+                cx={RING_SIZE / 2}
+                cy={RING_SIZE / 2}
+                r={RING_RADIUS}
+                stroke={bgColor || theme.colors.primary}
+                strokeWidth={RING_STROKE}
+                fill="none"
+                strokeDasharray={RING_CIRCUMFERENCE}
+                animatedProps={ringAnimated}
+                strokeLinecap="round"
+                rotation="-90"
+                origin={`${RING_SIZE / 2}, ${RING_SIZE / 2}`}
+              />
+            </Svg>
+            <View style={styles.countdown}>
+              <Text
+                style={[styles.time, { color: theme.colors.onSurface }]}
+                accessibilityLabel={`${state.remaining} seconds remaining`}
+              >
+                {format(state.remaining)}
+              </Text>
+            </View>
+          </View>
+
+          {/* Round label */}
+          {(state.status === "running" || state.status === "paused") && (
+            <Text
+              variant="titleMedium"
+              style={[styles.rounds, { color: theme.colors.onSurfaceVariant }]}
+            >
+              {roundLabel(state)}
+            </Text>
+          )}
+
+          {/* Completed */}
+          {state.status === "completed" && (
+            <Text
+              variant="headlineSmall"
+              style={[styles.done, { color: theme.colors.primary }]}
+              accessibilityRole="text"
+            >
+              Complete!
+            </Text>
+          )}
+
+          {/* AMRAP +1 Round */}
+          {mode === "amrap" && state.status === "running" && (
+            <Pressable
+              onPress={handleAddRound}
+              style={[styles.addRound, { backgroundColor: theme.colors.primaryContainer }]}
+              accessibilityLabel={`Add round. Current: ${state.amrapRounds} rounds`}
+              accessibilityRole="button"
+            >
+              <Text variant="titleLarge" style={{ color: theme.colors.onPrimaryContainer }}>
+                +1 Round
+              </Text>
+            </Pressable>
+          )}
+
+          {/* Controls */}
+          <View style={styles.controls}>
+            <Pressable
+              onPress={handleStart}
+              style={[styles.btn, { backgroundColor: theme.colors.primary }]}
+              accessibilityLabel={startA11y}
+              accessibilityRole="button"
+            >
+              <Text variant="titleMedium" style={{ color: theme.colors.onPrimary }}>
+                {startLabel}
+              </Text>
+            </Pressable>
+            {(state.status === "paused" || state.status === "completed") && (
+              <Pressable
+                onPress={handleReset}
+                style={[styles.btn, { backgroundColor: theme.colors.surfaceVariant }]}
+                accessibilityLabel="Reset timer"
+                accessibilityRole="button"
+              >
+                <Text variant="titleMedium" style={{ color: theme.colors.onSurfaceVariant }}>
+                  Reset
+                </Text>
+              </Pressable>
+            )}
+          </View>
+        </ScrollView>
+      </Animated.View>
+    </>
+  )
+}
+
+// Stepper component
+function Stepper({ label, value, suffix, min, max, onUp, onDown }: {
+  label: string
+  value: number
+  suffix: string
+  min: number
+  max: number
+  onUp: () => void
+  onDown: () => void
+}) {
+  const theme = useTheme()
+  return (
+    <View style={styles.stepper}>
+      <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
+        {label}
+      </Text>
+      <View style={styles.stepperRow}>
+        <Pressable
+          onPress={onDown}
+          disabled={value <= min}
+          style={[styles.stepBtn, { backgroundColor: theme.colors.surfaceVariant, opacity: value <= min ? 0.4 : 1 }]}
+          accessibilityLabel={`Decrease ${label}`}
+          accessibilityRole="button"
+          accessibilityValue={{ min, max, now: value, text: `${value}${suffix}` }}
+        >
+          <Text variant="titleMedium" style={{ color: theme.colors.onSurfaceVariant }}>−</Text>
+        </Pressable>
+        <Text
+          variant="titleLarge"
+          style={[styles.stepVal, { color: theme.colors.onSurface }]}
+          accessibilityLabel={`${label}: ${value}${suffix}`}
+        >
+          {value}{suffix}
+        </Text>
+        <Pressable
+          onPress={onUp}
+          disabled={value >= max}
+          style={[styles.stepBtn, { backgroundColor: theme.colors.surfaceVariant, opacity: value >= max ? 0.4 : 1 }]}
+          accessibilityLabel={`Increase ${label}`}
+          accessibilityRole="button"
+          accessibilityValue={{ min, max, now: value, text: `${value}${suffix}` }}
+        >
+          <Text variant="titleMedium" style={{ color: theme.colors.onSurfaceVariant }}>+</Text>
+        </Pressable>
+      </View>
+    </View>
+  )
+}
+
+function hexToRgb(hex: string): string {
+  const h = hex.replace("#", "")
+  const r = parseInt(h.substring(0, 2), 16)
+  const g = parseInt(h.substring(2, 4), 16)
+  const b = parseInt(h.substring(4, 6), 16)
+  if (isNaN(r) || isNaN(g) || isNaN(b)) return "0, 0, 0"
+  return `${r}, ${g}, ${b}`
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scroll: {
+    flexGrow: 1,
+    padding: 16,
+    alignItems: "center",
+  },
+  modes: {
+    marginBottom: 16,
+    alignSelf: "stretch",
+  },
+  config: {
+    flexDirection: "row",
+    gap: 16,
+    marginBottom: 24,
+    flexWrap: "wrap",
+    justifyContent: "center",
+  },
+  stepper: {
+    alignItems: "center",
+    gap: 8,
+  },
+  stepperRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  stepBtn: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  stepVal: {
+    minWidth: 60,
+    textAlign: "center",
+    fontVariant: ["tabular-nums"],
+  },
+  phaseRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  phaseText: {
+    fontWeight: "700",
+    letterSpacing: 2,
+  },
+  pauseMsg: {
+    marginBottom: 8,
+    opacity: 0.7,
+  },
+  ringWrap: {
+    width: RING_SIZE,
+    height: RING_SIZE,
+    justifyContent: "center",
+    alignItems: "center",
+    marginVertical: 16,
+  },
+  ringSvg: {
+    position: "absolute",
+  },
+  countdown: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  time: {
+    fontSize: 56,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+    fontFamily: Platform.select({ ios: "Menlo", android: "monospace", default: "monospace" }),
+  },
+  rounds: {
+    marginBottom: 16,
+    textAlign: "center",
+  },
+  done: {
+    marginBottom: 16,
+    textAlign: "center",
+    fontWeight: "700",
+  },
+  addRound: {
+    minWidth: 160,
+    minHeight: 56,
+    borderRadius: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 16,
+  },
+  controls: {
+    flexDirection: "row",
+    gap: 16,
+    marginTop: 8,
+  },
+  btn: {
+    minWidth: 120,
+    minHeight: 56,
+    borderRadius: 28,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 24,
+  },
+})

--- a/app/tools/timer.tsx
+++ b/app/tools/timer.tsx
@@ -115,24 +115,22 @@ export default function TimerScreen() {
     }
 
     intervalRef.current = setInterval(() => {
-      setState(prev => {
-        const result = tick(prev, Date.now())
-        if (result.transition === "work") {
-          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
-          setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 150)
-        } else if (result.transition === "rest") {
-          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
-        } else if (result.transition === "minute") {
-          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
-        } else if (result.transition === "warning30" || result.transition === "warning10") {
-          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning)
-        } else if (result.transition === "completed") {
-          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
-          setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 150)
-          setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 300)
-        }
-        return result.state
-      })
+      const result = tick(appRef.current, Date.now())
+      if (result.transition === "work") {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+        setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 150)
+      } else if (result.transition === "rest") {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
+      } else if (result.transition === "minute") {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+      } else if (result.transition === "warning30" || result.transition === "warning10") {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning)
+      } else if (result.transition === "completed") {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
+        setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 150)
+        setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 300)
+      }
+      setState(result.state)
     }, 200)
 
     return () => {
@@ -199,9 +197,13 @@ export default function TimerScreen() {
 
   const handleStart = useCallback(() => {
     debounced(() => {
-      if (state.status === "idle" || state.status === "completed") {
+      if (state.status === "idle") {
         save(mode, state.config)
         setState(prev => start(prev, Date.now()))
+        setPauseMsg("")
+      } else if (state.status === "completed") {
+        save(mode, state.config)
+        setState(prev => start(reset(prev), Date.now()))
         setPauseMsg("")
       } else if (state.status === "running") {
         setState(prev => pause(prev, Date.now()))

--- a/app/tools/timer.tsx
+++ b/app/tools/timer.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   IconButton,
   SegmentedButtons,
+  Snackbar,
   Text,
   useTheme,
 } from "react-native-paper"
@@ -71,6 +72,7 @@ export default function TimerScreen() {
   const [mode, setMode] = useState<Mode>("tabata")
   const [state, setState] = useState<State>(init("tabata"))
   const [pauseMsg, setPauseMsg] = useState("")
+  const [error, setError] = useState("")
   const lastTap = useRef(0)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const timeoutRefs = useRef<ReturnType<typeof setTimeout>[]>([])
@@ -104,7 +106,9 @@ export default function TimerScreen() {
             const cfg = JSON.parse(raw) as Config
             setState(init(mode, cfg))
           }
-        } catch { /* use defaults on parse or DB error */ }
+        } catch {
+          setError("Could not load saved settings")
+        }
       })()
     }, [mode])
   )
@@ -113,7 +117,9 @@ export default function TimerScreen() {
   const save = useCallback(async (m: Mode, cfg: Config) => {
     try {
       await setAppSetting(STORAGE_KEYS[m], JSON.stringify(cfg))
-    } catch { /* non-critical: config won't persist */ }
+    } catch {
+      setError("Could not save settings")
+    }
   }, [])
 
   // Tick interval
@@ -508,6 +514,14 @@ export default function TimerScreen() {
           </View>
         </ScrollView>
       </Animated.View>
+      <Snackbar
+        visible={!!error}
+        onDismiss={() => setError("")}
+        duration={3000}
+        accessibilityLiveRegion="polite"
+      >
+        {error}
+      </Snackbar>
     </>
   )
 }

--- a/app/tools/timer.tsx
+++ b/app/tools/timer.tsx
@@ -18,7 +18,7 @@ import {
 import { Stack } from "expo-router"
 import { useFocusEffect } from "expo-router"
 import * as Haptics from "expo-haptics"
-import { useKeepAwake } from "expo-keep-awake"
+import { activateKeepAwakeAsync, deactivateKeepAwake } from "expo-keep-awake"
 import Svg, { Circle } from "react-native-svg"
 import Animated, {
   useSharedValue,
@@ -73,11 +73,21 @@ export default function TimerScreen() {
   const [pauseMsg, setPauseMsg] = useState("")
   const lastTap = useRef(0)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const timeoutRefs = useRef<ReturnType<typeof setTimeout>[]>([])
   const appRef = useRef(state)
   appRef.current = state
 
   const active = state.status === "running" || state.status === "paused"
-  useKeepAwake()
+
+  // Keep awake only when timer is active
+  useEffect(() => {
+    if (active) {
+      activateKeepAwakeAsync().catch(() => {})
+    } else {
+      deactivateKeepAwake()
+    }
+    return () => { deactivateKeepAwake() }
+  }, [active])
 
   // Animated values
   const bgOpacity = useSharedValue(0)
@@ -88,20 +98,22 @@ export default function TimerScreen() {
   useFocusEffect(
     useCallback(() => {
       (async () => {
-        const raw = await getAppSetting(STORAGE_KEYS[mode])
-        if (raw) {
-          try {
+        try {
+          const raw = await getAppSetting(STORAGE_KEYS[mode])
+          if (raw) {
             const cfg = JSON.parse(raw) as Config
             setState(init(mode, cfg))
-          } catch { /* use defaults */ }
-        }
+          }
+        } catch { /* use defaults on parse or DB error */ }
       })()
     }, [mode])
   )
 
   // Save config on start
   const save = useCallback(async (m: Mode, cfg: Config) => {
-    await setAppSetting(STORAGE_KEYS[m], JSON.stringify(cfg))
+    try {
+      await setAppSetting(STORAGE_KEYS[m], JSON.stringify(cfg))
+    } catch { /* non-critical: config won't persist */ }
   }, [])
 
   // Tick interval
@@ -118,7 +130,8 @@ export default function TimerScreen() {
       const result = tick(appRef.current, Date.now())
       if (result.transition === "work") {
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
-        setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 150)
+        const t = setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 150)
+        timeoutRefs.current.push(t)
       } else if (result.transition === "rest") {
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
       } else if (result.transition === "minute") {
@@ -127,8 +140,9 @@ export default function TimerScreen() {
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning)
       } else if (result.transition === "completed") {
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy)
-        setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 150)
-        setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 300)
+        const t1 = setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 150)
+        const t2 = setTimeout(() => Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy), 300)
+        timeoutRefs.current.push(t1, t2)
       }
       setState(result.state)
     }, 200)
@@ -138,6 +152,8 @@ export default function TimerScreen() {
         clearInterval(intervalRef.current)
         intervalRef.current = null
       }
+      timeoutRefs.current.forEach(clearTimeout)
+      timeoutRefs.current = []
     }
   }, [state.status])
 
@@ -420,6 +436,7 @@ export default function TimerScreen() {
               <Text
                 style={[styles.time, { color: theme.colors.onSurface }]}
                 accessibilityLabel={`${state.remaining} seconds remaining`}
+                accessibilityLiveRegion="polite"
               >
                 {format(state.remaining)}
               </Text>
@@ -454,6 +471,7 @@ export default function TimerScreen() {
               style={[styles.addRound, { backgroundColor: theme.colors.primaryContainer }]}
               accessibilityLabel={`Add round. Current: ${state.amrapRounds} rounds`}
               accessibilityRole="button"
+              accessibilityState={{ disabled: false }}
             >
               <Text variant="titleLarge" style={{ color: theme.colors.onPrimaryContainer }}>
                 +1 Round
@@ -468,6 +486,7 @@ export default function TimerScreen() {
               style={[styles.btn, { backgroundColor: theme.colors.primary }]}
               accessibilityLabel={startA11y}
               accessibilityRole="button"
+              accessibilityState={{ disabled: false }}
             >
               <Text variant="titleMedium" style={{ color: theme.colors.onPrimary }}>
                 {startLabel}
@@ -479,6 +498,7 @@ export default function TimerScreen() {
                 style={[styles.btn, { backgroundColor: theme.colors.surfaceVariant }]}
                 accessibilityLabel="Reset timer"
                 accessibilityRole="button"
+                accessibilityState={{ disabled: false }}
               >
                 <Text variant="titleMedium" style={{ color: theme.colors.onSurfaceVariant }}>
                   Reset
@@ -515,6 +535,7 @@ function Stepper({ label, value, suffix, min, max, onUp, onDown }: {
           style={[styles.stepBtn, { backgroundColor: theme.colors.surfaceVariant, opacity: value <= min ? 0.4 : 1 }]}
           accessibilityLabel={`Decrease ${label}`}
           accessibilityRole="button"
+          accessibilityState={{ disabled: value <= min }}
           accessibilityValue={{ min, max, now: value, text: `${value}${suffix}` }}
         >
           <Text variant="titleMedium" style={{ color: theme.colors.onSurfaceVariant }}>−</Text>
@@ -532,6 +553,7 @@ function Stepper({ label, value, suffix, min, max, onUp, onDown }: {
           style={[styles.stepBtn, { backgroundColor: theme.colors.surfaceVariant, opacity: value >= max ? 0.4 : 1 }]}
           accessibilityLabel={`Increase ${label}`}
           accessibilityRole="button"
+          accessibilityState={{ disabled: value >= max }}
           accessibilityValue={{ min, max, now: value, text: `${value}${suffix}` }}
         >
           <Text variant="titleMedium" style={{ color: theme.colors.onSurfaceVariant }}>+</Text>

--- a/lib/timer.ts
+++ b/lib/timer.ts
@@ -82,14 +82,12 @@ export function totalDuration(mode: Mode, config: Config): number {
 
 export function start(state: State, now: number): State {
   if (state.status === "running") return state
-  if (state.status === "completed") return state
-  const phase: Phase = state.mode === "amrap" ? "work" : "work"
   const round = state.mode === "tabata" ? 1 : (state.mode === "emom" ? 1 : 0)
   const rem = duration(state.mode, state.config)
   return {
     ...state,
     status: "running",
-    phase,
+    phase: "work",
     round,
     remaining: rem,
     total: rem,

--- a/lib/timer.ts
+++ b/lib/timer.ts
@@ -1,0 +1,267 @@
+// Interval workout timer — pure state machine
+
+export type Mode = "tabata" | "emom" | "amrap"
+export type Phase = "work" | "rest" | "idle" | "completed"
+export type Status = "idle" | "running" | "paused" | "completed"
+
+export type TabataConfig = {
+  work: number
+  rest: number
+  rounds: number
+}
+
+export type EmomConfig = {
+  minutes: number
+}
+
+export type AmrapConfig = {
+  minutes: number
+}
+
+export type Config = TabataConfig | EmomConfig | AmrapConfig
+
+export type State = {
+  mode: Mode
+  config: Config
+  status: Status
+  phase: Phase
+  round: number
+  remaining: number
+  total: number
+  startedAt: number | null
+  pausedAt: number | null
+  elapsed: number
+  amrapRounds: number
+}
+
+export const DEFAULTS: Record<Mode, Config> = {
+  tabata: { work: 20, rest: 10, rounds: 8 },
+  emom: { minutes: 10 },
+  amrap: { minutes: 10 },
+}
+
+export function init(mode: Mode, config?: Config): State {
+  const cfg = config ?? DEFAULTS[mode]
+  return {
+    mode,
+    config: cfg,
+    status: "idle",
+    phase: "idle",
+    round: 0,
+    remaining: duration(mode, cfg),
+    total: duration(mode, cfg),
+    startedAt: null,
+    pausedAt: null,
+    elapsed: 0,
+    amrapRounds: 0,
+  }
+}
+
+export function duration(mode: Mode, config: Config): number {
+  if (mode === "tabata") {
+    const c = config as TabataConfig
+    return c.work
+  }
+  if (mode === "emom") return 60
+  const c = config as AmrapConfig
+  return c.minutes * 60
+}
+
+export function totalDuration(mode: Mode, config: Config): number {
+  if (mode === "tabata") {
+    const c = config as TabataConfig
+    return (c.work + c.rest) * c.rounds
+  }
+  if (mode === "emom") {
+    const c = config as EmomConfig
+    return c.minutes * 60
+  }
+  const c = config as AmrapConfig
+  return c.minutes * 60
+}
+
+export function start(state: State, now: number): State {
+  if (state.status === "running") return state
+  if (state.status === "completed") return state
+  const phase: Phase = state.mode === "amrap" ? "work" : "work"
+  const round = state.mode === "tabata" ? 1 : (state.mode === "emom" ? 1 : 0)
+  const rem = duration(state.mode, state.config)
+  return {
+    ...state,
+    status: "running",
+    phase,
+    round,
+    remaining: rem,
+    total: rem,
+    startedAt: now,
+    pausedAt: null,
+    elapsed: 0,
+    amrapRounds: 0,
+  }
+}
+
+export function pause(state: State, now: number): State {
+  if (state.status !== "running") return state
+  return {
+    ...state,
+    status: "paused",
+    pausedAt: now,
+    elapsed: state.elapsed + (now - (state.startedAt ?? now)),
+  }
+}
+
+export function resume(state: State, now: number): State {
+  if (state.status !== "paused") return state
+  return {
+    ...state,
+    status: "running",
+    startedAt: now,
+    pausedAt: null,
+  }
+}
+
+export function reset(state: State): State {
+  return init(state.mode, state.config)
+}
+
+export function addRound(state: State): State {
+  if (state.mode !== "amrap") return state
+  if (state.status !== "running") return state
+  return { ...state, amrapRounds: state.amrapRounds + 1 }
+}
+
+export type TickResult = {
+  state: State
+  transition: "none" | "work" | "rest" | "minute" | "warning30" | "warning10" | "completed"
+}
+
+export function tick(state: State, now: number): TickResult {
+  if (state.status !== "running" || state.startedAt === null) {
+    return { state, transition: "none" }
+  }
+
+  const sinceStart = (now - state.startedAt) / 1000
+  const totalElapsed = state.elapsed / 1000 + sinceStart
+
+  if (state.mode === "tabata") return tickTabata(state, totalElapsed)
+  if (state.mode === "emom") return tickEmom(state, totalElapsed)
+  return tickAmrap(state, totalElapsed)
+}
+
+function tickTabata(state: State, elapsed: number): TickResult {
+  const cfg = state.config as TabataConfig
+  const cycle = cfg.work + cfg.rest
+  const total = cycle * cfg.rounds
+
+  if (elapsed >= total) {
+    return {
+      state: { ...state, status: "completed", phase: "completed", remaining: 0, round: cfg.rounds },
+      transition: "completed",
+    }
+  }
+
+  const pos = elapsed % cycle
+  const round = Math.min(Math.floor(elapsed / cycle) + 1, cfg.rounds)
+  const inWork = pos < cfg.work
+  const phase: Phase = inWork ? "work" : "rest"
+  const remaining = inWork
+    ? Math.max(0, Math.ceil(cfg.work - pos))
+    : Math.max(0, Math.ceil(cfg.rest - (pos - cfg.work)))
+
+  let transition: TickResult["transition"] = "none"
+  if (phase !== state.phase) {
+    transition = phase === "work" ? "work" : "rest"
+  }
+
+  return {
+    state: { ...state, phase, round, remaining, total: inWork ? cfg.work : cfg.rest },
+    transition,
+  }
+}
+
+function tickEmom(state: State, elapsed: number): TickResult {
+  const cfg = state.config as EmomConfig
+  const total = cfg.minutes * 60
+
+  if (elapsed >= total) {
+    return {
+      state: { ...state, status: "completed", phase: "completed", remaining: 0, round: cfg.minutes },
+      transition: "completed",
+    }
+  }
+
+  const minute = Math.floor(elapsed / 60) + 1
+  const inMinute = elapsed % 60
+  const remaining = Math.max(0, Math.ceil(60 - inMinute))
+
+  let transition: TickResult["transition"] = "none"
+  if (minute !== state.round && state.round > 0) {
+    transition = "minute"
+  }
+
+  return {
+    state: { ...state, phase: "work", round: minute, remaining, total: 60 },
+    transition,
+  }
+}
+
+function tickAmrap(state: State, elapsed: number): TickResult {
+  const cfg = state.config as AmrapConfig
+  const total = cfg.minutes * 60
+  const remaining = Math.max(0, Math.ceil(total - elapsed))
+
+  if (elapsed >= total) {
+    return {
+      state: { ...state, status: "completed", phase: "completed", remaining: 0 },
+      transition: "completed",
+    }
+  }
+
+  let transition: TickResult["transition"] = "none"
+  if (remaining === 30 && state.remaining > 30) transition = "warning30"
+  if (remaining === 10 && state.remaining > 10) transition = "warning10"
+
+  return {
+    state: { ...state, phase: "work", remaining, total: total },
+    transition,
+  }
+}
+
+export function format(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${m}:${s.toString().padStart(2, "0")}`
+}
+
+export function roundLabel(state: State): string {
+  if (state.mode === "tabata") {
+    const cfg = state.config as TabataConfig
+    return `${state.round} / ${cfg.rounds}`
+  }
+  if (state.mode === "emom") {
+    const cfg = state.config as EmomConfig
+    return `Minute ${state.round} / ${cfg.minutes}`
+  }
+  return `${state.amrapRounds} rounds`
+}
+
+export function phaseLabel(state: State): string {
+  if (state.phase === "work") return "WORK"
+  if (state.phase === "rest") return "REST"
+  if (state.phase === "completed") return "DONE"
+  return ""
+}
+
+export function pauseDuration(state: State, now: number): number {
+  if (state.status !== "paused" || !state.pausedAt) return 0
+  return Math.floor((now - state.pausedAt) / 1000)
+}
+
+export function clamp(val: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, val))
+}
+
+export function progress(state: State): number {
+  if (state.total === 0) return 0
+  return 1 - state.remaining / state.total
+}


### PR DESCRIPTION
## Summary

Adds interval workout timer tool with three modes: Tabata, EMOM, and AMRAP. Timer uses a pure state machine in lib/timer.ts with absolute timestamps for drift-free timing.

## Changes

- **lib/timer.ts** — Pure timer state machine (init, tick, start, pause, resume, reset, addRound)
- **app/tools/timer.tsx** — Timer screen with Reanimated progress ring, haptic feedback, keep-awake, AppState handling
- **app/_layout.tsx** — Register tools/timer route
- **app/(tabs)/index.tsx** — Add Interval Timer card in Tools section
- **__tests__/lib/timer.test.ts** — 57 unit tests covering state transitions, phases, round counting, edge cases

## Technical Highlights

- Absolute timestamp timing (Date.now()) — no cumulative drift over 60-minute sessions
- Reanimated animated progress ring (SVG Circle strokeDashoffset)
- Animated background color transitions (work=green, rest=red)
- Haptic feedback: double at work, single at rest, triple at completion
- AppState listener pauses on background, shows elapsed pause time
- useFocusEffect pauses on tab switch
- useReducedMotion support for instant transitions
- Last-used settings per mode saved to app_settings
- 56dp touch targets, accessibility labels, screen reader announcements
- useKeepAwake during active timer

## Testing

- 57 new tests in __tests__/lib/timer.test.ts
- All 397 tests pass (57 new + 340 existing)
- TypeScript typecheck passes (zero errors)

## Issue

Resolves BLD-88