### PR TITLE
feat: Weekly Training Summary & Insights (BLD-182)

### DIFF
--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -71,6 +71,7 @@ jest.mock('expo-haptics', () => ({ impactAsync: jest.fn(), notificationAsync: je
 jest.mock('expo-keep-awake', () => ({ useKeepAwake: jest.fn(), activateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined), deactivateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined) }))
 jest.mock('victory-native', () => ({ CartesianChart: 'CartesianChart', Line: 'Line', Bar: 'Bar' }))
 jest.mock('../../components/MuscleVolumeSegment', () => 'MuscleVolumeSegment')
+jest.mock('../../components/WeeklySummary', () => 'WeeklySummary')
 jest.mock('../../lib/rpe', () => ({ rpeColor: jest.fn().mockReturnValue('#888'), rpeText: jest.fn().mockReturnValue('#fff') }))
 jest.mock('../../lib/starter-templates', () => ({ STARTER_TEMPLATES: [] }))
 jest.mock('../../lib/units', () => ({ toDisplay: (v: number) => v, toKg: (v: number) => v, KG_TO_LB: 2.20462, LB_TO_KG: 0.453592 }))

--- a/__tests__/acceptance/body-progress.acceptance.test.tsx
+++ b/__tests__/acceptance/body-progress.acceptance.test.tsx
@@ -33,6 +33,7 @@ jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache'
 jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
 jest.mock('victory-native', () => ({ CartesianChart: 'CartesianChart', Line: 'Line', Bar: 'Bar' }))
 jest.mock('../../components/MuscleVolumeSegment', () => 'MuscleVolumeSegment')
+jest.mock('../../components/WeeklySummary', () => 'WeeklySummary')
 
 const mockSettings = createBodySettings({ weight_unit: 'kg', measurement_unit: 'cm', weight_goal: 70, body_fat_goal: 15 })
 const mockLatest = createBodyWeight({ id: 'bw1', weight: 75, date: '2024-01-15' })

--- a/__tests__/acceptance/body-tracking.acceptance.test.tsx
+++ b/__tests__/acceptance/body-tracking.acceptance.test.tsx
@@ -32,6 +32,7 @@ jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache'
 jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
 jest.mock('victory-native', () => ({ CartesianChart: 'CartesianChart', Line: 'Line', Bar: 'Bar' }))
 jest.mock('../../components/MuscleVolumeSegment', () => 'MuscleVolumeSegment')
+jest.mock('../../components/WeeklySummary', () => 'WeeklySummary')
 
 const mockSettings = createBodySettings({ weight_unit: 'kg', measurement_unit: 'cm', weight_goal: 70, body_fat_goal: 15 })
 const mockLatest = createBodyWeight({ id: 'bw1', weight: 75, date: '2024-01-15' })

--- a/__tests__/acceptance/weekly-summary.acceptance.test.tsx
+++ b/__tests__/acceptance/weekly-summary.acceptance.test.tsx
@@ -1,0 +1,290 @@
+jest.setTimeout(10000)
+
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+import { createBodySettings, resetIds } from '../helpers/factories'
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    useRouter: () => mockRouter,
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/test',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({
+  useLayout: () => ({
+    wide: false,
+    width: 375,
+    scale: 1.0,
+    windowClass: 'compact' as const,
+    compact: true,
+    medium: false,
+    expanded: false,
+    atLeastMedium: false,
+    horizontalPadding: 16,
+  }),
+}))
+jest.mock('../../lib/errors', () => ({ logError: jest.fn() }))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn() }))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+jest.mock('victory-native', () => ({ CartesianChart: 'CartesianChart', Line: 'Line', Bar: 'Bar' }))
+jest.mock('../../components/MuscleVolumeSegment', () => 'MuscleVolumeSegment')
+jest.mock('react-native-reanimated', () => {
+  const { View: RNView } = require('react-native')
+  return {
+    __esModule: true,
+    default: {
+      View: RNView,
+      Text: require('react-native').Text,
+      createAnimatedComponent: (c: unknown) => c,
+    },
+    useSharedValue: (v: number) => ({ value: v }),
+    useAnimatedStyle: () => ({}),
+    withTiming: (v: number) => v,
+    withSpring: (v: number) => v,
+    withSequence: (...args: number[]) => args[args.length - 1],
+    withDelay: (_d: number, v: number) => v,
+    useReducedMotion: () => false,
+    Easing: { bezier: () => (t: number) => t },
+  }
+})
+
+const mockSettings = createBodySettings({
+  weight_unit: 'kg',
+  measurement_unit: 'cm',
+  weight_goal: 70,
+  body_fat_goal: 15,
+})
+
+const mockSummaryData = {
+  workouts: {
+    sessionCount: 4,
+    totalDurationSeconds: 13500,
+    totalVolume: 24500,
+    previousWeekVolume: 21875,
+    previousWeekSessionCount: 3,
+    hasBodyweightOnly: false,
+    scheduledCount: null,
+  },
+  prs: [
+    { exerciseId: 'ex1', exerciseName: 'Bench Press', newMax: 100, previousMax: 95 },
+    { exerciseId: 'ex2', exerciseName: 'Squat', newMax: 140, previousMax: 130 },
+  ],
+  nutrition: {
+    daysTracked: 4,
+    avgCalories: 2150,
+    avgProtein: 162,
+    avgCarbs: 220,
+    avgFat: 60,
+    calorieTarget: 2200,
+    proteinTarget: 150,
+    carbsTarget: 250,
+    fatTarget: 65,
+    daysOnTarget: 3,
+  },
+  body: {
+    startWeight: 82.0,
+    endWeight: 81.7,
+    entryCount: 3,
+  },
+  streak: 12,
+}
+
+jest.mock('../../lib/db', () => ({
+  getWeeklySessionCounts: jest.fn().mockResolvedValue([{ week: '1/15', count: 3 }]),
+  getWeeklyVolume: jest.fn().mockResolvedValue([{ week: '1/15', volume: 5000 }]),
+  getPersonalRecords: jest.fn().mockResolvedValue([{ exercise_id: 'ex1', name: 'Bench Press', max_weight: 100 }]),
+  getCompletedSessionsWithSetCount: jest.fn().mockResolvedValue([{
+    id: 's1', template_id: null, name: 'Morning', started_at: Date.now(), completed_at: Date.now(), duration_seconds: 3600, notes: '', set_count: 10,
+  }]),
+  getBodySettings: jest.fn().mockResolvedValue(mockSettings),
+  getLatestBodyWeight: jest.fn().mockResolvedValue(null),
+  getPreviousBodyWeight: jest.fn().mockResolvedValue(null),
+  getBodyWeightEntries: jest.fn().mockResolvedValue([]),
+  getBodyWeightCount: jest.fn().mockResolvedValue(0),
+  getBodyWeightChartData: jest.fn().mockResolvedValue([]),
+  getLatestMeasurements: jest.fn().mockResolvedValue(null),
+  upsertBodyWeight: jest.fn().mockResolvedValue(undefined),
+  deleteBodyWeight: jest.fn().mockResolvedValue(undefined),
+  updateBodySettings: jest.fn().mockResolvedValue(undefined),
+  getWeeklySummary: jest.fn().mockResolvedValue(mockSummaryData),
+}))
+
+jest.mock('../../lib/units', () => ({
+  toDisplay: (v: number) => v,
+  toKg: (v: number) => v,
+  KG_TO_LB: 2.20462,
+  LB_TO_KG: 0.453592,
+}))
+
+import Progress from '../../app/(tabs)/progress'
+
+const mockDb = require('../../lib/db') as Record<string, jest.Mock>
+
+describe('Weekly Summary Acceptance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+    mockDb.getWeeklySummary.mockResolvedValue(mockSummaryData)
+    mockDb.getBodySettings.mockResolvedValue(mockSettings)
+  })
+
+  it('shows weekly summary card with headline metrics on Progress tab', async () => {
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getAllByText(/4 workouts/).length).toBeGreaterThan(0)
+    })
+    expect(utils.getAllByText(/2 PRs/).length).toBeGreaterThan(0)
+  })
+
+  it('shows View Details button that expands summary', async () => {
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getByText('View Details')).toBeTruthy()
+    })
+    fireEvent.press(utils.getByText('View Details'))
+    await waitFor(() => {
+      expect(utils.getByText('Hide Details')).toBeTruthy()
+    })
+  })
+
+  it('shows empty state when no workouts logged', async () => {
+    mockDb.getWeeklySummary.mockResolvedValue({
+      ...mockSummaryData,
+      workouts: {
+        ...mockSummaryData.workouts,
+        sessionCount: 0,
+        totalDurationSeconds: 0,
+        totalVolume: 0,
+        previousWeekVolume: null,
+        previousWeekSessionCount: null,
+        hasBodyweightOnly: false,
+        scheduledCount: null,
+      },
+      prs: [],
+      nutrition: null,
+      body: null,
+      streak: 0,
+    })
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getByText(/No workouts logged this week/)).toBeTruthy()
+    })
+  })
+
+  it('shows error fallback when summary query fails', async () => {
+    mockDb.getWeeklySummary.mockRejectedValue(new Error('DB error'))
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getByText(/Couldn.t load summary/)).toBeTruthy()
+    })
+  })
+
+  it('shows scheduled count format when active program exists', async () => {
+    mockDb.getWeeklySummary.mockResolvedValue({
+      ...mockSummaryData,
+      workouts: { ...mockSummaryData.workouts, scheduledCount: 5 },
+    })
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getByText(/4\/5 workouts/)).toBeTruthy()
+    })
+  })
+
+  it('has week navigation with previous/next buttons', async () => {
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getByLabelText('Previous week')).toBeTruthy()
+    })
+    expect(utils.getByLabelText('Next week')).toBeTruthy()
+  })
+
+  it('navigates to previous week when pressing left arrow', async () => {
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getByLabelText('Previous week')).toBeTruthy()
+    })
+    fireEvent.press(utils.getByLabelText('Previous week'))
+    // Should trigger a new data load (may also trigger preload)
+    await waitFor(() => {
+      expect(mockDb.getWeeklySummary.mock.calls.length).toBeGreaterThan(1)
+    })
+  })
+
+  it('has Share Summary button when expanded', async () => {
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getByText('View Details')).toBeTruthy()
+    })
+    fireEvent.press(utils.getByText('View Details'))
+    await waitFor(() => {
+      expect(utils.getByLabelText('Share weekly summary')).toBeTruthy()
+    })
+  })
+
+  it('has correct accessibility state for expand/collapse', async () => {
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(
+        utils.getByLabelText(/Weekly summary for/)
+      ).toBeTruthy()
+    })
+  })
+
+  it('shows PRs with exercise name and weight delta', async () => {
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getByText('View Details')).toBeTruthy()
+    })
+    fireEvent.press(utils.getByText('View Details'))
+    await waitFor(() => {
+      expect(utils.getAllByText('Bench Press').length).toBeGreaterThanOrEqual(1)
+      expect(utils.getByText('Squat')).toBeTruthy()
+    })
+  })
+
+  it('hides nutrition section when no data', async () => {
+    mockDb.getWeeklySummary.mockResolvedValue({
+      ...mockSummaryData,
+      nutrition: null,
+    })
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getByText('View Details')).toBeTruthy()
+    })
+    fireEvent.press(utils.getByText('View Details'))
+    await waitFor(() => {
+      expect(utils.queryByText(/NUTRITION/)).toBeNull()
+    })
+  })
+
+  it('hides body section when no data', async () => {
+    mockDb.getWeeklySummary.mockResolvedValue({
+      ...mockSummaryData,
+      body: null,
+    })
+    const utils = renderScreen(<Progress />)
+    await waitFor(() => {
+      expect(utils.getByText('View Details')).toBeTruthy()
+    })
+    fireEvent.press(utils.getByText('View Details'))
+    await waitFor(() => {
+      expect(utils.queryByText(/^BODY$/)).toBeNull()
+    })
+  })
+})

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -43,6 +43,7 @@ import type { BodyWeight, BodySettings, BodyMeasurements } from "../../lib/types
 import { useLayout } from "../../lib/layout";
 import { toDisplay, toKg } from "../../lib/units";
 import MuscleVolumeSegment from "../../components/MuscleVolumeSegment";
