### PR TITLE
fix: remove eccentric movement tempo input (BLD-164)

### DIFF
--- a/__tests__/components/TrainingModeSelector.test.tsx
+++ b/__tests__/components/TrainingModeSelector.test.tsx
@@ -13,10 +13,7 @@ describe('TrainingModeSelector', () => {
     modes: [...modes],
     selected: 'weight' as const,
     exercise: 'Cable Curl',
-    tempo: '',
     onSelect: jest.fn(),
-    onTempoChange: jest.fn(),
-    onTempoBlur: jest.fn(),
   }
 
   beforeEach(() => jest.clearAllMocks())
@@ -51,27 +48,11 @@ describe('TrainingModeSelector', () => {
     )
   })
 
-  it('does NOT show tempo field when mode is not eccentric', () => {
+  it('does NOT show tempo field when eccentric mode is selected (tempo removed)', () => {
     const { queryByPlaceholderText } = renderScreen(
-      <TrainingModeSelector {...defaults} selected="weight" />
+      <TrainingModeSelector {...defaults} selected="eccentric_overload" />
     )
     expect(queryByPlaceholderText(/Tempo/)).toBeNull()
-  })
-
-  it('shows tempo field when eccentric mode is selected', () => {
-    const { getByPlaceholderText, getByText } = renderScreen(
-      <TrainingModeSelector {...defaults} selected="eccentric_overload" />
-    )
-    expect(getByPlaceholderText('Tempo (e.g. 3-1-5-1)')).toBeTruthy()
-    expect(getByText(/Eccentric – Pause – Concentric – Pause/)).toBeTruthy()
-  })
-
-  it('calls onTempoChange when tempo text changes', () => {
-    const { getByPlaceholderText } = renderScreen(
-      <TrainingModeSelector {...defaults} selected="eccentric_overload" />
-    )
-    fireEvent.changeText(getByPlaceholderText('Tempo (e.g. 3-1-5-1)'), '3-1-5-1')
-    expect(defaults.onTempoChange).toHaveBeenCalledWith('3-1-5-1')
   })
 
   it('has radiogroup accessibility role on container', () => {
@@ -93,13 +74,5 @@ describe('TrainingModeSelector', () => {
     expect(band.props.accessibilityState).toEqual({ selected: true })
     const std = getByLabelText('Standard training mode')
     expect(std.props.accessibilityState).toEqual({ selected: false })
-  })
-
-  it('tempo field has accessibility hint', () => {
-    const { getByLabelText } = renderScreen(
-      <TrainingModeSelector {...defaults} selected="eccentric_overload" />
-    )
-    const field = getByLabelText(/Tempo notation/)
-    expect(field.props.accessibilityHint).toContain('eccentric, pause, concentric, pause')
   })
 })

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -53,7 +53,6 @@ import {
   updateSetRPE,
   updateSetNotes,
   updateSetTrainingMode,
-  updateSetTempo,
   getExerciseById,
   getAppSetting,
 } from "../../lib/db";
@@ -298,7 +297,6 @@ type GroupCardProps = {
   unit: "kg" | "lb";
   suggestions: Record<string, Suggestion | null>;
   modes: Record<string, TrainingMode>;
-  tempoDraft: Record<string, string>;
   notesOpenMap: Record<string, boolean>;
   notesDraftMap: Record<string, string>;
   halfStep: { setId: string; base: number } | null;
@@ -310,8 +308,6 @@ type GroupCardProps = {
   onDelete: (setId: string) => void;
   onAddSet: (exerciseId: string) => void;
   onModeChange: (exerciseId: string, mode: TrainingMode) => void;
-  onTempoChange: (exerciseId: string, val: string) => void;
-  onTempoBlur: (exerciseId: string, val: string) => void;
   onRPE: (set: SetWithMeta, val: number) => void;
   onHalfStep: (setId: string, val: number) => void;
   onHalfStepClear: () => void;
@@ -323,10 +319,10 @@ type GroupCardProps = {
 };
 
 const ExerciseGroupCard = memo(function ExerciseGroupCard({
-  group, step, unit, suggestions, modes, tempoDraft,
+  group, step, unit, suggestions, modes,
   notesOpenMap, notesDraftMap, halfStep, linkIds, groups, palette,
   onUpdate, onCheck, onDelete, onAddSet, onModeChange,
-  onTempoChange, onTempoBlur, onRPE, onHalfStep, onHalfStepClear,
+  onRPE, onHalfStep, onHalfStepClear,
   onHalfStepOpen, onNotes, onNotesDraftChange, onToggleNotes,
   onShowDetail,
 }: GroupCardProps) {
@@ -417,10 +413,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
             modes={group.training_modes}
             selected={modes[group.exercise_id] ?? group.training_modes[0]}
             exercise={group.name}
-            tempo={tempoDraft[group.exercise_id] ?? ""}
             onSelect={(m) => onModeChange(group.exercise_id, m)}
-            onTempoChange={(v) => onTempoChange(group.exercise_id, v)}
-            onTempoBlur={() => onTempoBlur(group.exercise_id, tempoDraft[group.exercise_id] ?? "")}
             compact
           />
         )}
@@ -698,7 +691,6 @@ export default function ActiveSession() {
   }, []);
   const [suggestions, setSuggestions] = useState<Record<string, Suggestion | null>>({});
   const [modes, setModes] = useState<Record<string, TrainingMode>>({});
-  const [tempoDraft, setTempoDraft] = useState<Record<string, string>>({});
   const [detailExercise, setDetailExercise] = useState<Exercise | null>(null);
 
   const linkIds = useMemo(() => {
@@ -1022,8 +1014,7 @@ export default function ActiveSession() {
     const num = (group?.sets.length ?? 0) + 1;
     const fallback = group?.is_voltra && group.training_modes.length > 1 ? group.training_modes[0] : null;
     const mode = modes[exerciseId] ?? fallback;
-    const tp = mode === "eccentric_overload" ? (tempoDraft[exerciseId] || null) : null;
-    const newSet = await addSet(id!, exerciseId, num, null, null, mode, tp);
+    const newSet = await addSet(id!, exerciseId, num, null, null, mode, null);
     setGroups((prev) =>
       prev.map((g) =>
         g.exercise_id === exerciseId
@@ -1031,7 +1022,7 @@ export default function ActiveSession() {
           : g
       )
     );
-  }, [id, groups, modes, tempoDraft]);
+  }, [id, groups, modes]);
 
   const handleModeChange = useCallback(async (exerciseId: string, mode: TrainingMode) => {
     setModes((prev) => ({ ...prev, [exerciseId]: mode }));
@@ -1047,18 +1038,6 @@ export default function ActiveSession() {
     for (const set of group.sets) {
       if (!set.completed) {
         await updateSetTrainingMode(set.id, mode);
-      }
-    }
-  }, [groups]);
-
-  const handleTempoBlur = useCallback(async (exerciseId: string, val: string) => {
-    const clean = val && !/^[\s-]*$/.test(val) ? val : null;
-    setTempoDraft((prev) => ({ ...prev, [exerciseId]: clean ?? "" }));
-    const group = groups.find((g) => g.exercise_id === exerciseId);
-    if (!group) return;
-    for (const set of group.sets) {
-      if (!set.completed) {
-        await updateSetTempo(set.id, clean);
       }
     }
   }, [groups]);
@@ -1119,10 +1098,6 @@ export default function ActiveSession() {
     setNotesDraft((prev) => { const next = { ...prev }; delete next[setId]; return next; });
     await updateSetNotes(setId, text);
   }, [updateGroupSet]);
-
-  const handleTempoChange = useCallback((exerciseId: string, val: string) => {
-    setTempoDraft((prev) => ({ ...prev, [exerciseId]: val }));
-  }, []);
 
   const handleNotesDraftChange = useCallback((setId: string, text: string) => {
     setNotesDraft((prev) => ({ ...prev, [setId]: text }));
@@ -1254,7 +1229,6 @@ export default function ActiveSession() {
             unit={unit}
             suggestions={suggestions}
             modes={modes}
-            tempoDraft={tempoDraft}
             notesOpenMap={notesOpen}
             notesDraftMap={notesDraft}
             halfStep={halfStep}
@@ -1266,8 +1240,6 @@ export default function ActiveSession() {
             onDelete={handleDelete}
             onAddSet={handleAddSet}
             onModeChange={handleModeChange}
-            onTempoChange={handleTempoChange}
-            onTempoBlur={handleTempoBlur}
             onRPE={handleRPE}
             onHalfStep={handleHalfStep}
             onHalfStepClear={handleHalfStepClear}

--- a/components/TrainingModeSelector.tsx
+++ b/components/TrainingModeSelector.tsx
@@ -5,7 +5,7 @@ import {
   StyleSheet,
   View,
 } from "react-native";
-import { Text, TextInput, useTheme } from "react-native-paper";
+import { Text, useTheme } from "react-native-paper";
 import type { TrainingMode } from "../lib/types";
 import { TRAINING_MODE_LABELS } from "../lib/types";
 
@@ -13,14 +13,11 @@ type Props = {
   modes: TrainingMode[];
   selected: TrainingMode;
   exercise: string;
-  tempo: string;
   onSelect: (mode: TrainingMode) => void;
-  onTempoChange: (tempo: string) => void;
-  onTempoBlur: () => void;
   compact?: boolean;
 };
 
-function TrainingModeSelector({ modes, selected, exercise, tempo, onSelect, onTempoChange, onTempoBlur, compact: isCompact }: Props) {
+function TrainingModeSelector({ modes, selected, exercise, onSelect, compact: isCompact }: Props) {
   const theme = useTheme();
   const [tooltip, setTooltip] = useState<string | null>(null);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -87,28 +84,6 @@ function TrainingModeSelector({ modes, selected, exercise, tempo, onSelect, onTe
         </View>
       )}
 
-      {selected === "eccentric_overload" && (
-        <View style={styles.tempoContainer}>
-          <TextInput
-            mode="outlined"
-            dense
-            placeholder="Tempo (e.g. 3-1-5-1)"
-            value={tempo}
-            onChangeText={onTempoChange}
-            onBlur={onTempoBlur}
-            maxLength={15}
-            style={styles.tempoInput}
-            accessibilityLabel="Tempo notation, for example 3 1 5 1"
-            accessibilityHint="Enter four numbers separated by dashes: eccentric, pause, concentric, pause seconds"
-          />
-          <Text
-            variant="labelSmall"
-            style={[styles.helper, { color: theme.colors.onSurfaceVariant }]}
-          >
-            Seconds: Eccentric – Pause – Concentric – Pause
-          </Text>
-        </View>
-      )}
     </View>
   );
 }
@@ -167,17 +142,5 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderRadius: 8,
-  },
-  tempoContainer: {
-    paddingHorizontal: 4,
-    marginTop: 8,
-  },
-  tempoInput: {
-    fontSize: 14,
-  },
-  helper: {
-    marginTop: 4,
-    fontSize: 12,
-    fontStyle: "italic",
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2066,397 +2066,6 @@
         }
       }
     },
-    "node_modules/@expo/metro/node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "license": "MIT"
-    },
-    "node_modules/@expo/metro/node_modules/hermes-estree": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
-      "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
-      "license": "MIT"
-    },
-    "node_modules/@expo/metro/node_modules/hermes-parser": {
-      "version": "0.33.3",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
-      "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.33.3"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.5.tgz",
-      "integrity": "sha512-BgsXevY1MBac/3ZYv/RfNFf/4iuW9X7f4H8ZNkiH+r667HD9sVujxcmu4jvEzGCAm4/WyKdZCuyhAcyhTHOucQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.29.1",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "accepts": "^2.0.0",
-        "chalk": "^4.0.0",
-        "ci-info": "^2.0.0",
-        "connect": "^3.6.5",
-        "debug": "^4.4.0",
-        "error-stack-parser": "^2.0.6",
-        "flow-enums-runtime": "^0.0.6",
-        "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.33.3",
-        "image-size": "^1.0.2",
-        "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
-        "jsc-safe-url": "^0.2.2",
-        "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.83.5",
-        "metro-cache": "0.83.5",
-        "metro-cache-key": "0.83.5",
-        "metro-config": "0.83.5",
-        "metro-core": "0.83.5",
-        "metro-file-map": "0.83.5",
-        "metro-resolver": "0.83.5",
-        "metro-runtime": "0.83.5",
-        "metro-source-map": "0.83.5",
-        "metro-symbolicate": "0.83.5",
-        "metro-transform-plugins": "0.83.5",
-        "metro-transform-worker": "0.83.5",
-        "mime-types": "^3.0.1",
-        "nullthrows": "^1.1.1",
-        "serialize-error": "^2.1.0",
-        "source-map": "^0.5.6",
-        "throat": "^5.0.0",
-        "ws": "^7.5.10",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "metro": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-babel-transformer": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.5.tgz",
-      "integrity": "sha512-d9FfmgUEVejTiSb7bkQeLRGl6aeno2UpuPm3bo3rCYwxewj03ymvOn8s8vnS4fBqAPQ+cE9iQM40wh7nGXR+eA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.33.3",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-cache": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.5.tgz",
-      "integrity": "sha512-oH+s4U+IfZyg8J42bne2Skc90rcuESIYf86dYittcdWQtPfcaFXWpByPyTuWk3rR1Zz3Eh5HOrcVImfEhhJLng==",
-      "license": "MIT",
-      "dependencies": {
-        "exponential-backoff": "^3.1.1",
-        "flow-enums-runtime": "^0.0.6",
-        "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.83.5"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-cache-key": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.5.tgz",
-      "integrity": "sha512-Ycl8PBajB7bhbAI7Rt0xEyiF8oJ0RWX8EKkolV1KfCUlC++V/GStMSGpPLwnnBZXZWkCC5edBPzv1Hz1Yi0Euw==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-config": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.5.tgz",
-      "integrity": "sha512-JQ/PAASXH7yczgV6OCUSRhZYME+NU8NYjI2RcaG5ga4QfQ3T/XdiLzpSb3awWZYlDCcQb36l4Vl7i0Zw7/Tf9w==",
-      "license": "MIT",
-      "dependencies": {
-        "connect": "^3.6.5",
-        "flow-enums-runtime": "^0.0.6",
-        "jest-validate": "^29.7.0",
-        "metro": "0.83.5",
-        "metro-cache": "0.83.5",
-        "metro-core": "0.83.5",
-        "metro-runtime": "0.83.5",
-        "yaml": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-core": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.5.tgz",
-      "integrity": "sha512-YcVcLCrf0ed4mdLa82Qob0VxYqfhmlRxUS8+TO4gosZo/gLwSvtdeOjc/Vt0pe/lvMNrBap9LlmvZM8FIsMgJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.83.5"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-file-map": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.5.tgz",
-      "integrity": "sha512-ZEt8s3a1cnYbn40nyCD+CsZdYSlwtFh2kFym4lo+uvfM+UMMH+r/BsrC6rbNClSrt+B7rU9T+Te/sh/NL8ZZKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "fb-watchman": "^2.0.0",
-        "flow-enums-runtime": "^0.0.6",
-        "graceful-fs": "^4.2.4",
-        "invariant": "^2.2.4",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "nullthrows": "^1.1.1",
-        "walker": "^1.0.7"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-minify-terser": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.5.tgz",
-      "integrity": "sha512-Toe4Md1wS1PBqbvB0cFxBzKEVyyuYTUb0sgifAZh/mSvLH84qA1NAWik9sISWatzvfWf3rOGoUoO5E3f193a3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "terser": "^5.15.0"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-resolver": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.5.tgz",
-      "integrity": "sha512-7p3GtzVUpbAweJeCcUJihJeOQl1bDuimO5ueo1K0BUpUtR41q5EilbQ3klt16UTPPMpA+tISWBtsrqU556mY1A==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-runtime": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.5.tgz",
-      "integrity": "sha512-f+b3ue9AWTVlZe2Xrki6TAoFtKIqw30jwfk7GQ1rDUBQaE0ZQ+NkiMEtb9uwH7uAjJ87U7Tdx1Jg1OJqUfEVlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.0",
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-source-map": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.5.tgz",
-      "integrity": "sha512-VT9bb2KO2/4tWY9Z2yeZqTUao7CicKAOps9LUg2aQzsz+04QyuXL3qgf1cLUVRjA/D6G5u1RJAlN1w9VNHtODQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "flow-enums-runtime": "^0.0.6",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.83.5",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.83.5",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-symbolicate": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.5.tgz",
-      "integrity": "sha512-EMIkrjNRz/hF+p0RDdxoE60+dkaTLPN3vaaGkFmX5lvFdO6HPfHA/Ywznzkev+za0VhPQ5KSdz49/MALBRteHA==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6",
-        "invariant": "^2.2.4",
-        "metro-source-map": "0.83.5",
-        "nullthrows": "^1.1.1",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      },
-      "bin": {
-        "metro-symbolicate": "src/index.js"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-transform-plugins": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.5.tgz",
-      "integrity": "sha512-KxYKzZL+lt3Os5H2nx7YkbkWVduLZL5kPrE/Yq+Prm/DE1VLhpfnO6HtPs8vimYFKOa58ncl60GpoX0h7Wm0Vw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.29.1",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "flow-enums-runtime": "^0.0.6",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/metro-transform-worker": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.5.tgz",
-      "integrity": "sha512-8N4pjkNXc6ytlP9oAM6MwqkvUepNSW39LKYl9NjUMpRDazBQ7oBpQDc8Sz4aI8jnH6AGhF7s1m/ayxkN1t04yA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.29.1",
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "flow-enums-runtime": "^0.0.6",
-        "metro": "0.83.5",
-        "metro-babel-transformer": "0.83.5",
-        "metro-cache": "0.83.5",
-        "metro-cache-key": "0.83.5",
-        "metro-minify-terser": "0.83.5",
-        "metro-source-map": "0.83.5",
-        "metro-transform-plugins": "0.83.5",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/ob1": {
-      "version": "0.83.5",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.5.tgz",
-      "integrity": "sha512-vNKPYC8L5ycVANANpF/S+WZHpfnRWKx/F3AYP4QMn6ZJTh+l2HOrId0clNkEmua58NB9vmI9Qh7YOoV/4folYg==",
-      "license": "MIT",
-      "dependencies": {
-        "flow-enums-runtime": "^0.0.6"
-      },
-      "engines": {
-        "node": ">=20.19.4"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@expo/metro/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@expo/osascript": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.4.2.tgz",
@@ -3752,9 +3361,9 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.0.tgz",
-      "integrity": "sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
@@ -3973,6 +3582,30 @@
       },
       "peerDependencies": {
         "@babel/core": "*"
+      }
+    },
+    "node_modules/@react-native/babel-preset/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-parser": "0.32.0"
+      }
+    },
+    "node_modules/@react-native/babel-preset/node_modules/hermes-estree": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-native/babel-preset/node_modules/hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.32.0"
       }
     },
     "node_modules/@react-native/codegen": {
@@ -5536,27 +5169,27 @@
       "license": "MIT"
     },
     "node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
