### PR TITLE
fix: repair starter template names and add rendering fallback (BLD-187)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -577,7 +577,7 @@ export default function Workouts() {
                               <Pressable
                                 onPress={() => startFromTemplate(item)}
                                 style={styles.cardInfo}
-                                accessibilityLabel={`Starter template: ${item.name}, ${counts[item.id] ?? 0} exercises`}
+                                accessibilityLabel={`Starter template: ${meta?.name || item.name}, ${counts[item.id] ?? 0} exercises`}
                                 accessibilityHint="Double-tap to start workout"
                                 accessibilityRole="button"
                               >
@@ -586,7 +586,7 @@ export default function Workouts() {
                                     variant="titleSmall"
                                     style={{ color: theme.colors.onSurface }}
                                   >
-                                    {item.name}
+                                    {meta?.name || item.name}
                                   </Text>
                                   <View style={[styles.badge, { backgroundColor: theme.colors.surfaceVariant }]} accessibilityLabel="Starter template">
                                     <Text style={[styles.badgeText, { color: theme.colors.onSurfaceVariant }]}>STARTER</Text>

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -568,17 +568,28 @@ async function seedStarters(database: SQLite.SQLiteDatabase): Promise<void> {
     );
   }
 
-  // Always repair is_starter flags — handles cases where import or
-  // migration left starters with is_starter=0
+  // Always repair is_starter flags and names — handles cases where import,
+  // migration, or prior seeding left starters with is_starter=0 or empty names
   const starterTplIds = STARTER_TEMPLATES.map((t) => t.id);
   const tplPlaceholders = starterTplIds.map(() => "?").join(",");
   await database.runAsync(
     `UPDATE workout_templates SET is_starter = 1 WHERE id IN (${tplPlaceholders}) AND is_starter = 0`,
     starterTplIds
   );
+  // Repair names from canonical STARTER_TEMPLATES data
+  for (const tpl of STARTER_TEMPLATES) {
+    await database.runAsync(
+      "UPDATE workout_templates SET name = ? WHERE id = ? AND (name IS NULL OR name = '')",
+      [tpl.name, tpl.id]
+    );
+  }
   await database.runAsync(
     "UPDATE programs SET is_starter = 1 WHERE id = ? AND is_starter = 0",
     [STARTER_PROGRAM.id]
+  );
+  await database.runAsync(
+    "UPDATE programs SET name = ? WHERE id = ? AND (name IS NULL OR name = '')",
+    [STARTER_PROGRAM.name, STARTER_PROGRAM.id]
   );
 
   if (row && Number(row.value) >= STARTER_VERSION) return;


### PR DESCRIPTION
## Summary

Fixes starter workout cards showing only the "STARTER" badge with no name, metadata, or card content. Follow-up fix for GitHub #89.

## Root Cause

`seedStarters()` repaired `is_starter` flags (PR #91) but never repaired template names. If a prior migration or import left templates with empty/null names, the cards rendered with invisible text.

## Changes

- **`lib/db/helpers.ts`**: `seedStarters()` now repairs empty/null `name` fields from canonical `STARTER_TEMPLATES` data on every DB init, alongside the existing `is_starter` flag repair. Also repairs program names.
- **`app/(tabs)/index.tsx`**: Starter template card rendering now falls back to `meta?.name || item.name` using the JS `STARTER_TEMPLATES` constant as a secondary source, ensuring names always display even if DB data is corrupted.

## Testing

- `npx tsc --noEmit` — passes
- 1090 tests pass (5 suites fail due to pre-existing babel config issue)
- ESLint — no new warnings

## Issue

Resolves BLD-187 / GitHub #89