### PR TITLE
test: acceptance tests for history, error handling, a11y, and food database (BLD-44, BLD-52, BLD-53, BLD-57)

### DIFF
--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -9,8 +9,7 @@ jest.setTimeout(10000)
 import React from 'react'
 import { waitFor } from '@testing-library/react-native'
 import { renderScreen } from '../helpers/render'
-import { createExercise, createSession, resetIds } from '../helpers/factories'
-import type { Exercise } from '../../lib/types'
+import { resetIds } from '../helpers/factories'
 
 const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
 const mockParams: Record<string, string> = {}
@@ -52,12 +51,6 @@ jest.mock('@react-navigation/native', () => {
     },
   }
 })
-
-// Exercises screen mocks
-const exercises: Exercise[] = [
-  createExercise({ id: 'ex-1', name: 'Bench Press', category: 'chest' }),
-  createExercise({ id: 'ex-2', name: 'Squat', category: 'legs_glutes' }),
-]
 
 jest.mock('../../lib/db', () => ({
   getAllExercises: jest.fn().mockResolvedValue([

--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -1,0 +1,252 @@
+jest.setTimeout(10000)
+
+/**
+ * Cross-screen accessibility compliance audit.
+ * Verifies all interactive elements have accessible labels,
+ * proper roles, and screen reader hints.
+ */
+
+import React from 'react'
+import { waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+import { createExercise, createSession, resetIds } from '../helpers/factories'
+import type { Exercise } from '../../lib/types'
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
+const mockParams: Record<string, string> = {}
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    useRouter: () => mockRouter,
+    useLocalSearchParams: () => mockParams,
+    usePathname: () => '/test',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
+jest.mock('../../lib/errors', () => ({ logError: jest.fn(), generateReport: jest.fn().mockResolvedValue('{}'), getRecentErrors: jest.fn().mockResolvedValue([]), generateGitHubURL: jest.fn().mockReturnValue('https://github.com'), getErrorCount: jest.fn().mockResolvedValue(0) }))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+jest.mock('expo-document-picker', () => ({ getDocumentAsync: jest.fn() }))
+
+jest.mock('@react-navigation/native', () => {
+  const RealReact = require('react')
+  return {
+    useNavigation: () => ({ setOptions: jest.fn() }),
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+  }
+})
+
+// Exercises screen mocks
+const exercises: Exercise[] = [
+  createExercise({ id: 'ex-1', name: 'Bench Press', category: 'chest' }),
+  createExercise({ id: 'ex-2', name: 'Squat', category: 'legs_glutes' }),
+]
+
+jest.mock('../../lib/db', () => ({
+  getAllExercises: jest.fn().mockResolvedValue([
+    { id: 'ex-1', name: 'Bench Press', category: 'chest', primary_muscles: ['chest'], secondary_muscles: [], equipment: 'barbell', instructions: 'Press', difficulty: 'intermediate', is_custom: false, deleted_at: null },
+    { id: 'ex-2', name: 'Squat', category: 'legs_glutes', primary_muscles: ['quads'], secondary_muscles: [], equipment: 'barbell', instructions: 'Squat down', difficulty: 'intermediate', is_custom: false, deleted_at: null },
+  ]),
+  getExerciseById: jest.fn().mockResolvedValue({ id: 'ex-1', name: 'Bench Press', category: 'chest', primary_muscles: ['chest'], secondary_muscles: [], equipment: 'barbell', instructions: 'Press', difficulty: 'intermediate', is_custom: false, deleted_at: null }),
+  createCustomExercise: jest.fn().mockResolvedValue(undefined),
+  getRecentSessions: jest.fn().mockResolvedValue([]),
+  getActiveProgram: jest.fn().mockResolvedValue(null),
+  getTemplates: jest.fn().mockResolvedValue([]),
+  getSessionsByMonth: jest.fn().mockResolvedValue([]),
+  getSessionCountsByDay: jest.fn().mockResolvedValue([]),
+  getAllCompletedSessionWeeks: jest.fn().mockResolvedValue([]),
+  getTotalSessionCount: jest.fn().mockResolvedValue(0),
+  searchSessions: jest.fn().mockResolvedValue([]),
+  getDailyLogs: jest.fn().mockResolvedValue([]),
+  getDailySummary: jest.fn().mockResolvedValue({ calories: 0, protein: 0, carbs: 0, fat: 0 }),
+  getMacroTargets: jest.fn().mockResolvedValue({ id: '1', calories: 2000, protein: 150, carbs: 250, fat: 65, created_at: Date.now(), updated_at: Date.now() }),
+  deleteDailyLog: jest.fn().mockResolvedValue(undefined),
+  getAppSetting: jest.fn().mockResolvedValue(null),
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+  exportAllData: jest.fn().mockResolvedValue('{}'),
+  importData: jest.fn().mockResolvedValue(undefined),
+  getWorkoutCSVData: jest.fn().mockResolvedValue([]),
+  getNutritionCSVData: jest.fn().mockResolvedValue([]),
+  getBodyWeightCSVData: jest.fn().mockResolvedValue([]),
+  getBodyMeasurementsCSVData: jest.fn().mockResolvedValue([]),
+  getCSVCounts: jest.fn().mockResolvedValue({ workouts: 0, nutrition: 0, bodyWeight: 0, measurements: 0 }),
+  getBodySettings: jest.fn().mockResolvedValue({ weight_unit: 'kg', measurement_unit: 'cm', weight_goal: null, body_fat_goal: null }),
+  getBodyWeightHistory: jest.fn().mockResolvedValue([]),
+  getLatestBodyWeight: jest.fn().mockResolvedValue(null),
+  getPersonalRecords: jest.fn().mockResolvedValue([]),
+  getProgressChartData: jest.fn().mockResolvedValue([]),
+  getSessionById: jest.fn(),
+  getSessionSets: jest.fn().mockResolvedValue([]),
+  getTemplateById: jest.fn().mockResolvedValue(null),
+  addSet: jest.fn().mockResolvedValue(undefined),
+  completeSet: jest.fn().mockResolvedValue(undefined),
+  uncompleteSet: jest.fn().mockResolvedValue(undefined),
+  completeSession: jest.fn().mockResolvedValue(undefined),
+  cancelSession: jest.fn().mockResolvedValue(undefined),
+  updateSet: jest.fn().mockResolvedValue(undefined),
+  updateSetRPE: jest.fn().mockResolvedValue(undefined),
+  updateSetNotes: jest.fn().mockResolvedValue(undefined),
+  updateSetTrainingMode: jest.fn().mockResolvedValue(undefined),
+  updateSetTempo: jest.fn().mockResolvedValue(undefined),
+  getMaxWeightByExercise: jest.fn().mockResolvedValue({}),
+  getPreviousSets: jest.fn().mockResolvedValue([]),
+  getRecentExerciseSets: jest.fn().mockResolvedValue([]),
+  getRestSecondsForExercise: jest.fn().mockResolvedValue(90),
+  getRestSecondsForLink: jest.fn().mockResolvedValue(90),
+  getSessionPRs: jest.fn().mockResolvedValue([]),
+  getSessionRepPRs: jest.fn().mockResolvedValue([]),
+  getSessionWeightIncreases: jest.fn().mockResolvedValue([]),
+  getSessionComparison: jest.fn().mockResolvedValue(null),
+  updateBodySettings: jest.fn().mockResolvedValue(undefined),
+  addBodyWeight: jest.fn().mockResolvedValue(undefined),
+  getBodyMeasurements: jest.fn().mockResolvedValue([]),
+  addBodyMeasurement: jest.fn().mockResolvedValue(undefined),
+  getFoodEntries: jest.fn().mockResolvedValue([]),
+  getAchievements: jest.fn().mockResolvedValue([]),
+  getProgressPhotos: jest.fn().mockResolvedValue([]),
+  getSchedule: jest.fn().mockResolvedValue(null),
+}))
+
+jest.mock('../../lib/programs', () => ({
+  activateProgram: jest.fn(),
+  getActiveProgram: jest.fn().mockResolvedValue(null),
+}))
+
+jest.mock('../../lib/audio', () => ({
+  loadSounds: jest.fn().mockResolvedValue(new Map()),
+  setEnabled: jest.fn(),
+}))
+
+jest.mock('../../lib/notifications', () => ({
+  requestPermission: jest.fn().mockResolvedValue('granted'),
+  scheduleReminders: jest.fn().mockResolvedValue(undefined),
+  cancelAll: jest.fn().mockResolvedValue(undefined),
+  getPermissionStatus: jest.fn().mockResolvedValue('granted'),
+}))
+
+jest.mock('../../lib/csv-format', () => ({
+  workoutCSV: jest.fn().mockReturnValue(''),
+  nutritionCSV: jest.fn().mockReturnValue(''),
+  bodyWeightCSV: jest.fn().mockReturnValue(''),
+  bodyMeasurementsCSV: jest.fn().mockReturnValue(''),
+}))
+
+import Exercises from '../../app/(tabs)/exercises'
+import Settings from '../../app/(tabs)/settings'
+import Nutrition from '../../app/(tabs)/nutrition'
+
+describe('Accessibility Compliance Audit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+    Object.keys(mockParams).forEach((k) => delete mockParams[k])
+  })
+
+  describe('exercises.tsx', () => {
+    it('search bar has accessible label', async () => {
+      const screen = renderScreen(<Exercises />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Search exercises')).toBeTruthy()
+      })
+    })
+
+    it('category filter chips have accessible labels', async () => {
+      const screen = renderScreen(<Exercises />)
+      await waitFor(() => {
+        const chips = screen.getAllByLabelText(/Filter by/)
+        expect(chips.length).toBeGreaterThan(0)
+      })
+    })
+
+    it('exercise items have accessible labels with name and category', async () => {
+      const screen = renderScreen(<Exercises />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Bench Press/)).toBeTruthy()
+        expect(screen.getByLabelText(/Squat/)).toBeTruthy()
+      })
+    })
+
+    it('FAB has accessible label for creating exercise', async () => {
+      const screen = renderScreen(<Exercises />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Add custom exercise')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('nutrition.tsx', () => {
+    it('has accessible FAB for adding food', async () => {
+      const screen = renderScreen(<Nutrition />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Add food')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('settings.tsx', () => {
+    it('renders setting cards with accessible labels', async () => {
+      const screen = renderScreen(<Settings />)
+      await waitFor(() => {
+        // Settings screen should have accessible elements
+        expect(screen.getByText('Settings')).toBeTruthy()
+      })
+    })
+
+    it('export and import buttons have accessible labels', async () => {
+      const screen = renderScreen(<Settings />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Export all data as JSON')).toBeTruthy()
+        expect(screen.getByLabelText('Import data')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('cross-screen patterns', () => {
+    it('exercises screen has labeled search and FAB', async () => {
+      const screen = renderScreen(<Exercises />)
+      await waitFor(() => {
+        // Verify key interactive elements have accessible labels
+        expect(screen.getByLabelText('Search exercises')).toBeTruthy()
+        expect(screen.getByLabelText('Add custom exercise')).toBeTruthy()
+        // All exercises should be labeled
+        expect(screen.getByLabelText(/Bench Press/)).toBeTruthy()
+      })
+    })
+
+    it('settings screen has labeled data management buttons', async () => {
+      const screen = renderScreen(<Settings />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Export all data as JSON')).toBeTruthy()
+        expect(screen.getByLabelText('Import data')).toBeTruthy()
+        expect(screen.getByLabelText('Workout Reminders')).toBeTruthy()
+        expect(screen.getByLabelText('Timer Sound')).toBeTruthy()
+      })
+    })
+
+    it('nutrition screen has labeled day navigation', async () => {
+      const screen = renderScreen(<Nutrition />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Previous day')).toBeTruthy()
+        expect(screen.getByLabelText('Next day')).toBeTruthy()
+        expect(screen.getByLabelText('Add food')).toBeTruthy()
+      })
+    })
+  })
+})

--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -3,11 +3,11 @@ jest.setTimeout(10000)
 /**
  * Cross-screen accessibility compliance audit.
  * Verifies all interactive elements have accessible labels,
- * proper roles, and screen reader hints.
+ * proper roles, and screen reader hints across 6 screens.
  */
 
 import React from 'react'
-import { waitFor } from '@testing-library/react-native'
+import { fireEvent, waitFor } from '@testing-library/react-native'
 import { renderScreen } from '../helpers/render'
 import { resetIds } from '../helpers/factories'
 
@@ -24,7 +24,7 @@ jest.mock('expo-router', () => {
       RealReact.useEffect(() => {
         const cleanup = cb()
         return typeof cleanup === 'function' ? cleanup : undefined
-      }, [])
+      }, [cb])
     },
     Stack: { Screen: () => null },
     Redirect: () => null,
@@ -38,6 +38,64 @@ jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().m
 jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
 jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
 jest.mock('expo-document-picker', () => ({ getDocumentAsync: jest.fn() }))
+
+jest.mock('react-native-reanimated', () => {
+  const RN = require('react-native')
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const AnimatedView = ({ entering: _entering, ...rest }: Record<string, unknown>) => {
+    return require('react').createElement(RN.View, rest)
+  }
+  const chainable = () => {
+    const obj: Record<string, unknown> = {}
+    obj.delay = () => obj
+    obj.duration = () => obj
+    return obj
+  }
+  return {
+    __esModule: true,
+    default: {
+      View: AnimatedView,
+      createAnimatedComponent: <T,>(c: T) => c,
+    },
+    FadeIn: chainable(),
+    FadeInDown: chainable(),
+    useAnimatedStyle: () => ({}),
+    useSharedValue: <T,>(v: T) => ({ value: v }),
+    withTiming: <T,>(v: T) => v,
+    interpolateColor: () => '#000',
+    createAnimatedComponent: <T,>(c: T) => c,
+  }
+})
+
+jest.mock('expo-haptics', () => ({ impactAsync: jest.fn(), notificationAsync: jest.fn(), ImpactFeedbackStyle: { Light: 'light', Heavy: 'heavy' }, NotificationFeedbackType: { Success: 'success', Warning: 'warning' } }))
+jest.mock('expo-keep-awake', () => ({ useKeepAwake: jest.fn(), activateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined), deactivateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined) }))
+jest.mock('victory-native', () => ({ CartesianChart: 'CartesianChart', Line: 'Line', Bar: 'Bar' }))
+jest.mock('../../components/MuscleVolumeSegment', () => 'MuscleVolumeSegment')
+jest.mock('../../lib/rpe', () => ({ rpeColor: jest.fn().mockReturnValue('#888'), rpeText: jest.fn().mockReturnValue('#fff') }))
+jest.mock('../../lib/starter-templates', () => ({ STARTER_TEMPLATES: [] }))
+jest.mock('../../lib/units', () => ({ toDisplay: (v: number) => v, toKg: (v: number) => v, KG_TO_LB: 2.20462, LB_TO_KG: 0.453592 }))
+jest.mock('../../lib/rm', () => ({ suggest: jest.fn().mockReturnValue(null) }))
+jest.mock('../../lib/confirm', () => ({ confirmAction: jest.fn() }))
+jest.mock('../../components/TrainingModeSelector', () => 'TrainingModeSelector')
+jest.mock('../../components/MuscleMap', () => ({ MuscleMap: 'MuscleMap' }))
+jest.mock('../../components/WeightPicker', () => 'WeightPicker')
+jest.mock('../../components/ExercisePickerSheet', () => 'ExercisePickerSheet')
+jest.mock('../../components/SnackbarProvider', () => ({ useSnackbar: () => ({ showSnack: jest.fn() }) }))
+jest.mock('../../lib/query', () => ({ useFocusRefetch: jest.fn() }))
+
+jest.mock('../../components/ui/FlowContainer', () => {
+  const RN = require('react-native')
+  const R = require('react')
+  const FlowContainer = ({ children }: { children: React.ReactNode }) => R.createElement(RN.View, null, children)
+  FlowContainer.displayName = 'FlowContainer'
+  return {
+    __esModule: true,
+    default: FlowContainer,
+    flowCardStyle: {},
+    FLOW_CARD_MIN: 280,
+    FLOW_CARD_MAX: 420,
+  }
+})
 
 jest.mock('@react-navigation/native', () => {
   const RealReact = require('react')
@@ -60,6 +118,7 @@ jest.mock('../../lib/db', () => ({
   getExerciseById: jest.fn().mockResolvedValue({ id: 'ex-1', name: 'Bench Press', category: 'chest', primary_muscles: ['chest'], secondary_muscles: [], equipment: 'barbell', instructions: 'Press', difficulty: 'intermediate', is_custom: false, deleted_at: null }),
   createCustomExercise: jest.fn().mockResolvedValue(undefined),
   getRecentSessions: jest.fn().mockResolvedValue([]),
+  getActiveSession: jest.fn().mockResolvedValue(null),
   getActiveProgram: jest.fn().mockResolvedValue(null),
   getTemplates: jest.fn().mockResolvedValue([]),
   getSessionsByMonth: jest.fn().mockResolvedValue([]),
@@ -83,17 +142,31 @@ jest.mock('../../lib/db', () => ({
   getBodySettings: jest.fn().mockResolvedValue({ weight_unit: 'kg', measurement_unit: 'cm', weight_goal: null, body_fat_goal: null }),
   getBodyWeightHistory: jest.fn().mockResolvedValue([]),
   getLatestBodyWeight: jest.fn().mockResolvedValue(null),
+  getPreviousBodyWeight: jest.fn().mockResolvedValue(null),
+  getBodyWeightEntries: jest.fn().mockResolvedValue([]),
+  getBodyWeightCount: jest.fn().mockResolvedValue(0),
+  getBodyWeightChartData: jest.fn().mockResolvedValue([]),
+  getLatestMeasurements: jest.fn().mockResolvedValue(null),
+  upsertBodyWeight: jest.fn().mockResolvedValue(undefined),
+  deleteBodyWeight: jest.fn().mockResolvedValue(undefined),
+  updateBodySettings: jest.fn().mockResolvedValue(undefined),
   getPersonalRecords: jest.fn().mockResolvedValue([]),
+  getWeeklySessionCounts: jest.fn().mockResolvedValue([]),
+  getWeeklyVolume: jest.fn().mockResolvedValue([]),
+  getCompletedSessionsWithSetCount: jest.fn().mockResolvedValue([]),
   getProgressChartData: jest.fn().mockResolvedValue([]),
   getSessionById: jest.fn(),
   getSessionSets: jest.fn().mockResolvedValue([]),
   getTemplateById: jest.fn().mockResolvedValue(null),
   addSet: jest.fn().mockResolvedValue(undefined),
+  addSetsBatch: jest.fn().mockResolvedValue(undefined),
+  deleteSet: jest.fn().mockResolvedValue(undefined),
   completeSet: jest.fn().mockResolvedValue(undefined),
   uncompleteSet: jest.fn().mockResolvedValue(undefined),
   completeSession: jest.fn().mockResolvedValue(undefined),
   cancelSession: jest.fn().mockResolvedValue(undefined),
   updateSet: jest.fn().mockResolvedValue(undefined),
+  updateSetsBatch: jest.fn().mockResolvedValue(undefined),
   updateSetRPE: jest.fn().mockResolvedValue(undefined),
   updateSetNotes: jest.fn().mockResolvedValue(undefined),
   updateSetTrainingMode: jest.fn().mockResolvedValue(undefined),
@@ -107,7 +180,6 @@ jest.mock('../../lib/db', () => ({
   getSessionRepPRs: jest.fn().mockResolvedValue([]),
   getSessionWeightIncreases: jest.fn().mockResolvedValue([]),
   getSessionComparison: jest.fn().mockResolvedValue(null),
-  updateBodySettings: jest.fn().mockResolvedValue(undefined),
   addBodyWeight: jest.fn().mockResolvedValue(undefined),
   getBodyMeasurements: jest.fn().mockResolvedValue([]),
   addBodyMeasurement: jest.fn().mockResolvedValue(undefined),
@@ -115,15 +187,34 @@ jest.mock('../../lib/db', () => ({
   getAchievements: jest.fn().mockResolvedValue([]),
   getProgressPhotos: jest.fn().mockResolvedValue([]),
   getSchedule: jest.fn().mockResolvedValue(null),
+  getRecentPRs: jest.fn().mockResolvedValue([]),
+  getSessionAvgRPE: jest.fn().mockResolvedValue(null),
+  getSessionSetCount: jest.fn().mockResolvedValue(0),
+  getTemplateExerciseCount: jest.fn().mockResolvedValue(0),
+  startSession: jest.fn().mockResolvedValue({ id: 'qs-1', name: 'Quick Start', started_at: Date.now() }),
+  getTodaySchedule: jest.fn().mockResolvedValue(null),
+  isTodayCompleted: jest.fn().mockResolvedValue(false),
+  getWeekAdherence: jest.fn().mockResolvedValue([]),
+  deleteTemplate: jest.fn().mockResolvedValue(undefined),
+  duplicateTemplate: jest.fn().mockResolvedValue('dup-1'),
+  duplicateProgram: jest.fn().mockResolvedValue('dup-p1'),
 }))
 
 jest.mock('../../lib/programs', () => ({
   activateProgram: jest.fn(),
   getActiveProgram: jest.fn().mockResolvedValue(null),
+  getNextWorkout: jest.fn().mockResolvedValue(null),
+  getPrograms: jest.fn().mockResolvedValue([]),
+  getProgramDayCount: jest.fn().mockResolvedValue(0),
+  softDeleteProgram: jest.fn().mockResolvedValue(undefined),
+  getSessionProgramDayId: jest.fn().mockResolvedValue(null),
+  getProgramDayById: jest.fn().mockResolvedValue(null),
+  advanceProgram: jest.fn().mockResolvedValue({ wrapped: false }),
 }))
 
 jest.mock('../../lib/audio', () => ({
   loadSounds: jest.fn().mockResolvedValue(new Map()),
+  play: jest.fn(),
   setEnabled: jest.fn(),
 }))
 
@@ -144,6 +235,11 @@ jest.mock('../../lib/csv-format', () => ({
 import Exercises from '../../app/(tabs)/exercises'
 import Settings from '../../app/(tabs)/settings'
 import Nutrition from '../../app/(tabs)/nutrition'
+import HomeDashboard from '../../app/(tabs)/index'
+import Progress from '../../app/(tabs)/progress'
+import ActiveSession from '../../app/session/[id]'
+
+const mockDb = require('../../lib/db') as Record<string, jest.Mock>
 
 describe('Accessibility Compliance Audit', () => {
   beforeEach(() => {
@@ -191,13 +287,20 @@ describe('Accessibility Compliance Audit', () => {
         expect(screen.getByLabelText('Add food')).toBeTruthy()
       })
     })
+
+    it('has labeled day navigation', async () => {
+      const screen = renderScreen(<Nutrition />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Previous day')).toBeTruthy()
+        expect(screen.getByLabelText('Next day')).toBeTruthy()
+      })
+    })
   })
 
   describe('settings.tsx', () => {
     it('renders setting cards with accessible labels', async () => {
       const screen = renderScreen(<Settings />)
       await waitFor(() => {
-        // Settings screen should have accessible elements
         expect(screen.getByText('Settings')).toBeTruthy()
       })
     })
@@ -209,36 +312,132 @@ describe('Accessibility Compliance Audit', () => {
         expect(screen.getByLabelText('Import data')).toBeTruthy()
       })
     })
-  })
 
-  describe('cross-screen patterns', () => {
-    it('exercises screen has labeled search and FAB', async () => {
-      const screen = renderScreen(<Exercises />)
-      await waitFor(() => {
-        // Verify key interactive elements have accessible labels
-        expect(screen.getByLabelText('Search exercises')).toBeTruthy()
-        expect(screen.getByLabelText('Add custom exercise')).toBeTruthy()
-        // All exercises should be labeled
-        expect(screen.getByLabelText(/Bench Press/)).toBeTruthy()
-      })
-    })
-
-    it('settings screen has labeled data management buttons', async () => {
+    it('toggle switches have accessible labels', async () => {
       const screen = renderScreen(<Settings />)
       await waitFor(() => {
-        expect(screen.getByLabelText('Export all data as JSON')).toBeTruthy()
-        expect(screen.getByLabelText('Import data')).toBeTruthy()
         expect(screen.getByLabelText('Workout Reminders')).toBeTruthy()
         expect(screen.getByLabelText('Timer Sound')).toBeTruthy()
       })
     })
+  })
 
-    it('nutrition screen has labeled day navigation', async () => {
-      const screen = renderScreen(<Nutrition />)
+  describe('(tabs)/index.tsx — Home Dashboard', () => {
+    it('quick start button has accessible label', async () => {
+      const screen = renderScreen(<HomeDashboard />)
       await waitFor(() => {
-        expect(screen.getByLabelText('Previous day')).toBeTruthy()
-        expect(screen.getByLabelText('Next day')).toBeTruthy()
-        expect(screen.getByLabelText('Add food')).toBeTruthy()
+        expect(screen.getByLabelText('Quick start workout')).toBeTruthy()
+      })
+    })
+
+    it('tab buttons have accessible labels', async () => {
+      const screen = renderScreen(<HomeDashboard />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Templates tab')).toBeTruthy()
+        expect(screen.getByLabelText('Programs tab')).toBeTruthy()
+      })
+    })
+
+    it('streak and stats have accessible labels', async () => {
+      const screen = renderScreen(<HomeDashboard />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/week streak/)).toBeTruthy()
+        expect(screen.getByLabelText(/workouts this week/)).toBeTruthy()
+        expect(screen.getByLabelText(/recent personal records/)).toBeTruthy()
+      })
+    })
+
+    it('create template button has accessible label', async () => {
+      const screen = renderScreen(<HomeDashboard />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Create new template')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('(tabs)/progress.tsx', () => {
+    it('segment buttons have accessible labels', async () => {
+      const screen = renderScreen(<Progress />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Workouts progress')).toBeTruthy()
+        expect(screen.getByLabelText('Body metrics')).toBeTruthy()
+        expect(screen.getByLabelText('Muscle volume analysis')).toBeTruthy()
+      })
+    })
+
+    it('body segment has log weight button with accessible label', async () => {
+      const { findByLabelText } = renderScreen(<Progress />)
+      const bodyBtn = await findByLabelText('Body metrics')
+      fireEvent.press(bodyBtn)
+      await waitFor(async () => {
+        expect(await findByLabelText('Log body weight')).toBeTruthy()
+      })
+    })
+
+    it('body empty state shows log prompt', async () => {
+      const { findByLabelText, findByText } = renderScreen(<Progress />)
+      const bodyBtn = await findByLabelText('Body metrics')
+      fireEvent.press(bodyBtn)
+      await waitFor(async () => {
+        expect(await findByText('Log your first weigh-in')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('session/[id].tsx — Active Session', () => {
+    const session = {
+      id: 'sess-1',
+      name: 'Test Workout',
+      template_id: null,
+      started_at: Date.now(),
+      completed_at: null,
+      duration_seconds: null,
+      notes: null,
+    }
+
+    beforeEach(() => {
+      mockParams['id'] = 'sess-1'
+      mockDb.getSessionById.mockResolvedValue(session)
+      mockDb.getSessionSets.mockResolvedValue([
+        {
+          id: 'set-1', session_id: 'sess-1', exercise_id: 'ex-1', set_number: 1,
+          weight: 80, reps: 8, completed: false, completed_at: null,
+          rpe: null, notes: null, link_id: null, training_mode: null, tempo: null,
+          exercise_name: 'Bench Press', exercise_deleted: false,
+        },
+      ])
+      mockDb.getAppSetting.mockResolvedValue('true')
+    })
+
+    it('finish and cancel buttons have accessible labels', async () => {
+      const screen = renderScreen(<ActiveSession />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Finish workout')).toBeTruthy()
+        expect(screen.getByLabelText('Cancel workout')).toBeTruthy()
+      })
+    })
+
+    it('add exercise button has accessible label', async () => {
+      const screen = renderScreen(<ActiveSession />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Add exercise to workout')).toBeTruthy()
+      })
+    })
+
+    it('set controls have accessible labels', async () => {
+      const screen = renderScreen(<ActiveSession />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Set 1 weight')).toBeTruthy()
+        expect(screen.getByLabelText('Set 1 reps')).toBeTruthy()
+        expect(screen.getByLabelText(/Mark set 1/)).toBeTruthy()
+      })
+    })
+
+    it('mark-complete has checkbox role', async () => {
+      const screen = renderScreen(<ActiveSession />)
+      await waitFor(() => {
+        const checkbox = screen.getByLabelText(/Mark set 1/)
+        expect(checkbox.props.accessibilityRole).toBe('checkbox')
       })
     })
   })

--- a/__tests__/acceptance/error-handling.acceptance.test.tsx
+++ b/__tests__/acceptance/error-handling.acceptance.test.tsx
@@ -1,0 +1,241 @@
+jest.setTimeout(10000)
+
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+import { createErrorEntry, resetIds } from '../helpers/factories'
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+
+// Mock @react-navigation/native for errors.tsx
+const mockSetOptions = jest.fn()
+jest.mock('@react-navigation/native', () => {
+  const RealReact = require('react')
+  return {
+    useNavigation: () => ({ setOptions: mockSetOptions }),
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+  }
+})
+
+const fatalError = createErrorEntry({
+  id: 'err-1',
+  message: 'NullPointerException in WorkoutSession',
+  stack: 'at WorkoutSession.render (session.tsx:42)',
+  fatal: true,
+  timestamp: Date.now() - 60000,
+})
+
+const nonFatalError = createErrorEntry({
+  id: 'err-2',
+  message: 'Network request failed',
+  stack: 'at fetch (network.ts:10)',
+  fatal: false,
+  timestamp: Date.now() - 120000,
+})
+
+const mockGetRecentErrors = jest.fn().mockResolvedValue([fatalError, nonFatalError])
+const mockClearErrorLog = jest.fn().mockResolvedValue(undefined)
+const mockLogError = jest.fn()
+const mockGenerateReport = jest.fn().mockResolvedValue('{}')
+const mockGenerateGitHubURL = jest.fn().mockReturnValue('https://github.com')
+
+jest.mock('../../lib/errors', () => ({
+  getRecentErrors: (...args: any[]) => mockGetRecentErrors(...args),
+  clearErrorLog: (...args: any[]) => mockClearErrorLog(...args),
+  logError: (...args: any[]) => mockLogError(...args),
+  generateReport: (...args: any[]) => mockGenerateReport(...args),
+  generateGitHubURL: (...args: any[]) => mockGenerateGitHubURL(...args),
+}))
+
+jest.mock('../../lib/interactions', () => ({
+  log: jest.fn(),
+  recent: jest.fn().mockResolvedValue([]),
+}))
+
+import Errors from '../../app/errors'
+import ErrorBoundary from '../../components/ErrorBoundary'
+
+describe('Error Handling Acceptance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+    mockGetRecentErrors.mockResolvedValue([fatalError, nonFatalError])
+    mockClearErrorLog.mockResolvedValue(undefined)
+  })
+
+  describe('Error Log Screen', () => {
+    it('displays error entries with messages', async () => {
+      const screen = renderScreen(<Errors />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/NullPointerException/)).toBeTruthy()
+        expect(screen.getByLabelText(/Network request failed/)).toBeTruthy()
+      })
+    })
+
+    it('shows FATAL chip on fatal errors', async () => {
+      const screen = renderScreen(<Errors />)
+      await waitFor(() => {
+        expect(screen.getByText('FATAL')).toBeTruthy()
+      })
+    })
+
+    it('error cards have accessible labels with message and timestamp', async () => {
+      const screen = renderScreen(<Errors />)
+      await waitFor(() => {
+        const card = screen.getByLabelText(/NullPointerException.*fatal/)
+        expect(card).toBeTruthy()
+      })
+    })
+
+    it('error cards have button role', async () => {
+      const screen = renderScreen(<Errors />)
+      await waitFor(() => {
+        const card = screen.getByLabelText(/NullPointerException/)
+        expect(card.props.accessibilityRole || card.props.role).toBe('button')
+      })
+    })
+
+    it('expands error details on card press', async () => {
+      const screen = renderScreen(<Errors />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/NullPointerException/)).toBeTruthy()
+      })
+
+      fireEvent.press(screen.getByLabelText(/NullPointerException/))
+
+      await waitFor(() => {
+        expect(screen.getByText(/WorkoutSession\.render/)).toBeTruthy()
+      })
+    })
+
+    it('shows empty state when no errors', async () => {
+      mockGetRecentErrors.mockResolvedValue([])
+
+      const screen = renderScreen(<Errors />)
+      await waitFor(() => {
+        expect(screen.getByText('No errors recorded')).toBeTruthy()
+      })
+    })
+
+    it('sets header right with Clear All button', async () => {
+      renderScreen(<Errors />)
+      await waitFor(() => {
+        expect(mockSetOptions).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('ErrorBoundary', () => {
+    const ThrowingComponent = () => {
+      throw new Error('Test crash in render')
+    }
+
+    it('catches render errors and shows fallback UI', () => {
+      const screen = renderScreen(
+        <ErrorBoundary>
+          <ThrowingComponent />
+        </ErrorBoundary>
+      )
+
+      expect(screen.getByText('Something went wrong')).toBeTruthy()
+    })
+
+    it('shows Show Details button with accessible label', () => {
+      const screen = renderScreen(
+        <ErrorBoundary>
+          <ThrowingComponent />
+        </ErrorBoundary>
+      )
+
+      expect(screen.getByLabelText('Show error details')).toBeTruthy()
+    })
+
+    it('expands error details on Show Details press', () => {
+      const screen = renderScreen(
+        <ErrorBoundary>
+          <ThrowingComponent />
+        </ErrorBoundary>
+      )
+
+      fireEvent.press(screen.getByLabelText('Show error details'))
+      expect(screen.getByText(/Test crash in render/)).toBeTruthy()
+      expect(screen.getByLabelText('Hide error details')).toBeTruthy()
+    })
+
+    it('shows Restart button with accessible label', () => {
+      const screen = renderScreen(
+        <ErrorBoundary>
+          <ThrowingComponent />
+        </ErrorBoundary>
+      )
+
+      expect(screen.getByLabelText('Restart app')).toBeTruthy()
+    })
+
+    it('restarts app (re-renders children) on Restart press', () => {
+      const screen = renderScreen(
+        <ErrorBoundary>
+          <ThrowingComponent />
+        </ErrorBoundary>
+      )
+
+      expect(screen.getByText('Something went wrong')).toBeTruthy()
+      fireEvent.press(screen.getByLabelText('Restart app'))
+
+      // After restart, ErrorBoundary clears state and tries children again.
+      // ThrowingComponent throws again, so fallback reappears.
+      expect(screen.getByText('Something went wrong')).toBeTruthy()
+    })
+
+    it('shows Share Crash Report button with accessible label', () => {
+      const screen = renderScreen(
+        <ErrorBoundary>
+          <ThrowingComponent />
+        </ErrorBoundary>
+      )
+
+      expect(screen.getByLabelText('Share crash report')).toBeTruthy()
+    })
+
+    it('shows Report on GitHub button with accessible label', () => {
+      const screen = renderScreen(
+        <ErrorBoundary>
+          <ThrowingComponent />
+        </ErrorBoundary>
+      )
+
+      expect(screen.getByLabelText('Report crash on GitHub')).toBeTruthy()
+    })
+
+    it('renders children normally when no error', () => {
+      const screen = renderScreen(
+        <ErrorBoundary>
+          <>{/* No error */}</>
+        </ErrorBoundary>
+      )
+
+      expect(screen.queryByText('Something went wrong')).toBeNull()
+    })
+
+    it('logs error via logError', () => {
+      renderScreen(
+        <ErrorBoundary>
+          <ThrowingComponent />
+        </ErrorBoundary>
+      )
+
+      expect(mockLogError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Test crash in render' }),
+        expect.objectContaining({ fatal: true })
+      )
+    })
+  })
+})

--- a/__tests__/acceptance/error-handling.acceptance.test.tsx
+++ b/__tests__/acceptance/error-handling.acceptance.test.tsx
@@ -48,11 +48,11 @@ const mockGenerateReport = jest.fn().mockResolvedValue('{}')
 const mockGenerateGitHubURL = jest.fn().mockReturnValue('https://github.com')
 
 jest.mock('../../lib/errors', () => ({
-  getRecentErrors: (...args: any[]) => mockGetRecentErrors(...args),
-  clearErrorLog: (...args: any[]) => mockClearErrorLog(...args),
-  logError: (...args: any[]) => mockLogError(...args),
-  generateReport: (...args: any[]) => mockGenerateReport(...args),
-  generateGitHubURL: (...args: any[]) => mockGenerateGitHubURL(...args),
+  getRecentErrors: (...args: unknown[]) => mockGetRecentErrors(...args),
+  clearErrorLog: (...args: unknown[]) => mockClearErrorLog(...args),
+  logError: (...args: unknown[]) => mockLogError(...args),
+  generateReport: (...args: unknown[]) => mockGenerateReport(...args),
+  generateGitHubURL: (...args: unknown[]) => mockGenerateGitHubURL(...args),
 }))
 
 jest.mock('../../lib/interactions', () => ({

--- a/__tests__/acceptance/food-database.acceptance.test.tsx
+++ b/__tests__/acceptance/food-database.acceptance.test.tsx
@@ -1,0 +1,303 @@
+jest.setTimeout(10000)
+
+/**
+ * BLD-57: Built-in Food Database acceptance tests.
+ * Tests search, category filtering, macro display, serving multipliers,
+ * favorites toggle, and logging flow in the add-nutrition screen.
+ */
+
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+import { resetIds } from '../helpers/factories'
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
+const mockParams: Record<string, string> = {}
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    router: { back: jest.fn(), push: jest.fn() },
+    useRouter: () => mockRouter,
+    useLocalSearchParams: () => mockParams,
+    usePathname: () => '/nutrition/add',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
+jest.mock('../../lib/errors', () => ({ logError: jest.fn() }))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn() }))
+
+const mockAddFoodEntry = jest.fn().mockResolvedValue({ id: 'fe-1', name: 'Chicken Breast (grilled)', calories: 165, protein: 31, carbs: 0, fat: 3.6, serving: '100g', is_favorite: false })
+const mockAddDailyLog = jest.fn().mockResolvedValue(undefined)
+const mockGetFavoriteFoods = jest.fn().mockResolvedValue([])
+
+jest.mock('../../lib/db', () => ({
+  addFoodEntry: (...args: unknown[]) => mockAddFoodEntry(...args),
+  addDailyLog: (...args: unknown[]) => mockAddDailyLog(...args),
+  getFavoriteFoods: (...args: unknown[]) => mockGetFavoriteFoods(...args),
+}))
+
+import AddFood from '../../app/nutrition/add'
+
+function renderAddFood() {
+  return renderScreen(<AddFood />)
+}
+
+async function switchToDatabase(screen: ReturnType<typeof renderScreen>) {
+  const dbBtn = await screen.findByText('Database')
+  fireEvent.press(dbBtn)
+}
+
+describe('Built-in Food Database (BLD-57)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+    Object.keys(mockParams).forEach((k) => delete mockParams[k])
+    mockGetFavoriteFoods.mockResolvedValue([])
+  })
+
+  describe('database tab rendering', () => {
+    it('shows search input after switching to database tab', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Search foods')).toBeTruthy()
+      })
+    })
+
+    it('shows category filter chips', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+      await waitFor(() => {
+        expect(screen.getByText('All')).toBeTruthy()
+        expect(screen.getByText('Protein')).toBeTruthy()
+        expect(screen.getByText('Grains')).toBeTruthy()
+        expect(screen.getByText('Dairy')).toBeTruthy()
+      })
+    })
+
+    it('shows food items from the built-in database', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Chicken Breast \(grilled\), 165 calories/)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('search functionality', () => {
+    it('filters foods by search query', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken')
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Chicken Breast/)).toBeTruthy()
+        expect(screen.queryByLabelText(/Brown Rice/)).toBeNull()
+      })
+    })
+
+    it('shows all foods when search is cleared', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken')
+      fireEvent.changeText(searchInput, '')
+
+      await waitFor(() => {
+        // Should show items from various categories
+        expect(screen.getByLabelText(/Chicken Breast/)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('category filtering', () => {
+    it('filters by Protein category', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const proteinChip = await screen.findByText('Protein')
+      fireEvent.press(proteinChip)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Chicken Breast/)).toBeTruthy()
+        // Rice is in grains category, should not appear
+        expect(screen.queryByLabelText(/Brown Rice/)).toBeNull()
+      })
+    })
+
+    it('resets filter when pressing same category again', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const proteinChip = await screen.findByText('Protein')
+      fireEvent.press(proteinChip)
+      fireEvent.press(proteinChip)
+
+      await waitFor(() => {
+        // All category should show all foods
+        expect(screen.getByLabelText(/Chicken Breast/)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('food item expansion and macros', () => {
+    it('expands food item showing macro details', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast \(grilled\), 165 calories/)
+      fireEvent.press(foodCard)
+
+      await waitFor(() => {
+        expect(screen.getByText(/Serving: 100g/)).toBeTruthy()
+        expect(screen.getByLabelText('Log food')).toBeTruthy()
+      })
+    })
+
+    it('shows serving multiplier chips when expanded', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast \(grilled\), 165 calories/)
+      fireEvent.press(foodCard)
+
+      await waitFor(() => {
+        expect(screen.getByText('0.5x')).toBeTruthy()
+        expect(screen.getByText('1x')).toBeTruthy()
+        expect(screen.getByText('1.5x')).toBeTruthy()
+        expect(screen.getByText('2x')).toBeTruthy()
+      })
+    })
+
+    it('updates scaled macros when multiplier changes', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast \(grilled\), 165 calories/)
+      fireEvent.press(foodCard)
+
+      // Press 2x multiplier
+      const twoX = await screen.findByText('2x')
+      fireEvent.press(twoX)
+
+      await waitFor(() => {
+        // 165 * 2 = 330 cal, 31 * 2 = 62.0p
+        expect(screen.getByText(/330 cal/)).toBeTruthy()
+        expect(screen.getByText(/62\.0p/)).toBeTruthy()
+      })
+    })
+
+    it('shows serving multiplier input with accessible label', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast \(grilled\), 165 calories/)
+      fireEvent.press(foodCard)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Serving multiplier/)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('favorites toggle', () => {
+    it('shows save as favorite button when food is expanded', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast \(grilled\), 165 calories/)
+      fireEvent.press(foodCard)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Save as favorite')).toBeTruthy()
+      })
+    })
+
+    it('toggles favorite label when pressed', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast \(grilled\), 165 calories/)
+      fireEvent.press(foodCard)
+
+      const favBtn = await screen.findByLabelText('Save as favorite')
+      fireEvent.press(favBtn)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Remove from favorites')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('logging flow', () => {
+    it('calls addFoodEntry and addDailyLog when logging food', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast \(grilled\), 165 calories/)
+      fireEvent.press(foodCard)
+
+      const logBtn = await screen.findByLabelText('Log food')
+      fireEvent.press(logBtn)
+
+      await waitFor(() => {
+        expect(mockAddFoodEntry).toHaveBeenCalledWith(
+          'Chicken Breast (grilled)',
+          165, 31, 0, 3.6,
+          '100g',
+          false
+        )
+        expect(mockAddDailyLog).toHaveBeenCalled()
+      })
+    })
+
+    it('logs with correct multiplier', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast \(grilled\), 165 calories/)
+      fireEvent.press(foodCard)
+
+      const twoX = await screen.findByText('2x')
+      fireEvent.press(twoX)
+
+      const logBtn = await screen.findByLabelText('Log food')
+      fireEvent.press(logBtn)
+
+      await waitFor(() => {
+        expect(mockAddDailyLog).toHaveBeenCalledWith(
+          'fe-1',
+          expect.any(String),
+          'snack',
+          2
+        )
+      })
+    })
+
+    it('meal selector chips are accessible', async () => {
+      const screen = renderAddFood()
+      await switchToDatabase(screen)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Meal: Breakfast/)).toBeTruthy()
+        expect(screen.getByLabelText(/Meal: Lunch/)).toBeTruthy()
+        expect(screen.getByLabelText(/Meal: Dinner/)).toBeTruthy()
+        expect(screen.getByLabelText(/Meal: Snack/)).toBeTruthy()
+      })
+    })
+  })
+})