-      "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.1.tgz",
+      "integrity": "sha512-HgErPZTghW76Rkq9uqn5ESeiD97FbqpZ1V170T1RG2RDp+7pJVQV2pQJs7y5YzN0/gcT6GM5ci9apRnIwuyPdQ==",
       "license": "MIT",
       "dependencies": {
-        "hermes-parser": "0.32.0"
+        "hermes-parser": "0.32.1"
       }
     },
     "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-estree": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
-      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.1.tgz",
+      "integrity": "sha512-ne5hkuDxheNBAikDjqvCZCwihnz0vVu9YsBzAEO1puiyFR4F1+PAz/SiPHSsNTuOveCYGRMX8Xbx4LOubeC0Qg==",
       "license": "MIT"
     },
     "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-parser": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
-      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.1.tgz",
+      "integrity": "sha512-175dz634X/W5AiwrpLdoMl/MOb17poLHyIqgyExlE8D9zQ1OPnoORnGMB5ltRKnpvQzBjMYvT2rN/sHeIfZW5Q==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.32.0"
+        "hermes-estree": "0.32.1"
       }
     },
     "node_modules/babel-plugin-transform-flow-enums": {
@@ -5640,30 +5273,6 @@
         "expo-widgets": {
           "optional": true
         }
-      }
-    },
-    "node_modules/babel-preset-expo/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.1.tgz",
-      "integrity": "sha512-HgErPZTghW76Rkq9uqn5ESeiD97FbqpZ1V170T1RG2RDp+7pJVQV2pQJs7y5YzN0/gcT6GM5ci9apRnIwuyPdQ==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-parser": "0.32.1"
-      }
-    },
-    "node_modules/babel-preset-expo/node_modules/hermes-estree": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.1.tgz",
-      "integrity": "sha512-ne5hkuDxheNBAikDjqvCZCwihnz0vVu9YsBzAEO1puiyFR4F1+PAz/SiPHSsNTuOveCYGRMX8Xbx4LOubeC0Qg==",
-      "license": "MIT"
-    },
-    "node_modules/babel-preset-expo/node_modules/hermes-parser": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.1.tgz",
-      "integrity": "sha512-175dz634X/W5AiwrpLdoMl/MOb17poLHyIqgyExlE8D9zQ1OPnoORnGMB5ltRKnpvQzBjMYvT2rN/sHeIfZW5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.32.1"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -7068,9 +6677,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.336",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
-      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "version": "1.5.337",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.337.tgz",
+      "integrity": "sha512-15gKW9mRUNP9RdzhedJNypFUxtYWSXohFz2nTLzM272xbRXHws68kNDzyATG3qej+vUj/7Sn9hf5XTDh0XK6/w==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -11872,9 +11481,9 @@
       "license": "MIT"
     },
     "node_modules/metro": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.6.tgz",