+import WeeklySummary from "../../components/WeeklySummary";
 import { formatDuration, formatDateShort, movingAvg } from "../../lib/format";
 
 type PR = { exercise_id: string; name: string; max_weight: number };
@@ -219,10 +220,15 @@ export default function Progress() {
 
     if (empty) {
       return (
-        <View style={[styles.center, { flex: 1 }]}>
-          <Text variant="bodyLarge" style={{ color: theme.colors.onSurfaceVariant, textAlign: "center", padding: 32 }}>
-            Complete your first workout to see progress
-          </Text>
+        <View style={{ flex: 1 }}>
+          <View style={{ padding: 16 }}>
+            <WeeklySummary />
+          </View>
+          <View style={[styles.center, { flex: 1 }]}>
+            <Text variant="bodyLarge" style={{ color: theme.colors.onSurfaceVariant, textAlign: "center", padding: 32 }}>
+              Complete your first workout to see progress
+            </Text>
+          </View>
         </View>
       );
     }
@@ -363,6 +369,7 @@ export default function Progress() {
         ListHeaderComponent={
           layout.atLeastMedium ? (
             <>
+              <WeeklySummary />
               {achievementsCard}
               <View style={styles.grid}>
                 {freqCard}
@@ -375,6 +382,7 @@ export default function Progress() {
             </>
           ) : (
             <>
+              <WeeklySummary />
               {achievementsCard}
               {freqCard}
               {volCard}

--- a/components/WeeklySummary.tsx
+++ b/components/WeeklySummary.tsx
@@ -1,0 +1,664 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Pressable,
+  Share,
+  StyleSheet,
+  View,
+} from "react-native";
+import {
+  Button,
+  Card,
+  Divider,
+  IconButton,
+  Text,
+  useTheme,
+} from "react-native-paper";
+import { useFocusEffect } from "expo-router";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  useReducedMotion,
+} from "react-native-reanimated";
+
+import {
+  getWeeklySummary,
+  getBodySettings,
+} from "../lib/db";
+import type { WeeklySummaryData } from "../lib/db";
+import type { BodySettings } from "../lib/types";
+import { mondayOf, formatDuration } from "../lib/format";
+import { toDisplay } from "../lib/units";
+import { duration, easing } from "../constants/design-tokens";
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_WEEKS_BACK = 12;
+
+function formatWeekRange(weekStartMs: number): string {
+  const start = new Date(weekStartMs);
+  const end = new Date(weekStartMs + 6 * 24 * 60 * 60 * 1000);
+  const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+  return `${start.toLocaleDateString(undefined, opts)} – ${end.toLocaleDateString(undefined, opts)}`;
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+function volumeChangePercent(current: number, previous: number | null): string | null {
+  if (previous === null || previous === 0) return null;
+  const pct = Math.round(((current - previous) / previous) * 100);
+  if (pct === 0) return null;
+  return pct > 0 ? `+${pct}%` : `${pct}%`;
+}
+
+// ─── Component ─────────────────────────────────────────────────────
+
+export default function WeeklySummary() {
+  const theme = useTheme();
+  const reducedMotion = useReducedMotion();
+
+  const [expanded, setExpanded] = useState(false);
+  const [weekOffset, setWeekOffset] = useState(0); // 0 = current week
+  const [data, setData] = useState<WeeklySummaryData | null>(null);
+  const [settings, setSettings] = useState<BodySettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  // Cache for preloaded weeks (ref to avoid re-render loops)
+  const cacheRef = useRef<Record<number, WeeklySummaryData>>({});
+
+  const currentMonday = useMemo(() => mondayOf(new Date()), []);
+  const weekStartMs = currentMonday + weekOffset * ONE_WEEK_MS;
+
+  // Animation
+  const expandHeight = useSharedValue(0);
+  const expandOpacity = useSharedValue(0);
+
+  const expandAnimStyle = useAnimatedStyle(() => ({
+    maxHeight: expandHeight.value,
+    opacity: expandOpacity.value,
+    overflow: "hidden" as const,
+  }));
+
+  useEffect(() => {
+    if (reducedMotion) {
+      expandHeight.value = expanded ? 2000 : 0;
+      expandOpacity.value = expanded ? 1 : 0;
+      return;
+    }
+    expandHeight.value = withTiming(expanded ? 2000 : 0, {
+      duration: duration.normal,
+      easing: easing.standard,
+    });
+    expandOpacity.value = withTiming(expanded ? 1 : 0, {
+      duration: duration.normal,
+      easing: easing.standard,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expanded, reducedMotion]);
+
+  const loadWeek = useCallback(
+    async (offset: number): Promise<WeeklySummaryData | null> => {
+      const monday = currentMonday + offset * ONE_WEEK_MS;
+      try {
+        return await getWeeklySummary(monday);
+      } catch {
+        return null;
+      }
+    },
+    [currentMonday]
+  );
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const cached = cacheRef.current[weekOffset];
+      const [summary, bodySettings] = await Promise.all([
+        cached ? Promise.resolve(cached) : loadWeek(weekOffset),
+        getBodySettings(),
+      ]);
+      if (summary) {
+        setData(summary);
+        cacheRef.current[weekOffset] = summary;
+      } else {
+        setError(true);
+      }
+      setSettings(bodySettings);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [weekOffset, loadWeek]);
+
+  // Preload adjacent weeks after initial render
+  useEffect(() => {
+    let cancelled = false;
+    const preload = async () => {
+      // Small delay to not block initial render
+      await new Promise((r) => setTimeout(r, 100));
+      if (cancelled) return;
+      const offsets = [weekOffset - 1, weekOffset + 1].filter(
+        (o) => o <= 0 && o >= -MAX_WEEKS_BACK && !cacheRef.current[o]
+      );
+      for (const o of offsets) {
+        if (cancelled) return;
+        const result = await loadWeek(o);
+        if (result && !cancelled) {
+          cacheRef.current[o] = result;
+        }
+      }
+    };
+    preload();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [weekOffset]);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadData();
+    }, [loadData])
+  );
+
+  const unit = settings?.weight_unit ?? "kg";
+  const canGoBack = weekOffset > -MAX_WEEKS_BACK;
+  const canGoForward = weekOffset < 0;
+
+  const navigateWeek = (dir: -1 | 1) => {
+    const next = weekOffset + dir;
+    if (next < -MAX_WEEKS_BACK || next > 0) return;
+    setWeekOffset(next);
+  };
+
+  // ─── Share ─────────────────────────────────────────────────────
+
+  const buildShareText = (): string => {
+    if (!data) return "";
+    const { workouts, prs, nutrition, body, streak } = data;
+    const range = formatWeekRange(weekStartMs);
+    const lines: string[] = [
+      `📊 FitForge Weekly Summary`,
+      `Week of ${range}`,
+      "",
+    ];
+
+    if (workouts.sessionCount > 0) {
+      lines.push(
+        `💪 Workouts: ${workouts.sessionCount} completed (${formatDuration(workouts.totalDurationSeconds)} total)`
+      );
+      const volChange = volumeChangePercent(workouts.totalVolume, workouts.previousWeekVolume);
+      const volStr = `${formatNumber(Math.round(toDisplay(workouts.totalVolume, unit)))} ${unit}`;
+      lines.push(
+        `📈 Volume: ${volStr}${volChange ? ` (${volChange} vs last week)` : ""}`
+      );
+    }
+
+    if (prs.length > 0) {
+      const prParts = prs.map((pr) => {
+        const w = toDisplay(pr.newMax, unit);
+        const delta =
+          pr.previousMax !== null
+            ? ` (+${toDisplay(pr.newMax - pr.previousMax, unit)})`
+            : "";
+        return `${pr.exerciseName} ${w}${unit}${delta}`;
+      });
+      lines.push(`🏆 PRs: ${prParts.join(", ")}`);
+    }
+
+    if (nutrition) {
+      lines.push(
+        `🥗 Nutrition: ${nutrition.daysOnTarget}/${nutrition.daysTracked} days on target (avg ${formatNumber(nutrition.avgCalories)} cal)`
+      );
+    }
+
+    if (body && body.startWeight !== null && body.endWeight !== null) {
+      const start = toDisplay(body.startWeight, unit);
+      const end = toDisplay(body.endWeight, unit);
+      const delta = Math.round((end - start) * 10) / 10;
+      const sign = delta >= 0 ? "+" : "";
+      lines.push(`⚖️ Weight: ${start} → ${end} ${unit} (${sign}${delta})`);
+    }
+
+    if (streak > 0) {
+      lines.push(`🔥 Streak: ${streak} weeks`);
+    }
+
+    lines.push("", "Tracked with FitForge");
+    return lines.join("\n");
+  };
+
+  const handleShare = async () => {
+    try {
+      await Share.share({ message: buildShareText() });
+    } catch {
+      // Share cancelled or failed — ignore
+    }
+  };
+
+  // ─── Error / Loading states ────────────────────────────────────
+
+  if (error) {
+    return (
+      <Card
+        style={[styles.card, { backgroundColor: theme.colors.surface }]}
+        accessibilityLabel="Weekly summary unavailable"
+      >
+        <Card.Content>
+          <Text
+            variant="bodyMedium"
+            style={{ color: theme.colors.onSurfaceVariant, textAlign: "center" }}
+          >
+            Couldn&apos;t load summary
+          </Text>
+        </Card.Content>
+      </Card>
+    );
+  }
+
+  if (loading || !data) {
+    return (
+      <Card style={[styles.card, { backgroundColor: theme.colors.surface }]}>
+        <Card.Content>
+          <View style={styles.headerRow}>
+            <Text variant="titleMedium" style={{ color: theme.colors.onSurface }}>
+              📊 Loading…
+            </Text>
+          </View>
+        </Card.Content>
+      </Card>
+    );
+  }
+
+  // ─── Headline metrics ──────────────────────────────────────────
+
+  const { workouts, prs, nutrition, body, streak } = data;
+  const volChange = volumeChangePercent(workouts.totalVolume, workouts.previousWeekVolume);
+  const isEmpty = workouts.sessionCount === 0;
+
+  const headlineParts: string[] = [];
+  if (workouts.scheduledCount !== null) {
+    headlineParts.push(`${workouts.sessionCount}/${workouts.scheduledCount} workouts`);
+  } else {
+    headlineParts.push(
+      `${workouts.sessionCount} workout${workouts.sessionCount !== 1 ? "s" : ""}`
+    );
+  }
+  if (volChange) headlineParts.push(`${volChange} volume`);
+  if (prs.length > 0) headlineParts.push(`${prs.length} PR${prs.length !== 1 ? "s" : ""}`);
+
+  const headline = headlineParts.join("  ·  ");
+
+  // ─── Render ────────────────────────────────────────────────────
+
+  return (
+    <Card
+      style={[styles.card, { backgroundColor: theme.colors.surface }]}
+      accessibilityLabel={`Weekly summary for ${formatWeekRange(weekStartMs)}`}
+      accessibilityState={{ expanded }}
+    >
+      <Card.Content>
+        {/* Header with week navigation */}
+        <View style={styles.headerRow}>
+          <Text style={{ fontSize: 20, marginRight: 8 }}>📊</Text>
+          <Text
+            variant="titleMedium"
+            style={{ color: theme.colors.onSurface, flex: 1 }}
+          >
+            Week of {formatWeekRange(weekStartMs)}
+          </Text>
+          <IconButton
+            icon="chevron-left"
+            size={20}
+            onPress={() => navigateWeek(-1)}
+            disabled={!canGoBack}
+            accessibilityLabel="Previous week"
+            style={styles.navButton}
+          />
+          <IconButton
+            icon="chevron-right"
+            size={20}
+            onPress={() => navigateWeek(1)}
+            disabled={!canGoForward}
+            accessibilityLabel="Next week"
+            style={styles.navButton}
+          />
+        </View>
+
+        {isEmpty ? (
+          <Text
+            variant="bodyMedium"
+            style={{ color: theme.colors.onSurfaceVariant, marginTop: 8 }}
+          >
+            No workouts logged this week. Start one from the Workouts tab!
+          </Text>
+        ) : (
+          <>
+            {/* Collapsed headline */}
+            <Text
+              variant="bodyMedium"
+              style={{ color: theme.colors.onSurfaceVariant, marginTop: 4 }}
+              accessibilityLabel={headline}
+            >
+              {headline}
+            </Text>
+
+            {/* Expand/collapse toggle */}
+            <Pressable
+              onPress={() => setExpanded(!expanded)}
+              accessibilityHint="Double tap to expand weekly summary"
+              accessibilityRole="button"
+              style={styles.toggleButton}
+              hitSlop={{ top: 8, bottom: 8, left: 16, right: 16 }}
+            >
+              <Text
+                variant="labelMedium"
+                style={{ color: theme.colors.primary }}
+              >
+                {expanded ? "Hide Details" : "View Details"}
+              </Text>
+            </Pressable>
+
+            {/* Expanded content */}
+            <Animated.View style={expandAnimStyle}>
+              <View style={styles.expandedContent}>
+                <Divider style={{ marginVertical: 12 }} />
+
+                {/* WORKOUTS */}
+                <Text
+                  variant="labelLarge"
+                  style={[styles.sectionLabel, { color: theme.colors.onSurfaceVariant }]}
+                >
+                  WORKOUTS
+                </Text>
+                {workouts.scheduledCount !== null ? (
+                  <StatRow
+                    label="Completed"
+                    value={`${workouts.sessionCount} of ${workouts.scheduledCount} scheduled (${Math.round((workouts.sessionCount / workouts.scheduledCount) * 100)}%)`}
+                    theme={theme}
+                  />
+                ) : (
+                  <StatRow
+                    label="Completed"
+                    value={`${workouts.sessionCount} workout${workouts.sessionCount !== 1 ? "s" : ""}`}
+                    theme={theme}
+                  />
+                )}
+                <StatRow
+                  label="Total duration"
+                  value={formatDuration(workouts.totalDurationSeconds)}
+                  theme={theme}
+                />
+                {workouts.sessionCount > 0 && (
+                  <StatRow
+                    label="Avg session"
+                    value={formatDuration(
+                      Math.round(workouts.totalDurationSeconds / workouts.sessionCount)
+                    )}
+                    theme={theme}
+                  />
+                )}
+
+                {/* VOLUME */}
+                <Divider style={{ marginVertical: 12 }} />
+                <Text
+                  variant="labelLarge"
+                  style={[styles.sectionLabel, { color: theme.colors.onSurfaceVariant }]}
+                >
+                  VOLUME
+                </Text>
+                <StatRow
+                  label="Total"
+                  value={`${formatNumber(Math.round(toDisplay(workouts.totalVolume, unit)))} ${unit}${volChange ? `  ▲ ${volChange} vs last` : ""}`}
+                  theme={theme}
+                />
+                {workouts.sessionCount > 0 && (
+                  <StatRow
+                    label="Avg per session"
+                    value={`${formatNumber(Math.round(toDisplay(workouts.totalVolume / workouts.sessionCount, unit)))} ${unit}`}
+                    theme={theme}
+                  />
+                )}
+                {workouts.hasBodyweightOnly && (
+                  <Text
+                    variant="bodySmall"
+                    style={{ color: theme.colors.onSurfaceVariant, fontStyle: "italic", marginTop: 4 }}
+                  >
+                    Volume tracks weighted exercises only
+                  </Text>
+                )}
+
+                {/* PRs */}
+                {prs.length > 0 && (
+                  <>
+                    <Divider style={{ marginVertical: 12 }} />
+                    <Text
+                      variant="labelLarge"
+                      style={[styles.sectionLabel, { color: theme.colors.onSurfaceVariant }]}
+                    >
+                      PERSONAL RECORDS
+                    </Text>
+                    {prs.map((pr) => {
+                      const w = toDisplay(pr.newMax, unit);
+                      const delta =
+                        pr.previousMax !== null
+                          ? ` (+${toDisplay(pr.newMax - pr.previousMax, unit)} ${unit})`
+                          : "";
+                      return (
+                        <View key={pr.exerciseId} style={styles.prRow}>
+                          <Text style={{ fontSize: 16, marginRight: 8 }}>🏆</Text>
+                          <Text
+                            variant="bodyMedium"
+                            style={{ color: theme.colors.onSurface, flex: 1 }}
+                          >
+                            {pr.exerciseName}
+                          </Text>
+                          <Text
+                            variant="bodyMedium"
+                            style={{ color: theme.colors.primary }}
+                          >
+                            {w} {unit}{delta}
+                          </Text>
+                        </View>
+                      );
+                    })}
+                  </>
+                )}
+
+                {/* NUTRITION */}
+                {nutrition && (
+                  <>
+                    <Divider style={{ marginVertical: 12 }} />
+                    <Text
+                      variant="labelLarge"
+                      style={[styles.sectionLabel, { color: theme.colors.onSurfaceVariant }]}
+                    >
+                      NUTRITION ({nutrition.daysTracked}/7 days tracked)
+                    </Text>
+                    <StatRow
+                      label="Avg calories"
+                      value={`${formatNumber(nutrition.avgCalories)} / ${formatNumber(nutrition.calorieTarget)} target`}
+                      theme={theme}
+                    />
+                    <StatRow
+                      label={`Protein avg`}
+                      value={`${nutrition.avgProtein}g / ${nutrition.proteinTarget}g target${nutrition.avgProtein >= nutrition.proteinTarget ? " ✓" : ""}`}
+                      theme={theme}
+                    />
+                    <StatRow
+                      label="Days on target"
+                      value={`${nutrition.daysOnTarget}/${nutrition.daysTracked}`}
+                      theme={theme}
+                    />
+                  </>
+                )}
+
+                {/* BODY */}
+                {body && (
+                  <>
+                    <Divider style={{ marginVertical: 12 }} />
+                    <Text
+                      variant="labelLarge"
+                      style={[styles.sectionLabel, { color: theme.colors.onSurfaceVariant }]}
+                    >
+                      BODY
+                    </Text>
+                    {body.entryCount === 1 ? (
+                      <StatRow
+                        label="Weight"
+                        value={`${toDisplay(body.startWeight!, unit)} ${unit}`}
+                        theme={theme}
+                      />
+                    ) : (
+                      <>
+                        <StatRow
+                          label="Weight"
+                          value={(() => {
+                            const s = toDisplay(body.startWeight!, unit);
+                            const e = toDisplay(body.endWeight!, unit);
+                            const d = Math.round((e - s) * 10) / 10;
+                            const sign = d > 0 ? "+" : "";
+                            return `${s} ${unit} → ${e} ${unit} (${sign}${d})`;
+                          })()}
+                          theme={theme}
+                        />
+                        {body.entryCount >= 3 && (
+                          <Text
+                            variant="bodySmall"
+                            style={{ color: theme.colors.onSurfaceVariant, fontStyle: "italic", marginTop: 2 }}
+                          >
+                            (3-day rolling avg)
+                          </Text>
+                        )}
+                      </>
+                    )}
+                  </>
+                )}
+
+                {/* STREAK */}
+                {streak > 0 && (
+                  <>
+                    <Divider style={{ marginVertical: 12 }} />
+                    <Text
+                      variant="labelLarge"
+                      style={[styles.sectionLabel, { color: theme.colors.onSurfaceVariant }]}
+                    >
+                      STREAK
+                    </Text>
+                    <View style={styles.streakRow}>
+                      <Text
+                        variant="bodyMedium"
+                        style={{ color: theme.colors.onSurface }}
+                      >
+                        Current: {streak} week{streak !== 1 ? "s" : ""}  🔥
+                      </Text>
+                    </View>
+                    {weekOffset === 0 && (
+                      <Text
+                        variant="bodySmall"
+                        style={{ color: theme.colors.onSurfaceVariant, fontStyle: "italic", marginTop: 2 }}
+                      >
+                        (current week in progress)
+                      </Text>
+                    )}
+                  </>
+                )}
+
+                {/* Share button */}
+                <View style={styles.shareContainer}>
+                  <Button
+                    mode="outlined"
+                    onPress={handleShare}
+                    icon="share-variant"
+                    accessibilityLabel="Share weekly summary"
+                    accessibilityHint="Share your weekly training summary as text"
+                    style={{ marginTop: 16 }}
+                    contentStyle={{ paddingVertical: 8 }}
+                  >
+                    Share Summary
+                  </Button>
+                </View>
+              </View>
+            </Animated.View>
+          </>
+        )}
+      </Card.Content>
+    </Card>
+  );
+}
+
+// ─── StatRow helper ────────────────────────────────────────────────
+
+function StatRow({
+  label,
+  value,
+  theme,
+}: {
+  label: string;
+  value: string;
+  theme: { colors: { onSurface: string; onSurfaceVariant: string } };
+}) {
+  return (
+    <View style={styles.statRow}>
+      <Text variant="bodyMedium" style={{ color: theme.colors.onSurfaceVariant, flex: 1 }}>
+        {label}
+      </Text>
+      <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+// ─── Styles ────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  navButton: {
+    margin: 0,
+    width: 48,
+    height: 48,
+  },
+  toggleButton: {
+    paddingVertical: 8,
+    alignSelf: "flex-start",
+    minHeight: 48,
+    justifyContent: "center",
+  },
+  expandedContent: {
+    paddingTop: 0,
+  },
+  sectionLabel: {
+    marginBottom: 8,
+    letterSpacing: 0.5,
+  },
+  statRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 4,
+  },
+  prRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 4,
+  },
+  streakRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 4,
+  },
+  shareContainer: {
+    alignItems: "center",
+    marginTop: 8,
+  },
+});

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -176,6 +176,23 @@ export {
 export type { ProgressPhoto, PoseCategory } from "./photos";
 
 export {
+  getWeeklySummary,
+  getWeeklyWorkouts,
+  getWeeklyPRs,
+  getWeeklyNutrition,
+  getWeeklyBody,
+  getWeeklyStreak,
+  NUTRITION_ON_TARGET_TOLERANCE,
+} from "./weekly-summary";
+export type {
+  WeeklySummaryData,
+  WeeklyWorkoutSummary,
+  WeeklyPR,
+  WeeklyNutritionSummary,
+  WeeklyBodySummary,
+} from "./weekly-summary";
+
+export {
   buildAchievementContext,
   getEarnedAchievements,
   getEarnedAchievementIds,

--- a/lib/db/weekly-summary.ts
+++ b/lib/db/weekly-summary.ts
@@ -1,5 +1,5 @@
 import { query, queryOne } from "./helpers";
-import { mondayOf } from "../format";
+import { mondayOf, movingAvg } from "../format";
 
 // ─── Types ─────────────────────────────────────────────────────────
 
@@ -126,7 +126,7 @@ export async function getWeeklyWorkouts(
         [start, end]
       ),
       queryOne<{ count: number }>(
-        `SELECT COUNT(*) AS count
+        `SELECT COUNT(DISTINCT ps.day_of_week) AS count
          FROM program_schedule ps
          JOIN programs p ON p.id = ps.program_id AND p.is_active = 1 AND p.deleted_at IS NULL`
       ),
@@ -286,6 +286,16 @@ export async function getWeeklyBody(
   );
 
   if (entries.length === 0) return null;
+
+  // Use 3-day rolling average when ≥3 entries, raw values for <3
+  if (entries.length >= 3) {
+    const smoothed = movingAvg(entries, 3);
+    return {
+      startWeight: smoothed[0].avg,
+      endWeight: smoothed[smoothed.length - 1].avg,
+      entryCount: entries.length,
+    };
+  }
 
   return {
     startWeight: entries[0].weight,

--- a/lib/db/weekly-summary.ts
+++ b/lib/db/weekly-summary.ts
@@ -1,0 +1,341 @@
+import { query, queryOne } from "./helpers";
+import { mondayOf } from "../format";
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export type WeeklyWorkoutSummary = {
+  sessionCount: number;
+  totalDurationSeconds: number;
+  totalVolume: number;
+  previousWeekVolume: number | null;
+  previousWeekSessionCount: number | null;
+  hasBodyweightOnly: boolean;
+  /** Only present when an active program exists */
+  scheduledCount: number | null;
+};
+
+export type WeeklyPR = {
+  exerciseId: string;
+  exerciseName: string;
+  newMax: number;
+  previousMax: number | null;
+};
+
+export type WeeklyNutritionSummary = {
+  daysTracked: number;
+  avgCalories: number;
+  avgProtein: number;
+  avgCarbs: number;
+  avgFat: number;
+  calorieTarget: number;
+  proteinTarget: number;
+  carbsTarget: number;
+  fatTarget: number;
+  daysOnTarget: number;
+};
+
+export type WeeklyBodySummary = {
+  startWeight: number | null;
+  endWeight: number | null;
+  entryCount: number;
+};
+
+export type WeeklySummaryData = {
+  workouts: WeeklyWorkoutSummary;
+  prs: WeeklyPR[];
+  nutrition: WeeklyNutritionSummary | null;
+  body: WeeklyBodySummary | null;
+  streak: number;
+};
+
+// ─── Constants ─────────────────────────────────────────────────────
+
+export const NUTRITION_ON_TARGET_TOLERANCE = 0.10;
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function weekRange(weekStartMs: number): { start: number; end: number } {
+  return { start: weekStartMs, end: weekStartMs + ONE_WEEK_MS };
+}
+
+function dateKeyFromMs(ms: number): string {
+  const d = new Date(ms);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/** Generate array of YYYY-MM-DD date keys for a given week. */
+function weekDateKeys(weekStartMs: number): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    keys.push(dateKeyFromMs(weekStartMs + i * 24 * 60 * 60 * 1000));
+  }
+  return keys;
+}
+
+// ─── Query Functions ───────────────────────────────────────────────
+
+export async function getWeeklyWorkouts(
+  weekStartMs: number
+): Promise<WeeklyWorkoutSummary> {
+  const { start, end } = weekRange(weekStartMs);
+  const prevStart = weekStartMs - ONE_WEEK_MS;
+
+  const [sessions, volume, prevSessions, prevVolume, bodyweightCheck, scheduled] =
+    await Promise.all([
+      queryOne<{ count: number; total_duration: number }>(
+        `SELECT COUNT(*) AS count, COALESCE(SUM(duration_seconds), 0) AS total_duration
+         FROM workout_sessions
+         WHERE completed_at IS NOT NULL AND started_at >= ? AND started_at < ?`,
+        [start, end]
+      ),
+      queryOne<{ volume: number }>(
+        `SELECT COALESCE(SUM(ws.weight * ws.reps), 0) AS volume
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+         WHERE ws.completed = 1 AND wss.completed_at IS NOT NULL
+           AND wss.started_at >= ? AND wss.started_at < ?`,
+        [start, end]
+      ),
+      queryOne<{ count: number }>(
+        `SELECT COUNT(*) AS count
+         FROM workout_sessions
+         WHERE completed_at IS NOT NULL AND started_at >= ? AND started_at < ?`,
+        [prevStart, start]
+      ),
+      queryOne<{ volume: number }>(
+        `SELECT COALESCE(SUM(ws.weight * ws.reps), 0) AS volume
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+         WHERE ws.completed = 1 AND wss.completed_at IS NOT NULL
+           AND wss.started_at >= ? AND wss.started_at < ?`,
+        [prevStart, start]
+      ),
+      queryOne<{ count: number }>(
+        `SELECT COUNT(*) AS count
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+         WHERE ws.completed = 1 AND wss.completed_at IS NOT NULL
+           AND wss.started_at >= ? AND wss.started_at < ?
+           AND (ws.weight IS NULL OR ws.weight = 0)
+           AND ws.reps IS NOT NULL`,
+        [start, end]
+      ),
+      queryOne<{ count: number }>(
+        `SELECT COUNT(*) AS count
+         FROM program_schedule ps
+         JOIN programs p ON p.id = ps.program_id AND p.is_active = 1 AND p.deleted_at IS NULL`
+      ),
+    ]);
+
+  const sessionCount = sessions?.count ?? 0;
+  const prevSessionCount = prevSessions?.count ?? null;
+  const scheduledCount = (scheduled?.count ?? 0) > 0 ? scheduled!.count : null;
+
+  return {
+    sessionCount,
+    totalDurationSeconds: sessions?.total_duration ?? 0,
+    totalVolume: volume?.volume ?? 0,
+    previousWeekVolume: prevVolume?.volume ?? null,
+    previousWeekSessionCount: prevSessionCount,
+    hasBodyweightOnly: (bodyweightCheck?.count ?? 0) > 0 && (volume?.volume ?? 0) === 0,
+    scheduledCount,
+  };
+}
+
+export async function getWeeklyPRs(weekStartMs: number): Promise<WeeklyPR[]> {
+  const { start, end } = weekRange(weekStartMs);
+
+  // Get max weight per exercise THIS week
+  const weekMaxes = await query<{
+    exercise_id: string;
+    name: string;
+    max_weight: number;
+  }>(
+    `SELECT ws.exercise_id, COALESCE(e.name, 'Deleted Exercise') AS name,
+            MAX(ws.weight) AS max_weight
+     FROM workout_sets ws
+     LEFT JOIN exercises e ON ws.exercise_id = e.id
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.completed = 1 AND ws.weight IS NOT NULL AND ws.weight > 0
+       AND wss.completed_at IS NOT NULL
+       AND wss.started_at >= ? AND wss.started_at < ?
+     GROUP BY ws.exercise_id`,
+    [start, end]
+  );
+
+  if (weekMaxes.length === 0) return [];
+
+  // For each exercise, check if this week's max exceeds all prior maxes
+  const prs: WeeklyPR[] = [];
+  for (const wm of weekMaxes) {
+    const prior = await queryOne<{ max_weight: number }>(
+      `SELECT MAX(ws.weight) AS max_weight
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1 AND ws.weight IS NOT NULL AND ws.weight > 0
+         AND wss.completed_at IS NOT NULL
+         AND ws.exercise_id = ?
+         AND wss.started_at < ?`,
+      [wm.exercise_id, start]
+    );
+
+    const priorMax = prior?.max_weight ?? null;
+    if (priorMax === null || wm.max_weight > priorMax) {
+      prs.push({
+        exerciseId: wm.exercise_id,
+        exerciseName: wm.name,
+        newMax: wm.max_weight,
+        previousMax: priorMax,
+      });
+    }
+  }
+
+  return prs;
+}
+
+export async function getWeeklyNutrition(
+  weekStartMs: number
+): Promise<WeeklyNutritionSummary | null> {
+  const dateKeys = weekDateKeys(weekStartMs);
+  const placeholders = dateKeys.map(() => "?").join(",");
+
+  // Get daily totals for the week
+  const dailyTotals = await query<{
+    date: string;
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  }>(
+    `SELECT dl.date,
+            SUM(f.calories * dl.servings) AS calories,
+            SUM(f.protein * dl.servings) AS protein,
+            SUM(f.carbs * dl.servings) AS carbs,
+            SUM(f.fat * dl.servings) AS fat
+     FROM daily_log dl
+     JOIN food_entries f ON dl.food_entry_id = f.id
+     WHERE dl.date IN (${placeholders})
+     GROUP BY dl.date`,
+    dateKeys
+  );
+
+  if (dailyTotals.length === 0) return null;
+
+  const targets = await queryOne<{
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  }>("SELECT calories, protein, carbs, fat FROM macro_targets LIMIT 1");
+
+  const calorieTarget = targets?.calories ?? 2000;
+  const proteinTarget = targets?.protein ?? 150;
+  const carbsTarget = targets?.carbs ?? 250;
+  const fatTarget = targets?.fat ?? 65;
+
+  const daysTracked = dailyTotals.length;
+  const avgCalories = Math.round(
+    dailyTotals.reduce((sum, d) => sum + d.calories, 0) / daysTracked
+  );
+  const avgProtein = Math.round(
+    dailyTotals.reduce((sum, d) => sum + d.protein, 0) / daysTracked
+  );
+  const avgCarbs = Math.round(
+    dailyTotals.reduce((sum, d) => sum + d.carbs, 0) / daysTracked
+  );
+  const avgFat = Math.round(
+    dailyTotals.reduce((sum, d) => sum + d.fat, 0) / daysTracked
+  );
+
+  const daysOnTarget = dailyTotals.filter((d) => {
+    const diff = Math.abs(d.calories - calorieTarget) / calorieTarget;
+    return diff <= NUTRITION_ON_TARGET_TOLERANCE;
+  }).length;
+
+  return {
+    daysTracked,
+    avgCalories,
+    avgProtein,
+    avgCarbs,
+    avgFat,
+    calorieTarget,
+    proteinTarget,
+    carbsTarget,
+    fatTarget,
+    daysOnTarget,
+  };
+}
+
+export async function getWeeklyBody(
+  weekStartMs: number
+): Promise<WeeklyBodySummary | null> {
+  const dateKeys = weekDateKeys(weekStartMs);
+  const startDate = dateKeys[0];
+  const endDate = dateKeys[6];
+
+  const entries = await query<{ date: string; weight: number }>(
+    `SELECT date, weight FROM body_weight
+     WHERE date >= ? AND date <= ?
+     ORDER BY date ASC`,
+    [startDate, endDate]
+  );
+
+  if (entries.length === 0) return null;
+
+  return {
+    startWeight: entries[0].weight,
+    endWeight: entries[entries.length - 1].weight,
+    entryCount: entries.length,
+  };
+}
+
+/**
+ * Compute streak of consecutive completed weeks (excluding current week).
+ * A week is "completed" if at least one workout session was finished.
+ */
+export async function getWeeklyStreak(): Promise<number> {
+  const twoYearsAgo = Date.now() - 2 * 365 * 24 * 60 * 60 * 1000;
+  const rows = await query<{ started_at: number }>(
+    `SELECT started_at FROM workout_sessions
+     WHERE completed_at IS NOT NULL AND started_at >= ?
+     ORDER BY started_at DESC`,
+    [twoYearsAgo]
+  );
+
+  if (rows.length === 0) return 0;
+
+  const weeks = new Set(rows.map((r) => mondayOf(new Date(r.started_at))));
+  const currentWeekMonday = mondayOf(new Date());
+
+  // Start counting from previous week (current week excluded)
+  let checkWeek = currentWeekMonday - ONE_WEEK_MS;
+  let count = 0;
+  while (weeks.has(checkWeek)) {
+    count++;
+    checkWeek -= ONE_WEEK_MS;
+  }
+
+  return count;
+}
+
+/**
+ * Fetch all summary data for a given week.
+ */
+export async function getWeeklySummary(
+  weekStartMs: number
+): Promise<WeeklySummaryData> {
+  const [workouts, prs, nutrition, body, streak] = await Promise.all([
+    getWeeklyWorkouts(weekStartMs),
+    getWeeklyPRs(weekStartMs),
+    getWeeklyNutrition(weekStartMs),
+    getWeeklyBody(weekStartMs),
+    getWeeklyStreak(),
+  ]);
+
+  return { workouts, prs, nutrition, body, streak };
+}


### PR DESCRIPTION
## Summary

Adds a Weekly Training Summary card to the Progress tab that auto-generates a weekly training digest from existing data. Covers workout count/volume/duration, PRs, nutrition adherence, body weight trends, and streaks.

## Changes

- **New `lib/db/weekly-summary.ts`**: Pure query functions for weekly workout stats, PR detection, nutrition adherence (±10% calorie tolerance), body weight trends, and streak calculation (excluding current week)
- **New `components/WeeklySummary.tsx`**: Self-contained expandable card with collapsed headline metrics, expanded detail sections, week navigation (current + 12 weeks back), and text sharing
- **Modified `app/(tabs)/progress.tsx`**: One-line import + render at top of workouts segment, zero new state hooks
- **Modified `lib/db/index.ts`**: Re-exports for new weekly-summary module
- **Updated 3 existing test files**: Added WeeklySummary component mock for non-regression

## Key Decisions

- Collapsed by default with 3 headline metrics (workouts, volume change, PRs)
- Monday = week start (ISO)
- Nutrition on-target = calories within ±10% (`NUTRITION_ON_TARGET_TOLERANCE`)
- Streak: completed weeks only, current week excluded
- PR detection: weighted exercises only (weight > 0)
- All state management inside WeeklySummary — progress.tsx unchanged except import
- Uses `useReducedMotion()` for accessibility
- Error fallback: "Couldn't load summary" card, rest of tab unaffected

## Testing

- 12 acceptance tests covering:
  - Headline metrics display
  - Expand/collapse with View/Hide Details
  - Empty state (no workouts)
  - Error fallback (query failure)
  - Scheduled count with active program
  - Week navigation
  - Share button accessibility
  - PR display with weight delta
  - Hidden sections when no data (nutrition, body)
- All 1176 existing tests pass with zero regressions
- TypeScript: zero errors
- Build: passes

## Issue

Resolves BLD-182