### PR TITLE
fix: increase notes and delete icon sizes to match checkbox visual weight

### DIFF
--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -181,7 +181,7 @@ const SetRow = memo(function SetRow({
           >
             <MaterialCommunityIcons
               name={set.notes ? "note-text" : "note-text-outline"}
-              size={18}
+              size={22}
               color={theme.colors.onSurfaceVariant}
             />
           </Pressable>
@@ -191,7 +191,7 @@ const SetRow = memo(function SetRow({
             accessibilityLabel={`Delete set ${set.set_number}`}
             accessibilityRole="button"
           >
-            <MaterialCommunityIcons name="delete-outline" size={18} color={theme.colors.error} />
+            <MaterialCommunityIcons name="delete-outline" size={22} color={theme.colors.error} />
           </Pressable>
         </View>
 


### PR DESCRIPTION
## Summary
Increase notes and delete icon sizes from 18px to 22px in the workout set row to match the visual weight of the 28x28 checkbox.

## Changes
- `app/session/[id].tsx`: Change `size={18}` to `size={22}` for `note-text`/`note-text-outline` and `delete-outline` icons

## Testing
- `npx tsc --noEmit` passes
- ESLint passes (lint-staged verified on commit)
- Checkbox size unchanged (28x28 with 16px check icon)

## Issue
Fixes: BLD-166 (GitHub #81)