-      "integrity": "sha512-pbdndsAZ2F/ceopDdhVbttpa/hfLzXPJ/husc+QvQ33R0D9UXJKzTn5+OzOXx4bpQNtAKF2bY88cCI3Zl44xDQ==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.5.tgz",
+      "integrity": "sha512-BgsXevY1MBac/3ZYv/RfNFf/4iuW9X7f4H8ZNkiH+r667HD9sVujxcmu4jvEzGCAm4/WyKdZCuyhAcyhTHOucQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
@@ -11892,24 +11501,24 @@
         "error-stack-parser": "^2.0.6",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.35.0",
+        "hermes-parser": "0.33.3",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.83.6",
-        "metro-cache": "0.83.6",
-        "metro-cache-key": "0.83.6",
-        "metro-config": "0.83.6",
-        "metro-core": "0.83.6",
-        "metro-file-map": "0.83.6",
-        "metro-resolver": "0.83.6",
-        "metro-runtime": "0.83.6",
-        "metro-source-map": "0.83.6",
-        "metro-symbolicate": "0.83.6",
-        "metro-transform-plugins": "0.83.6",
-        "metro-transform-worker": "0.83.6",
+        "metro-babel-transformer": "0.83.5",
+        "metro-cache": "0.83.5",
+        "metro-cache-key": "0.83.5",
+        "metro-config": "0.83.5",
+        "metro-core": "0.83.5",
+        "metro-file-map": "0.83.5",
+        "metro-resolver": "0.83.5",
+        "metro-runtime": "0.83.5",
+        "metro-source-map": "0.83.5",
+        "metro-symbolicate": "0.83.5",
+        "metro-transform-plugins": "0.83.5",
+        "metro-transform-worker": "0.83.5",
         "mime-types": "^3.0.1",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
