### PR TITLE
feat: body anatomy reflects profile gender setting (BLD-207)

### DIFF
--- a/__tests__/lib/useProfileGender.test.ts
+++ b/__tests__/lib/useProfileGender.test.ts
@@ -1,0 +1,67 @@
+// Mock getAppSetting directly
+const mockGetAppSetting = jest.fn<Promise<string | null>, [string]>();
+jest.mock("../../lib/db", () => ({
+  getAppSetting: (...args: [string]) => mockGetAppSetting(...args),
+}));
+
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { useProfileGender } from "../../lib/useProfileGender";
+
+beforeEach(() => {
+  mockGetAppSetting.mockReset();
+});
+
+describe("useProfileGender", () => {
+  it("defaults to male when no profile is saved", async () => {
+    mockGetAppSetting.mockResolvedValue(null);
+    const { result } = renderHook(() => useProfileGender());
+    expect(result.current).toBe("male");
+    await waitFor(() => {
+      expect(mockGetAppSetting).toHaveBeenCalledWith("nutrition_profile");
+    });
+    expect(result.current).toBe("male");
+  });
+
+  it("returns male when profile sex is male", async () => {
+    mockGetAppSetting.mockResolvedValue(JSON.stringify({ sex: "male", age: 30 }));
+    const { result } = renderHook(() => useProfileGender());
+    await waitFor(() => {
+      expect(result.current).toBe("male");
+    });
+  });
+
+  it("returns female when profile sex is female", async () => {
+    mockGetAppSetting.mockResolvedValue(JSON.stringify({ sex: "female", age: 25 }));
+    const { result } = renderHook(() => useProfileGender());
+    await waitFor(() => {
+      expect(result.current).toBe("female");
+    });
+  });
+
+  it("defaults to male when profile has invalid JSON", async () => {
+    mockGetAppSetting.mockResolvedValue("not-json");
+    const { result } = renderHook(() => useProfileGender());
+    await waitFor(() => {
+      expect(mockGetAppSetting).toHaveBeenCalled();
+    });
+    expect(result.current).toBe("male");
+  });
+
+  it("defaults to male when profile sex field is missing", async () => {
+    mockGetAppSetting.mockResolvedValue(JSON.stringify({ age: 30 }));
+    const { result } = renderHook(() => useProfileGender());
+    await waitFor(() => {
+      expect(mockGetAppSetting).toHaveBeenCalled();
+    });
+    expect(result.current).toBe("male");
+  });
+
+  it("defaults to male when DB throws an error", async () => {
+    mockGetAppSetting.mockRejectedValue(new Error("DB error"));
+    const { result } = renderHook(() => useProfileGender());
+    await waitFor(() => {
+      expect(mockGetAppSetting).toHaveBeenCalled();
+    });
+    expect(result.current).toBe("male");
+  });
+});

--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -23,6 +23,7 @@ import { useLayout } from "../../lib/layout";
 import { MuscleMap } from "../../components/MuscleMap";
 import { useFocusRefetch } from "../../lib/query";
 import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
+import { useProfileGender } from "../../lib/useProfileGender";
 
 type FilterType = Category | "custom";
 const FILTER_ALL: FilterType[] = [...CATEGORIES, "custom"];
