### PR TITLE
fix: add missing getAppSetting mock to exercise tests (BLD-202)

### DIFF
--- a/__tests__/acceptance/exercise-crud.acceptance.test.tsx
+++ b/__tests__/acceptance/exercise-crud.acceptance.test.tsx
@@ -52,6 +52,7 @@ jest.mock('../../lib/db', () => ({
   getAllExercises: (...args: unknown[]) => mockGetAll(...args),
   getExerciseById: (...args: unknown[]) => mockGetById(...args),
   createCustomExercise: (...args: unknown[]) => mockCreateCustom(...args),
+  getAppSetting: jest.fn().mockResolvedValue(null),
 }))
 
 import Exercises from '../../app/(tabs)/exercises'

--- a/__tests__/acceptance/voltra-exercises.test.tsx
+++ b/__tests__/acceptance/voltra-exercises.test.tsx
@@ -47,6 +47,7 @@ jest.mock('../../lib/db', () => ({
   getAllExercises: (...args: unknown[]) => mockGetAll(...args),
   getExerciseById: (...args: unknown[]) => mockGetById(...args),
   createCustomExercise: (...args: unknown[]) => mockCreateCustom(...args),
+  getAppSetting: jest.fn().mockResolvedValue(null),
 }))
 
 import Exercises from '../../app/(tabs)/exercises'

--- a/__tests__/flows/exercise.test.tsx
+++ b/__tests__/flows/exercise.test.tsx
@@ -73,6 +73,7 @@ const mockGetById = jest.fn().mockImplementation((id: string) =>
 jest.mock('../../lib/db', () => ({
   getAllExercises: (...args: unknown[]) => mockGetAll(...args),
   getExerciseById: (...args: unknown[]) => mockGetById(...args),
+  getAppSetting: jest.fn().mockResolvedValue(null),
 }))
 
 import Exercises from '../../app/(tabs)/exercises'


### PR DESCRIPTION
## Summary

Fixes 3 broken test suites (30 failing tests) on main caused by the BottomSheet + gender profile changes that were pushed directly to main.

## Changes

- Added `getAppSetting: jest.fn().mockResolvedValue(null)` to the `lib/db` mock in:
  - `__tests__/flows/exercise.test.tsx`
  - `__tests__/acceptance/voltra-exercises.test.tsx`
  - `__tests__/acceptance/exercise-crud.acceptance.test.tsx`

## Root Cause

The `useProfileGender` hook (BLD-207) calls `getAppSetting('nutrition_profile')` in the exercises screen. Test mocks for `lib/db` didn't include this function, causing `TypeError: (0 , _db.getAppSetting) is not a function`.

## Testing

- All 78 test suites pass (1285 tests, 0 failures)
- `tsc --noEmit` passes with zero errors
- ESLint passes via lint-staged

## Issue

Resolves BLD-202