### PR TITLE
fix: symbol-agnostic exercise search with full normalization

### DIFF
--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -42,15 +42,13 @@ export default function Exercises() {
   useFocusRefetch(["exercises"]);
 
   const filtered = useMemo(() => {
-    const norm = (s: string) => s.toLowerCase().replace(/[-_]/g, " ").replace(/\s+/g, " ").trim();
-    const q = norm(query);
-    const qNoSpace = q.replace(/ /g, "");
+    const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+    const q = normalize(query);
     const customFilter = selected.has("custom");
     const cats = new Set([...selected].filter((s): s is Category => s !== "custom"));
     return exercises.filter((ex) => {
       if (q) {
-        const n = norm(ex.name);
-        if (!n.includes(q) && !n.replace(/ /g, "").includes(qNoSpace)) return false;
+        if (!normalize(ex.name).includes(q)) return false;
       }
       if (customFilter && !ex.is_custom) return false;
       if (cats.size > 0 && !cats.has(ex.category)) return false;

--- a/app/template/pick-exercise.tsx
+++ b/app/template/pick-exercise.tsx
@@ -45,13 +45,11 @@ export default function PickExercise() {
   }, []);
 
   const filtered = useMemo(() => {
-    const norm = (s: string) => s.toLowerCase().replace(/[-_]/g, " ").replace(/\s+/g, " ").trim();
-    const q = norm(query);
-    const qNoSpace = q.replace(/ /g, "");
+    const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+    const q = normalize(query);
     return exercises.filter((ex) => {
       if (q) {
-        const n = norm(ex.name);
-        if (!n.includes(q) && !n.replace(/ /g, "").includes(qNoSpace)) return false;
+        if (!normalize(ex.name).includes(q)) return false;
       }
       if (selected.size > 0 && !selected.has(ex.category)) return false;
       return true;


### PR DESCRIPTION
## Summary
Upgrades exercise search normalization to strip **all** non-alphanumeric characters (not just hyphens/underscores) before comparison, so queries like `pushup` match `Push-Up`, `farmers` matches `Farmer's Walk`, etc.

## Changes
- `app/(tabs)/exercises.tsx`: Replace `norm()` with `normalize()` using `/[^a-z0-9]/g` regex; remove redundant `qNoSpace` logic
- `app/template/pick-exercise.tsx`: Same normalization update

## Testing
- `npx tsc --noEmit` — zero errors
- `npx jest` — 1065 tests pass
- ESLint (lint-staged) — zero warnings

## Verification
| Query | Exercise | Result |
|-------|----------|--------|
| `pushup` | Push-Up | ✅ match |
| `tbar` | T-Bar Row | ✅ match |
| `bench` | Bench Press | ✅ match |
| `push-up` | Push-Up | ✅ match |
| empty | — | ✅ shows all |

Closes #87
Refs: BLD-178