### PR TITLE
feat: full data export & import with v3 backup format (BLD-163)

### DIFF
--- a/__mocks__/react-native-gesture-handler.js
+++ b/__mocks__/react-native-gesture-handler.js
@@ -1,0 +1,65 @@
+// Lightweight mock for react-native-gesture-handler in Jest
+const React = require('react');
+
+const GestureDetector = ({ children }) => children;
+const GestureHandlerRootView = ({ children, ...props }) =>
+  React.createElement('View', props, children);
+
+const createGesture = () => {
+  const gesture = {
+    onStart: () => gesture,
+    onUpdate: () => gesture,
+    onEnd: () => gesture,
+    onFinalize: () => gesture,
+    onChange: () => gesture,
+    onTouchesDown: () => gesture,
+    onTouchesMove: () => gesture,
+    onTouchesUp: () => gesture,
+    onTouchesCancelled: () => gesture,
+    enabled: () => gesture,
+    minDistance: () => gesture,
+    minPointers: () => gesture,
+    maxPointers: () => gesture,
+    activeOffsetX: () => gesture,
+    activeOffsetY: () => gesture,
+    failOffsetX: () => gesture,
+    failOffsetY: () => gesture,
+    hitSlop: () => gesture,
+    simultaneousWithExternalGesture: () => gesture,
+    requireExternalGestureToFail: () => gesture,
+    withTestId: () => gesture,
+    runOnJS: () => gesture,
+  };
+  return gesture;
+};
+
+const Gesture = {
+  Pan: createGesture,
+  Tap: createGesture,
+  LongPress: createGesture,
+  Pinch: createGesture,
+  Rotation: createGesture,
+  Fling: createGesture,
+  Native: createGesture,
+  Manual: createGesture,
+  Race: (...args) => createGesture(),
+  Simultaneous: (...args) => createGesture(),
+  Exclusive: (...args) => createGesture(),
+};
+
+module.exports = {
+  GestureDetector,
+  GestureHandlerRootView,
+  Gesture,
+  Directions: { RIGHT: 1, LEFT: 2, UP: 4, DOWN: 8 },
+  State: { UNDETERMINED: 0, FAILED: 1, BEGAN: 2, CANCELLED: 3, ACTIVE: 4, END: 5 },
+  PanGestureHandler: 'PanGestureHandler',
+  TapGestureHandler: 'TapGestureHandler',
+  FlingGestureHandler: 'FlingGestureHandler',
+  LongPressGestureHandler: 'LongPressGestureHandler',
+  PinchGestureHandler: 'PinchGestureHandler',
+  RotationGestureHandler: 'RotationGestureHandler',
+  ScrollView: React.forwardRef((props, ref) => React.createElement('ScrollView', { ...props, ref })),
+  FlatList: React.forwardRef((props, ref) => React.createElement('FlatList', { ...props, ref })),
+  gestureHandlerRootHOC: (Component) => Component,
+};

--- a/__mocks__/react-native-reanimated.js
+++ b/__mocks__/react-native-reanimated.js
@@ -50,6 +50,7 @@ module.exports = {
     inOut: noop,
   },
   interpolate: (v) => v,
+  interpolateColor: (_value, _inputRange, outputRange) => outputRange[0],
   Extrapolation: { CLAMP: 'clamp', EXTEND: 'extend', IDENTITY: 'identity' },
   runOnUI: (fn) => fn,
   runOnJS: (fn) => fn,

--- a/__mocks__/react-native-reanimated.js
+++ b/__mocks__/react-native-reanimated.js
@@ -6,6 +6,21 @@ const React = require('react');
 const noop = () => {};
 const noopValue = (v) => ({ value: v });
 