@@ -11926,15 +11535,14 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.6.tgz",
-      "integrity": "sha512-1AnuazBpzY3meRMr04WUw14kRBkV0W3Ez+AA75FAeNpRyWNN5S3M3PHLUbZw7IXq7ZeOzceyRsHStaFrnWd+8w==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.5.tgz",
+      "integrity": "sha512-d9FfmgUEVejTiSb7bkQeLRGl6aeno2UpuPm3bo3rCYwxewj03ymvOn8s8vnS4fBqAPQ+cE9iQM40wh7nGXR+eA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.35.0",
-        "metro-cache-key": "0.83.6",
+        "hermes-parser": "0.33.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -11942,39 +11550,39 @@
       }
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
-      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
+      "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
       "license": "MIT"
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
-      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
+      "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.35.0"
+        "hermes-estree": "0.33.3"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.6.tgz",
-      "integrity": "sha512-DpvZE32feNkqfZkI4Fic7YI/Kw8QP9wdl1rC4YKPrA77wQbI9vXbxjmfkCT/EGwBTFOPKqvIXo+H3BNe93YyiQ==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.5.tgz",
+      "integrity": "sha512-oH+s4U+IfZyg8J42bne2Skc90rcuESIYf86dYittcdWQtPfcaFXWpByPyTuWk3rR1Zz3Eh5HOrcVImfEhhJLng==",
       "license": "MIT",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.83.6"
