### PR TITLE
fix: resolve 14 pre-existing TypeScript errors on main branch (BLD-112)

### DIFF
--- a/__tests__/acceptance/workout-session.acceptance.test.tsx
+++ b/__tests__/acceptance/workout-session.acceptance.test.tsx
@@ -137,7 +137,7 @@ describe('Workout Session Acceptance', () => {
 
     const buttons = alertSpy.mock.calls[0][2] as { text?: string; style?: string; onPress?: () => Promise<void> | void }[]
     const completeBtn = buttons.find((b) => b.text === 'OK')
-    await completeBtn.onPress()
+    await completeBtn!.onPress!()
 
     expect(mockDb.completeSession).toHaveBeenCalledWith('sess-2')
 
@@ -166,7 +166,7 @@ describe('Workout Session Acceptance', () => {
 
     const buttons = alertSpy.mock.calls[0][2] as { text?: string; style?: string; onPress?: () => Promise<void> | void }[]
     const discardBtn = buttons.find((b) => b.text === 'Delete')
-    await discardBtn.onPress()
+    await discardBtn!.onPress!()
 
     expect(mockDb.cancelSession).toHaveBeenCalledWith('sess-3')
     expect(mockRouter.back).toHaveBeenCalled()
@@ -373,7 +373,7 @@ describe('Workout Session Acceptance', () => {
 
     const buttons = alertSpy.mock.calls[0][2] as { text?: string; style?: string; onPress?: () => Promise<void> | void }[]
     const completeBtn = buttons.find((b) => b.text === 'OK')
-    await completeBtn.onPress()
+    await completeBtn!.onPress!()
 
     expect(mockDb.completeSession).toHaveBeenCalledWith('sess-nav')
     expect(mockRouter.replace).toHaveBeenCalledWith('/session/summary/sess-nav')
@@ -399,7 +399,7 @@ describe('Workout Session Acceptance', () => {
 
     const buttons = alertSpy.mock.calls[0][2] as { text?: string; style?: string; onPress?: () => Promise<void> | void }[]
     const completeBtn = buttons.find((b) => b.text === 'OK')
-    await completeBtn.onPress()
+    await completeBtn!.onPress!()
 
     expect(mockDb.completeSession).toHaveBeenCalledWith('sess-empty')
     expect(mockRouter.replace).toHaveBeenCalledWith('/(tabs)')
@@ -424,7 +424,7 @@ describe('Workout Session Acceptance', () => {
     const buttons = alertSpy.mock.calls[0][2] as { text?: string; style?: string; onPress?: () => Promise<void> | void }[]
     const keepBtn = buttons.find((b) => b.text === 'Cancel')
     expect(keepBtn).toBeDefined()
-    expect(keepBtn.style).toBe('cancel')
+    expect(keepBtn!.style).toBe('cancel')
 
     expect(mockDb.cancelSession).not.toHaveBeenCalled()
     expect(mockRouter.back).not.toHaveBeenCalled()

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -57,7 +57,7 @@ export default function RootLayout() {
         const skipOnboarding =
           Platform.OS === "web" &&
           typeof window !== "undefined" &&
-          (window as Record<string, unknown>).__SKIP_ONBOARDING__ === true;
+          (window as unknown as Record<string, unknown>).__SKIP_ONBOARDING__ === true;
         const complete = skipOnboarding || (await isOnboardingComplete());
         setOnboarded(complete);
         setReady(true);

--- a/app/program/[id].tsx
+++ b/app/program/[id].tsx
@@ -490,7 +490,6 @@ export default function ProgramDetail() {
                           : templates
                       }
                       keyExtractor={(item) => item.id}
-                      estimatedItemSize={48}
                       style={{ maxHeight: 300 }}
                       renderItem={({ item }) => {
                         if (item.id === "__remove__") {

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -1279,7 +1279,6 @@ export default function ActiveSession() {
           />
         )}
         keyExtractor={(item) => item.exercise_id}
-        estimatedItemSize={250}
         contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: 48 }}
         keyboardShouldPersistTaps="handled"
         ListHeaderComponent={

--- a/app/tools/plates.tsx
+++ b/app/tools/plates.tsx
@@ -132,7 +132,7 @@ export function PlateCalculatorContent({ initialWeight }: { initialWeight?: stri
                 if (v === "" || isNaN(num)) {
                   setCustom("")
                   setBar(presets[presets.length - 1])
-                } else if (presets.includes(num as typeof presets[number])) {
+                } else if ((presets as readonly number[]).includes(num)) {
                   setCustom("")
                   setBar(num)
                 } else {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -15,7 +15,7 @@ const KNOWN_LIBRARY_RULES = ["role-img-alt", "nested-interactive"];
  */
 export async function skipOnboarding(page: Page) {
   await page.addInitScript(() => {
-    (window as Record<string, unknown>).__SKIP_ONBOARDING__ = true;
+    (window as unknown as Record<string, unknown>).__SKIP_ONBOARDING__ = true;
   });
   await page.goto("/");
   await page.waitForTimeout(500);


### PR DESCRIPTION
## Summary

Fix 14 TypeScript compilation errors that were breaking the main branch build.

## Changes

- **Acceptance tests**: Add non-null assertions for possibly undefined button refs from Array.find() in workout session tests (9 errors)
- **Window type casts**: Use double assertion (window as unknown as Record<string, unknown>) in _layout.tsx and e2e/helpers.ts (2 errors)
- **FlashList v2**: Remove estimatedItemSize prop removed in @shopify/flash-list v2 from program/[id].tsx and session/[id].tsx (2 errors)
- **Array.includes narrowing**: Cast presets to readonly number[] in plates.tsx to fix type narrowing issue (1 error)

## Testing

- tsc --noEmit passes with zero errors
- ESLint passes with zero warnings (via lint-staged)

## Issue

Resolves BLD-112