@@ -32,6 +33,7 @@ export default function Exercises() {
   const router = useRouter();
   const layout = useLayout();
   const tabBarHeight = useFloatingTabBarHeight();
+  const profileGender = useProfileGender();
   const mc = theme.dark ? muscle.dark : muscle.light;
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<Set<FilterType>>(new Set());
@@ -317,6 +319,7 @@ export default function Exercises() {
                   primary={detail.primary_muscles}
                   secondary={detail.secondary_muscles}
                   width={360}
+                  gender={profileGender}
                 />
                 <View style={styles.muscleColumns}>
                   <View style={{ flex: 1 }}>

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -31,6 +31,7 @@ import { toDisplay } from "../../lib/units";
 import { percentageTable } from "../../lib/rm";
 import { useLayout } from "../../lib/layout";
 import FlowContainer, { flowCardStyle } from "../../components/ui/FlowContainer";
+import { useProfileGender } from "../../lib/useProfileGender";
 
 const PAGE_SIZE = 10;
 const MAX_ITEMS = 50;
@@ -48,6 +49,7 @@ export default function ExerciseDetail() {
   const router = useRouter();
   const { width: screenWidth } = useWindowDimensions();
   const layout = useLayout();
+  const profileGender = useProfileGender();
   const { id } = useLocalSearchParams<{ id: string }>();
   const [exercise, setExercise] = useState<Exercise | null>(null);
   const [toast, setToast] = useState("");
@@ -293,6 +295,7 @@ export default function ExerciseDetail() {
               primary={exercise.primary_muscles}
               secondary={exercise.secondary_muscles}
               width={Math.min(screenWidth * 0.45, 400)}
+              gender={profileGender}
             />
           </View>
           <View style={{ flex: 1 }}>
@@ -324,6 +327,7 @@ export default function ExerciseDetail() {
               primary={exercise.primary_muscles}
               secondary={exercise.secondary_muscles}
               width={screenWidth - 32}
+              gender={profileGender}
             />
           </View>
           {steps.length > 0 && (

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -65,6 +65,7 @@ import { CATEGORY_LABELS, ATTACHMENT_LABELS } from "../../lib/types";
 import { rpeColor, rpeText } from "../../lib/rpe";
 import { difficultyText, DIFFICULTY_COLORS } from "../../constants/theme";
 import { MuscleMap } from "../../components/MuscleMap";
+import { useProfileGender } from "../../lib/useProfileGender";
 import { suggest, type Suggestion } from "../../lib/rm";
 import TrainingModeSelector from "../../components/TrainingModeSelector";
 import { formatTime } from "../../lib/format";
@@ -508,6 +509,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
 function ExerciseDetailDrawerContent({ exercise }: { exercise: Exercise }) {
   const theme = useTheme();
   const layout = useLayout();
+  const profileGender = useProfileGender();
   const { width: screenWidth } = useWindowDimensions();
 
   const steps = exercise.instructions
@@ -624,6 +626,7 @@ function ExerciseDetailDrawerContent({ exercise }: { exercise: Exercise }) {
                 primary={exercise.primary_muscles}
                 secondary={exercise.secondary_muscles}
                 width={mapWidth}
+                gender={profileGender}
               />
             </>
           ) : (

--- a/components/MuscleMap.tsx
+++ b/components/MuscleMap.tsx
@@ -10,6 +10,7 @@ type Props = {
   primary: MuscleGroup[];
   secondary: MuscleGroup[];
   width?: number;
+  gender?: "male" | "female";
 };
 
 const SLUG_MAP: Record<MuscleGroup, Slug[]> = {
@@ -51,7 +52,7 @@ function buildData(
   return result;
 }
 
-function MuscleMapInner({ primary, secondary, width: w }: Props) {
+function MuscleMapInner({ primary, secondary, width: w, gender = "male" }: Props) {
   const theme = useTheme();
   const isDark = theme.dark;
   const c = isDark ? muscle.dark : muscle.light;
@@ -87,21 +88,19 @@ function MuscleMapInner({ primary, secondary, width: w }: Props) {
       <View style={styles.horizontal}>
         <Body
           data={data}
-          gender="male"
+          gender={gender}
           side="front"
           scale={scale}
           colors={[c.secondary, c.primary]}
           border={isDark ? "#555" : "#dfdfdf"}
-          hiddenParts={["hair"]}
         />
         <Body
           data={data}
-          gender="male"
+          gender={gender}
           side="back"
           scale={scale}
           colors={[c.secondary, c.primary]}
           border={isDark ? "#555" : "#dfdfdf"}
-          hiddenParts={["hair"]}
         />
       </View>
       <Legend primary={primary} secondary={secondary} isDark={isDark} />

--- a/lib/useProfileGender.ts
+++ b/lib/useProfileGender.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+import { getAppSetting } from "./db";
+import type { Sex } from "./nutrition-calc";
+
+/**
+ * Returns the user's sex/gender from their nutrition profile.
+ * Defaults to "male" if no profile is saved or the field is missing.
+ */
+export function useProfileGender(): Sex {
+  const [gender, setGender] = useState<Sex>("male");
+
+  useEffect(() => {
+    getAppSetting("nutrition_profile")
+      .then((saved) => {
+        if (saved) {
+          try {
+            const profile = JSON.parse(saved);
+            if (profile.sex === "male" || profile.sex === "female") {
+              setGender(profile.sex);
+            }
+          } catch {
+            // Invalid JSON — keep default
+          }
+        }
+      })
+      .catch(() => {
+        // DB error — keep default
+      });
+  }, []);
+
+  return gender;
+}


### PR DESCRIPTION
## Summary

MuscleMap body diagrams now reflect the user's sex/gender preference from their nutrition profile instead of always showing the male body.

## Changes

- Added `useProfileGender` hook in `lib/useProfileGender.ts` — reads sex from nutrition_profile app setting
- Added `gender` prop to `MuscleMap` component (default: `"male"`)
- Removed hardcoded `hiddenParts={["hair"]}` from Body components (hair now shown)
- Updated all 3 callers to pass profile gender:
  - `app/(tabs)/exercises.tsx`
  - `app/exercise/[id].tsx`
  - `app/session/[id].tsx` (ExerciseDetailDrawerContent)

## Testing

- 6 unit tests for `useProfileGender` hook covering:
  - Default (no profile) → male
  - Male profile → male
  - Female profile → female
  - Invalid JSON → male (no crash)
  - Missing sex field → male
  - DB error → male (no crash)
- tsc --noEmit passes
- eslint --max-warnings=0 passes
- All 1184 existing tests pass

## Issue

Resolves BLD-207