+        "metro-core": "0.83.5"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.6.tgz",
-      "integrity": "sha512-5gdK4PVpgNOHi7xCGrgesNP1AuOA2TiPqpcirGXZi4RLLzX1VMowpkgTVtBfpQQCqWoosQF9yrSo9/KDQg1eBg==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.5.tgz",
+      "integrity": "sha512-Ycl8PBajB7bhbAI7Rt0xEyiF8oJ0RWX8EKkolV1KfCUlC++V/GStMSGpPLwnnBZXZWkCC5edBPzv1Hz1Yi0Euw==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -12006,18 +11614,18 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.6.tgz",
-      "integrity": "sha512-G5622400uNtnAMlppEA5zkFAZltEf7DSGhOu09BkisCxOlVMWfdosD/oPyh4f2YVQsc1MBYyp4w6OzbExTYarg==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.5.tgz",
+      "integrity": "sha512-JQ/PAASXH7yczgV6OCUSRhZYME+NU8NYjI2RcaG5ga4QfQ3T/XdiLzpSb3awWZYlDCcQb36l4Vl7i0Zw7/Tf9w==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.83.6",
-        "metro-cache": "0.83.6",
-        "metro-core": "0.83.6",
-        "metro-runtime": "0.83.6",
+        "metro": "0.83.5",
+        "metro-cache": "0.83.5",
+        "metro-core": "0.83.5",
+        "metro-runtime": "0.83.5",
         "yaml": "^2.6.1"
       },
       "engines": {
@@ -12025,23 +11633,23 @@
       }
     },
     "node_modules/metro-core": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.6.tgz",
