### PR TITLE
fix: seed community exercises independently of Voltra exercises (BLD-99)

### DIFF
--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -502,17 +502,31 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
 }
 
 async function seed(database: SQLite.SQLiteDatabase): Promise<void> {
-  const result = await database.getFirstAsync<{ count: number }>(
+  const exercises = seedExercises();
+  const voltraExercises = exercises.filter(e => e.is_voltra);
+  const communityExercises = exercises.filter(e => !e.is_voltra);
+
+  const voltraResult = await database.getFirstAsync<{ count: number }>(
     "SELECT COUNT(*) as count FROM exercises WHERE is_custom = 0 AND deleted_at IS NULL AND is_voltra = 1"
   );
-  if (!result || result.count === 0) {
-    const exercises = seedExercises();
+  const communityResult = await database.getFirstAsync<{ count: number }>(
+    "SELECT COUNT(*) as count FROM exercises WHERE is_custom = 0 AND deleted_at IS NULL AND is_voltra = 0"
+  );
+
+  const needVoltra = !voltraResult || voltraResult.count === 0;
+  const needCommunity = !communityResult || communityResult.count === 0;
+  const toInsert = [
+    ...(needVoltra ? voltraExercises : []),
+    ...(needCommunity ? communityExercises : []),
+  ];
+
+  if (toInsert.length > 0) {
     const stmt = await database.prepareAsync(
       `INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty, is_custom, mount_position, attachment, training_modes, is_voltra)
      VALUES ($id, $name, $category, $primary_muscles, $secondary_muscles, $equipment, $instructions, $difficulty, $is_custom, $mount_position, $attachment, $training_modes, $is_voltra)`
     );
     try {
-      for (const ex of exercises) {
+      for (const ex of toInsert) {
         await stmt.executeAsync({
           $id: ex.id,
           $name: ex.name,


### PR DESCRIPTION
## Summary

Fixes a bug where the 65 community-sourced exercises were never inserted for users who already had Voltra exercises from a prior app version. The seed function previously checked only for Voltra exercises and skipped the entire seed if any existed.

## Root Cause

The `seed()` function in `lib/db/helpers.ts` only checked:
```sql
SELECT COUNT(*) as count FROM exercises WHERE is_custom = 0 AND deleted_at IS NULL AND is_voltra = 1
```

If Voltra exercises existed (count > 0), the entire seed was skipped — including the new community exercises.

## Fix

Split the seed check into two independent queries:
- Check Voltra exercises (`is_voltra = 1`) — only seed if count is 0
- Check community exercises (`is_voltra = 0`) — only seed if count is 0

This ensures existing users who upgrade get the community exercises inserted without re-seeding Voltra exercises.

## Testing

- All 756 tests pass
- Lint clean (0 warnings)

## Issue

Fixes BLD-99 (reopened)