### PR TITLE
feat: achievement & milestone system with 18 achievements (BLD-137)

### DIFF
--- a/__tests__/achievements.test.ts
+++ b/__tests__/achievements.test.ts
@@ -1,0 +1,313 @@
+import {
+  evaluateAchievements,
+  getAllAchievementProgress,
+  ACHIEVEMENTS,
+} from "../lib/achievements";
+import type { AchievementContext } from "../lib/achievements";
+
+function emptyContext(): AchievementContext {
+  return {
+    totalWorkouts: 0,
+    workoutDates: [],
+    prCount: 0,
+    maxSessionVolume: 0,
+    lifetimeVolume: 0,
+    nutritionDays: [],
+    bodyWeightCount: 0,
+    progressPhotoCount: 0,
+    bodyMeasurementCount: 0,
+  };
+}
+
+describe("Achievement Definitions", () => {
+  it("should have 18 achievements defined", () => {
+    expect(ACHIEVEMENTS.length).toBe(18);
+  });
+
+  it("should have unique IDs", () => {
+    const ids = ACHIEVEMENTS.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("should cover all 5 categories", () => {
+    const categories = new Set(ACHIEVEMENTS.map((a) => a.category));
+    expect(categories).toEqual(
+      new Set(["consistency", "strength", "volume", "nutrition", "body"]),
+    );
+  });
+});
+
+describe("evaluateAchievements", () => {
+  it("returns empty for fresh user with no data", () => {
+    const ctx = emptyContext();
+    const result = evaluateAchievements(ctx, new Set());
+    expect(result).toHaveLength(0);
+  });
+
+  it("earns First Steps after 1 workout", () => {
+    const ctx = { ...emptyContext(), totalWorkouts: 1, workoutDates: ["2026-01-01"] };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("first_steps");
+  });
+
+  it("earns Getting Started after 5 workouts", () => {
+    const ctx = {
+      ...emptyContext(),
+      totalWorkouts: 5,
+      workoutDates: ["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04", "2026-01-05"],
+    };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("first_steps");
+    expect(earned).toContain("getting_started");
+  });
+
+  it("skips already-earned achievements", () => {
+    const ctx = { ...emptyContext(), totalWorkouts: 5, workoutDates: ["2026-01-01"] };
+    const result = evaluateAchievements(ctx, new Set(["first_steps"]));
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).not.toContain("first_steps");
+    expect(earned).toContain("getting_started");
+  });
+
+  it("earns PR Breaker with 1 PR", () => {
+    const ctx = { ...emptyContext(), prCount: 1 };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("pr_breaker");
+  });
+
+  it("earns Ton Club with 1000kg session volume", () => {
+    const ctx = { ...emptyContext(), maxSessionVolume: 1000 };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("ton_club");
+  });
+
+  it("earns Volume King with 100k lifetime volume", () => {
+    const ctx = { ...emptyContext(), lifetimeVolume: 100000 };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("volume_king");
+  });
+
+  it("earns Progress Pic with 1 photo", () => {
+    const ctx = { ...emptyContext(), progressPhotoCount: 1 };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("progress_pic");
+  });
+
+  it("earns Body Journal with 10 weight logs", () => {
+    const ctx = { ...emptyContext(), bodyWeightCount: 10 };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("body_journal");
+  });
+
+  it("earns Transformation with 5 measurement dates", () => {
+    const ctx = { ...emptyContext(), bodyMeasurementCount: 5 };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("transformation");
+  });
+
+  it("earns Week Warrior with 7-day streak", () => {
+    const ctx = {
+      ...emptyContext(),
+      totalWorkouts: 7,
+      workoutDates: [
+        "2026-01-01",
+        "2026-01-02",
+        "2026-01-03",
+        "2026-01-04",
+        "2026-01-05",
+        "2026-01-06",
+        "2026-01-07",
+      ],
+    };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("week_warrior");
+  });
+
+  it("does not earn Week Warrior with gap in dates", () => {
+    const ctx = {
+      ...emptyContext(),
+      totalWorkouts: 6,
+      workoutDates: [
+        "2026-01-01",
+        "2026-01-02",
+        "2026-01-03",
+        "2026-01-05", // gap
+        "2026-01-06",
+        "2026-01-07",
+      ],
+    };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).not.toContain("week_warrior");
+  });
+
+  it("earns Macro Tracker with 7 consecutive nutrition days", () => {
+    const ctx = {
+      ...emptyContext(),
+      nutritionDays: [
+        "2026-01-01",
+        "2026-01-02",
+        "2026-01-03",
+        "2026-01-04",
+        "2026-01-05",
+        "2026-01-06",
+        "2026-01-07",
+      ],
+    };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("macro_tracker");
+  });
+
+  it("does not earn Macro Tracker with non-consecutive days", () => {
+    const ctx = {
+      ...emptyContext(),
+      nutritionDays: [
+        "2026-01-01",
+        "2026-01-02",
+        "2026-01-04", // gap
+        "2026-01-05",
+        "2026-01-06",
+        "2026-01-07",
+        "2026-01-08",
+      ],
+    };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).not.toContain("macro_tracker");
+  });
+
+  it("earns Monthly Grind with 4 consecutive weeks of 3+ sessions", () => {
+    // 4 weeks, each with 3 sessions (Mon/Wed/Fri pattern)
+    const ctx = {
+      ...emptyContext(),
+      totalWorkouts: 12,
+      workoutDates: [
+        // Week 1 (Mon 2026-01-05, Wed 2026-01-07, Fri 2026-01-09)
+        "2026-01-05",
+        "2026-01-07",
+        "2026-01-09",
+        // Week 2
+        "2026-01-12",
+        "2026-01-14",
+        "2026-01-16",
+        // Week 3
+        "2026-01-19",
+        "2026-01-21",
+        "2026-01-23",
+        // Week 4
+        "2026-01-26",
+        "2026-01-28",
+        "2026-01-30",
+      ],
+    };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("monthly_grind");
+  });
+
+  it("does not earn Monthly Grind with only 3 qualifying weeks", () => {
+    const ctx = {
+      ...emptyContext(),
+      totalWorkouts: 9,
+      workoutDates: [
+        "2026-01-05",
+        "2026-01-07",
+        "2026-01-09",
+        "2026-01-12",
+        "2026-01-14",
+        "2026-01-16",
+        "2026-01-19",
+        "2026-01-21",
+        "2026-01-23",
+      ],
+    };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).not.toContain("monthly_grind");
+  });
+});
+
+describe("getAllAchievementProgress", () => {
+  it("returns all 18 achievements", () => {
+    const ctx = emptyContext();
+    const progress = getAllAchievementProgress(ctx, new Map());
+    expect(progress).toHaveLength(18);
+  });
+
+  it("shows 0% progress for empty context", () => {
+    const ctx = emptyContext();
+    const progress = getAllAchievementProgress(ctx, new Map());
+    for (const p of progress) {
+      expect(p.earned).toBe(false);
+      expect(p.progress).toBe(0);
+    }
+  });
+
+  it("shows earned achievement with earnedAt", () => {
+    const ctx = emptyContext();
+    const earnedMap = new Map([["first_steps", 1700000000000]]);
+    const progress = getAllAchievementProgress(ctx, earnedMap);
+    const firstSteps = progress.find((p) => p.achievement.id === "first_steps");
+    expect(firstSteps?.earned).toBe(true);
+    expect(firstSteps?.earnedAt).toBe(1700000000000);
+    expect(firstSteps?.progress).toBe(1);
+  });
+
+  it("shows partial progress for Getting Started (3/5)", () => {
+    const ctx = { ...emptyContext(), totalWorkouts: 3 };
+    const progress = getAllAchievementProgress(ctx, new Map());
+    const gettingStarted = progress.find((p) => p.achievement.id === "getting_started");
+    expect(gettingStarted?.earned).toBe(false);
+    expect(gettingStarted?.progress).toBeCloseTo(0.6);
+  });
+
+  it("caps progress at 1 even if over target", () => {
+    const ctx = { ...emptyContext(), totalWorkouts: 10 };
+    const progress = getAllAchievementProgress(ctx, new Map());
+    const gettingStarted = progress.find((p) => p.achievement.id === "getting_started");
+    // Not earned because it's not in the earnedMap, but progress should cap at 1
+    expect(gettingStarted?.progress).toBe(1);
+  });
+});
+
+describe("Edge cases", () => {
+  it("handles duplicate workout dates for streak calculation", () => {
+    // Multiple workouts on the same day should count as one day in streak
+    const ctx = {
+      ...emptyContext(),
+      totalWorkouts: 10,
+      workoutDates: [
+        "2026-01-01",
+        "2026-01-01", // duplicate
+        "2026-01-02",
+        "2026-01-03",
+        "2026-01-04",
+        "2026-01-05",
+        "2026-01-06",
+        "2026-01-07",
+      ],
+    };
+    const result = evaluateAchievements(ctx, new Set());
+    const earned = result.map((r) => r.achievement.id);
+    expect(earned).toContain("week_warrior");
+  });
+
+  it("handles zero nutrition/body data gracefully", () => {
+    const ctx = emptyContext();
+    const progress = getAllAchievementProgress(ctx, new Map());
+    const nutri = progress.find((p) => p.achievement.id === "macro_tracker");
+    const body = progress.find((p) => p.achievement.id === "body_journal");
+    expect(nutri?.progress).toBe(0);
+    expect(body?.progress).toBe(0);
+  });
+});

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -227,6 +227,28 @@ export default function Progress() {
       );
     }
 