--- a/__tests__/acceptance/history.acceptance.test.tsx
+++ b/__tests__/acceptance/history.acceptance.test.tsx
@@ -1,0 +1,382 @@
+jest.setTimeout(10000)
+
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+import { createSession, resetIds } from '../helpers/factories'
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    useRouter: () => mockRouter,
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/test',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
+jest.mock('../../lib/errors', () => ({ logError: jest.fn(), generateReport: jest.fn().mockResolvedValue('{}'), getRecentErrors: jest.fn().mockResolvedValue([]), generateGitHubURL: jest.fn().mockReturnValue('https://github.com') }))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+jest.mock('react-native-reanimated', () => {
+  const RN = require('react-native')
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const AnimatedView = ({ entering: _entering, ...rest }: Record<string, unknown>) => {
+    return require('react').createElement(RN.View, rest)
+  }
+  return {
+    __esModule: true,
+    default: {
+      View: AnimatedView,
+      createAnimatedComponent: <T,>(c: T) => c,
+    },
+    FadeIn: { duration: () => ({}) },
+    useAnimatedStyle: () => ({}),
+    useSharedValue: <T,>(v: T) => ({ value: v }),
+    withTiming: <T,>(v: T) => v,
+    createAnimatedComponent: <T,>(c: T) => c,
+  }
+})
+
+jest.mock('../../components/WorkoutHeatmap', () => {
+  const RealReact = require('react')
+  return {
+    __esModule: true,
+    default: () =>
+      RealReact.createElement('View', { testID: 'workout-heatmap' }),
+  }
+})
+
+type SessionRow = {
+  id: string
+  template_id: string | null
+  name: string
+  started_at: number
+  completed_at: number | null
+  duration_seconds: number | null
+  notes: string
+  set_count: number
+}
+
+const now = new Date()
+const thisYear = now.getFullYear()
+const thisMonth = now.getMonth()
+
+function makeSessionRow(overrides: Partial<SessionRow> = {}): SessionRow {
+  const base = createSession(overrides)
+  return {
+    ...base,
+    set_count: overrides.set_count ?? 12,
+    duration_seconds: overrides.duration_seconds ?? 3600,
+    completed_at: overrides.completed_at ?? (base.started_at + 3600000),
+  }
+}
+
+const day5 = new Date(thisYear, thisMonth, 5, 10, 0, 0).getTime()
+const day10 = new Date(thisYear, thisMonth, 10, 14, 0, 0).getTime()
+const day10b = new Date(thisYear, thisMonth, 10, 18, 0, 0).getTime()
+
+const sessionsThisMonth: SessionRow[] = [
+  makeSessionRow({ id: 's1', name: 'Push Day', started_at: day5, completed_at: day5 + 3600000, duration_seconds: 3600, set_count: 15 }),
+  makeSessionRow({ id: 's2', name: 'Pull Day', started_at: day10, completed_at: day10 + 2700000, duration_seconds: 2700, set_count: 12 }),
+  makeSessionRow({ id: 's3', name: 'Legs', started_at: day10b, completed_at: day10b + 3000000, duration_seconds: 3000, set_count: 18 }),
+]
+
+const mockGetSessionsByMonth = jest.fn().mockResolvedValue(sessionsThisMonth)
+const mockGetRecentSessions = jest.fn().mockResolvedValue([sessionsThisMonth[0]])
+const mockSearchSessions = jest.fn().mockResolvedValue([])
+const mockGetSessionCountsByDay = jest.fn().mockResolvedValue([])
+const mockGetAllCompletedSessionWeeks = jest.fn().mockResolvedValue([])
+const mockGetTotalSessionCount = jest.fn().mockResolvedValue(42)
+
+jest.mock('../../lib/db', () => ({
+  getSessionsByMonth: (...args: unknown[]) => mockGetSessionsByMonth(...args),
+  getRecentSessions: (...args: unknown[]) => mockGetRecentSessions(...args),
+  searchSessions: (...args: unknown[]) => mockSearchSessions(...args),
+  getSessionCountsByDay: (...args: unknown[]) => mockGetSessionCountsByDay(...args),
+  getAllCompletedSessionWeeks: (...args: unknown[]) => mockGetAllCompletedSessionWeeks(...args),
+  getTotalSessionCount: (...args: unknown[]) => mockGetTotalSessionCount(...args),
+}))
+
+import History from '../../app/history'
+
+describe('Workout History & Calendar Acceptance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+    mockGetSessionsByMonth.mockResolvedValue(sessionsThisMonth)
+    mockGetRecentSessions.mockResolvedValue([sessionsThisMonth[0]])
+    mockGetSessionCountsByDay.mockResolvedValue([])
+    mockGetAllCompletedSessionWeeks.mockResolvedValue([])
+    mockGetTotalSessionCount.mockResolvedValue(42)
+    mockSearchSessions.mockResolvedValue([])
+  })
+
+  describe('Calendar view', () => {
+    it('renders month label and navigation buttons', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Previous month')).toBeTruthy()
+        expect(screen.getByLabelText('Next month')).toBeTruthy()
+      })
+    })
+
+    it('navigates to previous month on chevron press', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Previous month')).toBeTruthy()
+      })
+
+      fireEvent.press(screen.getByLabelText('Previous month'))
+
+      // After pressing, the month label should have changed
+      // The component re-renders with new month state
+      expect(screen.getByLabelText('Previous month')).toBeTruthy()
+    })
+
+    it('navigates to next month on chevron press', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Next month')).toBeTruthy()
+      })
+
+      fireEvent.press(screen.getByLabelText('Next month'))
+
+      expect(screen.getByLabelText('Next month')).toBeTruthy()
+    })
+  })
+
+  describe('Workout indicators on dates', () => {
+    it('shows workout day labels on dates with sessions', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        const label5 = screen.getByLabelText(/5.*1 workout/)
+        expect(label5).toBeTruthy()
+      })
+    })
+
+    it('shows multiple workout indicators for dates with multiple sessions', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        const label10 = screen.getByLabelText(/10.*2 workouts/)
+        expect(label10).toBeTruthy()
+      })
+    })
+
+    it('shows rest day label on dates without sessions', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        const restDays = screen.getAllByLabelText(/rest day/)
+        expect(restDays.length).toBeGreaterThan(0)
+      })
+    })
+  })
+
+  describe('Session cards', () => {
+    it('renders session cards with name, duration, and set count', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Push Day/)).toBeTruthy()
+        expect(screen.getByLabelText(/Pull Day/)).toBeTruthy()
+        expect(screen.getByLabelText(/Legs/)).toBeTruthy()
+      })
+    })
+
+    it('shows set count on session cards', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/15 sets/)).toBeTruthy()
+        expect(screen.getByLabelText(/12 sets/)).toBeTruthy()
+        expect(screen.getByLabelText(/18 sets/)).toBeTruthy()
+      })
+    })
+
+    it('navigates to session detail on card press', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Push Day/)).toBeTruthy()
+      })
+
+      fireEvent.press(screen.getByLabelText(/Push Day/))
+      expect(mockRouter.push).toHaveBeenCalledWith('/session/detail/s1')
+    })
+  })
+
+  describe('Tapping a date filters sessions', () => {
+    it('filters to show only sessions for the tapped date', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/5.*1 workout/)).toBeTruthy()
+      })
+
+      fireEvent.press(screen.getByLabelText(/5.*1 workout/))
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Push Day/)).toBeTruthy()
+        expect(screen.queryByLabelText(/Pull Day/)).toBeNull()
+        expect(screen.queryByLabelText(/Legs/)).toBeNull()
+      })
+    })
+
+    it('shows clear filter chip when date is selected', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/5.*1 workout/)).toBeTruthy()
+      })
+
+      fireEvent.press(screen.getByLabelText(/5.*1 workout/))
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Clear filter')).toBeTruthy()
+      })
+    })
+
+    it('clears filter when chip is pressed', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/5.*1 workout/)).toBeTruthy()
+      })
+
+      fireEvent.press(screen.getByLabelText(/5.*1 workout/))
+      await waitFor(() => {
+        expect(screen.getByLabelText('Clear filter')).toBeTruthy()
+      })
+
+      fireEvent.press(screen.getByLabelText('Clear filter'))
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Push Day/)).toBeTruthy()
+        expect(screen.getByLabelText(/Pull Day/)).toBeTruthy()
+        expect(screen.getByLabelText(/Legs/)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('Empty states', () => {
+    it('shows empty state for days with no workouts', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        const restDays = screen.getAllByLabelText(/rest day/)
+        expect(restDays.length).toBeGreaterThan(0)
+      })
+
+      // Tap a specific rest day (day 2 or 3 which won't have sessions)
+      const restDays = screen.getAllByLabelText(/rest day/)
+      fireEvent.press(restDays[0])
+
+      await waitFor(() => {
+        expect(screen.getByText('Rest day!')).toBeTruthy()
+      })
+    })
+
+    it('shows empty state when no workouts exist at all', async () => {
+      mockGetSessionsByMonth.mockResolvedValue([])
+      mockGetRecentSessions.mockResolvedValue([])
+
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByText('No workouts yet. Start your first workout!')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('Search', () => {
+    it('renders search bar with accessible label', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Search workout history')).toBeTruthy()
+      })
+    })
+
+    it('calls searchSessions on query input', async () => {
+      jest.useFakeTimers()
+      const matchingSessions = [sessionsThisMonth[0]]
+      mockSearchSessions.mockResolvedValue(matchingSessions)
+
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Search workout history')).toBeTruthy()
+      })
+
+      fireEvent.changeText(screen.getByLabelText('Search workout history'), 'Push')
+      jest.advanceTimersByTime(350)
+
+      await waitFor(() => {
+        expect(mockSearchSessions).toHaveBeenCalledWith('Push')
+      })
+
+      jest.useRealTimers()
+    })
+  })
+
+  describe('Streak summary', () => {
+    it('shows streak and total workout stats', async () => {
+      mockGetAllCompletedSessionWeeks.mockResolvedValue([])
+      mockGetTotalSessionCount.mockResolvedValue(42)
+
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Total workouts: 42/)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('Heatmap section', () => {
+    it('renders heatmap toggle with accessible label', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Last 16 Weeks/)).toBeTruthy()
+      })
+    })
+
+    it('collapses and expands heatmap on toggle press', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByTestId('workout-heatmap')).toBeTruthy()
+      })
+
+      fireEvent.press(screen.getByLabelText(/Last 16 Weeks, collapse/))
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('workout-heatmap')).toBeNull()
+      })
+
+      fireEvent.press(screen.getByLabelText(/Last 16 Weeks, expand/))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('workout-heatmap')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('Accessible labels', () => {
+    it('all navigation buttons have accessible labels', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Previous month')).toBeTruthy()
+        expect(screen.getByLabelText('Next month')).toBeTruthy()
+        expect(screen.getByLabelText('Search workout history')).toBeTruthy()
+      })
+    })
+
+    it('session cards have role button', async () => {
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        const card = screen.getByLabelText(/Push Day/)
+        expect(card.props.accessibilityRole || card.props.role).toBe('button')
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds acceptance tests for 4 features across 4 new test files.

## Changes

- **history.acceptance.test.tsx** (BLD-44): 21 tests for workout history/calendar screen
- **error-handling.acceptance.test.tsx** (BLD-52): 16 tests for ErrorBoundary and error log
- **accessibility.acceptance.test.tsx** (BLD-53): 20 tests across 6 screens (exercises, nutrition, settings, home dashboard, progress, session) — addresses techlead review feedback
- **food-database.acceptance.test.tsx** (BLD-57): 16 tests for built-in food search, category filtering, macro scaling, and logging flow

## Testing

- All 59 test suites pass (863 tests)
- `tsc --noEmit` passes with zero errors
- No regressions in existing tests

## Issues

Resolves BLD-44, BLD-52, BLD-53, BLD-57