-      "integrity": "sha512-l+yQ2fuIgR//wszUlMrrAa9+Z+kbKazd0QOh0VQY7jC4ghb7yZBBSla/UMYRBZZ6fPg9IM+wD3+h+37a5f9etw==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.5.tgz",
+      "integrity": "sha512-YcVcLCrf0ed4mdLa82Qob0VxYqfhmlRxUS8+TO4gosZo/gLwSvtdeOjc/Vt0pe/lvMNrBap9LlmvZM8FIsMgJQ==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.83.6"
+        "metro-resolver": "0.83.5"
       },
       "engines": {
         "node": ">=20.19.4"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.6.tgz",
-      "integrity": "sha512-Jg3oN604C7GWbQwFAUXt8KsbMXeKfsxbZ5HFy4XFM3ggTS+ja9QgUmq9B613kgXv3G4M6rwiI6cvh9TRly4x3w==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.5.tgz",
+      "integrity": "sha512-ZEt8s3a1cnYbn40nyCD+CsZdYSlwtFh2kFym4lo+uvfM+UMMH+r/BsrC6rbNClSrt+B7rU9T+Te/sh/NL8ZZKQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -12059,9 +11667,9 @@
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.6.tgz",
-      "integrity": "sha512-Vx3/Ne9Q+EIEDLfKzZUOtn/rxSNa/QjlYxc42nvK4Mg8mB6XUgd3LXX5ZZVq7lzQgehgEqLrbgShJPGfeF8PnQ==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.5.tgz",
+      "integrity": "sha512-Toe4Md1wS1PBqbvB0cFxBzKEVyyuYTUb0sgifAZh/mSvLH84qA1NAWik9sISWatzvfWf3rOGoUoO5E3f193a3Q==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
@@ -12072,9 +11680,9 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.6.tgz",
-      "integrity": "sha512-lAwR/FsT1uJ5iCt4AIsN3boKfJ88aN8bjvDT5FwBS0tKeKw4/sbdSTWlFxc7W/MUTN5RekJ3nQkJRIWsvs28tA==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.5.tgz",
+      "integrity": "sha512-7p3GtzVUpbAweJeCcUJihJeOQl1bDuimO5ueo1K0BUpUtR41q5EilbQ3klt16UTPPMpA+tISWBtsrqU556mY1A==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -12084,9 +11692,9 @@
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.6.tgz",
-      "integrity": "sha512-WQPua1G2VgYbwRn6vSKxOhTX7CFbSf/JdUu6Nd8bZnPXckOf7HQ2y51NXNQHoEsiuawathrkzL8pBhv+zgZFmg==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.5.tgz",
+      "integrity": "sha512-f+b3ue9AWTVlZe2Xrki6TAoFtKIqw30jwfk7GQ1rDUBQaE0ZQ+NkiMEtb9uwH7uAjJ87U7Tdx1Jg1OJqUfEVlA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -12097,18 +11705,18 @@
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.6.tgz",
-      "integrity": "sha512-AqJbOMMpeyyM4iNI91pchqDIszzNuuHApEhg6OABqZ+9mjLEqzcIEQ/fboZ7x74fNU5DBd2K36FdUQYPqlGClA==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.5.tgz",
+      "integrity": "sha512-VT9bb2KO2/4tWY9Z2yeZqTUao7CicKAOps9LUg2aQzsz+04QyuXL3qgf1cLUVRjA/D6G5u1RJAlN1w9VNHtODQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.83.6",
+        "metro-symbolicate": "0.83.5",
         "nullthrows": "^1.1.1",
-        "ob1": "0.83.6",
+        "ob1": "0.83.5",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -12126,14 +11734,14 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.6.tgz",
-      "integrity": "sha512-4nvkmv9T7ozhprlPwk/+xm0SVPsxly5kYyMHdNaOlFemFz4df9BanvD46Ac6OISu/4Idinzfk2KVb++6OfzPAQ==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.5.tgz",
+      "integrity": "sha512-EMIkrjNRz/hF+p0RDdxoE60+dkaTLPN3vaaGkFmX5lvFdO6HPfHA/Ywznzkev+za0VhPQ5KSdz49/MALBRteHA==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.83.6",
+        "metro-source-map": "0.83.5",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -12155,9 +11763,9 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.6.tgz",
-      "integrity": "sha512-V+zoY2Ul0v0BW6IokJkTud3raXmDdbdwkUQ/5eiSoy0jKuKMhrDjdH+H5buCS5iiJdNbykOn69Eip+Sqymkodg==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.5.tgz",
+      "integrity": "sha512-KxYKzZL+lt3Os5H2nx7YkbkWVduLZL5kPrE/Yq+Prm/DE1VLhpfnO6HtPs8vimYFKOa58ncl60GpoX0h7Wm0Vw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -12172,9 +11780,9 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.6.tgz",
-      "integrity": "sha512-G5kDJ/P0ZTIf57t3iyAd5qIXbj2Wb1j7WtIDh82uTFQHe2Mq2SO9aXG9j1wI+kxZlIe58Z22XEXIKMl89z0ibQ==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.5.tgz",
+      "integrity": "sha512-8N4pjkNXc6ytlP9oAM6MwqkvUepNSW39LKYl9NjUMpRDazBQ7oBpQDc8Sz4aI8jnH6AGhF7s1m/ayxkN1t04yA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -12182,13 +11790,13 @@
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.83.6",
-        "metro-babel-transformer": "0.83.6",
-        "metro-cache": "0.83.6",
-        "metro-cache-key": "0.83.6",
-        "metro-minify-terser": "0.83.6",
-        "metro-source-map": "0.83.6",
-        "metro-transform-plugins": "0.83.6",
+        "metro": "0.83.5",
+        "metro-babel-transformer": "0.83.5",
+        "metro-cache": "0.83.5",
+        "metro-cache-key": "0.83.5",
+        "metro-minify-terser": "0.83.5",
+        "metro-source-map": "0.83.5",
+        "metro-transform-plugins": "0.83.5",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -12215,18 +11823,18 @@
       "license": "MIT"
     },
     "node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
