### PR TITLE
fix: correct schedule route name mismatch (BLD-96)

### DIFF
--- a/__tests__/app/route-names.test.ts
+++ b/__tests__/app/route-names.test.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const root = path.resolve(__dirname, "../..");
+const layout = fs.readFileSync(path.join(root, "app/_layout.tsx"), "utf-8");
+const names = [...layout.matchAll(/name="([^"]+)"/g)].map((m) => m[1]);
+
+function exists(route: string): boolean {
+  const base = path.join(root, "app", route);
+  if (fs.existsSync(base + ".tsx")) return true;
+  if (fs.existsSync(path.join(base, "_layout.tsx"))) return true;
+  if (fs.existsSync(path.join(base, ".tsx"))) return true;
+  if (fs.existsSync(base)) return fs.statSync(base).isFile();
+  return false;
+}
+
+describe("Stack.Screen route names", () => {
+  it("should have extracted route names from _layout.tsx", () => {
+    expect(names.length).toBeGreaterThan(0);
+  });
+
+  it.each(names)("route '%s' should map to an existing file", (name) => {
+    expect(exists(name)).toBe(true);
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -294,7 +294,7 @@ export default function RootLayout() {
               }}
             />
             <Stack.Screen
-              name="schedule"
+              name="schedule/index"
               options={{
                 headerShown: true,
                 title: "Weekly Schedule",


### PR DESCRIPTION
## Summary

Fixes the root layout crash caused by `Stack.Screen name="schedule"` not matching the actual Expo Router route `schedule/index` (from `app/schedule/index.tsx`). This broke all navigation including the onboarding "Get Started" button.

## Changes

- **app/_layout.tsx**: Changed `name="schedule"` → `name="schedule/index"` to match the filesystem route
- **__tests__/app/route-names.test.ts**: Added regression test that validates every Stack.Screen name in _layout.tsx maps to an actual route file

## Testing

- All 447 tests pass (26 new route-name validation tests)
- `tsc --noEmit` passes with zero errors
- Route name test catches future mismatches (directory/index patterns, orphaned screens)

## Issue

Resolves BLD-96 (parent: BLD-95)