### PR TITLE
fix: add consistent horizontal padding to feedback and errors screens

### DIFF
--- a/app/errors.tsx
+++ b/app/errors.tsx
@@ -5,10 +5,12 @@ import { Button, Card, Chip, Snackbar, Text, useTheme } from "react-native-paper
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { getRecentErrors, clearErrorLog } from "../lib/errors";
+import { useLayout } from "../lib/layout";
 import type { ErrorEntry } from "../lib/types";
 
 export default function Errors() {
   const theme = useTheme();
+  const layout = useLayout();
   const nav = useNavigation();
   const [errors, setErrors] = useState<ErrorEntry[]>([]);
   const [expanded, setExpanded] = useState<string | null>(null);
@@ -56,7 +58,7 @@ export default function Errors() {
 
   if (errors.length === 0) {
     return (
-      <View style={[styles.empty, { backgroundColor: theme.colors.background }]}>
+      <View style={[styles.empty, { backgroundColor: theme.colors.background, paddingHorizontal: layout.horizontalPadding }]}>
         <MaterialCommunityIcons
           name="check-circle-outline"
           size={64}
@@ -85,6 +87,7 @@ export default function Errors() {
       <FlashList
         data={errors}
         keyExtractor={(item) => item.id}
+        contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding }}
         renderItem={({ item }) => (
           <Card
             style={[styles.card, { backgroundColor: theme.colors.surface }]}

--- a/app/feedback.tsx
+++ b/app/feedback.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, Linking, StyleSheet, View } from "react-native";
+import { useLayout } from "../lib/layout";
 import { FlashList } from "@shopify/flash-list";
 import {
   Button,
@@ -32,6 +33,7 @@ const TYPE_OPTIONS = [
 
 export default function FeedbackScreen() {
   const theme = useTheme();
+  const layout = useLayout();
   const params = useLocalSearchParams<{ type?: string }>();
 
   const initial = (params.type === "bug" || params.type === "feature" || params.type === "crash")
@@ -191,6 +193,7 @@ export default function FeedbackScreen() {
         data={ITEMS}
         keyExtractor={(item) => item}
         style={StyleSheet.flatten([styles.container, { backgroundColor: theme.colors.background }])}
+        contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding }}
         renderItem={() => (
           <View>
             <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 8 }}>


### PR DESCRIPTION
## Summary
Add consistent horizontal padding to feedback and errors screens using the `useLayout()` hook, matching the pattern already used in settings.

## Changes
- `app/feedback.tsx`: Import `useLayout`, apply `horizontalPadding` via `contentContainerStyle` on FlashList
- `app/errors.tsx`: Import `useLayout`, apply `horizontalPadding` to FlashList `contentContainerStyle` and empty state view

## Testing
- `npx tsc --noEmit` passes
- ESLint passes (lint-staged verified on commit)
- Responsive padding: 16px compact (<600px), 24px medium (600-1023px), 32px expanded (1024px+)

## Issue
Fixes: BLD-165 (GitHub #80)