### PR TITLE
fix: floating tab bar theme tokens and accessible font sizing (BLD-212)

### DIFF
--- a/__tests__/acceptance/exercise-crud.acceptance.test.tsx
+++ b/__tests__/acceptance/exercise-crud.acceptance.test.tsx
@@ -52,6 +52,7 @@ jest.mock('../../lib/db', () => ({
   getAllExercises: (...args: unknown[]) => mockGetAll(...args),
   getExerciseById: (...args: unknown[]) => mockGetById(...args),
   createCustomExercise: (...args: unknown[]) => mockCreateCustom(...args),
+  getAppSetting: jest.fn().mockResolvedValue(null),
 }))
 
 import Exercises from '../../app/(tabs)/exercises'

--- a/__tests__/acceptance/voltra-exercises.test.tsx
+++ b/__tests__/acceptance/voltra-exercises.test.tsx
@@ -47,6 +47,7 @@ jest.mock('../../lib/db', () => ({
   getAllExercises: (...args: unknown[]) => mockGetAll(...args),
   getExerciseById: (...args: unknown[]) => mockGetById(...args),
   createCustomExercise: (...args: unknown[]) => mockCreateCustom(...args),
+  getAppSetting: jest.fn().mockResolvedValue(null),
 }))
 
 import Exercises from '../../app/(tabs)/exercises'

--- a/__tests__/app/floating-tab-bar.test.ts
+++ b/__tests__/app/floating-tab-bar.test.ts
@@ -40,6 +40,30 @@ describe("FloatingTabBar component (BLD-212)", () => {
     expect(floatingTabBarSrc).toContain("shadowOffset");
   });
 
+  it("uses theme.colors.shadow instead of hardcoded #000 for shadowColor", () => {
+    expect(floatingTabBarSrc).toContain("theme.colors.shadow");
+    expect(floatingTabBarSrc).not.toContain('shadowColor: "#000"');
+    expect(floatingTabBarSrc).not.toContain("shadowColor: '#000'");
+  });
+
+  it("CenterButton uses useTheme for theme-aware styling", () => {
+    // useTheme must appear at least twice: once in CenterButton, once in FloatingTabBar
+    const themeUsages = (floatingTabBarSrc.match(/const theme = useTheme\(\)/g) || []);
+    expect(themeUsages.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("tab label font size is at least 12 for accessibility", () => {
+    const fontSizeMatch = floatingTabBarSrc.match(/label:[\s\S]*?fontSize:\s*(\d+)/);
+    expect(fontSizeMatch).not.toBeNull();
+    expect(Number(fontSizeMatch![1])).toBeGreaterThanOrEqual(12);
+  });
+
+  it("tab label line height is proportional to font size", () => {
+    const lineHeightMatch = floatingTabBarSrc.match(/label:[\s\S]*?lineHeight:\s*(\d+)/);
+    expect(lineHeightMatch).not.toBeNull();
+    expect(Number(lineHeightMatch![1])).toBeGreaterThanOrEqual(16);
+  });
+
   it("defines center button with circular shape", () => {
     expect(floatingTabBarSrc).toContain("CENTER_BUTTON_SIZE");
     expect(floatingTabBarSrc).toContain("borderRadius: CENTER_BUTTON_SIZE / 2");

--- a/__tests__/flows/exercise.test.tsx
+++ b/__tests__/flows/exercise.test.tsx
@@ -73,6 +73,7 @@ const mockGetById = jest.fn().mockImplementation((id: string) =>
 jest.mock('../../lib/db', () => ({
   getAllExercises: (...args: unknown[]) => mockGetAll(...args),
   getExerciseById: (...args: unknown[]) => mockGetById(...args),
+  getAppSetting: jest.fn().mockResolvedValue(null),
 }))
 
 import Exercises from '../../app/(tabs)/exercises'


### PR DESCRIPTION
## Summary

Fix two quality issues in the FloatingTabBar component: hardcoded shadow colors and undersized tab labels.

## Changes

- Replace hardcoded `#000` shadowColor with `theme.colors.shadow` on both bar container and center button
- Raise tab label fontSize from 10 → 12px (lineHeight 14 → 16) for accessible text sizing
- Add `useTheme()` to CenterButton for theme-aware shadow color
- Add eslint-disable comments for reanimated shared value mutations

## Testing

- `tsc --noEmit` passes with zero errors
- ESLint passes via lint-staged pre-commit hook
- Existing FloatingTabBar structural tests unaffected

## Issue

Resolves BLD-212