### PR TITLE
test: add Body Goals & Measurements acceptance tests (BLD-50)

### DIFF
--- a/__tests__/acceptance/body.test.tsx
+++ b/__tests__/acceptance/body.test.tsx
@@ -1,0 +1,320 @@
+jest.setTimeout(10000)
+
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    useRouter: () => mockRouter,
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/test',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({
+  useLayout: () => ({ wide: false, width: 375, scale: 1.0, horizontalPadding: 16, atLeastMedium: false }),
+}))
+jest.mock('../../lib/errors', () => ({
+  logError: jest.fn(),
+  generateReport: jest.fn().mockResolvedValue('{}'),
+  getRecentErrors: jest.fn().mockResolvedValue([]),
+  generateGitHubURL: jest.fn().mockReturnValue('https://github.com'),
+}))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn() }))
+jest.mock('expo-file-system', () => ({
+  File: jest.fn(),
+  Paths: { cache: '/cache' },
+}))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+
+const mockGetBodySettings = jest.fn().mockResolvedValue({
+  weight_unit: 'kg',
+  measurement_unit: 'cm',
+  weight_goal: 75,
+  body_fat_goal: 15,
+})
+const mockUpdateBodySettings = jest.fn().mockResolvedValue(undefined)
+const mockGetLatestMeasurements = jest.fn().mockResolvedValue({
+  waist: 80,
+  chest: 100,
+  hips: 95,
+  left_arm: 35,
+  right_arm: 35.5,
+  left_thigh: 55,
+  right_thigh: 55,
+  left_calf: 37,
+  right_calf: 37,
+  neck: 38,
+  body_fat: 18,
+})
+const mockUpsertBodyMeasurements = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('../../lib/db', () => ({
+  getBodySettings: (...args: unknown[]) => mockGetBodySettings(...args),
+  updateBodySettings: (...args: unknown[]) => mockUpdateBodySettings(...args),
+  getLatestMeasurements: (...args: unknown[]) => mockGetLatestMeasurements(...args),
+  upsertBodyMeasurements: (...args: unknown[]) => mockUpsertBodyMeasurements(...args),
+}))
+
+import Goals from '../../app/body/goals'
+import Measurements from '../../app/body/measurements'
+
+describe('Body Measurements Acceptance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetBodySettings.mockResolvedValue({
+      weight_unit: 'kg',
+      measurement_unit: 'cm',
+      weight_goal: 75,
+      body_fat_goal: 15,
+    })
+    mockGetLatestMeasurements.mockResolvedValue({
+      waist: 80,
+      chest: 100,
+      hips: 95,
+      left_arm: 35,
+      right_arm: 35.5,
+      left_thigh: 55,
+      right_thigh: 55,
+      left_calf: 37,
+      right_calf: 37,
+      neck: 38,
+      body_fat: 18,
+    })
+  })
+
+  // ── Goals Screen ──────────────────────────────────
+
+  describe('Goals screen', () => {
+    it('renders Body Goals heading', async () => {
+      const { findByText } = renderScreen(<Goals />)
+      expect(await findByText('Body Goals')).toBeTruthy()
+    })
+
+    it('shows editable weight goal input with value from db', async () => {
+      const { findByLabelText } = renderScreen(<Goals />)
+      const input = await findByLabelText('Weight goal in kg')
+      await waitFor(() => {
+        expect(input.props.value).toBe('75')
+      })
+    })
+
+    it('shows editable body fat goal input with value from db', async () => {
+      const { findByLabelText } = renderScreen(<Goals />)
+      const input = await findByLabelText('Body fat percentage goal')
+      await waitFor(() => {
+        expect(input.props.value).toBe('15')
+      })
+    })
+
+    it('weight goal input is editable', async () => {
+      const { findByLabelText } = renderScreen(<Goals />)
+      const input = await findByLabelText('Weight goal in kg')
+      await waitFor(() => expect(input.props.value).toBe('75'))
+      fireEvent.changeText(input, '80')
+      expect(input.props.value).toBe('80')
+    })
+
+    it('body fat goal input is editable', async () => {
+      const { findByLabelText } = renderScreen(<Goals />)
+      const input = await findByLabelText('Body fat percentage goal')
+      await waitFor(() => expect(input.props.value).toBe('15'))
+      fireEvent.changeText(input, '12')
+      expect(input.props.value).toBe('12')
+    })
+
+    it('Save button calls updateBodySettings and navigates back', async () => {
+      const { findByLabelText } = renderScreen(<Goals />)
+      await findByLabelText('Weight goal in kg')
+
+      const saveBtn = await findByLabelText('Save body goals')
+      fireEvent.press(saveBtn)
+
+      await waitFor(() => {
+        expect(mockUpdateBodySettings).toHaveBeenCalledWith('kg', 'cm', 75, 15)
+      })
+      await waitFor(() => {
+        expect(mockRouter.back).toHaveBeenCalled()
+      })
+    })
+
+    it('Cancel button navigates back without saving', async () => {
+      const { findByLabelText } = renderScreen(<Goals />)
+      const cancelBtn = await findByLabelText('Cancel goal editing')
+      fireEvent.press(cancelBtn)
+
+      expect(mockRouter.back).toHaveBeenCalled()
+      expect(mockUpdateBodySettings).not.toHaveBeenCalled()
+    })
+
+    it('displays weight in lb when unit is lb', async () => {
+      mockGetBodySettings.mockResolvedValue({
+        weight_unit: 'lb',
+        measurement_unit: 'in',
+        weight_goal: 75,
+        body_fat_goal: 15,
+      })
+      const { findByLabelText } = renderScreen(<Goals />)
+      const input = await findByLabelText('Weight goal in lb')
+      await waitFor(() => {
+        const val = parseFloat(input.props.value)
+        // 75 kg * 2.20462 ≈ 165.3
+        expect(val).toBeGreaterThan(160)
+        expect(val).toBeLessThan(170)
+      })
+    })
+
+    it('accessible labels are present on all interactive elements', async () => {
+      const { findByLabelText } = renderScreen(<Goals />)
+      expect(await findByLabelText('Weight goal in kg')).toBeTruthy()
+      expect(await findByLabelText('Body fat percentage goal')).toBeTruthy()
+      expect(await findByLabelText('Save body goals')).toBeTruthy()
+      expect(await findByLabelText('Cancel goal editing')).toBeTruthy()
+    })
+  })
+
+  // ── Measurements Screen ──────────────────────────────────
+
+  describe('Measurements screen', () => {
+    it('renders Log Measurements heading', async () => {
+      const { findByText } = renderScreen(<Measurements />)
+      expect(await findByText('Log Measurements')).toBeTruthy()
+    })
+
+    it('shows date input with today date', async () => {
+      const { findByLabelText } = renderScreen(<Measurements />)
+      const dateInput = await findByLabelText('Measurement date')
+      expect(dateInput.props.value).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+
+    it('pre-fills measurement fields from latest data', async () => {
+      const { findByLabelText } = renderScreen(<Measurements />)
+      const waist = await findByLabelText('Waist in cm')
+      await waitFor(() => {
+        expect(waist.props.value).toBe('80')
+      })
+      const chest = await findByLabelText('Chest in cm')
+      expect(chest.props.value).toBe('100')
+    })
+
+    it('all measurement fields are editable', async () => {
+      const { findByLabelText } = renderScreen(<Measurements />)
+      const waist = await findByLabelText('Waist in cm')
+      await waitFor(() => expect(waist.props.value).toBe('80'))
+      fireEvent.changeText(waist, '78')
+      expect(waist.props.value).toBe('78')
+    })
+
+    it('shows body fat percentage input', async () => {
+      const { findByLabelText } = renderScreen(<Measurements />)
+      const fatInput = await findByLabelText('Body fat percentage')
+      await waitFor(() => {
+        expect(fatInput.props.value).toBe('18')
+      })
+    })
+
+    it('shows optional notes input', async () => {
+      const { findByLabelText } = renderScreen(<Measurements />)
+      expect(await findByLabelText('Optional notes')).toBeTruthy()
+    })
+
+    it('Save button calls upsertBodyMeasurements and navigates back', async () => {
+      const { findByLabelText } = renderScreen(<Measurements />)
+      await findByLabelText('Waist in cm')
+
+      const saveBtn = await findByLabelText('Save measurements')
+      fireEvent.press(saveBtn)
+
+      await waitFor(() => {
+        expect(mockUpsertBodyMeasurements).toHaveBeenCalled()
+      })
+      await waitFor(() => {
+        expect(mockRouter.back).toHaveBeenCalled()
+      })
+    })
+
+    it('Cancel button navigates back without saving', async () => {
+      const { findByLabelText } = renderScreen(<Measurements />)
+      const cancelBtn = await findByLabelText('Cancel measurement log')
+      fireEvent.press(cancelBtn)
+
+      expect(mockRouter.back).toHaveBeenCalled()
+      expect(mockUpsertBodyMeasurements).not.toHaveBeenCalled()
+    })
+
+    it('displays all 10 measurement fields', async () => {
+      const { findByLabelText } = renderScreen(<Measurements />)
+      const fields = [
+        'Waist in cm', 'Chest in cm', 'Hips in cm',
+        'Left Arm in cm', 'Right Arm in cm',
+        'Left Thigh in cm', 'Right Thigh in cm',
+        'Left Calf in cm', 'Right Calf in cm',
+        'Neck in cm',
+      ]
+      for (const label of fields) {
+        expect(await findByLabelText(label)).toBeTruthy()
+      }
+    })
+
+    it('displays measurements in inches when unit is in', async () => {
+      mockGetBodySettings.mockResolvedValue({
+        weight_unit: 'lb',
+        measurement_unit: 'in',
+        weight_goal: null,
+        body_fat_goal: null,
+      })
+      mockGetLatestMeasurements.mockResolvedValue({
+        waist: 80,
+        chest: null,
+        hips: null,
+        left_arm: null,
+        right_arm: null,
+        left_thigh: null,
+        right_thigh: null,
+        left_calf: null,
+        right_calf: null,
+        neck: null,
+        body_fat: null,
+      })
+
+      const { findByLabelText } = renderScreen(<Measurements />)
+      const waist = await findByLabelText('Waist in in')
+      await waitFor(() => {
+        const val = parseFloat(waist.props.value)
+        // 80 cm * 0.393701 ≈ 31.5
+        expect(val).toBeGreaterThan(30)
+        expect(val).toBeLessThan(33)
+      })
+    })
+
+    it('empty state renders with blank fields when no prior measurements', async () => {
+      mockGetLatestMeasurements.mockResolvedValue(null)
+
+      const { findByLabelText } = renderScreen(<Measurements />)
+      const waist = await findByLabelText('Waist in cm')
+      expect(waist.props.value).toBe('')
+    })
+
+    it('accessible labels are present on all interactive elements', async () => {
+      const { findByLabelText } = renderScreen(<Measurements />)
+      expect(await findByLabelText('Measurement date')).toBeTruthy()
+      expect(await findByLabelText('Body fat percentage')).toBeTruthy()
+      expect(await findByLabelText('Optional notes')).toBeTruthy()
+      expect(await findByLabelText('Save measurements')).toBeTruthy()
+      expect(await findByLabelText('Cancel measurement log')).toBeTruthy()
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "expo-keep-awake": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-local-authentication": "~17.0.8",
-        "expo-modules-core": "~3.0.29",
+        "expo-modules-core": "^3.0.29",
         "expo-notifications": "~0.32.16",
         "expo-router": "~6.0.23",
         "expo-sharing": "~14.0.8",
@@ -5875,15 +5875,19 @@
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^5.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-spinners": {
@@ -5915,52 +5919,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-truncate/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -5979,6 +5937,29 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/clone": {
@@ -7700,21 +7681,6 @@
         "expo": "*"
       }
     },
-    "node_modules/expo-asset": {
-      "version": "12.0.12",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
-      "integrity": "sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/image-utils": "^0.8.8",
-        "expo-constants": "~18.0.12"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/expo-audio": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-1.1.1.tgz",
@@ -8071,6 +8037,21 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo/node_modules/expo-asset": {
+      "version": "12.0.12",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
+      "integrity": "sha512-CsXFCQbx2fElSMn0lyTdRIyKlSXOal6ilLJd+yeZ6xaC7I9AICQgscY5nj0QcwgA+KYYCCEQEBndMsmj7drOWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "expo-constants": "~18.0.12"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/exponential-backoff": {
@@ -9294,12 +9275,19 @@
       }
     },
     "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-generator-fn": {
@@ -11465,90 +11453,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/cli-cursor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/log-update/node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/onetime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/restore-cursor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^7.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/log-update/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/log-update/node_modules/slice-ansi": {
       "version": "7.1.2",
@@ -12720,6 +12630,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/ora/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ora/node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -12749,6 +12671,40 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
       "engines": {
         "node": ">=4"
       }
@@ -13739,6 +13695,29 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/react-native-vector-icons/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/react-native-vector-icons/node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -14240,37 +14219,49 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor/node_modules/onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mimic-fn": "^1.0.0"
+        "mimic-function": "^5.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/reusify": {
@@ -14892,22 +14883,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/slugify": {
       "version": "1.6.9",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
@@ -15117,17 +15092,49 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -16472,6 +16479,29 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -16628,6 +16658,29 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {


### PR DESCRIPTION
## Summary

RNTL acceptance tests for Body Goals and Measurements screens covering editable targets, measurement logging, unit switching, and accessibility.

## Changes

- Add `__tests__/acceptance/body.test.tsx` with 21 acceptance tests
- Goals screen: editable weight/body-fat targets, save/cancel, kg↔lb conversion
- Measurements screen: all 10 body fields, pre-fill from latest data, cm↔in conversion
- Empty state handling for no prior measurements
- Accessible labels on all interactive elements

## Testing

- All 21 tests pass: `npx jest __tests__/acceptance/body.test.tsx`
- TypeScript: `tsc --noEmit` passes
- ESLint: zero warnings (lint-staged)

## Issue

Resolves BLD-50