-      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
+      "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
       "license": "MIT"
     },
     "node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
-      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
+      "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.35.0"
+        "hermes-estree": "0.33.3"
       }
     },
     "node_modules/metro/node_modules/mime-types": {
@@ -12638,9 +12246,9 @@
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.83.6",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.6.tgz",
-      "integrity": "sha512-m/xZYkwcjo6UqLMrUICEB3iHk7Bjt3RSR7KXMi6Y1MO/kGkPhoRmfUDF6KAan3rLAZ7ABRqnQyKUTwaqZgUV4w==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.5.tgz",
+      "integrity": "sha512-vNKPYC8L5ycVANANpF/S+WZHpfnRWKx/F3AYP4QMn6ZJTh+l2HOrId0clNkEmua58NB9vmI9Qh7YOoV/4folYg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -14138,6 +13746,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-parser": "0.32.0"
+      }
+    },
     "node_modules/react-native/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -14182,6 +13799,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/react-native/node_modules/hermes-estree": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-native/node_modules/hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.32.0"
       }
     },
     "node_modules/react-native/node_modules/minimatch": {
@@ -16062,9 +15694,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
## Summary

Remove the tempo input TextInput and helper text that appeared when eccentric_overload training mode was selected. Per owner request (GitHub #79), this input is not useful.

## Changes

- Remove tempo, onTempoChange, onTempoBlur props from TrainingModeSelector component
- Remove tempoDraft state, handleTempoChange, handleTempoBlur handlers from session screen
- Remove unused updateSetTempo import
- Clean up TrainingModeSelector styles (tempoContainer, tempoInput, helper)
- Update TrainingModeSelector tests to verify tempo field is NOT shown

## Testing

- `npx tsc --noEmit` passes
- All TrainingModeSelector tests pass (8/8)
- Lint passes (eslint --max-warnings=0)
- Eccentric_overload training mode option still selectable

## Issue

Closes #79
Resolves BLD-164