### PR TITLE
chore: bump version to v0.3.0 (BLD-232)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,7 +4,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: "FitForge",
   slug: "fitforge",
-  version: "0.2.0",
+  version: "0.3.0",
   orientation: "default",
   icon: "./assets/icon.png",
   userInterfaceStyle: "automatic",
@@ -23,6 +23,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       backgroundColor: "#ffffff",
     },
     package: "com.anomalyco.fitforge",
+    versionCode: 2,
   },
   web: {
     favicon: "./assets/favicon.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fitforge",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary

Version bump for the v0.3.0 release. Includes version update in both `app.config.ts` and `package.json`, and adds `android.versionCode: 2` for the Android build.

## Changes

- `app.config.ts`: version `0.2.0` → `0.3.0`, added `android.versionCode: 2`
- `package.json`: version `0.2.0` → `0.3.0`

## Testing

- `npx tsc --noEmit` passes with zero errors

## Issue

Resolves BLD-232