### PR TITLE
fix: exercise category chip active/inactive styling (BLD-189)

### DIFF
--- a/__tests__/app/exercise-chip-styling.test.ts
+++ b/__tests__/app/exercise-chip-styling.test.ts
@@ -1,0 +1,51 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const exercisesSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../app/(tabs)/exercises.tsx"),
+  "utf-8"
+);
+
+describe("Exercise category chip active/inactive styling (BLD-189)", () => {
+  it("uses 'flat' mode for active chips", () => {
+    expect(exercisesSrc).toContain('mode={active ? "flat" : "outlined"}');
+  });
+
+  it("uses 'outlined' mode for inactive chips", () => {
+    expect(exercisesSrc).toContain('"outlined"');
+  });
+
+  it("applies primaryContainer background only when active", () => {
+    expect(exercisesSrc).toContain(
+      "active && { backgroundColor: theme.colors.primaryContainer }"
+    );
+  });
+
+  it("applies onPrimaryContainer text color only when active", () => {
+    expect(exercisesSrc).toContain("color: theme.colors.onPrimaryContainer");
+  });
+
+  it("sets flexShrink: 0 on chip text to prevent ellipsis truncation", () => {
+    expect(exercisesSrc).toContain("flexShrink: 0");
+  });
+
+  it("only shows selected overlay when chip is active", () => {
+    expect(exercisesSrc).toContain("showSelectedOverlay={active}");
+  });
+
+  it("does NOT use a static showSelectedOverlay without condition", () => {
+    // Ensure we don't have the old unconditional showSelectedOverlay
+    const lines = exercisesSrc.split("\n");
+    const overlayLines = lines.filter(
+      (l) => l.includes("showSelectedOverlay") && !l.includes("{active}")
+    );
+    expect(overlayLines).toHaveLength(0);
+  });
+
+  it("uses theme tokens for chip icon colors (no hardcoded hex)", () => {
+    // Icon color should use theme.colors, not raw hex values
+    expect(exercisesSrc).toContain(
+      "color={active ? theme.colors.onPrimaryContainer : theme.colors.onSurface}"
+    );
+  });
+});

--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -171,14 +171,18 @@ export default function Exercises() {
             return (
             <Chip
               selected={active}
+              mode={active ? "flat" : "outlined"}
               onPress={() => toggle(f)}
               style={[
                 styles.filterChip,
                 active && { backgroundColor: theme.colors.primaryContainer },
               ]}
-              textStyle={active ? { color: theme.colors.onPrimaryContainer, fontWeight: "600" } : undefined}
+              textStyle={[
+                { flexShrink: 0 },
+                active ? { color: theme.colors.onPrimaryContainer, fontWeight: "600" } : undefined,
+              ]}
               compact
-              showSelectedOverlay
+              showSelectedOverlay={active}
               icon={f !== "custom" && CATEGORY_ICONS[f] ? () => (
                 <MaterialCommunityIcons
                   name={CATEGORY_ICONS[f] as keyof typeof MaterialCommunityIcons.glyphMap}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fitforge",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fitforge",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.9",


### PR DESCRIPTION
## Summary

Fix exercise category filter chips to use outlined mode when inactive and flat mode when active, with text truncation prevention.

## Changes

- Set chip `mode` to `'outlined'` for inactive categories, `'flat'` for active
- Add `flexShrink: 0` to chip text style to prevent ellipsis truncation
- Only show selected overlay when chip is actually active
- All styling uses theme tokens — no hardcoded hex values

## Testing

- TypeScript compiles with zero errors
- ESLint passes with zero warnings
- 8 new tests in `__tests__/app/exercise-chip-styling.test.ts` — all pass
- Visual: inactive chips show outline border only; active chips show filled background

## Issue

Resolves BLD-189 (GitHub #93)