### PR TITLE
fix: repair starter template is_starter flags on every DB init (BLD-174)

### DIFF
--- a/__tests__/lib/db/import-export.test.ts
+++ b/__tests__/lib/db/import-export.test.ts
@@ -326,6 +326,58 @@ describe("importData", () => {
     expect(progress[progress.length - 1]).toBe("done");
   });
 
+  it("preserves is_starter flag when importing workout_templates", async () => {
+    const sqlCalls: { sql: string; params: unknown[] }[] = [];
+    mockDb.runAsync.mockImplementation(async (sql: string, params?: unknown[]) => {
+      sqlCalls.push({ sql, params: params ?? [] });
+      return { changes: 1 };
+    });
+
+    const data = {
+      version: 3,
+      data: {
+        workout_templates: [
+          { id: "starter-tpl-1", name: "Full Body", created_at: 0, updated_at: 0, is_starter: 1 },
+          { id: "user-tpl-1", name: "My Custom", created_at: 1, updated_at: 1 },
+        ],
+      },
+    };
+
+    await importData(data);
+    const tplInserts = sqlCalls.filter((c) => c.sql.includes("INSERT OR IGNORE INTO workout_templates"));
+    expect(tplInserts).toHaveLength(2);
+    // Starter template should have is_starter=1
+    expect(tplInserts[0].params).toContain(1);
+    // User template should default to is_starter=0
+    expect(tplInserts[1].params).toContain(0);
+  });
+
+  it("preserves is_starter flag when importing programs", async () => {
+    const sqlCalls: { sql: string; params: unknown[] }[] = [];
+    mockDb.runAsync.mockImplementation(async (sql: string, params?: unknown[]) => {
+      sqlCalls.push({ sql, params: params ?? [] });
+      return { changes: 1 };
+    });
+
+    const data = {
+      version: 3,
+      data: {
+        programs: [
+          { id: "starter-prog-1", name: "PPL", description: "", is_active: 0, current_day_id: null, created_at: 0, updated_at: 0, is_starter: 1 },
+          { id: "user-prog-1", name: "My Program", description: "", is_active: 1, current_day_id: null, created_at: 1, updated_at: 1 },
+        ],
+      },
+    };
+
+    await importData(data);
+    const progInserts = sqlCalls.filter((c) => c.sql.includes("INSERT OR IGNORE INTO programs"));
+    expect(progInserts).toHaveLength(2);
+    // Starter program should have is_starter=1
+    expect(progInserts[0].params).toContain(1);
+    // User program should default to is_starter=0
+    expect(progInserts[1].params).toContain(0);
+  });
+
   it("imports new tables: programs, achievements_earned, app_settings", async () => {
     const inserted: string[] = [];
     mockDb.runAsync.mockImplementation(async (sql: string) => {

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -567,6 +567,20 @@ async function seedStarters(database: SQLite.SQLiteDatabase): Promise<void> {
       "INSERT OR IGNORE INTO app_settings (key, value) VALUES ('onboarding_complete', '1')"
     );
   }
+
+  // Always repair is_starter flags — handles cases where import or
+  // migration left starters with is_starter=0
+  const starterTplIds = STARTER_TEMPLATES.map((t) => t.id);
+  const tplPlaceholders = starterTplIds.map(() => "?").join(",");
+  await database.runAsync(
+    `UPDATE workout_templates SET is_starter = 1 WHERE id IN (${tplPlaceholders}) AND is_starter = 0`,
+    starterTplIds
+  );
+  await database.runAsync(
+    "UPDATE programs SET is_starter = 1 WHERE id = ? AND is_starter = 0",
+    [STARTER_PROGRAM.id]
+  );
+
   if (row && Number(row.value) >= STARTER_VERSION) return;
 
   await database.withTransactionAsync(async () => {

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -366,15 +366,15 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
     }
     case "workout_templates": {
       const r = await database.runAsync(
-        "INSERT OR IGNORE INTO workout_templates (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)",
-        [row.id, row.name, row.created_at, row.updated_at]
+        "INSERT OR IGNORE INTO workout_templates (id, name, created_at, updated_at, is_starter) VALUES (?, ?, ?, ?, ?)",
+        [row.id, row.name, row.created_at, row.updated_at, row.is_starter ?? 0]
       );
       return r.changes > 0;
     }
     case "programs": {
       const r = await database.runAsync(
-        "INSERT OR IGNORE INTO programs (id, name, description, is_active, current_day_id, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        [row.id, row.name, row.description ?? "", row.is_active ?? 0, row.current_day_id ?? null, row.created_at, row.updated_at, row.deleted_at ?? null]
+        "INSERT OR IGNORE INTO programs (id, name, description, is_active, current_day_id, created_at, updated_at, deleted_at, is_starter) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.name, row.description ?? "", row.is_active ?? 0, row.current_day_id ?? null, row.created_at, row.updated_at, row.deleted_at ?? null, row.is_starter ?? 0]
       );
       return r.changes > 0;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fitforge",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fitforge",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.9",


### PR DESCRIPTION
## Summary

Fixes starter workout templates disappearing from the Workout tab. The root cause was that `seedStarters()` used `INSERT OR IGNORE`, which cannot repair templates that lost their `is_starter=1` flag. Additionally, the import function didn't preserve the `is_starter` column when importing workout templates and programs.

## Changes

- **`lib/db/helpers.ts`**: `seedStarters()` now always repairs `is_starter=0` on known starter template/program IDs before checking the version gate — ensures self-healing on every app launch
- **`lib/db/import-export.ts`**: Import now preserves `is_starter` for `workout_templates` and `programs`, defaulting to 0 for user-created entries
- **`__tests__/lib/db/import-export.test.ts`**: 2 new tests verifying `is_starter` preservation in import

## Testing

- `npx -p typescript tsc --noEmit` — passes
- `npx jest --no-coverage` — 69 suites, 1067 tests pass (2 new)
- ESLint (lint-staged) — zero warnings

## Issue

Resolves BLD-174 / GitHub #89