### PR TITLE
feat: Session Rating & Save-as-Template (BLD-235)

### DIFF
--- a/__tests__/acceptance/rpe-notes.test.tsx
+++ b/__tests__/acceptance/rpe-notes.test.tsx
@@ -29,6 +29,9 @@ jest.mock('../../lib/db', () => ({
   getSessionRepPRs: jest.fn().mockResolvedValue([]),
   getSessionWeightIncreases: jest.fn().mockResolvedValue([]),
   getSessionComparison: jest.fn().mockResolvedValue(null),
+  updateSession: jest.fn().mockResolvedValue(undefined),
+  getSessionSetCount: jest.fn().mockResolvedValue(0),
+  createTemplateFromSession: jest.fn().mockResolvedValue('new-template-id'),
 }))
 
 jest.mock('../../lib/programs', () => ({

--- a/__tests__/acceptance/workout-session.acceptance.test.tsx
+++ b/__tests__/acceptance/workout-session.acceptance.test.tsx
@@ -26,6 +26,12 @@ jest.mock('../../lib/db', () => ({
   getSessionRepPRs: jest.fn().mockResolvedValue([]),
   getSessionWeightIncreases: jest.fn().mockResolvedValue([]),
   getSessionComparison: jest.fn().mockResolvedValue(null),
+  updateSession: jest.fn().mockResolvedValue(undefined),
+  getSessionSetCount: jest.fn().mockResolvedValue(0),
+  createTemplateFromSession: jest.fn().mockResolvedValue('new-template-id'),
+  buildAchievementContext: jest.fn().mockResolvedValue({}),
+  getEarnedAchievementIds: jest.fn().mockResolvedValue([]),
+  saveEarnedAchievements: jest.fn().mockResolvedValue(undefined),
 }))
 
 jest.mock('../../lib/programs', () => ({

--- a/__tests__/components/RatingWidget.test.tsx
+++ b/__tests__/components/RatingWidget.test.tsx
@@ -1,0 +1,106 @@
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => {
+  const { Text } = require('react-native');
+  return function MockIcon(props: { name: string; size?: number; color?: string; testID?: string }) {
+    return <Text testID={props.testID || `icon-${props.name}`}>{props.name}</Text>;
+  };
+});
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { PaperProvider } from 'react-native-paper';
+import RatingWidget from '../../components/RatingWidget';
+
+function renderWidget(props: { value: number | null; onChange?: (v: number | null) => void; readOnly?: boolean; size?: 'small' | 'medium' | 'large' }) {
+  return render(
+    <PaperProvider>
+      <RatingWidget {...props} />
+    </PaperProvider>
+  );
+}
+
+describe('RatingWidget', () => {
+  it('shows rating label for medium size', () => {
+    const { getByText } = renderWidget({ value: 4 });
+    expect(getByText('Good')).toBeTruthy();
+  });
+
+  it('shows "Not rated" when value is null', () => {
+    const { getByText } = renderWidget({ value: null });
+    expect(getByText('Not rated')).toBeTruthy();
+  });
+
+  it('shows correct labels for each rating', () => {
+    const labels = [
+      [1, 'Terrible'],
+      [2, 'Poor'],
+      [3, 'Okay'],
+      [4, 'Good'],
+      [5, 'Amazing'],
+    ] as const;
+    for (const [val, label] of labels) {
+      const { getByText, unmount } = renderWidget({ value: val });
+      expect(getByText(label)).toBeTruthy();
+      unmount();
+    }
+  });
+
+  it('does not show label in small size', () => {
+    const { queryByText } = renderWidget({ value: 4, size: 'small' });
+    expect(queryByText('Good')).toBeNull();
+  });
+
+  it('does not show label in readOnly mode', () => {
+    const { queryByText } = renderWidget({ value: 4, readOnly: true });
+    expect(queryByText('Good')).toBeNull();
+  });
+
+  it('has correct accessibilityLabel when rated', () => {
+    const { getByLabelText } = renderWidget({ value: 3 });
+    expect(getByLabelText('Rating: 3 out of 5, Okay')).toBeTruthy();
+  });
+
+  it('has "Not rated" accessibilityLabel when null', () => {
+    const { getByLabelText } = renderWidget({ value: null });
+    expect(getByLabelText('Not rated')).toBeTruthy();
+  });
+
+  it('increments rating via accessibility action', () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = renderWidget({ value: null, onChange });
+    const widget = getByLabelText('Not rated');
+    fireEvent(widget, 'accessibilityAction', { nativeEvent: { actionName: 'increment' } });
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it('does not increment past 5', () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = renderWidget({ value: 5, onChange });
+    const widget = getByLabelText('Rating: 5 out of 5, Amazing');
+    fireEvent(widget, 'accessibilityAction', { nativeEvent: { actionName: 'increment' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('decrements rating via accessibility action', () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = renderWidget({ value: 3, onChange });
+    const widget = getByLabelText('Rating: 3 out of 5, Okay');
+    fireEvent(widget, 'accessibilityAction', { nativeEvent: { actionName: 'decrement' } });
+    expect(onChange).toHaveBeenCalledWith(2);
+  });
+
+  it('clears rating when decrementing from 1', () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = renderWidget({ value: 1, onChange });
+    const widget = getByLabelText('Rating: 1 out of 5, Terrible');
+    fireEvent(widget, 'accessibilityAction', { nativeEvent: { actionName: 'decrement' } });
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('does not call onChange in readOnly mode', () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = renderWidget({ value: 3, onChange, readOnly: true });
+    const widget = getByLabelText('Rating: 3 out of 5, Okay');
+    fireEvent(widget, 'accessibilityAction', { nativeEvent: { actionName: 'increment' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/helpers/factories.ts
+++ b/__tests__/helpers/factories.ts
@@ -117,6 +117,7 @@ export function createSession(overrides: Partial<WorkoutSession> = {}): WorkoutS
     completed_at: null,
     duration_seconds: null,
     notes: '',
+    rating: null,
     ...overrides,
   }
 }

--- a/__tests__/lib/db/import-export.test.ts
+++ b/__tests__/lib/db/import-export.test.ts
@@ -30,10 +30,10 @@ beforeEach(() => {
 // ---- Export v3 Format ----
 
 describe("exportAllData", () => {
-  it("produces v3 format with data wrapper and counts", async () => {
+  it("produces v4 format with data wrapper and counts", async () => {
     mockDb.getAllAsync.mockResolvedValue([]);
     const result = await exportAllData();
-    expect(result.version).toBe(3);
+    expect(result.version).toBe(4);
     expect(result.data).toBeDefined();
     expect(result.counts).toBeDefined();
     expect(result.exported_at).toBeDefined();
@@ -99,11 +99,19 @@ describe("validateBackupData", () => {
     expect(err!.type).toBe("missing_version");
   });
 
-  it("rejects future version (v4+)", () => {
-    const err = validateBackupData({ version: 4, data: { exercises: [{ id: "1" }] } });
+  it("rejects future version (v5+)", () => {
+    const err = validateBackupData({ version: 5, data: { exercises: [{ id: "1" }] } });
     expect(err).not.toBeNull();
     expect(err!.type).toBe("future_version");
     expect(err!.message).toContain("update the app");
+  });
+
+  it("accepts v4 backup", () => {
+    const err = validateBackupData({
+      version: 4,
+      data: { exercises: [{ id: "1", name: "Bench" }] },
+    });
+    expect(err).toBeNull();
   });
 
   it("accepts v2 backup", () => {

--- a/__tests__/lib/db/session-rating.test.ts
+++ b/__tests__/lib/db/session-rating.test.ts
@@ -1,0 +1,199 @@
+// Unit tests for session rating, notes, save-as-template, and export/import v4
+const mockStmt = {
+  executeAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  finalizeAsync: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  getFirstAsync: jest.fn().mockResolvedValue(null),
+  runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+  prepareAsync: jest.fn().mockResolvedValue(mockStmt),
+};
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+}));
+
+import { updateSession, createTemplateFromSession } from '../../../lib/db/sessions';
+import {
+  validateBackupData,
+} from '../../../lib/db/import-export';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.getAllAsync.mockResolvedValue([]);
+  mockDb.getFirstAsync.mockResolvedValue(null);
+  mockDb.runAsync.mockResolvedValue({ changes: 1 });
+  mockDb.withTransactionAsync.mockImplementation(async (cb: () => Promise<void>) => cb());
+});
+
+// ---- Rating CRUD ----
+
+describe('updateSession', () => {
+  it('updates rating for a session', async () => {
+    await updateSession('sess-1', { rating: 4 });
+    // execute calls db.runAsync under the hood
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'UPDATE workout_sessions SET rating = ? WHERE id = ?',
+      [4, 'sess-1']
+    );
+  });
+
+  it('clears rating to null', async () => {
+    await updateSession('sess-1', { rating: null });
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'UPDATE workout_sessions SET rating = ? WHERE id = ?',
+      [null, 'sess-1']
+    );
+  });
+
+  it('updates notes for a session', async () => {
+    await updateSession('sess-1', { notes: 'Great workout!' });
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'UPDATE workout_sessions SET notes = ? WHERE id = ?',
+      ['Great workout!', 'sess-1']
+    );
+  });
+
+  it('updates both rating and notes', async () => {
+    await updateSession('sess-1', { rating: 5, notes: 'Best ever' });
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'UPDATE workout_sessions SET rating = ?, notes = ? WHERE id = ?',
+      [5, 'Best ever', 'sess-1']
+    );
+  });
+
+  it('does nothing when no fields provided', async () => {
+    await updateSession('sess-1', {});
+    // No runAsync calls for the UPDATE (there may be other calls for getDatabase)
+    const updateCalls = mockDb.runAsync.mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('UPDATE')
+    );
+    expect(updateCalls.length).toBe(0);
+  });
+
+  it('handles all rating values 1-5', async () => {
+    for (const r of [1, 2, 3, 4, 5]) {
+      jest.clearAllMocks();
+      await updateSession('sess-1', { rating: r });
+      expect(mockDb.runAsync).toHaveBeenCalledWith(
+        'UPDATE workout_sessions SET rating = ? WHERE id = ?',
+        [r, 'sess-1']
+      );
+    }
+  });
+});
+
+// ---- Save as Template ----
+
+describe('createTemplateFromSession', () => {
+  it('creates template from session with exercises', async () => {
+    const sessionSets = [
+      { exercise_id: 'ex-1', set_number: 1, reps: 8, link_id: null, training_mode: 'weight' },
+      { exercise_id: 'ex-1', set_number: 2, reps: 10, link_id: null, training_mode: 'weight' },
+      { exercise_id: 'ex-2', set_number: 1, reps: 12, link_id: null, training_mode: null },
+    ];
+    mockDb.getAllAsync.mockResolvedValue(sessionSets);
+
+    const result = await createTemplateFromSession('sess-1', 'My Template');
+    expect(result).toBeTruthy();
+    expect(typeof result).toBe('string');
+
+    // Should create template + 2 template_exercises
+    expect(mockDb.runAsync).toHaveBeenCalledTimes(3); // 1 template + 2 exercises
+  });
+
+  it('handles empty session (no completed sets)', async () => {
+    mockDb.getAllAsync.mockResolvedValue([]);
+
+    const result = await createTemplateFromSession('sess-1', 'Empty Template');
+    expect(result).toBeTruthy();
+    // Should only create template
+    expect(mockDb.runAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves superset groupings via link_id remapping', async () => {
+    const sessionSets = [
+      { exercise_id: 'ex-1', set_number: 1, reps: 8, link_id: 'link-old', training_mode: 'weight' },
+      { exercise_id: 'ex-2', set_number: 1, reps: 10, link_id: 'link-old', training_mode: 'weight' },
+    ];
+    mockDb.getAllAsync.mockResolvedValue(sessionSets);
+
+    await createTemplateFromSession('sess-1', 'Superset Template');
+
+    // Should create template + 2 template exercises
+    const insertCalls = mockDb.runAsync.mock.calls;
+    expect(insertCalls.length).toBe(3); // template + 2 exercises
+
+    // Both exercises should have same (new) link_id, different from 'link-old'
+    const ex1LinkId = insertCalls[1][1][7]; // link_id param in template_exercises insert
+    const ex2LinkId = insertCalls[2][1][7];
+    expect(ex1LinkId).toBeTruthy();
+    expect(ex2LinkId).toBeTruthy();
+    expect(ex1LinkId).toBe(ex2LinkId);
+    expect(ex1LinkId).not.toBe('link-old');
+  });
+
+  it('uses max reps as target_reps', async () => {
+    const sessionSets = [
+      { exercise_id: 'ex-1', set_number: 1, reps: 8, link_id: null, training_mode: 'weight' },
+      { exercise_id: 'ex-1', set_number: 2, reps: 12, link_id: null, training_mode: 'weight' },
+      { exercise_id: 'ex-1', set_number: 3, reps: 10, link_id: null, training_mode: 'weight' },
+    ];
+    mockDb.getAllAsync.mockResolvedValue(sessionSets);
+
+    await createTemplateFromSession('sess-1', 'Rep Template');
+
+    const insertCalls = mockDb.runAsync.mock.calls;
+    // template_exercises insert is call index 1
+    const targetReps = insertCalls[1][1][5]; // target_reps param
+    expect(targetReps).toBe('12');
+  });
+
+  it('sets target_sets to count of completed sets per exercise', async () => {
+    const sessionSets = [
+      { exercise_id: 'ex-1', set_number: 1, reps: 8, link_id: null, training_mode: 'weight' },
+      { exercise_id: 'ex-1', set_number: 2, reps: 8, link_id: null, training_mode: 'weight' },
+      { exercise_id: 'ex-1', set_number: 3, reps: 8, link_id: null, training_mode: 'weight' },
+    ];
+    mockDb.getAllAsync.mockResolvedValue(sessionSets);
+
+    await createTemplateFromSession('sess-1', 'Set Count Template');
+
+    const insertCalls = mockDb.runAsync.mock.calls;
+    const targetSets = insertCalls[1][1][4]; // target_sets param
+    expect(targetSets).toBe(3);
+  });
+});
+
+// ---- Export/Import v4 validation ----
+
+describe('validateBackupData v4', () => {
+  it('accepts v4 backup', () => {
+    const err = validateBackupData({
+      version: 4,
+      data: { exercises: [{ id: '1', name: 'Bench' }] },
+    });
+    expect(err).toBeNull();
+  });
+
+  it('rejects v5 as future version', () => {
+    const err = validateBackupData({
+      version: 5,
+      data: { exercises: [{ id: '1' }] },
+    });
+    expect(err).not.toBeNull();
+    expect(err!.type).toBe('future_version');
+  });
+
+  it('accepts v3 backup (backward compatible)', () => {
+    const err = validateBackupData({
+      version: 3,
+      data: { exercises: [{ id: '1', name: 'Bench' }] },
+    });
+    expect(err).toBeNull();
+  });
+});

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -28,6 +28,7 @@ import {
 import type { WorkoutSession } from "../lib/types";
 import { useLayout } from "../lib/layout";
 import ErrorBoundary from "../components/ErrorBoundary";
+import RatingWidget from "../components/RatingWidget";
 import WorkoutHeatmap from "../components/WorkoutHeatmap";
 import {
   computeLongestStreak,
@@ -300,13 +301,18 @@ function HistoryScreen() {
         <Card
           style={[styles.card, { backgroundColor: theme.colors.surface }]}
           onPress={() => router.push(`/session/detail/${item.id}`)}
-          accessibilityLabel={`${item.name || "Untitled workout"}, ${date}, ${formatDuration(item.duration_seconds)}, ${item.set_count} sets`}
+          accessibilityLabel={`${item.name || "Untitled workout"}, ${date}, ${formatDuration(item.duration_seconds)}, ${item.set_count} sets${item.rating ? `, rated ${item.rating} out of 5` : ""}`}
           accessibilityRole="button"
         >
           <Card.Content>
-            <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>
-              {item.name || "Untitled workout"}
-            </Text>
+            <View style={styles.cardHeader}>
+              <Text variant="titleSmall" style={{ color: theme.colors.onSurface, flex: 1, minWidth: 0 }} numberOfLines={1}>
+                {item.name || "Untitled workout"}
+              </Text>
+              {item.rating != null && item.rating > 0 && (
+                <RatingWidget value={item.rating} readOnly size="small" />
+              )}
+            </View>
             <Text
               variant="bodySmall"
               style={{ color: theme.colors.onSurfaceVariant }}
@@ -546,6 +552,12 @@ const styles = StyleSheet.create({
   },
   card: {
     marginBottom: 8,
+  },
+  cardHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 8,
   },
   chip: {
     alignSelf: "flex-start",

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -1,15 +1,23 @@
-import { useEffect, useMemo, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Modal, Pressable, StyleSheet, TextInput, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Card, Divider, Text, useTheme } from "react-native-paper";
+import { Button, Card, Divider, IconButton, Snackbar, Text, useTheme } from "react-native-paper";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
-import { Stack, useLocalSearchParams } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useLayout } from "../../../lib/layout";
-import { getSessionById, getSessionPRs, getSessionSets } from "../../../lib/db";
+import {
+  createTemplateFromSession,
+  getSessionById,
+  getSessionPRs,
+  getSessionSetCount,
+  getSessionSets,
+  updateSession,
+} from "../../../lib/db";
 import type { WorkoutSession, WorkoutSet } from "../../../lib/types";
 import { TRAINING_MODE_LABELS } from "../../../lib/types";
 import { rpeColor, rpeText } from "../../../lib/rpe";
 import { formatDuration, formatDateShort } from "../../../lib/format";
+import RatingWidget from "../../../components/RatingWidget";
 
 type SetWithName = WorkoutSet & { exercise_name?: string; exercise_deleted?: boolean };
 
@@ -23,10 +31,19 @@ type ExerciseGroup = {
 export default function SessionDetail() {
   const theme = useTheme();
   const layout = useLayout();
+  const router = useRouter();
   const { id } = useLocalSearchParams<{ id: string }>();
   const [session, setSession] = useState<WorkoutSession | null>(null);
   const [groups, setGroups] = useState<ExerciseGroup[]>([]);
   const [prs, setPrs] = useState<{ exercise_id: string; name: string; weight: number; previous_max: number }[]>([]);
+  const [rating, setRating] = useState<number | null>(null);
+  const [notesText, setNotesText] = useState("");
+  const [notesExpanded, setNotesExpanded] = useState(false);
+  const [templateModalVisible, setTemplateModalVisible] = useState(false);
+  const [templateName, setTemplateName] = useState("");
+  const [snackbar, setSnackbar] = useState<{ message: string; action?: { label: string; onPress: () => void } } | null>(null);
+  const [completedSetCount, setCompletedSetCount] = useState(0);
+  const [saving, setSaving] = useState(false);
 
   const linkIds = useMemo(() => {
     const ids: string[] = [];
@@ -47,12 +64,17 @@ export default function SessionDetail() {
       const sess = await getSessionById(id);
       if (!sess) return;
       setSession(sess);
+      setRating(sess.rating ?? null);
+      setNotesText(sess.notes ?? "");
+      setNotesExpanded(!!(sess.notes && sess.notes.length > 0));
 
-      const [sets, prData] = await Promise.all([
+      const [sets, prData, setCount] = await Promise.all([
         getSessionSets(id),
         getSessionPRs(id),
+        getSessionSetCount(id),
       ]);
       setPrs(prData);
+      setCompletedSetCount(setCount);
       const map = new Map<string, ExerciseGroup>();
       for (const s of sets) {
         if (!map.has(s.exercise_id)) {
@@ -91,6 +113,38 @@ export default function SessionDetail() {
     return count;
   };
 
+  const handleRatingChange = useCallback(async (newRating: number | null) => {
+    if (!id) return;
+    setRating(newRating);
+    await updateSession(id, { rating: newRating });
+  }, [id]);
+
+  const handleNotesSave = useCallback(async () => {
+    if (!id) return;
+    await updateSession(id, { notes: notesText });
+  }, [id, notesText]);
+
+  const handleSaveAsTemplate = useCallback(async () => {
+    if (!id || saving) return;
+    setSaving(true);
+    try {
+      const truncatedName = templateName.slice(0, 100).trim() || "Untitled Template";
+      const newId = await createTemplateFromSession(id, truncatedName);
+      setTemplateModalVisible(false);
+      setSnackbar({
+        message: "Template saved!",
+        action: {
+          label: "View",
+          onPress: () => router.push(`/template/${newId}`),
+        },
+      });
+    } catch {
+      setSnackbar({ message: "Failed to save template" });
+    } finally {
+      setSaving(false);
+    }
+  }, [id, templateName, saving, router]);
+
   if (!session) {
     return (
       <>
@@ -111,7 +165,25 @@ export default function SessionDetail() {
 
   return (
     <>
-      <Stack.Screen options={{ title: session.name }} />
+      <Stack.Screen
+        options={{
+          title: session.name,
+          headerRight: session.completed_at
+            ? () => (
+                <IconButton
+                  icon="content-save-outline"
+                  onPress={() => {
+                    setTemplateName((session.name ?? "").slice(0, 100));
+                    setTemplateModalVisible(true);
+                  }}
+                  disabled={completedSetCount === 0}
+                  accessibilityLabel="Save as template"
+                  accessibilityHint={completedSetCount === 0 ? "No exercises to save" : "Save this workout as a reusable template"}
+                />
+              )
+            : undefined,
+        }}
+      />
       <FlashList
         data={groups}
         keyExtractor={(group) => group.exercise_id}
@@ -176,6 +248,80 @@ export default function SessionDetail() {
                 </View>
               </Card.Content>
             </Card>
+
+            {/* Rating & Notes */}
+            {session.completed_at && (
+              <Card style={[styles.summary, { backgroundColor: theme.colors.surface }]}>
+                <Card.Content style={{ alignItems: "center" }}>
+                  <Text
+                    variant="titleSmall"
+                    style={{ color: theme.colors.onSurface, marginBottom: 8 }}
+                  >
+                    Rating
+                  </Text>
+                  <RatingWidget value={rating} onChange={handleRatingChange} />
+                </Card.Content>
+              </Card>
+            )}
+
+            {session.completed_at && (
+              <Card style={[styles.summary, { backgroundColor: theme.colors.surface }]}>
+                <Card.Content>
+                  <Pressable
+                    onPress={() => setNotesExpanded(!notesExpanded)}
+                    style={styles.notesHeader}
+                    accessibilityRole="button"
+                    accessibilityLabel="Session notes"
+                    accessibilityState={{ expanded: notesExpanded }}
+                  >
+                    <MaterialCommunityIcons
+                      name="note-edit-outline"
+                      size={20}
+                      color={theme.colors.primary}
+                    />
+                    <Text
+                      variant="titleSmall"
+                      style={{ color: theme.colors.onSurface, marginLeft: 8, flex: 1 }}
+                    >
+                      Session notes
+                    </Text>
+                    <MaterialCommunityIcons
+                      name={notesExpanded ? "chevron-up" : "chevron-down"}
+                      size={20}
+                      color={theme.colors.onSurfaceVariant}
+                    />
+                  </Pressable>
+                  {notesExpanded && (
+                    <View style={{ marginTop: 8 }}>
+                      <TextInput
+                        value={notesText}
+                        onChangeText={(t) => setNotesText(t.slice(0, 500))}
+                        onBlur={handleNotesSave}
+                        placeholder="Add notes about this workout..."
+                        placeholderTextColor={theme.colors.onSurfaceDisabled}
+                        multiline
+                        maxLength={500}
+                        style={[
+                          styles.notesInput,
+                          {
+                            color: theme.colors.onSurface,
+                            backgroundColor: theme.colors.surfaceVariant,
+                            borderColor: theme.colors.outline,
+                          },
+                        ]}
+                        accessibilityLabel="Session notes"
+                      />
+                      <Text
+                        variant="bodySmall"
+                        style={{ color: theme.colors.onSurfaceVariant, textAlign: "right", marginTop: 4 }}
+                      >
+                        {notesText.length}/500
+                      </Text>
+                    </View>
+                  )}
+                </Card.Content>
+              </Card>
+            )}
 
             {/* Personal Records */}
             {prs.length > 0 && (
@@ -303,22 +449,70 @@ export default function SessionDetail() {
           );
         }}
         ListFooterComponent={
-          session.notes ? (
-            <View style={styles.notes}>
-              <Text
-                variant="labelLarge"
-                style={{ color: theme.colors.onSurfaceVariant }}
-              >
-                Notes
-              </Text>
-              <Text
-                variant="bodyMedium"
-                style={[styles.noteText, { color: theme.colors.onSurface }]}
-              >
-                {session.notes}
-              </Text>
-            </View>
-          ) : null
+          <>
+            {/* Save as Template Modal */}
+            <Modal
+              visible={templateModalVisible}
+              transparent
+              animationType="fade"
+              onRequestClose={() => setTemplateModalVisible(false)}
+            >
+              <View style={styles.modalOverlay}>
+                <View style={[styles.modalContent, { backgroundColor: theme.colors.surface }]}>
+                  <Text
+                    variant="titleMedium"
+                    style={{ color: theme.colors.onSurface, marginBottom: 16 }}
+                  >
+                    Save as Template
+                  </Text>
+                  <TextInput
+                    value={templateName}
+                    onChangeText={(t) => setTemplateName(t.slice(0, 100))}
+                    placeholder="Template name"
+                    placeholderTextColor={theme.colors.onSurfaceDisabled}
+                    maxLength={100}
+                    style={[
+                      styles.modalInput,
+                      {
+                        color: theme.colors.onSurface,
+                        backgroundColor: theme.colors.surfaceVariant,
+                        borderColor: theme.colors.outline,
+                      },
+                    ]}
+                    autoFocus
+                    accessibilityLabel="Template name"
+                  />
+                  <View style={styles.modalActions}>
+                    <Button
+                      mode="text"
+                      onPress={() => setTemplateModalVisible(false)}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      mode="contained"
+                      onPress={handleSaveAsTemplate}
+                      loading={saving}
+                      disabled={saving || !templateName.trim()}
+                      contentStyle={{ paddingVertical: 8 }}
+                    >
+                      Save
+                    </Button>
+                  </View>
+                </View>
+              </View>
+            </Modal>
+
+            {/* Snackbar */}
+            <Snackbar
+              visible={!!snackbar}
+              onDismiss={() => setSnackbar(null)}
+              duration={4000}
+              action={snackbar?.action}
+            >
+              {snackbar?.message ?? ""}
+            </Snackbar>
+          </>
         }
       />
     </>
@@ -413,5 +607,42 @@ const styles = StyleSheet.create({
   },
   noteText: {
     marginTop: 4,
+  },
+  notesHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  notesInput: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    minHeight: 80,
+    textAlignVertical: "top",
+    fontSize: 14,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  modalContent: {
+    width: "100%",
+    maxWidth: 400,
+    borderRadius: 16,
+    padding: 24,
+  },
+  modalInput: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  modalActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 8,
   },
 });

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -115,13 +115,23 @@ export default function SessionDetail() {
 
   const handleRatingChange = useCallback(async (newRating: number | null) => {
     if (!id) return;
+    const previousRating = rating;
     setRating(newRating);
-    await updateSession(id, { rating: newRating });
-  }, [id]);
+    try {
+      await updateSession(id, { rating: newRating });
+    } catch {
+      setRating(previousRating);
+      setSnackbar({ message: "Failed to save rating" });
+    }
+  }, [id, rating]);
 
   const handleNotesSave = useCallback(async () => {
     if (!id) return;
-    await updateSession(id, { notes: notesText });
+    try {
+      await updateSession(id, { notes: notesText });
+    } catch {
+      setSnackbar({ message: "Failed to save notes" });
+    }
   }, [id, notesText]);
 
   const handleSaveAsTemplate = useCallback(async () => {
@@ -611,6 +621,7 @@ const styles = StyleSheet.create({
   notesHeader: {
     flexDirection: "row",
     alignItems: "center",
+    minHeight: 48,
   },
   notesInput: {
     borderWidth: 1,

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -207,13 +207,23 @@ export default function Summary() {
 
   const handleRatingChange = useCallback(async (newRating: number | null) => {
     if (!id) return;
+    const previousRating = rating;
     setRating(newRating);
-    await updateSession(id, { rating: newRating });
-  }, [id]);
+    try {
+      await updateSession(id, { rating: newRating });
+    } catch {
+      setRating(previousRating);
+      setSnackbar({ message: "Failed to save rating" });
+    }
+  }, [id, rating]);
 
   const handleNotesSave = useCallback(async () => {
     if (!id) return;
-    await updateSession(id, { notes: notesText });
+    try {
+      await updateSession(id, { notes: notesText });
+    } catch {
+      setSnackbar({ message: "Failed to save notes" });
+    }
   }, [id, notesText]);
 
   const handleSaveAsTemplate = useCallback(async () => {
@@ -891,6 +901,7 @@ const styles = StyleSheet.create({
   notesHeader: {
     flexDirection: "row",
     alignItems: "center",
+    minHeight: 48,
   },
   notesInput: {
     borderWidth: 1,

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -1,15 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   AccessibilityInfo,
+  Modal,
   Platform,
+  Pressable,
   Share,
   StyleSheet,
+  TextInput,
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import {
   Button,
   Card,
+  Snackbar,
   Text,
   useTheme,
 } from "react-native-paper";
@@ -18,16 +22,19 @@ import * as Haptics from "expo-haptics";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useLayout } from "../../../lib/layout";
 import {
+  createTemplateFromSession,
   getBodySettings,
   getSessionById,
   getSessionComparison,
   getSessionPRs,
   getSessionRepPRs,
+  getSessionSetCount,
   getSessionSets,
   getSessionWeightIncreases,
   buildAchievementContext,
   getEarnedAchievementIds,
   saveEarnedAchievements,
+  updateSession,
 } from "../../../lib/db";
 import { evaluateAchievements } from "../../../lib/achievements";
 import type { AchievementDef } from "../../../lib/achievements";
@@ -35,6 +42,7 @@ import type { WorkoutSession, WorkoutSet } from "../../../lib/types";
 import { TRAINING_MODE_LABELS } from "../../../lib/types";
 import { toDisplay } from "../../../lib/units";
 import { formatTime } from "../../../lib/format";
+import RatingWidget from "../../../components/RatingWidget";
 
 type PR = { exercise_id: string; name: string; weight: number; previous_max: number };
 type RepPR = { exercise_id: string; name: string; reps: number; previous_max: number };
@@ -57,6 +65,14 @@ export default function Summary() {
   const [comparison, setComparison] = useState<Comparison>(null);
   const [unit, setUnit] = useState<"kg" | "lb">("kg");
   const [newAchievements, setNewAchievements] = useState<AchievementDef[]>([]);
+  const [rating, setRating] = useState<number | null>(null);
+  const [notesText, setNotesText] = useState("");
+  const [notesExpanded, setNotesExpanded] = useState(false);
+  const [templateModalVisible, setTemplateModalVisible] = useState(false);
+  const [templateName, setTemplateName] = useState("");
+  const [snackbar, setSnackbar] = useState<{ message: string; action?: { label: string; onPress: () => void } } | null>(null);
+  const [completedSetCount, setCompletedSetCount] = useState(0);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!id) return;
@@ -68,16 +84,21 @@ export default function Summary() {
       if (!sess) return;
       setSession(sess);
       setUnit(settings.weight_unit);
+      setRating(sess.rating ?? null);
+      setNotesText(sess.notes ?? "");
+      setNotesExpanded(!!(sess.notes && sess.notes.length > 0));
 
-      const [setsData, prData, repPrData, incData, compData] = await Promise.all([
+      const [setsData, prData, repPrData, incData, compData, setCount] = await Promise.all([
         getSessionSets(id),
         getSessionPRs(id),
         getSessionRepPRs(id),
         getSessionWeightIncreases(id),
         getSessionComparison(id),
+        getSessionSetCount(id),
       ]);
       setSets(setsData);
       setPrs(prData);
+      setCompletedSetCount(setCount);
       setRepPrs(repPrData);
       // Filter out exercises that are already weight PRs
       setIncreases(incData.filter(
@@ -184,6 +205,38 @@ export default function Summary() {
     }
   };
 
+  const handleRatingChange = useCallback(async (newRating: number | null) => {
+    if (!id) return;
+    setRating(newRating);
+    await updateSession(id, { rating: newRating });
+  }, [id]);
+
+  const handleNotesSave = useCallback(async () => {
+    if (!id) return;
+    await updateSession(id, { notes: notesText });
+  }, [id, notesText]);
+
+  const handleSaveAsTemplate = useCallback(async () => {
+    if (!id || saving) return;
+    setSaving(true);
+    try {
+      const truncatedName = templateName.slice(0, 100).trim() || "Untitled Template";
+      const newId = await createTemplateFromSession(id, truncatedName);
+      setTemplateModalVisible(false);
+      setSnackbar({
+        message: "Template saved!",
+        action: {
+          label: "View",
+          onPress: () => router.push(`/template/${newId}`),
+        },
+      });
+    } catch {
+      setSnackbar({ message: "Failed to save template" });
+    } finally {
+      setSaving(false);
+    }
+  }, [id, templateName, saving, router]);
+
   if (!session) {
     return (
       <>
@@ -281,6 +334,82 @@ export default function Summary() {
                 </Card.Content>
               </Card>
             </View>
+
+            {/* Rating Widget */}
+            {session.completed_at && (
+              <Card style={[styles.section, { backgroundColor: theme.colors.surface }]}>
+                <Card.Content style={{ alignItems: "center" }}>
+                  <Text
+                    variant="titleMedium"
+                    style={{ color: theme.colors.onSurface, marginBottom: 12, fontWeight: "600" }}
+                  >
+                    How was your workout?
+                  </Text>
+                  <RatingWidget value={rating} onChange={handleRatingChange} size="large" />
+                </Card.Content>
+              </Card>
+            )}
+
+            {/* Session Notes */}
+            {session.completed_at && (
+              <Card style={[styles.section, { backgroundColor: theme.colors.surface }]}>
+                <Card.Content>
+                  <Pressable
+                    onPress={() => setNotesExpanded(!notesExpanded)}
+                    style={styles.notesHeader}
+                    accessibilityRole="button"
+                    accessibilityLabel="Session notes"
+                    accessibilityHint="Double tap to add notes about this workout"
+                    accessibilityState={{ expanded: notesExpanded }}
+                  >
+                    <MaterialCommunityIcons
+                      name="note-edit-outline"
+                      size={20}
+                      color={theme.colors.primary}
+                    />
+                    <Text
+                      variant="titleSmall"
+                      style={{ color: theme.colors.onSurface, marginLeft: 8, flex: 1 }}
+                    >
+                      Session notes
+                    </Text>
+                    <MaterialCommunityIcons
+                      name={notesExpanded ? "chevron-up" : "chevron-down"}
+                      size={20}
+                      color={theme.colors.onSurfaceVariant}
+                    />
+                  </Pressable>
+                  {notesExpanded && (
+                    <View style={{ marginTop: 8 }}>
+                      <TextInput
+                        value={notesText}
+                        onChangeText={(t) => setNotesText(t.slice(0, 500))}
+                        onBlur={handleNotesSave}
+                        placeholder="Add notes about this workout..."
+                        placeholderTextColor={theme.colors.onSurfaceDisabled}
+                        multiline
+                        maxLength={500}
+                        style={[
+                          styles.notesInput,
+                          {
+                            color: theme.colors.onSurface,
+                            backgroundColor: theme.colors.surfaceVariant,
+                            borderColor: theme.colors.outline,
+                          },
+                        ]}
+                        accessibilityLabel="Session notes"
+                      />
+                      <Text
+                        variant="bodySmall"
+                        style={{ color: theme.colors.onSurfaceVariant, textAlign: "right", marginTop: 4 }}
+                      >
+                        {notesText.length}/500
+                      </Text>
+                    </View>
+                  )}
+                </Card.Content>
+              </Card>
+            )}
           </>
         }
         renderItem={({ item }) => {
@@ -559,6 +688,24 @@ export default function Summary() {
         }}
         ListFooterComponent={
           <View style={styles.actions}>
+            {session.completed_at && (
+              <Button
+                mode="outlined"
+                onPress={() => {
+                  setTemplateName((session.name ?? "").slice(0, 100));
+                  setTemplateModalVisible(true);
+                }}
+                icon="content-save-outline"
+                style={styles.shareBtn}
+                contentStyle={styles.btnContent}
+                disabled={completedSetCount === 0}
+                accessibilityRole="button"
+                accessibilityHint={completedSetCount === 0 ? "No exercises to save" : "Save this workout as a reusable template"}
+                accessibilityState={{ disabled: completedSetCount === 0 }}
+              >
+                Save as Template
+              </Button>
+            )}
             <Button
               mode="contained"
               onPress={() => router.replace("/(tabs)")}
@@ -588,6 +735,69 @@ export default function Summary() {
             >
               View Details
             </Button>
+
+            {/* Save as Template Modal */}
+            <Modal
+              visible={templateModalVisible}
+              transparent
+              animationType="fade"
+              onRequestClose={() => setTemplateModalVisible(false)}
+            >
+              <View style={styles.modalOverlay}>
+                <View style={[styles.modalContent, { backgroundColor: theme.colors.surface }]}>
+                  <Text
+                    variant="titleMedium"
+                    style={{ color: theme.colors.onSurface, marginBottom: 16 }}
+                  >
+                    Save as Template
+                  </Text>
+                  <TextInput
+                    value={templateName}
+                    onChangeText={(t) => setTemplateName(t.slice(0, 100))}
+                    placeholder="Template name"
+                    placeholderTextColor={theme.colors.onSurfaceDisabled}
+                    maxLength={100}
+                    style={[
+                      styles.modalInput,
+                      {
+                        color: theme.colors.onSurface,
+                        backgroundColor: theme.colors.surfaceVariant,
+                        borderColor: theme.colors.outline,
+                      },
+                    ]}
+                    autoFocus
+                    accessibilityLabel="Template name"
+                  />
+                  <View style={styles.modalActions}>
+                    <Button
+                      mode="text"
+                      onPress={() => setTemplateModalVisible(false)}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      mode="contained"
+                      onPress={handleSaveAsTemplate}
+                      loading={saving}
+                      disabled={saving || !templateName.trim()}
+                      contentStyle={{ paddingVertical: 8 }}
+                    >
+                      Save
+                    </Button>
+                  </View>
+                </View>
+              </View>
+            </Modal>
+
+            {/* Snackbar */}
+            <Snackbar
+              visible={!!snackbar}
+              onDismiss={() => setSnackbar(null)}
+              duration={4000}
+              action={snackbar?.action}
+            >
+              {snackbar?.message ?? ""}
+            </Snackbar>
           </View>
         }
       />
@@ -677,5 +887,42 @@ const styles = StyleSheet.create({
   },
   btnContent: {
     paddingVertical: 4,
+  },
+  notesHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  notesInput: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    minHeight: 80,
+    textAlignVertical: "top",
+    fontSize: 14,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  modalContent: {
+    width: "100%",
+    maxWidth: 400,
+    borderRadius: 16,
+    padding: 24,
+  },
+  modalInput: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  modalActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 8,
   },
 });

--- a/components/RatingWidget.tsx
+++ b/components/RatingWidget.tsx
@@ -1,0 +1,134 @@
+import { useRef } from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Text, useTheme } from "react-native-paper";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+
+const RATING_LABELS: { label: string; colorKey: "error" | "tertiary" | "secondary" | "primary" }[] = [
+  { label: "Terrible", colorKey: "error" },
+  { label: "Poor", colorKey: "tertiary" },
+  { label: "Okay", colorKey: "secondary" },
+  { label: "Good", colorKey: "primary" },
+  { label: "Amazing", colorKey: "primary" },
+];
+
+type Props = {
+  value: number | null;
+  onChange?: (rating: number | null) => void;
+  readOnly?: boolean;
+  size?: "small" | "medium" | "large";
+};
+
+const SIZES = {
+  small: { star: 16, touch: 24 },
+  medium: { star: 32, touch: 48 },
+  large: { star: 40, touch: 56 },
+};
+
+export default function RatingWidget({ value, onChange, readOnly = false, size = "medium" }: Props) {
+  const theme = useTheme();
+  const longPressRef = useRef(false);
+  const { star: starSize, touch: touchSize } = SIZES[size];
+
+  const ratingInfo = value != null && value >= 1 && value <= 5
+    ? RATING_LABELS[value - 1]
+    : null;
+  const labelColor = ratingInfo
+    ? theme.colors[ratingInfo.colorKey]
+    : theme.colors.onSurfaceDisabled;
+
+  const handlePress = (starNum: number) => {
+    if (readOnly || !onChange) return;
+    if (longPressRef.current) {
+      longPressRef.current = false;
+      return;
+    }
+    // Re-tap same star clears rating
+    onChange(value === starNum ? null : starNum);
+  };
+
+  const handleLongPress = () => {
+    if (readOnly || !onChange) return;
+    longPressRef.current = true;
+    onChange(null);
+  };
+
+  return (
+    <View
+      style={styles.container}
+      accessibilityRole="adjustable"
+      accessibilityValue={{ min: 0, max: 5, now: value ?? 0 }}
+      accessibilityLabel={
+        ratingInfo
+          ? `Rating: ${value} out of 5, ${ratingInfo.label}`
+          : "Not rated"
+      }
+      accessibilityActions={
+        readOnly
+          ? undefined
+          : [
+              { name: "increment", label: "Increase rating" },
+              { name: "decrement", label: "Decrease rating" },
+            ]
+      }
+      onAccessibilityAction={(event) => {
+        if (readOnly || !onChange) return;
+        const current = value ?? 0;
+        if (event.nativeEvent.actionName === "increment" && current < 5) {
+          onChange(current + 1);
+        } else if (event.nativeEvent.actionName === "decrement" && current > 1) {
+          onChange(current - 1);
+        } else if (event.nativeEvent.actionName === "decrement" && current <= 1) {
+          onChange(null);
+        }
+      }}
+    >
+      <View style={styles.stars}>
+        {[1, 2, 3, 4, 5].map((starNum) => (
+          <Pressable
+            key={starNum}
+            onPress={() => handlePress(starNum)}
+            onLongPress={handleLongPress}
+            disabled={readOnly}
+            style={{
+              minWidth: touchSize,
+              minHeight: touchSize,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+            accessibilityElementsHidden
+            importantForAccessibility="no"
+          >
+            <MaterialCommunityIcons
+              name={value != null && starNum <= value ? "star" : "star-outline"}
+              size={starSize}
+              color={
+                value != null && starNum <= value
+                  ? labelColor
+                  : theme.colors.onSurfaceDisabled
+              }
+            />
+          </Pressable>
+        ))}
+      </View>
+      {!readOnly && size !== "small" && (
+        <Text
+          variant="bodySmall"
+          style={{ color: labelColor, marginTop: 4, textAlign: "center" }}
+        >
+          {ratingInfo ? ratingInfo.label : "Not rated"}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+  },
+  stars: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 4,
+  },
+});

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -258,6 +258,11 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
       "ALTER TABLE workout_sessions ADD COLUMN program_day_id TEXT DEFAULT NULL"
     );
   }
+  if (!sessionCols.some((c) => c.name === "rating")) {
+    await database.execAsync(
+      "ALTER TABLE workout_sessions ADD COLUMN rating INTEGER DEFAULT NULL"
+    );
+  }
 
   const setCols = await database.getAllAsync<{ name: string }>(
     "PRAGMA table_info(workout_sets)"

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -105,7 +105,7 @@ export type BackupV3Data = {
 };
 
 export type BackupV3 = {
-  version: 3;
+  version: 3 | 4;
   app_version: string;
   exported_at: string;
   data: BackupV3Data;
@@ -169,7 +169,7 @@ export function validateBackupData(data: unknown): ValidationError | null {
   }
 
   const version = Number(obj.version);
-  if (version >= 4) {
+  if (version >= 5) {
     return { type: "future_version", message: "This backup was created with a newer version of FitForge. Please update the app first." };
   }
 
@@ -286,7 +286,7 @@ export async function exportAllData(
   onProgress?.({ table: "done", tableIndex: tables.length, totalTables: tables.length });
 
   return {
-    version: 3,
+    version: 4,
     app_version: "1.0.0",
     exported_at: new Date().toISOString(),
     data: data as unknown as BackupV3Data,
@@ -436,8 +436,8 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
     }
     case "workout_sessions": {
       const r = await database.runAsync(
-        "INSERT OR IGNORE INTO workout_sessions (id, template_id, name, started_at, completed_at, duration_seconds, notes) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        [row.id, row.template_id, row.name, row.started_at, row.completed_at, row.duration_seconds, row.notes]
+        "INSERT OR IGNORE INTO workout_sessions (id, template_id, name, started_at, completed_at, duration_seconds, notes, program_day_id, rating) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.template_id, row.name, row.started_at, row.completed_at, row.duration_seconds, row.notes, row.program_day_id ?? null, row.rating ?? null]
       );
       return r.changes > 0;
     }

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -78,6 +78,8 @@ export {
   getSessionWeightIncreases,
   getSessionCountsByDay,
   getTotalSessionCount,
+  updateSession,
+  createTemplateFromSession,
 } from "./sessions";
 export type { ExerciseSession, ExerciseRecords } from "./sessions";
 

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -1,6 +1,6 @@
 import type { WorkoutSession, WorkoutSet, TrainingMode, MuscleGroup } from "../types";
 import { uuid } from "../uuid";
-import { query, queryOne, execute, withTransaction } from "./helpers";
+import { query, queryOne, execute, getDatabase, withTransaction } from "./helpers";
 
 type SetRow = {
   id: string;
@@ -42,6 +42,7 @@ export async function startSession(
     completed_at: null,
     duration_seconds: null,
     notes: "",
+    rating: null,
   };
 }
 
@@ -1054,4 +1055,106 @@ export async function getTotalSessionCount(): Promise<number> {
     "SELECT COUNT(*) AS count FROM workout_sessions WHERE completed_at IS NOT NULL"
   );
   return row?.count ?? 0;
+}
+
+// ---- Session Rating & Notes ----
+
+export async function updateSession(
+  id: string,
+  fields: { rating?: number | null; notes?: string }
+): Promise<void> {
+  const clauses: string[] = [];
+  const params: (string | number | null)[] = [];
+
+  if (fields.rating !== undefined) {
+    clauses.push("rating = ?");
+    params.push(fields.rating);
+  }
+  if (fields.notes !== undefined) {
+    clauses.push("notes = ?");
+    params.push(fields.notes);
+  }
+  if (clauses.length === 0) return;
+
+  params.push(id);
+  await execute(
+    `UPDATE workout_sessions SET ${clauses.join(", ")} WHERE id = ?`,
+    params
+  );
+}
+
+// ---- Save Session as Template ----
+
+export async function createTemplateFromSession(
+  sessionId: string,
+  name: string
+): Promise<string> {
+  const database = await getDatabase();
+
+  const newTemplateId = uuid();
+  const now = Date.now();
+
+  await database.withTransactionAsync(async () => {
+    // Create template
+    await database.runAsync(
+      "INSERT INTO workout_templates (id, name, created_at, updated_at, is_starter) VALUES (?, ?, ?, ?, 0)",
+      [newTemplateId, name, now, now]
+    );
+
+    // Get completed sets from session grouped by exercise
+    const sets = await database.getAllAsync<{
+      exercise_id: string;
+      set_number: number;
+      reps: number | null;
+      link_id: string | null;
+      training_mode: string | null;
+    }>(
+      `SELECT exercise_id, set_number, reps, link_id, training_mode
+       FROM workout_sets
+       WHERE session_id = ? AND completed = 1
+       ORDER BY exercise_id, set_number ASC`,
+      [sessionId]
+    );
+
+    if (sets.length === 0) return;
+
+    // Group by exercise_id to determine position and set counts
+    const exerciseOrder: string[] = [];
+    const exerciseGroups = new Map<string, typeof sets>();
+    for (const s of sets) {
+      if (!exerciseGroups.has(s.exercise_id)) {
+        exerciseOrder.push(s.exercise_id);
+        exerciseGroups.set(s.exercise_id, []);
+      }
+      exerciseGroups.get(s.exercise_id)!.push(s);
+    }
+
+    // Map old link_ids to new UUIDs (preserve superset groupings)
+    const linkMap = new Map<string, string>();
+
+    for (let i = 0; i < exerciseOrder.length; i++) {
+      const exerciseId = exerciseOrder[i];
+      const group = exerciseGroups.get(exerciseId)!;
+      const teId = uuid();
+
+      // Determine link_id for supersets
+      const firstSet = group[0];
+      let linkId: string | null = firstSet.link_id;
+      if (linkId) {
+        if (!linkMap.has(linkId)) linkMap.set(linkId, uuid());
+        linkId = linkMap.get(linkId)!;
+      }
+
+      // Use the max reps from completed sets as target_reps
+      const maxReps = Math.max(...group.map((s) => s.reps ?? 0));
+      const targetReps = maxReps > 0 ? String(maxReps) : "8-12";
+
+      await database.runAsync(
+        "INSERT INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds, link_id, link_label) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [teId, newTemplateId, exerciseId, i, group.length, targetReps, 90, linkId, ""]
+      );
+    }
+  });
+
+  return newTemplateId;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -191,6 +191,7 @@ export type WorkoutSession = {
   completed_at: number | null;
   duration_seconds: number | null;
   notes: string;
+  rating: number | null;
 };
 
 export type WorkoutSet = {


### PR DESCRIPTION
## Summary

Add session rating (1-5 stars), notes editing, save-as-template from completed sessions, and v4 export/import format.

## Changes

- **DB**: Add `rating` column to `workout_sessions` with PRAGMA-guarded migration
- **DB Functions**: `updateSession(id, {rating, notes})` and `createTemplateFromSession(sessionId, name)` with superset link_id remapping
- **RatingWidget**: Reusable 5-star component with 3 sizes, read-only mode, and full accessibility support (adjustable role, increment/decrement actions)
- **Summary Screen**: Post-workout rating widget, collapsible notes input, save-as-template modal with name input
- **Detail Screen**: Editable rating and notes cards, save-as-template header button with modal
- **History Screen**: Mini read-only rating stars on session cards
- **Export/Import**: Bumped to v4 format with rating column; backward-compatible with v3 imports

## Testing

- 80 test suites, 1319 tests pass (0 failures)
- TypeScript: zero errors
- ESLint: zero warnings
- New tests: 14 unit tests for DB functions, 12 for RatingWidget component, 3 for v4 validation
- Updated 3 existing test files with new mock functions

## Issue

Resolves BLD-235