+// Chainable layout animation mock — supports .delay().duration() and .duration().delay()
+const makeLayoutAnim = () => {
+  const anim = {};
+  anim.duration = () => anim;
+  anim.delay = () => anim;
+  anim.springify = () => anim;
+  anim.damping = () => anim;
+  anim.stiffness = () => anim;
+  anim.withInitialValues = () => anim;
+  anim.withCallback = () => anim;
+  anim.randomDelay = () => anim;
+  anim.build = () => anim;
+  return anim;
+};
+
 module.exports = {
   __esModule: true,
   default: {
@@ -56,18 +71,18 @@ module.exports = {
   runOnJS: (fn) => fn,
   createAnimatedComponent: (Component) =>
     React.forwardRef((props, ref) => React.createElement(Component, { ...props, ref })),
-  FadeIn: { duration: () => ({ delay: () => ({}) }) },
-  FadeOut: { duration: () => ({ delay: () => ({}) }) },
-  FadeInDown: { duration: () => ({ delay: () => ({}) }) },
-  FadeInUp: { duration: () => ({ delay: () => ({}) }) },
-  FadeOutDown: { duration: () => ({ delay: () => ({}) }) },
-  FadeOutUp: { duration: () => ({ delay: () => ({}) }) },
-  SlideInRight: { duration: () => ({}) },
-  SlideOutRight: { duration: () => ({}) },
-  Layout: { duration: () => ({}) },
-  LinearTransition: { duration: () => ({}) },
-  ZoomIn: { duration: () => ({}) },
-  ZoomOut: { duration: () => ({}) },
+  FadeIn: makeLayoutAnim(),
+  FadeOut: makeLayoutAnim(),
+  FadeInDown: makeLayoutAnim(),
+  FadeInUp: makeLayoutAnim(),
+  FadeOutDown: makeLayoutAnim(),
+  FadeOutUp: makeLayoutAnim(),
+  SlideInRight: makeLayoutAnim(),
+  SlideOutRight: makeLayoutAnim(),
+  Layout: makeLayoutAnim(),
+  LinearTransition: makeLayoutAnim(),
+  ZoomIn: makeLayoutAnim(),
+  ZoomOut: makeLayoutAnim(),
   measure: () => ({ x: 0, y: 0, width: 0, height: 0, pageX: 0, pageY: 0 }),
   scrollTo: noop,
   setGestureState: noop,

--- a/__tests__/acceptance/data-management.acceptance.test.tsx
+++ b/__tests__/acceptance/data-management.acceptance.test.tsx
@@ -125,7 +125,7 @@ describe('Data Management Acceptance', () => {
 
     const { findByLabelText } = renderScreen(<Settings />)
 
-    const btn = await findByLabelText('Export all data as JSON backup')
+    const btn = await findByLabelText('Export all data as JSON')
     fireEvent.press(btn)
 
     await waitFor(() => {
@@ -158,7 +158,7 @@ describe('Data Management Acceptance', () => {
 
     const { findByLabelText } = renderScreen(<Settings />)
 
-    const btn = await findByLabelText('Import FitForge backup')
+    const btn = await findByLabelText('Import data')
     fireEvent.press(btn)
 
     await waitFor(() => {

--- a/__tests__/acceptance/data-management.acceptance.test.tsx
+++ b/__tests__/acceptance/data-management.acceptance.test.tsx
@@ -1,6 +1,7 @@
 jest.setTimeout(10000)
 
 import React from 'react'
+import { Alert } from 'react-native'
 import { fireEvent, waitFor } from '@testing-library/react-native'
 import { renderScreen } from '../helpers/render'
 
@@ -67,8 +68,14 @@ jest.mock('expo-document-picker', () => ({
 }))
 
 jest.mock('../../lib/db', () => ({
-  exportAllData: jest.fn().mockResolvedValue({ version: 1, exercises: [], templates: [], sessions: [], sets: [] }),
-  importData: jest.fn().mockResolvedValue({ inserted: 5 }),
+  exportAllData: jest.fn().mockResolvedValue({ version: 3, app_version: '1.0.0', exported_at: '2026-04-15T00:00:00.000Z', data: { exercises: [{ id: '1' }], workout_templates: [], workout_sessions: [], workout_sets: [] }, counts: { exercises: 1 } }),
+  importData: jest.fn().mockResolvedValue({ inserted: 5, skipped: 0, perTable: {} }),
+  estimateExportSize: jest.fn().mockResolvedValue({ bytes: 1024, label: '1 KB' }),
+  validateBackupFileSize: jest.fn().mockReturnValue(null),
+  validateBackupData: jest.fn().mockReturnValue(null),
+  getBackupCounts: jest.fn().mockReturnValue({}),
+  BACKUP_TABLE_LABELS: {},
+  IMPORT_TABLE_ORDER: [],
   getWorkoutCSVData: jest.fn().mockResolvedValue([{ date: '2024-01-15', exercise: 'Bench', set_number: 1, weight: 60, reps: 10, duration_seconds: 1800, notes: '', set_rpe: 8, set_notes: '', link_id: null }]),
   getNutritionCSVData: jest.fn().mockResolvedValue([]),
   getBodyWeightCSVData: jest.fn().mockResolvedValue([]),
@@ -83,9 +90,12 @@ jest.mock('../../lib/db', () => ({
 
 import Settings from '../../app/(tabs)/settings'
 
-const { exportAllData, importData, getWorkoutCSVData, setAppSetting } = require('../../lib/db')
+const { exportAllData, importData, getWorkoutCSVData, setAppSetting, estimateExportSize } = require('../../lib/db')
 const { shareAsync } = require('expo-sharing')
 const { getDocumentAsync } = require('expo-document-picker')
+
+// Spy on Alert.alert to auto-confirm
+const alertSpy = jest.spyOn(Alert, 'alert')
 
 describe('Data Management Acceptance', () => {
   beforeEach(() => {
@@ -106,11 +116,21 @@ describe('Data Management Acceptance', () => {
   })
 
   it('exports all data as JSON', async () => {
+    // Auto-press "Export" in the confirmation alert
+    alertSpy.mockImplementation((_title, _message, buttons) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const exportBtn = buttons?.find((b: any) => b.text === 'Export')
+      if (exportBtn?.onPress) exportBtn.onPress()
+    })
+
     const { findByLabelText } = renderScreen(<Settings />)
 
-    const btn = await findByLabelText('Export all data as JSON')
+    const btn = await findByLabelText('Export all data as JSON backup')
     fireEvent.press(btn)
 
+    await waitFor(() => {
+      expect(estimateExportSize).toHaveBeenCalled()
+    })
     await waitFor(() => {
       expect(exportAllData).toHaveBeenCalled()
     })
@@ -138,7 +158,7 @@ describe('Data Management Acceptance', () => {
 
     const { findByLabelText } = renderScreen(<Settings />)
 
-    const btn = await findByLabelText('Import data')
+    const btn = await findByLabelText('Import FitForge backup')
     fireEvent.press(btn)
 
     await waitFor(() => {

--- a/__tests__/acceptance/settings.test.tsx
+++ b/__tests__/acceptance/settings.test.tsx
@@ -304,7 +304,7 @@ describe('Settings Screen Acceptance', () => {
 
   it('Export All button is pressable and has accessible label', async () => {
     const { findByLabelText } = renderScreen(<Settings />)
-    const btn = await findByLabelText('Export all data as JSON backup')
+    const btn = await findByLabelText('Export all data as JSON')
     expect(btn).toBeTruthy()
     fireEvent.press(btn)
     // Pressing triggers the export — just verify it doesn't crash
@@ -312,7 +312,7 @@ describe('Settings Screen Acceptance', () => {
 
   it('Import button is pressable and has accessible label', async () => {
     const { findByLabelText } = renderScreen(<Settings />)
-    const btn = await findByLabelText('Import FitForge backup')
+    const btn = await findByLabelText('Import data')
     expect(btn).toBeTruthy()
     fireEvent.press(btn)
   })

--- a/__tests__/acceptance/settings.test.tsx
+++ b/__tests__/acceptance/settings.test.tsx
@@ -84,8 +84,14 @@ const mockGetBodySettings = jest.fn().mockResolvedValue({
 })
 
 jest.mock('../../lib/db', () => ({
-  exportAllData: jest.fn().mockResolvedValue({ version: 1 }),
-  importData: jest.fn().mockResolvedValue({ inserted: 0 }),
+  exportAllData: jest.fn().mockResolvedValue({ version: 3, app_version: '1.0.0', exported_at: '2026-04-15T00:00:00.000Z', data: {}, counts: {} }),
+  importData: jest.fn().mockResolvedValue({ inserted: 0, skipped: 0, perTable: {} }),
+  estimateExportSize: jest.fn().mockResolvedValue({ bytes: 1024, label: '1 KB' }),
+  validateBackupFileSize: jest.fn().mockReturnValue(null),
+  validateBackupData: jest.fn().mockReturnValue(null),
+  getBackupCounts: jest.fn().mockReturnValue({}),
+  BACKUP_TABLE_LABELS: {},
+  IMPORT_TABLE_ORDER: [],
   getWorkoutCSVData: jest.fn().mockResolvedValue([]),
   getNutritionCSVData: jest.fn().mockResolvedValue([]),
   getBodyWeightCSVData: jest.fn().mockResolvedValue([]),
@@ -126,7 +132,7 @@ describe('Settings Screen Acceptance', () => {
     const { findByText } = renderScreen(<Settings />)
     expect(await findByText('Units')).toBeTruthy()
     expect(await findByText('Preferences')).toBeTruthy()
-    expect(await findByText('Data')).toBeTruthy()
+    expect(await findByText('Data Management')).toBeTruthy()
     expect(await findByText('Feedback & Reports')).toBeTruthy()
     expect(await findByText('About')).toBeTruthy()
   })
@@ -298,7 +304,7 @@ describe('Settings Screen Acceptance', () => {
 
   it('Export All button is pressable and has accessible label', async () => {
     const { findByLabelText } = renderScreen(<Settings />)
-    const btn = await findByLabelText('Export all data as JSON')
+    const btn = await findByLabelText('Export all data as JSON backup')
     expect(btn).toBeTruthy()
     fireEvent.press(btn)
     // Pressing triggers the export — just verify it doesn't crash
@@ -306,7 +312,7 @@ describe('Settings Screen Acceptance', () => {
 
   it('Import button is pressable and has accessible label', async () => {
     const { findByLabelText } = renderScreen(<Settings />)
-    const btn = await findByLabelText('Import data')
+    const btn = await findByLabelText('Import FitForge backup')
     expect(btn).toBeTruthy()
     fireEvent.press(btn)
   })

--- a/__tests__/acceptance/template-crud.acceptance.test.tsx
+++ b/__tests__/acceptance/template-crud.acceptance.test.tsx
@@ -33,6 +33,23 @@ jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().m
 jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
 jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
 
+// Mock ExercisePickerSheet to avoid Portal infinite-update loop in test renderer
+jest.mock('../../components/ExercisePickerSheet', () => {
+  const RealReact = require('react')
+  const { getAllExercises } = require('../../lib/db')
+  // eslint-disable-next-line react/display-name
+  const MockPicker = ({ visible }: { visible: boolean; onDismiss: () => void; onPick: (e: unknown) => void }) => {
+    RealReact.useEffect(() => {
+      if (visible) getAllExercises()
+    }, [visible])
+    if (!visible) return null
+    return RealReact.createElement('View', { testID: 'exercise-picker-sheet' },
+      RealReact.createElement('View', { accessibilityLabel: 'Exercise picker open' })
+    )
+  }
+  return { __esModule: true, default: MockPicker }
+})
+
 const benchPress = createExercise({ id: 'ex-1', name: 'Bench Press', category: 'chest', primary_muscles: ['chest'] })
 const squat = createExercise({ id: 'ex-2', name: 'Squat', category: 'legs_glutes', primary_muscles: ['quads'] })
 

--- a/__tests__/lib/db/import-export.test.ts
+++ b/__tests__/lib/db/import-export.test.ts
@@ -1,0 +1,370 @@
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  getFirstAsync: jest.fn().mockResolvedValue(null),
+  runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+};
+
+jest.mock("expo-sqlite", () => ({
+  openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+}));
+
+import {
+  exportAllData,
+  importData,
+  validateBackupData,
+  validateBackupFileSize,
+  getBackupCounts,
+  estimateExportSize,
+  IMPORT_TABLE_ORDER,
+} from "../../../lib/db/import-export";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.getAllAsync.mockResolvedValue([]);
+  mockDb.getFirstAsync.mockResolvedValue({ cnt: 0 });
+  mockDb.runAsync.mockResolvedValue({ changes: 1 });
+});
+
+// ---- Export v3 Format ----
+
+describe("exportAllData", () => {
+  it("produces v3 format with data wrapper and counts", async () => {
+    mockDb.getAllAsync.mockResolvedValue([]);
+    const result = await exportAllData();
+    expect(result.version).toBe(3);
+    expect(result.data).toBeDefined();
+    expect(result.counts).toBeDefined();
+    expect(result.exported_at).toBeDefined();
+    expect(result.app_version).toBeDefined();
+  });
+
+  it("includes all 18 tables", async () => {
+    mockDb.getAllAsync.mockResolvedValue([]);
+    const result = await exportAllData();
+    for (const table of IMPORT_TABLE_ORDER) {
+      expect(result.data).toHaveProperty(table);
+      expect(Array.isArray((result.data as Record<string, unknown>)[table])).toBe(true);
+    }
+  });
+
+  it("calls progress callback per table", async () => {
+    mockDb.getAllAsync.mockResolvedValue([]);
+    const progress: string[] = [];
+    await exportAllData((p) => progress.push(p.table));
+    // Should have 18 table calls plus "done"
+    expect(progress.length).toBe(IMPORT_TABLE_ORDER.length + 1);
+    expect(progress[progress.length - 1]).toBe("done");
+  });
+
+  it("counts are accurate", async () => {
+    let callIdx = 0;
+    mockDb.getAllAsync.mockImplementation(async () => {
+      callIdx++;
+      // First table (exercises) returns 3 rows
+      if (callIdx === 1) return [{ id: "a" }, { id: "b" }, { id: "c" }];
+      return [];
+    });
+    const result = await exportAllData();
+    expect(result.counts.exercises).toBe(3);
+  });
+});
+
+// ---- Validation ----
+
+describe("validateBackupFileSize", () => {
+  it("rejects files over 50MB", () => {
+    const err = validateBackupFileSize(51 * 1024 * 1024);
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe("file_too_large");
+  });
+
+  it("accepts files under 50MB", () => {
+    const err = validateBackupFileSize(10 * 1024 * 1024);
+    expect(err).toBeNull();
+  });
+});
+
+describe("validateBackupData", () => {
+  it("rejects non-object data", () => {
+    const err = validateBackupData("not an object");
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe("corrupt_json");
+  });
+
+  it("rejects missing version", () => {
+    const err = validateBackupData({ data: {} });
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe("missing_version");
+  });
+
+  it("rejects future version (v4+)", () => {
+    const err = validateBackupData({ version: 4, data: { exercises: [{ id: "1" }] } });
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe("future_version");
+    expect(err!.message).toContain("update the app");
+  });
+
+  it("accepts v2 backup", () => {
+    const err = validateBackupData({
+      version: 2,
+      exercises: [{ id: "1", name: "Bench" }],
+    });
+    expect(err).toBeNull();
+  });
+
+  it("accepts v3 backup", () => {
+    const err = validateBackupData({
+      version: 3,
+      data: {
+        exercises: [{ id: "1", name: "Bench" }],
+      },
+    });
+    expect(err).toBeNull();
+  });
+
+  it("rejects v3 without data key", () => {
+    const err = validateBackupData({ version: 3 });
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe("missing_data");
+  });
+
+  it("rejects empty backup", () => {
+    const err = validateBackupData({
+      version: 3,
+      data: {
+        exercises: [],
+        workout_templates: [],
+      },
+    });
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe("empty_backup");
+  });
+
+  it("rejects invalid table (not an array)", () => {
+    const err = validateBackupData({
+      version: 3,
+      data: {
+        exercises: "not an array",
+      },
+    });
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe("invalid_table");
+  });
+
+  it("rejects negative calorie values", () => {
+    const err = validateBackupData({
+      version: 3,
+      data: {
+        food_entries: [{ id: "1", calories: -100 }],
+      },
+    });
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe("negative_values");
+  });
+
+  it("rejects negative weight values", () => {
+    const err = validateBackupData({
+      version: 3,
+      data: {
+        body_weight: [{ id: "1", weight: -5 }],
+      },
+    });
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe("negative_values");
+  });
+
+  it("rejects negative reps values", () => {
+    const err = validateBackupData({
+      version: 3,
+      data: {
+        workout_sets: [{ id: "1", reps: -3 }],
+      },
+    });
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe("negative_values");
+  });
+
+  it("allows null numeric values (nullable fields)", () => {
+    const err = validateBackupData({
+      version: 3,
+      data: {
+        body_weight: [{ id: "1", weight: 70 }],
+        workout_sets: [{ id: "1", weight: null, reps: null, set_number: 1 }],
+      },
+    });
+    expect(err).toBeNull();
+  });
+});
+
+// ---- getBackupCounts ----
+
+describe("getBackupCounts", () => {
+  it("returns counts for v3 format", () => {
+    const counts = getBackupCounts({
+      version: 3,
+      data: {
+        exercises: [{ id: "1" }, { id: "2" }],
+        workout_templates: [{ id: "t1" }],
+      },
+    });
+    expect(counts.exercises).toBe(2);
+    expect(counts.workout_templates).toBe(1);
+    expect(counts.programs).toBe(0);
+  });
+
+  it("returns counts for v2 format using legacy keys", () => {
+    const counts = getBackupCounts({
+      version: 2,
+      exercises: [{ id: "1" }],
+      templates: [{ id: "t1" }, { id: "t2" }],
+      sessions: [{ id: "s1" }],
+      sets: [{ id: "set1" }],
+    });
+    expect(counts.exercises).toBe(1);
+    expect(counts.workout_templates).toBe(2);
+    expect(counts.workout_sessions).toBe(1);
+    expect(counts.workout_sets).toBe(1);
+  });
+});
+
+// ---- Import FK Ordering ----
+
+describe("importData", () => {
+  it("imports tables in FK-dependency order", async () => {
+    const importOrder: string[] = [];
+    mockDb.withTransactionAsync.mockImplementation(async (cb: () => Promise<void>) => {
+      await cb();
+    });
+    mockDb.runAsync.mockImplementation(async (sql: string) => {
+      const match = sql.match(/INSERT OR IGNORE INTO (\w+)/);
+      if (match) importOrder.push(match[1]);
+      return { changes: 1 };
+    });
+
+    const data = {
+      version: 3,
+      data: {
+        exercises: [{ id: "e1", name: "Bench", category: "chest", primary_muscles: "", secondary_muscles: "", equipment: "barbell", instructions: "", difficulty: "beginner", is_custom: 0 }],
+        workout_templates: [{ id: "t1", name: "Push", created_at: 1, updated_at: 1 }],
+        template_exercises: [{ id: "te1", template_id: "t1", exercise_id: "e1", position: 0, target_sets: 3, target_reps: "8", rest_seconds: 60 }],
+        workout_sessions: [{ id: "s1", template_id: "t1", name: "Push Day", started_at: 1, completed_at: 2, duration_seconds: 3600, notes: "" }],
+        workout_sets: [{ id: "ws1", session_id: "s1", exercise_id: "e1", set_number: 1, weight: 100, reps: 8, completed: 1, completed_at: 2 }],
+      },
+    };
+
+    await importData(data);
+
+    // exercises must come before template_exercises and workout_sets
+    const exIdx = importOrder.indexOf("exercises");
+    const teIdx = importOrder.indexOf("template_exercises");
+    const wsIdx = importOrder.indexOf("workout_sets");
+    const tplIdx = importOrder.indexOf("workout_templates");
+    const sessIdx = importOrder.indexOf("workout_sessions");
+
+    expect(exIdx).toBeLessThan(teIdx);
+    expect(exIdx).toBeLessThan(wsIdx);
+    expect(tplIdx).toBeLessThan(teIdx);
+    expect(sessIdx).toBeLessThan(wsIdx);
+  });
+
+  it("returns inserted and skipped counts", async () => {
+    let callCount = 0;
+    mockDb.runAsync.mockImplementation(async () => {
+      callCount++;
+      // Alternate: first insert succeeds, second is duplicate
+      return { changes: callCount % 2 === 1 ? 1 : 0 };
+    });
+
+    const data = {
+      version: 3,
+      data: {
+        exercises: [
+          { id: "e1", name: "Bench", category: "chest", primary_muscles: "", secondary_muscles: "", equipment: "barbell", instructions: "", difficulty: "beginner", is_custom: 0 },
+          { id: "e2", name: "Squat", category: "legs_glutes", primary_muscles: "", secondary_muscles: "", equipment: "barbell", instructions: "", difficulty: "intermediate", is_custom: 0 },
+        ],
+      },
+    };
+
+    const result = await importData(data);
+    expect(result.inserted).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.perTable.exercises).toEqual({ inserted: 1, skipped: 1 });
+  });
+
+  it("handles v2 backward compatibility (missing tables as empty)", async () => {
+    mockDb.runAsync.mockResolvedValue({ changes: 1 });
+
+    const v2Data = {
+      version: 2,
+      exercises: [{ id: "e1", name: "Bench", category: "chest", primary_muscles: "", secondary_muscles: "", equipment: "barbell", instructions: "", difficulty: "beginner", is_custom: 0 }],
+      templates: [{ id: "t1", name: "Push", created_at: 1, updated_at: 1 }],
+    };
+
+    const result = await importData(v2Data);
+    expect(result.inserted).toBe(2);
+    // Missing tables should have 0 inserted
+    expect(result.perTable.programs).toEqual({ inserted: 0, skipped: 0 });
+    expect(result.perTable.achievements_earned).toEqual({ inserted: 0, skipped: 0 });
+  });
+
+  it("enables foreign keys pragma", async () => {
+    mockDb.runAsync.mockResolvedValue({ changes: 0 });
+    await importData({ version: 3, data: { exercises: [{ id: "1" }] } });
+    expect(mockDb.execAsync).toHaveBeenCalledWith("PRAGMA foreign_keys = ON");
+  });
+
+  it("calls progress callback during import", async () => {
+    mockDb.runAsync.mockResolvedValue({ changes: 1 });
+    const progress: string[] = [];
+    await importData(
+      { version: 3, data: { exercises: [{ id: "1" }] } },
+      (p) => progress.push(p.table)
+    );
+    expect(progress).toContain("exercises");
+    expect(progress[progress.length - 1]).toBe("done");
+  });
+
+  it("imports new tables: programs, achievements_earned, app_settings", async () => {
+    const inserted: string[] = [];
+    mockDb.runAsync.mockImplementation(async (sql: string) => {
+      const match = sql.match(/INSERT OR IGNORE INTO (\w+)/);
+      if (match) inserted.push(match[1]);
+      return { changes: 1 };
+    });
+
+    const data = {
+      version: 3,
+      data: {
+        programs: [{ id: "p1", name: "PPL", description: "", is_active: 1, current_day_id: null, created_at: 1, updated_at: 1, deleted_at: null }],
+        achievements_earned: [{ achievement_id: "first_workout", earned_at: 12345 }],
+        app_settings: [{ key: "theme", value: "dark" }],
+        program_days: [{ id: "pd1", program_id: "p1", template_id: null, position: 0, label: "Day 1" }],
+        program_log: [{ id: "pl1", program_id: "p1", day_id: "pd1", session_id: "s1", completed_at: 1 }],
+        weekly_schedule: [{ id: "ws1", day_of_week: 1, template_id: "t1", created_at: 1 }],
+        program_schedule: [{ program_id: "p1", day_of_week: 1, template_id: "t1" }],
+      },
+    };
+
+    await importData(data);
+    expect(inserted).toContain("programs");
+    expect(inserted).toContain("achievements_earned");
+    expect(inserted).toContain("app_settings");
+    expect(inserted).toContain("program_days");
+    expect(inserted).toContain("program_log");
+    expect(inserted).toContain("weekly_schedule");
+    expect(inserted).toContain("program_schedule");
+  });
+});
+
+// ---- estimateExportSize ----
+
+describe("estimateExportSize", () => {
+  it("returns size estimate based on row counts", async () => {
+    mockDb.getFirstAsync.mockResolvedValue({ cnt: 100 });
+    const { bytes, label } = await estimateExportSize();
+    expect(bytes).toBeGreaterThan(0);
+    expect(label).toBeTruthy();
+  });
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -8,9 +8,13 @@ import * as Sharing from "expo-sharing";
 import * as DocumentPicker from "expo-document-picker";
 import { useRouter } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
+import { Alert } from "react-native";
 import {
   exportAllData,
-  importData,
+  estimateExportSize,
+  validateBackupFileSize,
+  validateBackupData,
+  BACKUP_TABLE_LABELS,
   getWorkoutCSVData,
   getNutritionCSVData,
   getBodyWeightCSVData,
@@ -22,6 +26,7 @@ import {
   getBodySettings,
   updateBodySettings,
 } from "../../lib/db";
+import type { BackupTableName, ExportProgress } from "../../lib/db";
 
 import { getErrorCount } from "../../lib/errors";
 import { workoutCSV, nutritionCSV, bodyWeightCSV, bodyMeasurementsCSV } from "../../lib/csv-format";
@@ -68,6 +73,7 @@ export default function Settings() {
   const [measureUnit, setMeasureUnit] = useState<"cm" | "in">("cm");
   const [weightGoal, setWeightGoal] = useState<number | null>(null);
   const [fatGoal, setFatGoal] = useState<number | null>(null);
+  const [exportProgress, setExportProgress] = useState<string | null>(null);
 
   useFocusEffect(
     useCallback(() => {
@@ -183,21 +189,56 @@ export default function Settings() {
   };
 
   const handleExport = async () => {
-    setLoading(true);
     try {
-      const data = await exportAllData();
-      const json = JSON.stringify(data, null, 2);
-      const file = new File(Paths.cache, "fitforge-export.json");
-      await file.write(json);
-      await Sharing.shareAsync(file.uri, {
-        mimeType: "application/json",
-        dialogTitle: "Export FitForge Data",
-      });
-      setSnack("Data exported successfully");
+      const { label } = await estimateExportSize();
+      Alert.alert(
+        "Export All Data",
+        `Your backup will be approximately ${label}. This may take a moment. Continue?`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Export",
+            onPress: async () => {
+              setLoading(true);
+              setExportProgress("Preparing export...");
+              try {
+                const data = await exportAllData((progress: ExportProgress) => {
+                  if (progress.table === "done") {
+                    setExportProgress(null);
+                  } else {
+                    const label = BACKUP_TABLE_LABELS[progress.table as BackupTableName] ?? progress.table;
+                    setExportProgress(`Exporting ${label}... (${progress.tableIndex + 1}/${progress.totalTables})`);
+                  }
+                });
+
+                const totalRecords = Object.values(data.counts).reduce((a, b) => a + b, 0);
+                if (totalRecords === 0) {
+                  setSnack("No data to export");
+                  setLoading(false);
+                  setExportProgress(null);
+                  return;
+                }
+
+                const json = JSON.stringify(data, null, 2);
+                const file = new File(Paths.cache, `fitforge-backup-${dateStamp()}.json`);
+                await file.write(json);
+                await Sharing.shareAsync(file.uri, {
+                  mimeType: "application/json",
+                  dialogTitle: "Export FitForge Data",
+                });
+                setSnack("Data exported successfully");
+              } catch {
+                setSnack("Export failed");
+              } finally {
+                setLoading(false);
+                setExportProgress(null);
+              }
+            },
+          },
+        ]
+      );
     } catch {
-      setSnack("Export failed");
-    } finally {
-      setLoading(false);
+      setSnack("Could not estimate export size");
     }
   };
 
@@ -209,39 +250,51 @@ export default function Settings() {
       });
       if (result.canceled || !result.assets?.length) return;
 
+      const asset = result.assets[0];
+
+      // File size check
+      if (asset.size && asset.size > 50 * 1024 * 1024) {
+        Alert.alert("File Too Large", "This backup file is too large to process safely.");
+        return;
+      }
+
       setLoading(true);
-      const uri = result.assets[0].uri;
+      const uri = asset.uri;
       const file = new File(uri);
       const raw = await file.text();
+
+      // File size validation on content
+      const sizeError = validateBackupFileSize(raw.length);
+      if (sizeError) {
+        Alert.alert("File Too Large", sizeError.message);
+        setLoading(false);
+        return;
+      }
 
       let data: Record<string, unknown>;
       try {
         data = JSON.parse(raw);
       } catch {
-        setSnack("Invalid file format");
+        Alert.alert("Invalid File", "This file doesn't appear to be a valid FitForge backup.");
         setLoading(false);
         return;
       }
 
-      if (typeof data !== "object" || data === null) {
-        setSnack("Invalid file format");
+      const validationError = validateBackupData(data);
+      if (validationError) {
+        Alert.alert("Invalid Backup", validationError.message);
         setLoading(false);
         return;
       }
 
-      if (data.version !== 1 && data.version !== 2) {
-        setSnack("Unsupported format version");
-        setLoading(false);
-        return;
-      }
-
-      const { inserted } = await importData(
-        data as Parameters<typeof importData>[0]
-      );
-      setSnack(`Import complete — ${inserted} records added`);
+      // Navigate to import preview screen with the parsed data
+      setLoading(false);
+      router.push({
+        pathname: "/settings/import-backup",
+        params: { backupJson: raw },
+      });
     } catch {
       setSnack("Import failed");
-    } finally {
       setLoading(false);
     }
   };
@@ -468,7 +521,7 @@ export default function Settings() {
       <Card style={[styles.flowCard, styles.wideCard, { backgroundColor: theme.colors.surface }]}>
         <Card.Content>
           <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 16 }}>
-            Data
+            Data Management
           </Text>
 
           <View style={styles.buttonFlow}>
@@ -479,9 +532,10 @@ export default function Settings() {
               loading={loading}
               disabled={loading}
               contentStyle={styles.exportBtnContent}
-              accessibilityLabel="Export all data as JSON"
+              accessibilityLabel="Export all data as JSON backup"
+              accessibilityRole="button"
             >
-              Export All
+              Export All Data
             </Button>
 
             <Button
@@ -491,17 +545,50 @@ export default function Settings() {
               loading={loading}
               disabled={loading}
               contentStyle={styles.exportBtnContent}
-              accessibilityLabel="Import data"
+              accessibilityLabel="Import FitForge backup"
+              accessibilityRole="button"
             >
-              Import
+              Import FitForge Backup
             </Button>
           </View>
 
+          {exportProgress && (
+            <Text
+              variant="bodySmall"
+              style={{ color: theme.colors.primary, marginTop: 8 }}
+              accessibilityLiveRegion="polite"
+              accessibilityLabel={exportProgress}
+            >
+              {exportProgress}
+            </Text>
+          )}
+
           <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginTop: 8, marginBottom: 16 }}>
-            Export as JSON or import a previously exported file. Duplicates are skipped.
+            Export your complete FitForge data as a JSON backup file, or restore from a previous backup. Duplicates are skipped.
           </Text>
 
-          <Text variant="labelLarge" style={{ color: theme.colors.onSurface, marginBottom: 8 }}>
+          <Divider style={{ marginBottom: 16 }} />
+
+          <Button
+            mode="outlined"
+            icon="file-import-outline"
+            onPress={() => router.push("/settings/import-strong")}
+            contentStyle={styles.exportBtnContent}
+            accessibilityLabel="Import workout data from Strong CSV export"
+            accessibilityRole="button"
+          >
+            Import from Strong
+          </Button>
+
+          <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginTop: 8 }}>
+            Import workout history from the Strong app using a CSV export file.
+          </Text>
+        </Card.Content>
+      </Card>
+
+      <Card style={[styles.flowCard, styles.wideCard, { backgroundColor: theme.colors.surface }]}>
+        <Card.Content>
+          <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 16 }}>
             CSV Export
           </Text>
 
@@ -569,26 +656,6 @@ export default function Settings() {
               Measurements
             </Button>
           </View>
-
-          <Divider style={{ marginVertical: 16 }} />
-
-          <Text variant="labelLarge" style={{ color: theme.colors.onSurface, marginBottom: 8 }}>
-            CSV Import
-          </Text>
-
-          <Button
-            mode="outlined"
-            icon="file-import-outline"
-            onPress={() => router.push("/settings/import-strong")}
-            contentStyle={styles.exportBtnContent}
-            accessibilityLabel="Import workout data from Strong CSV export"
-          >
-            Import from Strong
-          </Button>
-
-          <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginTop: 8 }}>
-            Import workout history from the Strong app using a CSV export file.
-          </Text>
         </Card.Content>
       </Card>
 

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -532,7 +532,7 @@ export default function Settings() {
               loading={loading}
               disabled={loading}
               contentStyle={styles.exportBtnContent}
-              accessibilityLabel="Export all data as JSON backup"
+              accessibilityLabel="Export all data as JSON"
               accessibilityRole="button"
             >
               Export All Data
@@ -545,7 +545,7 @@ export default function Settings() {
               loading={loading}
               disabled={loading}
               contentStyle={styles.exportBtnContent}
-              accessibilityLabel="Import FitForge backup"
+              accessibilityLabel="Import data"
               accessibilityRole="button"
             >
               Import FitForge Backup

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -348,6 +348,15 @@ export default function RootLayout() {
               }}
             />
             <Stack.Screen
+              name="settings/import-backup"
+              options={{
+                headerShown: true,
+                title: "Import Backup",
+                headerStyle,
+                headerTintColor,
+              }}
+            />
+            <Stack.Screen
               name="tools/index"
               options={{
                 headerShown: true,

--- a/app/settings/import-backup.tsx
+++ b/app/settings/import-backup.tsx
@@ -1,0 +1,281 @@
+import { useState } from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
+import { Button, Card, DataTable, Snackbar, Text, useTheme } from "react-native-paper";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useLayout } from "../../lib/layout";
+import {
+  importData,
+  getBackupCounts,
+  BACKUP_TABLE_LABELS,
+  IMPORT_TABLE_ORDER,
+} from "../../lib/db";
+import type { BackupTableName, ImportProgress } from "../../lib/db";
+
+export default function ImportBackup() {
+  const theme = useTheme();
+  const router = useRouter();
+  const layout = useLayout();
+  const { backupJson } = useLocalSearchParams<{ backupJson: string }>();
+  const [loading, setLoading] = useState(false);
+  const [snack, setSnack] = useState("");
+  const [importProgress, setImportProgress] = useState<string | null>(null);
+  const [result, setResult] = useState<{
+    inserted: number;
+    skipped: number;
+    perTable: Record<string, { inserted: number; skipped: number }>;
+  } | null>(null);
+
+  if (!backupJson) {
+    return (
+      <View style={[styles.container, { backgroundColor: theme.colors.background, padding: 24 }]}>
+        <Text variant="bodyLarge" style={{ color: theme.colors.onBackground }}>
+          No backup data provided.
+        </Text>
+        <Button
+          mode="contained"
+          onPress={() => router.back()}
+          style={{ marginTop: 16 }}
+          contentStyle={{ paddingVertical: 8 }}
+          accessibilityLabel="Go back"
+          accessibilityRole="button"
+        >
+          Go Back
+        </Button>
+      </View>
+    );
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(backupJson);
+  } catch {
+    return (
+      <View style={[styles.container, { backgroundColor: theme.colors.background, padding: 24 }]}>
+        <Text variant="bodyLarge" style={{ color: theme.colors.error }}>
+          Invalid backup data.
+        </Text>
+        <Button
+          mode="contained"
+          onPress={() => router.back()}
+          style={{ marginTop: 16 }}
+          contentStyle={{ paddingVertical: 8 }}
+          accessibilityLabel="Go back"
+          accessibilityRole="button"
+        >
+          Go Back
+        </Button>
+      </View>
+    );
+  }
+
+  const version = Number(data.version ?? 0);
+  const exportedAt = (data.exported_at as string) ?? null;
+  const appVersion = (data.app_version as string) ?? null;
+  const counts = getBackupCounts(data);
+  const totalRecords = IMPORT_TABLE_ORDER.reduce((sum, t) => sum + counts[t], 0);
+
+  // Identify missing tables for v2 backups
+  const missingTables = version <= 2
+    ? IMPORT_TABLE_ORDER.filter((t) => counts[t] === 0 && ["programs", "program_days", "program_log", "app_settings", "weekly_schedule", "program_schedule", "achievements_earned"].includes(t))
+    : [];
+
+  const handleImport = async () => {
+    setLoading(true);
+    setImportProgress("Starting import...");
+    try {
+      const importResult = await importData(data, (progress: ImportProgress) => {
+        if (progress.table === "done") {
+          setImportProgress(null);
+        } else {
+          const label = BACKUP_TABLE_LABELS[progress.table as BackupTableName] ?? progress.table;
+          setImportProgress(`Importing ${label}... (${progress.tableIndex + 1}/${progress.totalTables})`);
+        }
+      });
+      setResult(importResult);
+      setSnack(`Import complete — ${importResult.inserted} records added, ${importResult.skipped} skipped`);
+    } catch {
+      setSnack("Import failed — all changes have been rolled back");
+    } finally {
+      setLoading(false);
+      setImportProgress(null);
+    }
+  };
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.colors.background }]}
+      contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
+    >
+      {!result ? (
+        <>
+          <Text variant="headlineSmall" style={{ color: theme.colors.onBackground, marginBottom: 16 }}>
+            Import Preview
+          </Text>
+
+          {(exportedAt || appVersion) && (
+            <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+              <Card.Content>
+                <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
+                  {exportedAt && `Exported: ${new Date(exportedAt).toLocaleDateString()}`}
+                  {exportedAt && appVersion && " · "}
+                  {appVersion && `App version: ${appVersion}`}
+                </Text>
+                <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
+                  Format version: {version} · Total records: {totalRecords}
+                </Text>
+              </Card.Content>
+            </Card>
+          )}
+
+          <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+            <Card.Content>
+              <Text variant="titleSmall" style={{ color: theme.colors.onSurface, marginBottom: 8 }}>
+                Records to Import
+              </Text>
+              <DataTable>
+                <DataTable.Header accessibilityRole="none">
+                  <DataTable.Title accessibilityLabel="Data type">Data</DataTable.Title>
+                  <DataTable.Title numeric accessibilityLabel="Number of records">Count</DataTable.Title>
+                </DataTable.Header>
+                {IMPORT_TABLE_ORDER.filter((t) => counts[t] > 0).map((tableName) => (
+                  <DataTable.Row key={tableName} accessibilityLabel={`${BACKUP_TABLE_LABELS[tableName]}: ${counts[tableName]} records`}>
+                    <DataTable.Cell>{BACKUP_TABLE_LABELS[tableName]}</DataTable.Cell>
+                    <DataTable.Cell numeric>{counts[tableName]}</DataTable.Cell>
+                  </DataTable.Row>
+                ))}
+              </DataTable>
+            </Card.Content>
+          </Card>
+
+          {missingTables.length > 0 && (
+            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 8 }}>
+              {missingTables.length} table{missingTables.length !== 1 ? "s" : ""} not present in this v{version} backup (this is normal for older backups).
+            </Text>
+          )}
+
+          <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 16 }}>
+            Existing records with the same ID will be skipped — your current data will not be overwritten.
+          </Text>
+
+          {importProgress && (
+            <Text
+              variant="bodySmall"
+              style={{ color: theme.colors.primary, marginBottom: 8 }}
+              accessibilityLiveRegion="polite"
+              accessibilityLabel={importProgress}
+            >
+              {importProgress}
+            </Text>
+          )}
+
+          <View style={styles.actions}>
+            <Button
+              mode="outlined"
+              onPress={() => router.back()}
+              disabled={loading}
+              style={styles.actionBtn}
+              contentStyle={{ paddingVertical: 8 }}
+              accessibilityLabel="Cancel import"
+              accessibilityRole="button"
+            >
+              Cancel
+            </Button>
+            <Button
+              mode="contained"
+              onPress={handleImport}
+              loading={loading}
+              disabled={loading}
+              style={styles.actionBtn}
+              contentStyle={{ paddingVertical: 8 }}
+              accessibilityLabel={`Import ${totalRecords} records`}
+              accessibilityRole="button"
+            >
+              Import
+            </Button>
+          </View>
+        </>
+      ) : (
+        <>
+          <Text variant="headlineSmall" style={{ color: theme.colors.onBackground, marginBottom: 16 }}>
+            Import Complete
+          </Text>
+
+          <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+            <Card.Content>
+              <Text variant="titleMedium" style={{ color: theme.colors.primary, marginBottom: 8 }}>
+                {result.inserted} records imported
+              </Text>
+              {result.skipped > 0 && (
+                <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 12 }}>
+                  {result.skipped} records skipped (already existed)
+                </Text>
+              )}
+
+              <DataTable>
+                <DataTable.Header accessibilityRole="none">
+                  <DataTable.Title accessibilityLabel="Data type">Data</DataTable.Title>
+                  <DataTable.Title numeric accessibilityLabel="Records imported">Imported</DataTable.Title>
+                  <DataTable.Title numeric accessibilityLabel="Records skipped">Skipped</DataTable.Title>
+                </DataTable.Header>
+                {IMPORT_TABLE_ORDER.filter(
+                  (t) => (result.perTable[t]?.inserted ?? 0) > 0 || (result.perTable[t]?.skipped ?? 0) > 0
+                ).map((tableName) => (
+                  <DataTable.Row
+                    key={tableName}
+                    accessibilityLabel={`${BACKUP_TABLE_LABELS[tableName]}: ${result.perTable[tableName]?.inserted ?? 0} imported, ${result.perTable[tableName]?.skipped ?? 0} skipped`}
+                  >
+                    <DataTable.Cell>{BACKUP_TABLE_LABELS[tableName]}</DataTable.Cell>
+                    <DataTable.Cell numeric>{result.perTable[tableName]?.inserted ?? 0}</DataTable.Cell>
+                    <DataTable.Cell numeric>{result.perTable[tableName]?.skipped ?? 0}</DataTable.Cell>
+                  </DataTable.Row>
+                ))}
+              </DataTable>
+            </Card.Content>
+          </Card>
+
+          <Button
+            mode="contained"
+            onPress={() => router.back()}
+            style={{ marginTop: 16 }}
+            contentStyle={{ paddingVertical: 8 }}
+            accessibilityLabel="Done, return to settings"
+            accessibilityRole="button"
+          >
+            Done
+          </Button>
+        </>
+      )}
+
+      <Snackbar
+        visible={!!snack}
+        onDismiss={() => setSnack("")}
+        duration={4000}
+        action={{ label: "OK", onPress: () => setSnack("") }}
+      >
+        {snack}
+      </Snackbar>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    paddingTop: 16,
+    paddingBottom: 48,
+  },
+  card: {
+    marginBottom: 16,
+    borderRadius: 12,
+  },
+  actions: {
+    flexDirection: "row",
+    gap: 12,
+    justifyContent: "flex-end",
+  },
+  actionBtn: {
+    minWidth: 120,
+  },
+});

--- a/app/settings/import-backup.tsx
+++ b/app/settings/import-backup.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { useMemo, useState } from "react";
+import { FlatList, StyleSheet, View } from "react-native";
 import { Button, Card, DataTable, Snackbar, Text, useTheme } from "react-native-paper";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useLayout } from "../../lib/layout";
@@ -25,6 +25,54 @@ export default function ImportBackup() {
     perTable: Record<string, { inserted: number; skipped: number }>;
   } | null>(null);
 
+  const parsed = useMemo(() => {
+    if (!backupJson) return null;
+    try {
+      return JSON.parse(backupJson) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }, [backupJson]);
+
+  const version = parsed ? Number(parsed.version ?? 0) : 0;
+  const exportedAt = parsed ? ((parsed.exported_at as string) ?? null) : null;
+  const appVersion = parsed ? ((parsed.app_version as string) ?? null) : null;
+  const counts = useMemo(
+    () => (parsed ? getBackupCounts(parsed) : ({} as Record<BackupTableName, number>)),
+    [parsed],
+  );
+  const totalRecords = useMemo(
+    () => (parsed ? IMPORT_TABLE_ORDER.reduce((sum, t) => sum + (counts[t] ?? 0), 0) : 0),
+    [parsed, counts],
+  );
+
+  const missingTables = useMemo(
+    () =>
+      parsed && version <= 2
+        ? IMPORT_TABLE_ORDER.filter(
+            (t) =>
+              (counts[t] ?? 0) === 0 &&
+              ["programs", "program_days", "program_log", "app_settings", "weekly_schedule", "program_schedule", "achievements_earned"].includes(t),
+          )
+        : [],
+    [parsed, version, counts],
+  );
+
+  const tablesToShow = useMemo(
+    () => (parsed ? IMPORT_TABLE_ORDER.filter((t) => (counts[t] ?? 0) > 0) : []),
+    [parsed, counts],
+  );
+
+  const resultTablesToShow = useMemo(
+    () =>
+      result
+        ? IMPORT_TABLE_ORDER.filter(
+            (t) => (result.perTable[t]?.inserted ?? 0) > 0 || (result.perTable[t]?.skipped ?? 0) > 0,
+          )
+        : [],
+    [result],
+  );
+
   if (!backupJson) {
     return (
       <View style={[styles.container, { backgroundColor: theme.colors.background, padding: 24 }]}>
@@ -45,10 +93,7 @@ export default function ImportBackup() {
     );
   }
 
-  let data: Record<string, unknown>;
-  try {
-    data = JSON.parse(backupJson);
-  } catch {
+  if (!parsed) {
     return (
       <View style={[styles.container, { backgroundColor: theme.colors.background, padding: 24 }]}>
         <Text variant="bodyLarge" style={{ color: theme.colors.error }}>
@@ -68,22 +113,11 @@ export default function ImportBackup() {
     );
   }
 
-  const version = Number(data.version ?? 0);
-  const exportedAt = (data.exported_at as string) ?? null;
-  const appVersion = (data.app_version as string) ?? null;
-  const counts = getBackupCounts(data);
-  const totalRecords = IMPORT_TABLE_ORDER.reduce((sum, t) => sum + counts[t], 0);
-
-  // Identify missing tables for v2 backups
-  const missingTables = version <= 2
-    ? IMPORT_TABLE_ORDER.filter((t) => counts[t] === 0 && ["programs", "program_days", "program_log", "app_settings", "weekly_schedule", "program_schedule", "achievements_earned"].includes(t))
-    : [];
-
   const handleImport = async () => {
     setLoading(true);
     setImportProgress("Starting import...");
     try {
-      const importResult = await importData(data, (progress: ImportProgress) => {
+      const importResult = await importData(parsed, (progress: ImportProgress) => {
         if (progress.table === "done") {
           setImportProgress(null);
         } else {
@@ -102,148 +136,168 @@ export default function ImportBackup() {
   };
 
   return (
-    <ScrollView
-      style={[styles.container, { backgroundColor: theme.colors.background }]}
-      contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
-    >
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
       {!result ? (
-        <>
-          <Text variant="headlineSmall" style={{ color: theme.colors.onBackground, marginBottom: 16 }}>
-            Import Preview
-          </Text>
-
-          {(exportedAt || appVersion) && (
-            <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
-              <Card.Content>
-                <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
-                  {exportedAt && `Exported: ${new Date(exportedAt).toLocaleDateString()}`}
-                  {exportedAt && appVersion && " · "}
-                  {appVersion && `App version: ${appVersion}`}
-                </Text>
-                <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
-                  Format version: {version} · Total records: {totalRecords}
-                </Text>
-              </Card.Content>
-            </Card>
-          )}
-
-          <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
-            <Card.Content>
-              <Text variant="titleSmall" style={{ color: theme.colors.onSurface, marginBottom: 8 }}>
-                Records to Import
+        <FlatList
+          data={tablesToShow}
+          keyExtractor={(item) => item}
+          contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
+          ListHeaderComponent={
+            <>
+              <Text variant="headlineSmall" style={{ color: theme.colors.onBackground, marginBottom: 16 }}>
+                Import Preview
               </Text>
+
+              {(exportedAt || appVersion) && (
+                <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+                  <Card.Content>
+                    <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
+                      {exportedAt && `Exported: ${new Date(exportedAt).toLocaleDateString()}`}
+                      {exportedAt && appVersion && " · "}
+                      {appVersion && `App version: ${appVersion}`}
+                    </Text>
+                    <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
+                      Format version: {version} · Total records: {totalRecords}
+                    </Text>
+                  </Card.Content>
+                </Card>
+              )}
+
+              <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+                <Card.Content>
+                  <Text variant="titleSmall" style={{ color: theme.colors.onSurface, marginBottom: 8 }}>
+                    Records to Import
+                  </Text>
+                  <DataTable>
+                    <DataTable.Header accessibilityRole="none">
+                      <DataTable.Title accessibilityLabel="Data type">Data</DataTable.Title>
+                      <DataTable.Title numeric accessibilityLabel="Number of records">Count</DataTable.Title>
+                    </DataTable.Header>
+                  </DataTable>
+                </Card.Content>
+              </Card>
+            </>
+          }
+          renderItem={({ item: tableName }) => (
+            <View style={{ paddingHorizontal: 0 }}>
               <DataTable>
-                <DataTable.Header accessibilityRole="none">
-                  <DataTable.Title accessibilityLabel="Data type">Data</DataTable.Title>
-                  <DataTable.Title numeric accessibilityLabel="Number of records">Count</DataTable.Title>
-                </DataTable.Header>
-                {IMPORT_TABLE_ORDER.filter((t) => counts[t] > 0).map((tableName) => (
-                  <DataTable.Row key={tableName} accessibilityLabel={`${BACKUP_TABLE_LABELS[tableName]}: ${counts[tableName]} records`}>
-                    <DataTable.Cell>{BACKUP_TABLE_LABELS[tableName]}</DataTable.Cell>
-                    <DataTable.Cell numeric>{counts[tableName]}</DataTable.Cell>
-                  </DataTable.Row>
-                ))}
+                <DataTable.Row accessibilityLabel={`${BACKUP_TABLE_LABELS[tableName]}: ${counts[tableName]} records`}>
+                  <DataTable.Cell>{BACKUP_TABLE_LABELS[tableName]}</DataTable.Cell>
+                  <DataTable.Cell numeric>{counts[tableName]}</DataTable.Cell>
+                </DataTable.Row>
               </DataTable>
-            </Card.Content>
-          </Card>
-
-          {missingTables.length > 0 && (
-            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 8 }}>
-              {missingTables.length} table{missingTables.length !== 1 ? "s" : ""} not present in this v{version} backup (this is normal for older backups).
-            </Text>
+            </View>
           )}
-
-          <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 16 }}>
-            Existing records with the same ID will be skipped — your current data will not be overwritten.
-          </Text>
-
-          {importProgress && (
-            <Text
-              variant="bodySmall"
-              style={{ color: theme.colors.primary, marginBottom: 8 }}
-              accessibilityLiveRegion="polite"
-              accessibilityLabel={importProgress}
-            >
-              {importProgress}
-            </Text>
-          )}
-
-          <View style={styles.actions}>
-            <Button
-              mode="outlined"
-              onPress={() => router.back()}
-              disabled={loading}
-              style={styles.actionBtn}
-              contentStyle={{ paddingVertical: 8 }}
-              accessibilityLabel="Cancel import"
-              accessibilityRole="button"
-            >
-              Cancel
-            </Button>
-            <Button
-              mode="contained"
-              onPress={handleImport}
-              loading={loading}
-              disabled={loading}
-              style={styles.actionBtn}
-              contentStyle={{ paddingVertical: 8 }}
-              accessibilityLabel={`Import ${totalRecords} records`}
-              accessibilityRole="button"
-            >
-              Import
-            </Button>
-          </View>
-        </>
-      ) : (
-        <>
-          <Text variant="headlineSmall" style={{ color: theme.colors.onBackground, marginBottom: 16 }}>
-            Import Complete
-          </Text>
-
-          <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
-            <Card.Content>
-              <Text variant="titleMedium" style={{ color: theme.colors.primary, marginBottom: 8 }}>
-                {result.inserted} records imported
-              </Text>
-              {result.skipped > 0 && (
-                <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 12 }}>
-                  {result.skipped} records skipped (already existed)
+          ListFooterComponent={
+            <>
+              {missingTables.length > 0 && (
+                <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 8 }}>
+                  {missingTables.length} table{missingTables.length !== 1 ? "s" : ""} not present in this v{version} backup (this is normal for older backups).
                 </Text>
               )}
 
-              <DataTable>
-                <DataTable.Header accessibilityRole="none">
-                  <DataTable.Title accessibilityLabel="Data type">Data</DataTable.Title>
-                  <DataTable.Title numeric accessibilityLabel="Records imported">Imported</DataTable.Title>
-                  <DataTable.Title numeric accessibilityLabel="Records skipped">Skipped</DataTable.Title>
-                </DataTable.Header>
-                {IMPORT_TABLE_ORDER.filter(
-                  (t) => (result.perTable[t]?.inserted ?? 0) > 0 || (result.perTable[t]?.skipped ?? 0) > 0
-                ).map((tableName) => (
-                  <DataTable.Row
-                    key={tableName}
-                    accessibilityLabel={`${BACKUP_TABLE_LABELS[tableName]}: ${result.perTable[tableName]?.inserted ?? 0} imported, ${result.perTable[tableName]?.skipped ?? 0} skipped`}
-                  >
-                    <DataTable.Cell>{BACKUP_TABLE_LABELS[tableName]}</DataTable.Cell>
-                    <DataTable.Cell numeric>{result.perTable[tableName]?.inserted ?? 0}</DataTable.Cell>
-                    <DataTable.Cell numeric>{result.perTable[tableName]?.skipped ?? 0}</DataTable.Cell>
-                  </DataTable.Row>
-                ))}
-              </DataTable>
-            </Card.Content>
-          </Card>
+              <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 16 }}>
+                Existing records with the same ID will be skipped — your current data will not be overwritten.
+              </Text>
 
-          <Button
-            mode="contained"
-            onPress={() => router.back()}
-            style={{ marginTop: 16 }}
-            contentStyle={{ paddingVertical: 8 }}
-            accessibilityLabel="Done, return to settings"
-            accessibilityRole="button"
-          >
-            Done
-          </Button>
-        </>
+              {importProgress && (
+                <Text
+                  variant="bodySmall"
+                  style={{ color: theme.colors.primary, marginBottom: 8 }}
+                  accessibilityLiveRegion="polite"
+                  accessibilityLabel={importProgress}
+                >
+                  {importProgress}
+                </Text>
+              )}
+
+              <View style={styles.actions}>
+                <Button
+                  mode="outlined"
+                  onPress={() => router.back()}
+                  disabled={loading}
+                  style={styles.actionBtn}
+                  contentStyle={{ paddingVertical: 8 }}
+                  accessibilityLabel="Cancel import"
+                  accessibilityRole="button"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  mode="contained"
+                  onPress={handleImport}
+                  loading={loading}
+                  disabled={loading}
+                  style={styles.actionBtn}
+                  contentStyle={{ paddingVertical: 8 }}
+                  accessibilityLabel={`Import ${totalRecords} records`}
+                  accessibilityRole="button"
+                >
+                  Import
+                </Button>
+              </View>
+            </>
+          }
+        />
+      ) : (
+        <FlatList
+          data={resultTablesToShow}
+          keyExtractor={(item) => item}
+          contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
+          ListHeaderComponent={
+            <>
+              <Text variant="headlineSmall" style={{ color: theme.colors.onBackground, marginBottom: 16 }}>
+                Import Complete
+              </Text>
+
+              <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+                <Card.Content>
+                  <Text variant="titleMedium" style={{ color: theme.colors.primary, marginBottom: 8 }}>
+                    {result.inserted} records imported
+                  </Text>
+                  {result.skipped > 0 && (
+                    <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 12 }}>
+                      {result.skipped} records skipped (already existed)
+                    </Text>
+                  )}
+
+                  <DataTable>
+                    <DataTable.Header accessibilityRole="none">
+                      <DataTable.Title accessibilityLabel="Data type">Data</DataTable.Title>
+                      <DataTable.Title numeric accessibilityLabel="Records imported">Imported</DataTable.Title>
+                      <DataTable.Title numeric accessibilityLabel="Records skipped">Skipped</DataTable.Title>
+                    </DataTable.Header>
+                  </DataTable>
+                </Card.Content>
+              </Card>
+            </>
+          }
+          renderItem={({ item: tableName }) => (
+            <View style={{ paddingHorizontal: 0 }}>
+              <DataTable>
+                <DataTable.Row
+                  accessibilityLabel={`${BACKUP_TABLE_LABELS[tableName]}: ${result.perTable[tableName]?.inserted ?? 0} imported, ${result.perTable[tableName]?.skipped ?? 0} skipped`}
+                >
+                  <DataTable.Cell>{BACKUP_TABLE_LABELS[tableName]}</DataTable.Cell>
+                  <DataTable.Cell numeric>{result.perTable[tableName]?.inserted ?? 0}</DataTable.Cell>
+                  <DataTable.Cell numeric>{result.perTable[tableName]?.skipped ?? 0}</DataTable.Cell>
+                </DataTable.Row>
+              </DataTable>
+            </View>
+          )}
+          ListFooterComponent={
+            <Button
+              mode="contained"
+              onPress={() => router.back()}
+              style={{ marginTop: 16 }}
+              contentStyle={{ paddingVertical: 8 }}
+              accessibilityLabel="Done, return to settings"
+              accessibilityRole="button"
+            >
+              Done
+            </Button>
+          }
+        />
       )}
 
       <Snackbar
@@ -254,7 +308,7 @@ export default function ImportBackup() {
       >
         {snack}
       </Snackbar>
-    </ScrollView>
+    </View>
   );
 }
 

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -7,181 +7,483 @@ import type {
   BodyWeight,
   BodyMeasurements,
   BodySettings,
+  Program,
+  ProgramDay,
+  ProgramLog,
 } from "../types";
 import { getDatabase } from "./helpers";
 
-export async function exportAllData(): Promise<{
-  version: number;
-  exported_at: string;
+// --------------- Backup Format Types ---------------
+
+export type BackupTableName =
+  | "exercises"
+  | "workout_templates"
+  | "programs"
+  | "food_entries"
+  | "macro_targets"
+  | "body_weight"
+  | "body_measurements"
+  | "body_settings"
+  | "app_settings"
+  | "achievements_earned"
+  | "template_exercises"
+  | "workout_sessions"
+  | "program_days"
+  | "workout_sets"
+  | "daily_log"
+  | "program_log"
+  | "weekly_schedule"
+  | "program_schedule";
+
+export const BACKUP_TABLE_LABELS: Record<BackupTableName, string> = {
+  exercises: "Exercises",
+  workout_templates: "Workout Templates",
+  programs: "Programs",
+  food_entries: "Food Entries",
+  macro_targets: "Macro Targets",
+  body_weight: "Body Weight",
+  body_measurements: "Body Measurements",
+  body_settings: "Body Settings",
+  app_settings: "App Settings",
+  achievements_earned: "Achievements",
+  template_exercises: "Template Exercises",
+  workout_sessions: "Workout Sessions",
+  program_days: "Program Days",
+  workout_sets: "Workout Sets",
+  daily_log: "Daily Log",
+  program_log: "Program Log",
+  weekly_schedule: "Weekly Schedule",
+  program_schedule: "Program Schedule",
+};
+
+// FK-dependency order for import — parents before children
+export const IMPORT_TABLE_ORDER: BackupTableName[] = [
+  "exercises",
+  "workout_templates",
+  "programs",
+  "food_entries",
+  "macro_targets",
+  "body_weight",
+  "body_measurements",
+  "body_settings",
+  "app_settings",
+  "achievements_earned",
+  "template_exercises",
+  "workout_sessions",
+  "program_days",
+  "workout_sets",
+  "daily_log",
+  "program_log",
+  "weekly_schedule",
+  "program_schedule",
+];
+
+export type AppSettingRow = { key: string; value: string };
+export type AchievementEarnedRow = { achievement_id: string; earned_at: number };
+export type WeeklyScheduleRow = { id: string; day_of_week: number; template_id: string; created_at: number };
+export type ProgramScheduleRow = { program_id: string; day_of_week: number; template_id: string };
+
+export type BackupV3Data = {
   exercises: unknown[];
-  templates: WorkoutTemplate[];
+  workout_templates: WorkoutTemplate[];
   template_exercises: TemplateExercise[];
-  sessions: WorkoutSession[];
-  sets: WorkoutSet[];
+  workout_sessions: WorkoutSession[];
+  workout_sets: WorkoutSet[];
   food_entries: unknown[];
   daily_log: { id: string; food_entry_id: string; date: string; meal: string; servings: number; logged_at: number }[];
   macro_targets: MacroTargets[];
   body_weight: BodyWeight[];
   body_measurements: BodyMeasurements[];
   body_settings: BodySettings[];
-}> {
+  programs: Program[];
+  program_days: ProgramDay[];
+  program_log: ProgramLog[];
+  app_settings: AppSettingRow[];
+  weekly_schedule: WeeklyScheduleRow[];
+  program_schedule: ProgramScheduleRow[];
+  achievements_earned: AchievementEarnedRow[];
+};
+
+export type BackupV3 = {
+  version: 3;
+  app_version: string;
+  exported_at: string;
+  data: BackupV3Data;
+  counts: Record<string, number>;
+};
+
+export type ExportProgress = {
+  table: string;
+  tableIndex: number;
+  totalTables: number;
+};
+
+export type ImportProgress = {
+  table: string;
+  tableIndex: number;
+  totalTables: number;
+};
+
+export type ImportResult = {
+  inserted: number;
+  skipped: number;
+  perTable: Record<string, { inserted: number; skipped: number }>;
+};
+
+// Numeric fields that must be non-negative for validation
+const NUMERIC_NONNEG_FIELDS: Record<string, string[]> = {
+  food_entries: ["calories", "protein", "carbs", "fat"],
+  macro_targets: ["calories", "protein", "carbs", "fat"],
+  body_weight: ["weight"],
+  workout_sets: ["weight", "reps", "set_number"],
+  template_exercises: ["position", "target_sets", "rest_seconds"],
+  program_days: ["position"],
+};
+
+const MAX_BACKUP_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+// --------------- Validation ---------------
+
+export type ValidationError = {
+  type: "corrupt_json" | "missing_version" | "future_version" | "missing_data" | "invalid_table" | "negative_values" | "empty_backup" | "file_too_large";
+  message: string;
+};
+
+export function validateBackupFileSize(sizeBytes: number): ValidationError | null {
+  if (sizeBytes > MAX_BACKUP_FILE_SIZE) {
+    return { type: "file_too_large", message: "This backup file is too large to process safely." };
+  }
+  return null;
+}
+
+export function validateBackupData(data: unknown): ValidationError | null {
+  if (typeof data !== "object" || data === null) {
+    return { type: "corrupt_json", message: "This file doesn't appear to be a valid FitForge backup." };
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  // Check version
+  if (obj.version === undefined || obj.version === null) {
+    return { type: "missing_version", message: "This file doesn't appear to be a valid FitForge backup." };
+  }
+
+  const version = Number(obj.version);
+  if (version >= 4) {
+    return { type: "future_version", message: "This backup was created with a newer version of FitForge. Please update the app first." };
+  }
+
+  // v2 backups have data at top level, v3 under data key
+  const tableData = version <= 2 ? obj : (obj.data as Record<string, unknown> | undefined);
+
+  if (version >= 3 && (!tableData || typeof tableData !== "object")) {
+    return { type: "missing_data", message: "This file doesn't appear to be a valid FitForge backup." };
+  }
+
+  // Validate arrays and numeric fields (check types before checking emptiness)
+  if (tableData && typeof tableData === "object") {
+    for (const tableName of IMPORT_TABLE_ORDER) {
+      const key = getV2Key(tableName, version);
+      const arr = (tableData as Record<string, unknown>)[key];
+      if (arr === undefined || arr === null) continue;
+      if (!Array.isArray(arr)) {
+        return { type: "invalid_table", message: `Invalid data format: "${tableName}" should be an array.` };
+      }
+
+      // Validate non-negative numerics
+      const numericFields = NUMERIC_NONNEG_FIELDS[tableName];
+      if (numericFields) {
+        for (const row of arr) {
+          if (typeof row !== "object" || row === null) continue;
+          const r = row as Record<string, unknown>;
+          for (const field of numericFields) {
+            const val = r[field];
+            if (val !== null && val !== undefined && typeof val === "number" && val < 0) {
+              return { type: "negative_values", message: "Backup contains invalid data (negative values)." };
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Check if backup is empty (no arrays with data)
+  if (tableData && typeof tableData === "object") {
+    const hasAnyData = IMPORT_TABLE_ORDER.some((tableName) => {
+      const key = getV2Key(tableName, version);
+      const arr = (tableData as Record<string, unknown>)[key];
+      return Array.isArray(arr) && arr.length > 0;
+    });
+    if (!hasAnyData) {
+      return { type: "empty_backup", message: "This backup file contains no data." };
+    }
+  }
+
+  return null;
+}
+
+// v2 backups use different key names for some tables
+function getV2Key(tableName: BackupTableName, version: number): string {
+  if (version <= 2) {
+    const v2KeyMap: Partial<Record<BackupTableName, string>> = {
+      workout_templates: "templates",
+      template_exercises: "template_exercises",
+      workout_sessions: "sessions",
+      workout_sets: "sets",
+    };
+    return v2KeyMap[tableName] ?? tableName;
+  }
+  return tableName;
+}
+
+/** Extract record counts from a parsed backup for the preview screen */
+export function getBackupCounts(data: Record<string, unknown>): Record<BackupTableName, number> {
+  const version = Number(data.version ?? 0);
+  const tableData = version <= 2 ? data : (data.data as Record<string, unknown> | undefined) ?? {};
+  const counts: Record<string, number> = {};
+  for (const tableName of IMPORT_TABLE_ORDER) {
+    const key = getV2Key(tableName, version);
+    const arr = (tableData as Record<string, unknown>)[key];
+    counts[tableName] = Array.isArray(arr) ? arr.length : 0;
+  }
+  return counts as Record<BackupTableName, number>;
+}
+
+/** Estimate export file size (rough estimate based on row counts) */
+export async function estimateExportSize(): Promise<{ bytes: number; label: string }> {
   const database = await getDatabase();
-  const exercises = await database.getAllAsync("SELECT * FROM exercises");
-  const templates = await database.getAllAsync<WorkoutTemplate>("SELECT * FROM workout_templates");
-  const tplExercises = await database.getAllAsync<TemplateExercise>("SELECT * FROM template_exercises");
-  const sessions = await database.getAllAsync<WorkoutSession>("SELECT * FROM workout_sessions");
-  const sets = await database.getAllAsync<WorkoutSet>("SELECT * FROM workout_sets");
-  const foods = await database.getAllAsync("SELECT * FROM food_entries");
-  const logs = await database.getAllAsync<{ id: string; food_entry_id: string; date: string; meal: string; servings: number; logged_at: number }>("SELECT * FROM daily_log");
-  const targets = await database.getAllAsync<MacroTargets>("SELECT * FROM macro_targets");
-  const weights = await database.getAllAsync<BodyWeight>("SELECT * FROM body_weight");
-  const measurements = await database.getAllAsync<BodyMeasurements>("SELECT * FROM body_measurements");
-  const bodySettings = await database.getAllAsync<BodySettings>("SELECT * FROM body_settings");
+  let totalRows = 0;
+  for (const table of IMPORT_TABLE_ORDER) {
+    const result = await database.getFirstAsync<{ cnt: number }>(`SELECT COUNT(*) as cnt FROM ${table}`);
+    totalRows += result?.cnt ?? 0;
+  }
+  // ~200 bytes per row average for JSON representation
+  const bytes = Math.max(totalRows * 200, 256);
+  const label = bytes < 1024 * 1024
+    ? `${Math.ceil(bytes / 1024)} KB`
+    : `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return { bytes, label };
+}
+
+// --------------- Export ---------------
+
+export async function exportAllData(
+  onProgress?: (progress: ExportProgress) => void
+): Promise<BackupV3> {
+  const database = await getDatabase();
+  const tables = IMPORT_TABLE_ORDER;
+  const data: Record<string, unknown[]> = {};
+  const counts: Record<string, number> = {};
+
+  for (let i = 0; i < tables.length; i++) {
+    const table = tables[i];
+    onProgress?.({ table, tableIndex: i, totalTables: tables.length });
+    const rows = await database.getAllAsync(`SELECT * FROM ${table}`);
+    data[table] = rows;
+    counts[table] = rows.length;
+  }
+
+  onProgress?.({ table: "done", tableIndex: tables.length, totalTables: tables.length });
+
   return {
-    version: 2,
+    version: 3,
+    app_version: "1.0.0",
     exported_at: new Date().toISOString(),
-    exercises,
-    templates,
-    template_exercises: tplExercises,
-    sessions,
-    sets,
-    food_entries: foods,
-    daily_log: logs,
-    macro_targets: targets,
-    body_weight: weights,
-    body_measurements: measurements,
-    body_settings: bodySettings,
+    data: data as unknown as BackupV3Data,
+    counts,
   };
 }
 
-export async function importData(data: {
-  version: number;
-  exercises?: { id: string; name: string; category: string; primary_muscles: string; secondary_muscles: string; equipment: string; instructions: string; difficulty: string; is_custom: number }[];
-  templates?: { id: string; name: string; created_at: number; updated_at: number }[];
-  template_exercises?: { id: string; template_id: string; exercise_id: string; position: number; target_sets: number; target_reps: string; rest_seconds: number; link_id?: string | null; link_label?: string }[];
-  sessions?: { id: string; template_id: string | null; name: string; started_at: number; completed_at: number | null; duration_seconds: number | null; notes: string }[];
-  sets?: { id: string; session_id: string; exercise_id: string; set_number: number; weight: number | null; reps: number | null; completed: number; completed_at: number | null; set_rpe?: number | null; set_notes?: string; link_id?: string | null; round?: number | null; training_mode?: string | null; tempo?: string | null }[];
-  food_entries?: { id: string; name: string; calories: number; protein: number; carbs: number; fat: number; serving_size: string; is_favorite: number; created_at: number }[];
-  daily_log?: { id: string; food_entry_id: string; date: string; meal: string; servings: number; logged_at: number }[];
-  macro_targets?: { id: string; calories: number; protein: number; carbs: number; fat: number; updated_at: number }[];
-  body_weight?: { id: string; weight: number; date: string; notes: string; logged_at: number }[];
-  body_measurements?: { id: string; date: string; waist: number | null; chest: number | null; hips: number | null; left_arm: number | null; right_arm: number | null; left_thigh: number | null; right_thigh: number | null; left_calf: number | null; right_calf: number | null; neck: number | null; body_fat: number | null; notes: string; logged_at: number }[];
-  body_settings?: { id: string; weight_unit: string; measurement_unit: string; weight_goal: number | null; body_fat_goal: number | null; updated_at: number }[];
-}): Promise<{ inserted: number }> {
+// --------------- Import ---------------
+
+export async function importData(
+  data: Record<string, unknown>,
+  onProgress?: (progress: ImportProgress) => void
+): Promise<ImportResult> {
   const database = await getDatabase();
-  let inserted = 0;
+  const version = Number(data.version ?? 0);
+  const tableData = version <= 2 ? data : (data.data as Record<string, unknown> | undefined) ?? {};
+  let totalInserted = 0;
+  let totalSkipped = 0;
+  const perTable: Record<string, { inserted: number; skipped: number }> = {};
 
   await database.withTransactionAsync(async () => {
-    if (data.exercises) {
-      for (const e of data.exercises) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty, is_custom) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-          [e.id, e.name, e.category, e.primary_muscles, e.secondary_muscles, e.equipment, e.instructions, e.difficulty, e.is_custom]
-        );
-        inserted += r.changes;
-      }
-    }
+    // Ensure foreign keys are enforced
+    await database.execAsync("PRAGMA foreign_keys = ON");
 
-    if (data.templates) {
-      for (const t of data.templates) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO workout_templates (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)",
-          [t.id, t.name, t.created_at, t.updated_at]
-        );
-        inserted += r.changes;
-      }
-    }
+    for (let i = 0; i < IMPORT_TABLE_ORDER.length; i++) {
+      const tableName = IMPORT_TABLE_ORDER[i];
+      const key = getV2Key(tableName, version);
+      const rows = (tableData as Record<string, unknown>)[key];
 
-    if (data.template_exercises) {
-      for (const te of data.template_exercises) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds, link_id, link_label) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-          [te.id, te.template_id, te.exercise_id, te.position, te.target_sets, te.target_reps, te.rest_seconds, te.link_id ?? null, te.link_label ?? ""]
-        );
-        inserted += r.changes;
-      }
-    }
+      onProgress?.({ table: tableName, tableIndex: i, totalTables: IMPORT_TABLE_ORDER.length });
 
-    if (data.sessions) {
-      for (const s of data.sessions) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO workout_sessions (id, template_id, name, started_at, completed_at, duration_seconds, notes) VALUES (?, ?, ?, ?, ?, ?, ?)",
-          [s.id, s.template_id, s.name, s.started_at, s.completed_at, s.duration_seconds, s.notes]
-        );
-        inserted += r.changes;
+      if (!Array.isArray(rows) || rows.length === 0) {
+        perTable[tableName] = { inserted: 0, skipped: 0 };
+        continue;
       }
-    }
 
-    if (data.sets) {
-      for (const s of data.sets) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, training_mode, tempo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-          [s.id, s.session_id, s.exercise_id, s.set_number, s.weight, s.reps, s.completed, s.completed_at, s.set_rpe ?? null, s.set_notes ?? "", s.link_id ?? null, s.round ?? null, s.training_mode ?? null, s.tempo ?? null]
-        );
-        inserted += r.changes;
-      }
-    }
-
-    if (data.food_entries) {
-      for (const f of data.food_entries) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO food_entries (id, name, calories, protein, carbs, fat, serving_size, is_favorite, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-          [f.id, f.name, f.calories, f.protein, f.carbs, f.fat, f.serving_size, f.is_favorite, f.created_at]
-        );
-        inserted += r.changes;
-      }
-    }
-
-    if (data.daily_log) {
-      for (const l of data.daily_log) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO daily_log (id, food_entry_id, date, meal, servings, logged_at) VALUES (?, ?, ?, ?, ?, ?)",
-          [l.id, l.food_entry_id, l.date, l.meal, l.servings, l.logged_at]
-        );
-        inserted += r.changes;
-      }
-    }
-
-    if (data.macro_targets) {
-      for (const t of data.macro_targets) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO macro_targets (id, calories, protein, carbs, fat, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-          [t.id, t.calories, t.protein, t.carbs, t.fat, t.updated_at]
-        );
-        inserted += r.changes;
-      }
-    }
-
-    if (data.body_weight) {
-      for (const w of data.body_weight) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO body_weight (id, weight, date, notes, logged_at) VALUES (?, ?, ?, ?, ?)",
-          [w.id, w.weight, w.date, w.notes, w.logged_at]
-        );
-        inserted += r.changes;
-      }
-    }
-
-    if (data.body_measurements) {
-      for (const m of data.body_measurements) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO body_measurements (id, date, waist, chest, hips, left_arm, right_arm, left_thigh, right_thigh, left_calf, right_calf, neck, body_fat, notes, logged_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-          [m.id, m.date, m.waist, m.chest, m.hips, m.left_arm, m.right_arm, m.left_thigh, m.right_thigh, m.left_calf, m.right_calf, m.neck, m.body_fat, m.notes, m.logged_at]
-        );
-        inserted += r.changes;
-      }
-    }
-
-    if (data.body_settings) {
-      for (const s of data.body_settings) {
-        const r = await database.runAsync(
-          "INSERT OR IGNORE INTO body_settings (id, weight_unit, measurement_unit, weight_goal, body_fat_goal, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-          [s.id, s.weight_unit, s.measurement_unit, s.weight_goal, s.body_fat_goal, s.updated_at]
-        );
-        inserted += r.changes;
-      }
+      const { inserted, skipped } = await importTable(database, tableName, rows);
+      totalInserted += inserted;
+      totalSkipped += skipped;
+      perTable[tableName] = { inserted, skipped };
     }
   });
 
-  return { inserted };
+  onProgress?.({ table: "done", tableIndex: IMPORT_TABLE_ORDER.length, totalTables: IMPORT_TABLE_ORDER.length });
+
+  return { inserted: totalInserted, skipped: totalSkipped, perTable };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic row insertion
+async function importTable(database: any, tableName: BackupTableName, rows: unknown[]): Promise<{ inserted: number; skipped: number }> {
+  let inserted = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    if (typeof row !== "object" || row === null) {
+      skipped++;
+      continue;
+    }
+    const r = row as Record<string, unknown>;
+    const result = await insertRow(database, tableName, r);
+    if (result) inserted++;
+    else skipped++;
+  }
+
+  return { inserted, skipped };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- generic database interface
+async function insertRow(database: any, tableName: BackupTableName, row: Record<string, unknown>): Promise<boolean> {
+  switch (tableName) {
+    case "exercises": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty, is_custom) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.name, row.category, row.primary_muscles, row.secondary_muscles, row.equipment, row.instructions, row.difficulty, row.is_custom]
+      );
+      return r.changes > 0;
+    }
+    case "workout_templates": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO workout_templates (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)",
+        [row.id, row.name, row.created_at, row.updated_at]
+      );
+      return r.changes > 0;
+    }
+    case "programs": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO programs (id, name, description, is_active, current_day_id, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.name, row.description ?? "", row.is_active ?? 0, row.current_day_id ?? null, row.created_at, row.updated_at, row.deleted_at ?? null]
+      );
+      return r.changes > 0;
+    }
+    case "food_entries": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO food_entries (id, name, calories, protein, carbs, fat, serving_size, is_favorite, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.name, row.calories, row.protein, row.carbs, row.fat, row.serving_size, row.is_favorite, row.created_at]
+      );
+      return r.changes > 0;
+    }
+    case "macro_targets": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO macro_targets (id, calories, protein, carbs, fat, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+        [row.id, row.calories, row.protein, row.carbs, row.fat, row.updated_at]
+      );
+      return r.changes > 0;
+    }
+    case "body_weight": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO body_weight (id, weight, date, notes, logged_at) VALUES (?, ?, ?, ?, ?)",
+        [row.id, row.weight, row.date, row.notes, row.logged_at]
+      );
+      return r.changes > 0;
+    }
+    case "body_measurements": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO body_measurements (id, date, waist, chest, hips, left_arm, right_arm, left_thigh, right_thigh, left_calf, right_calf, neck, body_fat, notes, logged_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.date, row.waist, row.chest, row.hips, row.left_arm, row.right_arm, row.left_thigh, row.right_thigh, row.left_calf, row.right_calf, row.neck, row.body_fat, row.notes, row.logged_at]
+      );
+      return r.changes > 0;
+    }
+    case "body_settings": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO body_settings (id, weight_unit, measurement_unit, weight_goal, body_fat_goal, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+        [row.id, row.weight_unit, row.measurement_unit, row.weight_goal, row.body_fat_goal, row.updated_at]
+      );
+      return r.changes > 0;
+    }
+    case "app_settings": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO app_settings (key, value) VALUES (?, ?)",
+        [row.key, row.value]
+      );
+      return r.changes > 0;
+    }
+    case "achievements_earned": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO achievements_earned (achievement_id, earned_at) VALUES (?, ?)",
+        [row.achievement_id, row.earned_at]
+      );
+      return r.changes > 0;
+    }
+    case "template_exercises": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds, link_id, link_label) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.template_id, row.exercise_id, row.position, row.target_sets, row.target_reps, row.rest_seconds, row.link_id ?? null, row.link_label ?? ""]
+      );
+      return r.changes > 0;
+    }
+    case "workout_sessions": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO workout_sessions (id, template_id, name, started_at, completed_at, duration_seconds, notes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.template_id, row.name, row.started_at, row.completed_at, row.duration_seconds, row.notes]
+      );
+      return r.changes > 0;
+    }
+    case "program_days": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO program_days (id, program_id, template_id, position, label) VALUES (?, ?, ?, ?, ?)",
+        [row.id, row.program_id, row.template_id ?? null, row.position, row.label ?? ""]
+      );
+      return r.changes > 0;
+    }
+    case "workout_sets": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, training_mode, tempo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.session_id, row.exercise_id, row.set_number, row.weight, row.reps, row.completed, row.completed_at, row.set_rpe ?? row.rpe ?? null, row.set_notes ?? row.notes ?? "", row.link_id ?? null, row.round ?? null, row.training_mode ?? null, row.tempo ?? null]
+      );
+      return r.changes > 0;
+    }
+    case "daily_log": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO daily_log (id, food_entry_id, date, meal, servings, logged_at) VALUES (?, ?, ?, ?, ?, ?)",
+        [row.id, row.food_entry_id, row.date, row.meal, row.servings, row.logged_at]
+      );
+      return r.changes > 0;
+    }
+    case "program_log": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO program_log (id, program_id, day_id, session_id, completed_at) VALUES (?, ?, ?, ?, ?)",
+        [row.id, row.program_id, row.day_id, row.session_id, row.completed_at]
+      );
+      return r.changes > 0;
+    }
+    case "weekly_schedule": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO weekly_schedule (id, day_of_week, template_id, created_at) VALUES (?, ?, ?, ?)",
+        [row.id, row.day_of_week, row.template_id, row.created_at ?? Date.now()]
+      );
+      return r.changes > 0;
+    }
+    case "program_schedule": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO program_schedule (program_id, day_of_week, template_id) VALUES (?, ?, ?)",
+        [row.program_id, row.day_of_week, row.template_id]
+      );
+      return r.changes > 0;
+    }
+    default:
+      return false;
+  }
 }

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -138,7 +138,24 @@ export {
 } from "./settings";
 export type { ScheduleEntry } from "./settings";
 
-export { exportAllData, importData } from "./import-export";
+export {
+  exportAllData,
+  importData,
+  estimateExportSize,
+  validateBackupFileSize,
+  validateBackupData,
+  getBackupCounts,
+  BACKUP_TABLE_LABELS,
+  IMPORT_TABLE_ORDER,
+} from "./import-export";
+export type {
+  BackupV3,
+  BackupTableName,
+  ExportProgress,
+  ImportProgress,
+  ImportResult,
+  ValidationError,
+} from "./import-export";
 
 export {
   insertPhoto,


### PR DESCRIPTION
## Summary

Extends FitForge's export/import system from 11 tables (v2) to all 18 user data tables (v3). Adds import preview screen, validation, progress indicators, and proper error handling.

## Changes

### Export
- Bump format to v3 with data wrapper and counts metadata
- Add 7 missing tables: programs, program_days, program_log, app_settings, weekly_schedule, program_schedule, achievements_earned
- Confirmation modal with estimated file size before export
- Per-table progress indicator during export
- Filename: fitforge-backup-YYYY-MM-DD.json

### Import
- FK-dependency ordered insertion across all 18 tables
- New import preview screen showing record counts before confirmation
- INSERT OR IGNORE conflict strategy with inserted/skipped counts
- Single transaction — failure rolls back completely
- Upfront validation: file size (50MB), version (reject v4+), non-negative numerics
- v2 backward compatibility (missing tables = empty arrays)

### Settings UI
- New Data Management section with Export All Data and Import FitForge Backup buttons
- Strong CSV import moved to Data Management section
- Separate CSV Export card for existing CSV export functionality

### Testing
- 27 new unit tests covering v3 format, FK ordering, v2 compat, validation
- Updated acceptance tests for new labels and export flow

## Testing
- tsc --noEmit passes with zero errors
- jest — all relevant tests pass (27 new + 33 updated acceptance)
- ESLint passes with zero warnings

## Issue
Resolves BLD-163