+    const achievementsCard = (
+      <Card
+        style={[styles.card, layout.atLeastMedium && styles.wideCard, { backgroundColor: theme.colors.surface }]}
+        onPress={() => router.push("/progress/achievements")}
+        accessibilityLabel="Achievements"
+        accessibilityRole="button"
+        accessibilityHint="View your achievements and milestones"
+      >
+        <Card.Content>
+          <View style={styles.cardHeader}>
+            <Text style={{ fontSize: 20, marginRight: 8 }}>🏆</Text>
+            <Text variant="titleMedium" style={{ color: theme.colors.onSurface }}>
+              Achievements
+            </Text>
+          </View>
+          <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant, marginTop: 4 }}>
+            Track your milestones and badges
+          </Text>
+        </Card.Content>
+      </Card>
+    );
+
     const freqCard = freq.length > 0 ? (
       <Card style={[styles.card, layout.atLeastMedium && styles.wideCard, { backgroundColor: theme.colors.surface }]}>
         <Card.Content>
@@ -341,6 +363,7 @@ export default function Progress() {
         ListHeaderComponent={
           layout.atLeastMedium ? (
             <>
+              {achievementsCard}
               <View style={styles.grid}>
                 {freqCard}
                 {volCard}
@@ -352,6 +375,7 @@ export default function Progress() {
             </>
           ) : (
             <>
+              {achievementsCard}
               {freqCard}
               {volCard}
               {prCard}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -315,6 +315,12 @@ export default function RootLayout() {
               }}
             />
             <Stack.Screen
+              name="progress"
+              options={{
+                headerShown: false,
+              }}
+            />
+            <Stack.Screen
               name="history"
               options={{
                 headerShown: true,

--- a/app/progress/_layout.tsx
+++ b/app/progress/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from "expo-router";
+
+export default function ProgressLayout() {
+  return <Stack screenOptions={{ headerBackTitle: "Back" }} />;
+}

--- a/app/progress/achievements.tsx
+++ b/app/progress/achievements.tsx
@@ -50,6 +50,7 @@ export default function AchievementsScreen() {
   const [items, setItems] = useState<AchievementItem[]>([]);
   const [earnedCount, setEarnedCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [retroBanner, setRetroBanner] = useState<number | null>(null);
 
   useFocusEffect(
@@ -80,6 +81,7 @@ export default function AchievementsScreen() {
 
           // Show retroactive banner on first open
           const seenBanner = await hasSeenRetroactiveBanner();
+          if (cancelled) return;
           if (!seenBanner && earnedMap.size > 0) {
             setRetroBanner(earnedMap.size);
             await markRetroactiveBannerSeen();
@@ -101,8 +103,9 @@ export default function AchievementsScreen() {
             })),
           );
           setEarnedCount(earnedMap.size);
-        } catch {
-          // Evaluation failed — show empty state with error
+        } catch (e) {
+          console.warn("Achievement evaluation failed:", e);
+          if (!cancelled) setError("Could not load achievements. Please try again later.");
         } finally {
           if (!cancelled) setLoading(false);
         }
@@ -129,6 +132,20 @@ export default function AchievementsScreen() {
         <Stack.Screen options={{ title: "Achievements" }} />
         <View style={[styles.center, { backgroundColor: theme.colors.background }]}>
           <Text style={{ color: theme.colors.onSurfaceVariant }}>Loading achievements...</Text>
+        </View>
+      </>
+    );
+  }
+
+  if (error) {
+    return (
+      <>
+        <Stack.Screen options={{ title: "Achievements" }} />
+        <View style={[styles.center, { backgroundColor: theme.colors.background }]}>
+          <Text variant="headlineMedium" style={{ marginBottom: 8 }}>⚠️</Text>
+          <Text variant="bodyLarge" style={{ color: theme.colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
+            {error}
+          </Text>
         </View>
       </>
     );
@@ -172,7 +189,7 @@ export default function AchievementsScreen() {
             ? `${item.name} achievement — Earned on ${formatDate(item.earnedAt!)}`
             : `${item.name} achievement — Locked, ${Math.round(item.progress * 100)}% complete`
         }
-        accessibilityRole="button"
+        accessibilityRole="summary"
       >
         <Card.Content style={styles.badgeContent}>
           <View style={styles.iconContainer}>

--- a/app/progress/achievements.tsx
+++ b/app/progress/achievements.tsx
@@ -1,0 +1,373 @@
+import { useCallback, useState } from "react";
+import {
+  FlatList,
+  StyleSheet,
+  View,
+} from "react-native";
+import {
+  Card,
+  ProgressBar,
+  Text,
+  useTheme,
+} from "react-native-paper";
+import { Stack } from "expo-router";
+import { useFocusEffect } from "expo-router";
+import {
+  buildAchievementContext,
+  getEarnedAchievementMap,
+  saveEarnedAchievements,
+  hasSeenRetroactiveBanner,
+  markRetroactiveBannerSeen,
+} from "../../lib/db";
+import {
+  ACHIEVEMENTS,
+  getAllAchievementProgress,
+  evaluateAchievements,
+} from "../../lib/achievements";
+import type { AchievementCategory } from "../../lib/achievements";
+
+type AchievementItem = {
+  id: string;
+  name: string;
+  description: string;
+  category: AchievementCategory;
+  icon: string;
+  earned: boolean;
+  earnedAt: number | null;
+  progress: number;
+};
+
+const CATEGORY_LABELS: Record<AchievementCategory, string> = {
+  consistency: "Consistency",
+  strength: "Strength",
+  volume: "Volume",
+  nutrition: "Nutrition",
+  body: "Body",
+};
+
+export default function AchievementsScreen() {
+  const theme = useTheme();
+  const [items, setItems] = useState<AchievementItem[]>([]);
+  const [earnedCount, setEarnedCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [retroBanner, setRetroBanner] = useState<number | null>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false;
+
+      (async () => {
+        try {
+          const [ctx, earnedMap] = await Promise.all([
+            buildAchievementContext(),
+            getEarnedAchievementMap(),
+          ]);
+
+          // Retroactive evaluation: earn any new achievements silently
+          const alreadyEarnedIds = new Set(earnedMap.keys());
+          const newlyEarned = evaluateAchievements(ctx, alreadyEarnedIds);
+
+          if (newlyEarned.length > 0) {
+            const now = Date.now();
+            await saveEarnedAchievements(
+              newlyEarned.map((n) => n.achievement.id),
+              now,
+            );
+            for (const n of newlyEarned) {
+              earnedMap.set(n.achievement.id, now);
+            }
+          }
+
+          // Show retroactive banner on first open
+          const seenBanner = await hasSeenRetroactiveBanner();
+          if (!seenBanner && earnedMap.size > 0) {
+            setRetroBanner(earnedMap.size);
+            await markRetroactiveBannerSeen();
+          }
+
+          const progress = getAllAchievementProgress(ctx, earnedMap);
+          if (cancelled) return;
+
+          setItems(
+            progress.map((p) => ({
+              id: p.achievement.id,
+              name: p.achievement.name,
+              description: p.achievement.description,
+              category: p.achievement.category,
+              icon: p.achievement.icon,
+              earned: p.earned,
+              earnedAt: p.earnedAt,
+              progress: p.progress,
+            })),
+          );
+          setEarnedCount(earnedMap.size);
+        } catch {
+          // Evaluation failed — show empty state with error
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    }, []),
+  );
+
+  // Group items by category
+  const sections = Object.entries(CATEGORY_LABELS)
+    .map(([cat, label]) => ({
+      category: cat as AchievementCategory,
+      label,
+      items: items.filter((i) => i.category === cat),
+    }))
+    .filter((s) => s.items.length > 0);
+
+  if (loading) {
+    return (
+      <>
+        <Stack.Screen options={{ title: "Achievements" }} />
+        <View style={[styles.center, { backgroundColor: theme.colors.background }]}>
+          <Text style={{ color: theme.colors.onSurfaceVariant }}>Loading achievements...</Text>
+        </View>
+      </>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <>
+        <Stack.Screen options={{ title: "Achievements" }} />
+        <View style={[styles.center, { backgroundColor: theme.colors.background }]}>
+          <Text variant="headlineMedium" style={{ marginBottom: 8 }}>🏆</Text>
+          <Text variant="bodyLarge" style={{ color: theme.colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
+            Complete your first workout to start earning achievements!
+          </Text>
+        </View>
+      </>
+    );
+  }
+
+  const formatDate = (ts: number) => {
+    return new Date(ts).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  };
+
+  const renderBadge = ({ item }: { item: AchievementItem }) => {
+    const badgeColor = item.earned
+      ? theme.colors.primaryContainer
+      : theme.colors.surfaceVariant;
+    const textColor = item.earned
+      ? theme.colors.onPrimaryContainer
+      : theme.colors.onSurfaceVariant;
+
+    return (
+      <Card
+        style={[styles.badge, { backgroundColor: badgeColor }]}
+        accessibilityLabel={
+          item.earned
+            ? `${item.name} achievement — Earned on ${formatDate(item.earnedAt!)}`
+            : `${item.name} achievement — Locked, ${Math.round(item.progress * 100)}% complete`
+        }
+        accessibilityRole="button"
+      >
+        <Card.Content style={styles.badgeContent}>
+          <View style={styles.iconContainer}>
+            <Text style={[styles.icon, !item.earned && styles.iconLocked]}>
+              {item.icon}
+            </Text>
+            {item.earned ? (
+              <Text style={styles.checkOverlay}>✅</Text>
+            ) : (
+              <Text style={styles.lockOverlay}>🔒</Text>
+            )}
+          </View>
+          <Text
+            variant="labelMedium"
+            numberOfLines={1}
+            style={[styles.badgeName, { color: textColor }]}
+          >
+            {item.name}
+          </Text>
+          <Text
+            variant="bodySmall"
+            numberOfLines={2}
+            style={[styles.badgeDesc, { color: textColor }]}
+          >
+            {item.description}
+          </Text>
+          {item.earned ? (
+            <Text variant="bodySmall" style={{ color: textColor, marginTop: 4 }}>
+              {formatDate(item.earnedAt!)}
+            </Text>
+          ) : (
+            <View
+              style={styles.progressContainer}
+              accessibilityValue={{
+                min: 0,
+                max: 100,
+                now: Math.round(item.progress * 100),
+                text: `${Math.round(item.progress * 100)}% complete`,
+              }}
+            >
+              <ProgressBar
+                progress={item.progress}
+                color={theme.colors.primary}
+                style={styles.progressBar}
+              />
+              <Text variant="bodySmall" style={{ color: textColor, marginTop: 2 }}>
+                {Math.round(item.progress * 100)}%
+              </Text>
+            </View>
+          )}
+        </Card.Content>
+      </Card>
+    );
+  };
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "Achievements" }} />
+      <FlatList
+        data={[{ key: "header" }, ...sections.map((s) => ({ key: s.category, ...s }))]}
+        keyExtractor={(item) => item.key}
+        style={{ backgroundColor: theme.colors.background }}
+        contentContainerStyle={styles.content}
+        renderItem={({ item }) => {
+          if (item.key === "header") {
+            return (
+              <View style={styles.header}>
+                <Text variant="headlineMedium" style={{ color: theme.colors.onBackground }}>
+                  🏆
+                </Text>
+                <Text
+                  variant="titleLarge"
+                  style={{ color: theme.colors.onBackground, fontWeight: "700", marginTop: 4 }}
+                  accessibilityRole="header"
+                >
+                  {earnedCount} / {ACHIEVEMENTS.length} Achievements Earned
+                </Text>
+                {retroBanner !== null && (
+                  <Card
+                    style={[styles.retroBanner, { backgroundColor: theme.colors.tertiaryContainer }]}
+                    accessibilityLiveRegion="polite"
+                  >
+                    <Card.Content>
+                      <Text variant="bodyMedium" style={{ color: theme.colors.onTertiaryContainer }}>
+                        Welcome back! We found {retroBanner} achievement{retroBanner !== 1 ? "s" : ""} from your workout history.
+                      </Text>
+                    </Card.Content>
+                  </Card>
+                )}
+              </View>
+            );
+          }
+
+          const section = item as { key: string; label: string; items: AchievementItem[] };
+          return (
+            <View style={styles.section}>
+              <Text
+                variant="titleMedium"
+                style={{ color: theme.colors.onBackground, marginBottom: 8, fontWeight: "700" }}
+                accessibilityRole="header"
+              >
+                {section.label}
+              </Text>
+              <View style={styles.grid}>
+                {section.items.map((badge) => (
+                  <View key={badge.id} style={styles.gridItem}>
+                    {renderBadge({ item: badge })}
+                  </View>
+                ))}
+              </View>
+            </View>
+          );
+        }}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 48,
+  },
+  header: {
+    alignItems: "center",
+    marginBottom: 24,
+  },
+  retroBanner: {
+    marginTop: 12,
+    width: "100%",
+  },
+  section: {
+    marginBottom: 24,
+  },
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  gridItem: {
+    width: "31%",
+    minWidth: 100,
+  },
+  badge: {
+    minHeight: 48,
+  },
+  badgeContent: {
+    alignItems: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+  },
+  iconContainer: {
+    position: "relative",
+    marginBottom: 4,
+  },
+  icon: {
+    fontSize: 32,
+  },
+  iconLocked: {
+    opacity: 0.4,
+  },
+  checkOverlay: {
+    position: "absolute",
+    bottom: -4,
+    right: -8,
+    fontSize: 14,
+  },
+  lockOverlay: {
+    position: "absolute",
+    bottom: -4,
+    right: -8,
+    fontSize: 14,
+  },
+  badgeName: {
+    fontWeight: "700",
+    textAlign: "center",
+    marginTop: 4,
+  },
+  badgeDesc: {
+    textAlign: "center",
+    marginTop: 2,
+  },
+  progressContainer: {
+    width: "100%",
+    marginTop: 6,
+    alignItems: "center",
+  },
+  progressBar: {
+    width: "100%",
+    height: 4,
+    borderRadius: 2,
+  },
+});

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -97,8 +97,8 @@ export default function Summary() {
             Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
           }
         }
-      } catch {
-        // Achievement evaluation is non-critical
+      } catch (e) {
+        console.warn("Achievement evaluation failed:", e);
       }
 
       AccessibilityInfo.announceForAccessibility("Workout Complete!");

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   AccessibilityInfo,
+  Platform,
   Share,
   StyleSheet,
   View,
@@ -13,6 +14,7 @@ import {
   useTheme,
 } from "react-native-paper";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import * as Haptics from "expo-haptics";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import {
   getBodySettings,
@@ -22,7 +24,12 @@ import {
   getSessionRepPRs,
   getSessionSets,
   getSessionWeightIncreases,
+  buildAchievementContext,
+  getEarnedAchievementIds,
+  saveEarnedAchievements,
 } from "../../../lib/db";
+import { evaluateAchievements } from "../../../lib/achievements";
+import type { AchievementDef } from "../../../lib/achievements";
 import type { WorkoutSession, WorkoutSet } from "../../../lib/types";
 import { TRAINING_MODE_LABELS } from "../../../lib/types";
 import { toDisplay } from "../../../lib/units";
@@ -47,6 +54,7 @@ export default function Summary() {
   const [increases, setIncreases] = useState<Increase[]>([]);
   const [comparison, setComparison] = useState<Comparison>(null);
   const [unit, setUnit] = useState<"kg" | "lb">("kg");
+  const [newAchievements, setNewAchievements] = useState<AchievementDef[]>([]);
 
   useEffect(() => {
     if (!id) return;
@@ -74,6 +82,24 @@ export default function Summary() {
         (inc) => !prData.some((pr) => pr.exercise_id === inc.exercise_id)
       ));
       setComparison(compData);
+
+      // Achievement evaluation
+      try {
+        const [ctx, alreadyEarnedIds] = await Promise.all([
+          buildAchievementContext(),
+          getEarnedAchievementIds(),
+        ]);
+        const earned = evaluateAchievements(ctx, alreadyEarnedIds);
+        if (earned.length > 0) {
+          await saveEarnedAchievements(earned.map((e) => e.achievement.id));
+          setNewAchievements(earned.map((e) => e.achievement));
+          if (Platform.OS !== "web") {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
+          }
+        }
+      } catch {
+        // Achievement evaluation is non-critical
+      }
 
       AccessibilityInfo.announceForAccessibility("Workout Complete!");
     })();
@@ -175,6 +201,7 @@ export default function Summary() {
       <FlashList
         data={
           [
+            ...(newAchievements.length > 0 ? [{ key: "achievements" }] : []),
             ...(allPrs.length > 0 ? [{ key: "prs" }] : []),
             ...(increases.length > 0 ? [{ key: "increases" }] : []),
             ...(comparison?.previous ? [{ key: "comparison" }] : []),
@@ -254,6 +281,61 @@ export default function Summary() {
           </>
         }
         renderItem={({ item }) => {
+          if (item.key === "achievements") {
+            const displayed = newAchievements.slice(0, 3);
+            const extraCount = newAchievements.length - 3;
+            return (
+              <Card
+                style={[styles.section, { backgroundColor: theme.colors.tertiaryContainer }]}
+                accessibilityLabel={`${newAchievements.length} achievement${newAchievements.length > 1 ? "s" : ""} unlocked`}
+                accessibilityLiveRegion="polite"
+              >
+                <Card.Content>
+                  <View style={styles.sectionHeader}>
+                    <Text style={{ fontSize: 20 }}>🏆</Text>
+                    <Text
+                      variant="titleMedium"
+                      style={{ color: theme.colors.onTertiaryContainer, marginLeft: 8, fontWeight: "700" }}
+                    >
+                      Achievement{newAchievements.length > 1 ? "s" : ""} Unlocked!
+                    </Text>
+                  </View>
+                  {displayed.map((a) => (
+                    <View key={a.id} style={styles.row}>
+                      <Text style={{ fontSize: 18, marginRight: 8 }}>{a.icon}</Text>
+                      <View style={{ flex: 1 }}>
+                        <Text
+                          variant="bodyMedium"
+                          style={{ color: theme.colors.onTertiaryContainer, fontWeight: "600" }}
+                        >
+                          {a.name}
+                        </Text>
+                        <Text
+                          variant="bodySmall"
+                          style={{ color: theme.colors.onTertiaryContainer }}
+                        >
+                          {a.description}
+                        </Text>
+                      </View>
+                    </View>
+                  ))}
+                  {extraCount > 0 && (
+                    <Button
+                      mode="text"
+                      onPress={() => router.push("/progress/achievements")}
+                      textColor={theme.colors.onTertiaryContainer}
+                      style={{ marginTop: 4 }}
+                      accessibilityLabel={`View ${extraCount} more achievements`}
+                      accessibilityRole="link"
+                    >
+                      +{extraCount} more
+                    </Button>
+                  )}
+                </Card.Content>
+              </Card>
+            );
+          }
+
           if (item.key === "prs") {
             return (
               <Card

--- a/lib/achievements.ts
+++ b/lib/achievements.ts
@@ -1,0 +1,348 @@
+// Achievement definitions and pure evaluation logic.
+// No side effects — all evaluation operates on a pre-built AchievementContext.
+
+export type AchievementCategory =
+  | "consistency"
+  | "strength"
+  | "volume"
+  | "nutrition"
+  | "body";
+
+export type AchievementContext = {
+  totalWorkouts: number;
+  workoutDates: string[]; // ISO date strings (YYYY-MM-DD), sorted ascending
+  prCount: number;
+  maxSessionVolume: number;
+  lifetimeVolume: number;
+  nutritionDays: string[]; // ISO date strings with daily_log entries, sorted ascending
+  bodyWeightCount: number;
+  progressPhotoCount: number;
+  bodyMeasurementCount: number;
+};
+
+export type AchievementEvalResult = {
+  earned: boolean;
+  progress: number; // 0..1
+};
+
+export type AchievementDef = {
+  id: string;
+  name: string;
+  description: string;
+  category: AchievementCategory;
+  icon: string;
+  evaluate: (ctx: AchievementContext) => AchievementEvalResult;
+};
+
+export type EarnedAchievement = {
+  achievement_id: string;
+  earned_at: number;
+};
+
+// --- Helper functions ---
+
+function countProgress(current: number, target: number): AchievementEvalResult {
+  return {
+    earned: current >= target,
+    progress: Math.min(current / target, 1),
+  };
+}
+
+/** Compute longest consecutive-day streak from sorted date strings. */
+function consecutiveDayStreak(dates: string[]): number {
+  if (dates.length === 0) return 0;
+  const unique = [...new Set(dates)].sort();
+  let maxStreak = 1;
+  let streak = 1;
+  for (let i = 1; i < unique.length; i++) {
+    const prev = new Date(unique[i - 1] + "T00:00:00Z");
+    const curr = new Date(unique[i] + "T00:00:00Z");
+    const diffMs = curr.getTime() - prev.getTime();
+    if (diffMs === 86400000) {
+      streak++;
+      if (streak > maxStreak) maxStreak = streak;
+    } else {
+      streak = 1;
+    }
+  }
+  return maxStreak;
+}
+
+/**
+ * Check if user has 4 consecutive ISO weeks with ≥3 sessions each.
+ * Groups workout dates by ISO week, then finds 4 consecutive qualifying weeks.
+ */
+function hasMonthlyGrind(dates: string[]): AchievementEvalResult {
+  if (dates.length === 0) return { earned: false, progress: 0 };
+
+  // Group dates by ISO week number + year
+  const weekMap = new Map<string, number>();
+  for (const d of dates) {
+    const dt = new Date(d + "T00:00:00Z");
+    const key = isoWeekKey(dt);
+    weekMap.set(key, (weekMap.get(key) ?? 0) + 1);
+  }
+
+  // Filter weeks with ≥3 sessions
+  const qualifyingWeeks = [...weekMap.entries()]
+    .filter(([, count]) => count >= 3)
+    .map(([key]) => key)
+    .sort();
+
+  if (qualifyingWeeks.length === 0) return { earned: false, progress: 0 };
+
+  // Find longest consecutive qualifying week run
+  let maxConsec = 1;
+  let consec = 1;
+  for (let i = 1; i < qualifyingWeeks.length; i++) {
+    if (isNextIsoWeek(qualifyingWeeks[i - 1], qualifyingWeeks[i])) {
+      consec++;
+      if (consec > maxConsec) maxConsec = consec;
+    } else {
+      consec = 1;
+    }
+  }
+
+  return {
+    earned: maxConsec >= 4,
+    progress: Math.min(maxConsec / 4, 1),
+  };
+}
+
+/** Returns "YYYY-WNN" ISO week key for a date. */
+function isoWeekKey(date: Date): string {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, "0")}`;
+}
+
+/** Check if weekB is the ISO week immediately after weekA. */
+function isNextIsoWeek(weekA: string, weekB: string): boolean {
+  const [yA, wA] = weekA.split("-W").map(Number);
+  const [yB, wB] = weekB.split("-W").map(Number);
+  if (yA === yB) return wB === wA + 1;
+  // Year boundary: last week of yA → first week of yB
+  if (yB === yA + 1 && wB === 1) {
+    // ISO year can have 52 or 53 weeks
+    const lastWeek = getIsoWeeksInYear(yA);
+    return wA === lastWeek;
+  }
+  return false;
+}
+
+function getIsoWeeksInYear(year: number): number {
+  const jan1 = new Date(Date.UTC(year, 0, 1));
+  const dec31 = new Date(Date.UTC(year, 11, 31));
+  return jan1.getUTCDay() === 4 || dec31.getUTCDay() === 4 ? 53 : 52;
+}
+
+// --- Achievement Definitions ---
+
+export const ACHIEVEMENTS: AchievementDef[] = [
+  // Consistency
+  {
+    id: "first_steps",
+    name: "First Steps",
+    description: "Complete your first workout",
+    category: "consistency",
+    icon: "🏃",
+    evaluate: (ctx) => countProgress(ctx.totalWorkouts, 1),
+  },
+  {
+    id: "getting_started",
+    name: "Getting Started",
+    description: "Complete 5 workouts",
+    category: "consistency",
+    icon: "🔥",
+    evaluate: (ctx) => countProgress(ctx.totalWorkouts, 5),
+  },
+  {
+    id: "dedicated",
+    name: "Dedicated",
+    description: "Complete 25 workouts",
+    category: "consistency",
+    icon: "💪",
+    evaluate: (ctx) => countProgress(ctx.totalWorkouts, 25),
+  },
+  {
+    id: "iron_will",
+    name: "Iron Will",
+    description: "Complete 100 workouts",
+    category: "consistency",
+    icon: "🏋️",
+    evaluate: (ctx) => countProgress(ctx.totalWorkouts, 100),
+  },
+  {
+    id: "legend",
+    name: "Legend",
+    description: "Complete 500 workouts",
+    category: "consistency",
+    icon: "👑",
+    evaluate: (ctx) => countProgress(ctx.totalWorkouts, 500),
+  },
+  {
+    id: "week_warrior",
+    name: "Week Warrior",
+    description: "Maintain a 7-day workout streak",
+    category: "consistency",
+    icon: "⚡",
+    evaluate: (ctx) => {
+      const streak = consecutiveDayStreak(ctx.workoutDates);
+      return countProgress(streak, 7);
+    },
+  },
+  {
+    id: "monthly_grind",
+    name: "Monthly Grind",
+    description: "4 consecutive weeks with 3+ sessions each",
+    category: "consistency",
+    icon: "🌟",
+    evaluate: (ctx) => hasMonthlyGrind(ctx.workoutDates),
+  },
+
+  // Strength
+  {
+    id: "pr_breaker",
+    name: "PR Breaker",
+    description: "Hit your first personal record",
+    category: "strength",
+    icon: "📈",
+    evaluate: (ctx) => countProgress(ctx.prCount, 1),
+  },
+  {
+    id: "pr_machine",
+    name: "PR Machine",
+    description: "Hit 10 personal records",
+    category: "strength",
+    icon: "🎯",
+    evaluate: (ctx) => countProgress(ctx.prCount, 10),
+  },
+  {
+    id: "record_setter",
+    name: "Record Setter",
+    description: "Hit 50 personal records",
+    category: "strength",
+    icon: "🏆",
+    evaluate: (ctx) => countProgress(ctx.prCount, 50),
+  },
+
+  // Volume
+  {
+    id: "ton_club",
+    name: "Ton Club",
+    description: "Lift 1,000 kg in a single session",
+    category: "volume",
+    icon: "🪨",
+    evaluate: (ctx) => countProgress(ctx.maxSessionVolume, 1000),
+  },
+  {
+    id: "heavy_hitter",
+    name: "Heavy Hitter",
+    description: "Lift 10,000 kg in a single session",
+    category: "volume",
+    icon: "💎",
+    evaluate: (ctx) => countProgress(ctx.maxSessionVolume, 10000),
+  },
+  {
+    id: "volume_king",
+    name: "Volume King",
+    description: "Accumulate 100,000 kg lifetime volume",
+    category: "volume",
+    icon: "🌍",
+    evaluate: (ctx) => countProgress(ctx.lifetimeVolume, 100000),
+  },
+
+  // Nutrition
+  {
+    id: "macro_tracker",
+    name: "Macro Tracker",
+    description: "Log nutrition for 7 consecutive days",
+    category: "nutrition",
+    icon: "🥗",
+    evaluate: (ctx) => {
+      const streak = consecutiveDayStreak(ctx.nutritionDays);
+      return countProgress(streak, 7);
+    },
+  },
+  {
+    id: "nutrition_pro",
+    name: "Nutrition Pro",
+    description: "Log nutrition for 30 consecutive days",
+    category: "nutrition",
+    icon: "🍎",
+    evaluate: (ctx) => {
+      const streak = consecutiveDayStreak(ctx.nutritionDays);
+      return countProgress(streak, 30);
+    },
+  },
+
+  // Body
+  {
+    id: "progress_pic",
+    name: "Progress Pic",
+    description: "Take your first progress photo",
+    category: "body",
+    icon: "📸",
+    evaluate: (ctx) => countProgress(ctx.progressPhotoCount, 1),
+  },
+  {
+    id: "body_journal",
+    name: "Body Journal",
+    description: "Log body weight 10 times",
+    category: "body",
+    icon: "⚖️",
+    evaluate: (ctx) => countProgress(ctx.bodyWeightCount, 10),
+  },
+  {
+    id: "transformation",
+    name: "Transformation",
+    description: "Log body measurements 5 times",
+    category: "body",
+    icon: "📐",
+    evaluate: (ctx) => countProgress(ctx.bodyMeasurementCount, 5),
+  },
+];
+
+/**
+ * Evaluate all achievements against a context.
+ * Returns newly earned achievements (those that evaluate to earned=true
+ * and are NOT in the alreadyEarned set).
+ */
+export function evaluateAchievements(
+  ctx: AchievementContext,
+  alreadyEarnedIds: Set<string>,
+): { achievement: AchievementDef; result: AchievementEvalResult }[] {
+  const newlyEarned: { achievement: AchievementDef; result: AchievementEvalResult }[] = [];
+  for (const a of ACHIEVEMENTS) {
+    if (alreadyEarnedIds.has(a.id)) continue;
+    const result = a.evaluate(ctx);
+    if (result.earned) {
+      newlyEarned.push({ achievement: a, result });
+    }
+  }
+  return newlyEarned;
+}
+
+/**
+ * Get progress for all achievements (for the grid screen).
+ */
+export function getAllAchievementProgress(
+  ctx: AchievementContext,
+  earnedMap: Map<string, number>, // achievement_id → earned_at timestamp
+): {
+  achievement: AchievementDef;
+  earned: boolean;
+  earnedAt: number | null;
+  progress: number;
+}[] {
+  return ACHIEVEMENTS.map((a) => {
+    const earnedAt = earnedMap.get(a.id) ?? null;
+    if (earnedAt !== null) {
+      return { achievement: a, earned: true, earnedAt, progress: 1 };
+    }
+    const result = a.evaluate(ctx);
+    return { achievement: a, earned: false, earnedAt: null, progress: result.progress };
+  });
+}

--- a/lib/db/achievements.ts
+++ b/lib/db/achievements.ts
@@ -1,7 +1,7 @@
 // Database queries for the achievement system.
 // Builds AchievementContext from batched queries and manages achievements_earned table.
 
-import { query, queryOne, execute } from "./helpers";
+import { query, queryOne, execute, withTransaction } from "./helpers";
 import type { AchievementContext, EarnedAchievement } from "../achievements";
 
 // --- Context Building ---
@@ -129,12 +129,14 @@ export async function saveEarnedAchievements(
   achievementIds: string[],
   earnedAt: number = Date.now(),
 ): Promise<void> {
-  for (const id of achievementIds) {
-    await execute(
-      "INSERT OR IGNORE INTO achievements_earned (achievement_id, earned_at) VALUES (?, ?)",
-      [id, earnedAt]
-    );
-  }
+  await withTransaction(async (db) => {
+    for (const id of achievementIds) {
+      await db.runAsync(
+        "INSERT OR IGNORE INTO achievements_earned (achievement_id, earned_at) VALUES (?, ?)",
+        [id, earnedAt]
+      );
+    }
+  });
 }
 
 export async function getEarnedCount(): Promise<number> {

--- a/lib/db/achievements.ts
+++ b/lib/db/achievements.ts
@@ -1,0 +1,158 @@
+// Database queries for the achievement system.
+// Builds AchievementContext from batched queries and manages achievements_earned table.
+
+import { query, queryOne, execute } from "./helpers";
+import type { AchievementContext, EarnedAchievement } from "../achievements";
+
+// --- Context Building ---
+
+export async function buildAchievementContext(): Promise<AchievementContext> {
+  const [
+    totalRow,
+    workoutDatesRows,
+    prCountRow,
+    maxSessionVolumeRow,
+    lifetimeVolumeRow,
+    nutritionDaysRows,
+    bodyWeightCountRow,
+    progressPhotoCountRow,
+    bodyMeasurementCountRow,
+  ] = await Promise.all([
+    queryOne<{ count: number }>(
+      "SELECT COUNT(*) AS count FROM workout_sessions WHERE completed_at IS NOT NULL"
+    ),
+    query<{ date: string }>(
+      `SELECT DISTINCT date(started_at / 1000, 'unixepoch', 'localtime') AS date
+       FROM workout_sessions
+       WHERE completed_at IS NOT NULL
+       ORDER BY date ASC`
+    ),
+    queryOne<{ count: number }>(
+      `SELECT COUNT(*) AS count FROM (
+        SELECT ws.exercise_id
+        FROM workout_sets ws
+        JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1
+          AND ws.weight IS NOT NULL
+          AND ws.weight > 0
+          AND wss.completed_at IS NOT NULL
+          AND ws.weight > (
+            SELECT MAX(ws2.weight)
+            FROM workout_sets ws2
+            JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
+            WHERE ws2.exercise_id = ws.exercise_id
+              AND ws2.session_id != ws.session_id
+              AND ws2.completed = 1
+              AND ws2.weight IS NOT NULL
+              AND ws2.weight > 0
+              AND wss2.completed_at IS NOT NULL
+              AND wss2.started_at < wss.started_at
+          )
+        GROUP BY ws.session_id, ws.exercise_id
+      )`
+    ),
+    queryOne<{ volume: number }>(
+      `SELECT COALESCE(MAX(sv.volume), 0) AS volume FROM (
+        SELECT ws.session_id, SUM(ws.weight * ws.reps) AS volume
+        FROM workout_sets ws
+        JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1
+          AND ws.weight IS NOT NULL
+          AND ws.reps IS NOT NULL
+          AND wss.completed_at IS NOT NULL
+        GROUP BY ws.session_id
+      ) sv`
+    ),
+    queryOne<{ volume: number }>(
+      `SELECT COALESCE(SUM(ws.weight * ws.reps), 0) AS volume
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1
+         AND ws.weight IS NOT NULL
+         AND ws.reps IS NOT NULL
+         AND wss.completed_at IS NOT NULL`
+    ),
+    query<{ date: string }>(
+      "SELECT DISTINCT date FROM daily_log ORDER BY date ASC"
+    ),
+    queryOne<{ count: number }>(
+      "SELECT COUNT(*) AS count FROM body_weight"
+    ),
+    queryOne<{ count: number }>(
+      "SELECT COUNT(*) AS count FROM progress_photos WHERE deleted_at IS NULL"
+    ),
+    queryOne<{ count: number }>(
+      "SELECT COUNT(DISTINCT date) AS count FROM body_measurements"
+    ),
+  ]);
+
+  return {
+    totalWorkouts: totalRow?.count ?? 0,
+    workoutDates: workoutDatesRows.map((r) => r.date),
+    prCount: prCountRow?.count ?? 0,
+    maxSessionVolume: maxSessionVolumeRow?.volume ?? 0,
+    lifetimeVolume: lifetimeVolumeRow?.volume ?? 0,
+    nutritionDays: nutritionDaysRows.map((r) => r.date),
+    bodyWeightCount: bodyWeightCountRow?.count ?? 0,
+    progressPhotoCount: progressPhotoCountRow?.count ?? 0,
+    bodyMeasurementCount: bodyMeasurementCountRow?.count ?? 0,
+  };
+}
+
+// --- Earned Achievements CRUD ---
+
+export async function getEarnedAchievements(): Promise<EarnedAchievement[]> {
+  return query<EarnedAchievement>(
+    "SELECT achievement_id, earned_at FROM achievements_earned ORDER BY earned_at ASC"
+  );
+}
+
+export async function getEarnedAchievementIds(): Promise<Set<string>> {
+  const rows = await query<{ achievement_id: string }>(
+    "SELECT achievement_id FROM achievements_earned"
+  );
+  return new Set(rows.map((r) => r.achievement_id));
+}
+
+export async function getEarnedAchievementMap(): Promise<Map<string, number>> {
+  const rows = await query<EarnedAchievement>(
+    "SELECT achievement_id, earned_at FROM achievements_earned"
+  );
+  const map = new Map<string, number>();
+  for (const r of rows) {
+    map.set(r.achievement_id, r.earned_at);
+  }
+  return map;
+}
+
+export async function saveEarnedAchievements(
+  achievementIds: string[],
+  earnedAt: number = Date.now(),
+): Promise<void> {
+  for (const id of achievementIds) {
+    await execute(
+      "INSERT OR IGNORE INTO achievements_earned (achievement_id, earned_at) VALUES (?, ?)",
+      [id, earnedAt]
+    );
+  }
+}
+
+export async function getEarnedCount(): Promise<number> {
+  const row = await queryOne<{ count: number }>(
+    "SELECT COUNT(*) AS count FROM achievements_earned"
+  );
+  return row?.count ?? 0;
+}
+
+export async function hasSeenRetroactiveBanner(): Promise<boolean> {
+  const row = await queryOne<{ value: string }>(
+    "SELECT value FROM app_settings WHERE key = 'achievements_retroactive_done'"
+  );
+  return row !== null;
+}
+
+export async function markRetroactiveBannerSeen(): Promise<void> {
+  await execute(
+    "INSERT OR REPLACE INTO app_settings (key, value) VALUES ('achievements_retroactive_done', '1')"
+  );
+}

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -499,6 +499,13 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   await database.execAsync(
     "CREATE INDEX IF NOT EXISTS idx_progress_photos_deleted ON progress_photos(deleted_at)"
   );
+
+  await database.execAsync(
+    `CREATE TABLE IF NOT EXISTS achievements_earned (
+      achievement_id TEXT PRIMARY KEY,
+      earned_at INTEGER NOT NULL
+    )`
+  );
 }
 
 async function seed(database: SQLite.SQLiteDatabase): Promise<void> {

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -157,3 +157,14 @@ export {
   getThumbnailDir,
 } from "./photos";
 export type { ProgressPhoto, PoseCategory } from "./photos";
+
+export {
+  buildAchievementContext,
+  getEarnedAchievements,
+  getEarnedAchievementIds,
+  getEarnedAchievementMap,
+  saveEarnedAchievements,
+  getEarnedCount,
+  hasSeenRetroactiveBanner,
+  markRetroactiveBannerSeen,
+} from "./achievements";


### PR DESCRIPTION
## Summary

Adds a client-side achievement system with 18 achievements across 5 categories (Consistency, Strength, Volume, Nutrition, Body). Achievements are evaluated after workout completion and displayed in a dedicated grid screen with progress bars.

## Changes

- `lib/achievements.ts` — Pure functions defining 18 achievements with evaluate pattern
- `lib/db/achievements.ts` — DB queries to build AchievementContext and store/retrieve earned achievements
- `app/progress/achievements.tsx` — Achievement grid screen (earned in color, unearned grayed with progress bars)
- `app/session/summary/[id].tsx` — Post-workout achievement unlock cards (max 3 stacked, +N more)
- `__tests__/achievements.test.ts` — 26 unit tests covering all categories and edge cases

## Testing

- 26 unit tests all passing
- TypeScript compiles with zero errors

## Issue

Resolves BLD-137