### PR TITLE
fix: pixel slop cleanup for investor demo (BLD-237)

### DIFF
--- a/__tests__/app/design-tokens-compliance.test.ts
+++ b/__tests__/app/design-tokens-compliance.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Structural tests verifying that design tokens are used instead of hardcoded
+ * magic values. Catches pixel-slop regressions before they reach the demo.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const COMPONENT_DIRS = [
+  path.resolve(__dirname, "../../components"),
+  path.resolve(__dirname, "../../app"),
+];
+
+const EXCLUDED_FILES = [
+  "design-tokens.ts",
+  "theme.ts",
+  "design-tokens-compliance.test.ts",
+];
+
+function collectTsxFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory() && entry.name !== "node_modules") {
+      results.push(...collectTsxFiles(full));
+    } else if (/\.(tsx?|ts)$/.test(entry.name) && !EXCLUDED_FILES.includes(entry.name)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const files = COMPONENT_DIRS.flatMap(collectTsxFiles);
+
+describe("Design Token Compliance", () => {
+  test("no borderRadius: 28 (should be radii.pill)", () => {
+    const violations: string[] = [];
+    for (const f of files) {
+      const content = fs.readFileSync(f, "utf-8");
+      if (/borderRadius:\s*28\b/.test(content)) {
+        violations.push(path.relative(process.cwd(), f));
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  test("no hardcoded modal overlay opacity other than 0.5", () => {
+    const violations: string[] = [];
+    const badOverlay = /rgba\(0\s*,\s*0\s*,\s*0\s*,\s*0\.(3|55|6)\)/;
+    for (const f of files) {
+      const content = fs.readFileSync(f, "utf-8");
+      if (badOverlay.test(content)) {
+        violations.push(path.relative(process.cwd(), f));
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  test("no hardcoded #555 or #dfdfdf colors in components", () => {
+    const violations: string[] = [];
+    for (const f of files) {
+      if (!f.includes("components")) continue;
+      const content = fs.readFileSync(f, "utf-8");
+      if (/#555(?!\w)|#dfdfdf/i.test(content)) {
+        violations.push(path.relative(process.cwd(), f));
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  test("scrim token exists in design-tokens", () => {
+    const tokens = fs.readFileSync(
+      path.resolve(__dirname, "../../constants/design-tokens.ts"),
+      "utf-8",
+    );
+    expect(tokens).toContain("export const scrim");
+  });
+});

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -15,7 +15,7 @@ export default function TabLayout() {
       return (
         <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
           <MaterialCommunityIcons name={icon} size={22} color={theme.colors.onSurface} />
-          <Text style={{ fontSize: 18, fontWeight: "600", color: theme.colors.onSurface }}>{title}</Text>
+          <Text style={{ fontSize: 16, fontWeight: "600", color: theme.colors.onSurface }}>{title}</Text>
         </View>
       );
     };

--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -24,6 +24,7 @@ import { MuscleMap } from "../../components/MuscleMap";
 import { useFocusRefetch } from "../../lib/query";
 import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
 import { useProfileGender } from "../../lib/useProfileGender";
+import { radii } from "../../constants/design-tokens";
 
 type FilterType = Category | "custom";
 const FILTER_ALL: FilterType[] = [...CATEGORIES, "custom"];
@@ -398,7 +399,7 @@ const styles = StyleSheet.create({
     flex: 1,
     marginHorizontal: 6,
     marginVertical: 4,
-    borderRadius: 10,
+    borderRadius: radii.lg,
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.3,
     shadowRadius: 3,
@@ -419,7 +420,7 @@ const styles = StyleSheet.create({
   customBadge: {
     height: 20,
     paddingHorizontal: 6,
-    borderRadius: 10,
+    borderRadius: radii.lg,
     justifyContent: "center",
     alignItems: "center",
   },
@@ -466,7 +467,7 @@ const styles = StyleSheet.create({
     bottom: 16,
     width: 56,
     height: 56,
-    borderRadius: 28,
+    borderRadius: radii.pill,
     justifyContent: "center",
     alignItems: "center",
   },

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -54,6 +54,7 @@ import { useSnackbar } from "../../components/SnackbarProvider";
 import { useLayout } from "../../lib/layout";
 import { flowCardStyle } from "../../components/ui/FlowContainer";
 import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
+import { radii } from "../../constants/design-tokens";
 
 async function loadHomeData() {
   const [tpls, sess, act, timestamps, prData, progs, nw, sched, done, adh] = await Promise.all([
@@ -1007,6 +1008,6 @@ const styles = StyleSheet.create({
   dot: {
     width: 12,
     height: 12,
-    borderRadius: 6,
+    borderRadius: radii.md,
   },
 });

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -31,6 +31,7 @@ import { useLayout } from "../../lib/layout";
 import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
 import { todayKey, formatDateKey } from "../../lib/format";
 import SwipeToDelete from "../../components/SwipeToDelete";
+import { radii } from "../../constants/design-tokens";
 
 const DAY_MS = 86_400_000;
 
@@ -417,7 +418,7 @@ const styles = StyleSheet.create({
   fab: { position: "absolute", right: 16, bottom: 16 },
   macro: { marginBottom: 8 },
   macroHeader: { flexDirection: "row", justifyContent: "space-between", marginBottom: 4 },
-  bar: { height: 6, borderRadius: 3 },
+  bar: { height: 6, borderRadius: radii.sm },
   wideRow: { flex: 1, flexDirection: "row" },
   wideLog: { flex: 6 },
   wideAdd: { flex: 4, borderLeftWidth: StyleSheet.hairlineWidth },

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -46,6 +46,7 @@ import { toDisplay, toKg } from "../../lib/units";
 import MuscleVolumeSegment from "../../components/MuscleVolumeSegment";
 import WeeklySummary from "../../components/WeeklySummary";
 import { formatDuration, formatDateShort, movingAvg } from "../../lib/format";
+import { radii } from "../../constants/design-tokens";
 
 type PR = { exercise_id: string; name: string; max_weight: number };
 type SessionRow = { id: string; name: string; started_at: number; duration_seconds: number | null; set_count: number };
@@ -877,7 +878,7 @@ const styles = StyleSheet.create({
     bottom: 16,
     width: 56,
     height: 56,
-    borderRadius: 28,
+    borderRadius: radii.pill,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -885,7 +886,7 @@ const styles = StyleSheet.create({
     marginTop: 16,
     width: 56,
     height: 56,
-    borderRadius: 28,
+    borderRadius: radii.pill,
     alignItems: "center",
     justifyContent: "center",
   },

--- a/app/body/compare.tsx
+++ b/app/body/compare.tsx
@@ -10,6 +10,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams } from "expo-router";
 import { getPhotoById } from "../../lib/db/photos";
 import type { ProgressPhoto } from "../../lib/db/photos";
+import { radii, scrim } from "../../constants/design-tokens";
 
 export default function CompareScreen() {
   const theme = useTheme();
@@ -134,8 +135,8 @@ const styles = StyleSheet.create({
     position: "absolute",
     bottom: 8,
     left: 8,
-    backgroundColor: "rgba(0,0,0,0.6)",
-    borderRadius: 6,
+    backgroundColor: scrim.dark,
+    borderRadius: radii.md,
     paddingHorizontal: 8,
     paddingVertical: 4,
   },

--- a/app/body/photos.tsx
+++ b/app/body/photos.tsx
@@ -40,6 +40,7 @@ import {
 import type { ProgressPhoto, PoseCategory } from "../../lib/db/photos";
 import { getAppSetting, setAppSetting } from "../../lib/db";
 import { uuid } from "../../lib/uuid";
+import { scrim } from "../../constants/design-tokens";
 
 const PAGE_SIZE = 20;
 const MAX_DIMENSION = 1200;
@@ -708,7 +709,7 @@ const styles = StyleSheet.create({
   },
   savingOverlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0,0,0,0.3)",
+    backgroundColor: scrim.dark,
     justifyContent: "center",
     alignItems: "center",
   },

--- a/app/errors.tsx
+++ b/app/errors.tsx
@@ -7,6 +7,7 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { getRecentErrors, clearErrorLog } from "../lib/errors";
 import { useLayout } from "../lib/layout";
 import type { ErrorEntry } from "../lib/types";
+import { radii } from "../constants/design-tokens";
 
 export default function Errors() {
   const theme = useTheme();
@@ -174,7 +175,7 @@ const styles = StyleSheet.create({
   },
   stackBox: {
     marginTop: 8,
-    borderRadius: 6,
+    borderRadius: radii.md,
     padding: 8,
   },
 });

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -38,6 +38,7 @@ import {
   formatDuration,
   withOpacity,
 } from "../lib/format";
+import { radii } from "../constants/design-tokens";
 
 type SessionRow = WorkoutSession & { set_count: number };
 
@@ -548,7 +549,7 @@ const styles = StyleSheet.create({
   dot: {
     width: 5,
     height: 5,
-    borderRadius: 2.5,
+    borderRadius: radii.sm,
   },
   card: {
     marginBottom: 8,

--- a/app/nutrition/targets.tsx
+++ b/app/nutrition/targets.tsx
@@ -83,7 +83,7 @@ export default function Targets() {
         accessibilityRole="button"
       >
         <Card.Content>
-          <Text variant="titleSmall" style={{ color: theme.colors.onPrimaryContainer, fontSize: 15 }}>
+          <Text variant="titleSmall" style={{ color: theme.colors.onPrimaryContainer, fontSize: 16 }}>
             {profile ? "Update your profile" : "Set your profile for personalized targets"}
           </Text>
           {profileSummary ? (

--- a/app/progress/achievements.tsx
+++ b/app/progress/achievements.tsx
@@ -25,6 +25,7 @@ import {
   evaluateAchievements,
 } from "../../lib/achievements";
 import type { AchievementCategory } from "../../lib/achievements";
+import { radii, typography } from "../../constants/design-tokens";
 
 type AchievementItem = {
   id: string;
@@ -351,7 +352,7 @@ const styles = StyleSheet.create({
     marginBottom: 4,
   },
   icon: {
-    fontSize: 32,
+    fontSize: typography.statValue.fontSize,
   },
   iconLocked: {
     opacity: 0.4,
@@ -385,6 +386,6 @@ const styles = StyleSheet.create({
   progressBar: {
     width: "100%",
     height: 4,
-    borderRadius: 2,
+    borderRadius: radii.sm,
   },
 });

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -73,6 +73,7 @@ import { useLayout } from "../../lib/layout";
 import { confirmAction } from "../../lib/confirm";
 import WeightPicker from "../../components/WeightPicker";
 import ExercisePickerSheet from "../../components/ExercisePickerSheet";
+import { radii, duration as durationTokens } from "../../constants/design-tokens";
 
 type SetWithMeta = WorkoutSet & {
   exercise_name?: string;
@@ -972,7 +973,7 @@ export default function ActiveSession() {
       // eslint-disable-next-line react-hooks/immutability
       restFlash.value = 1;
       // eslint-disable-next-line react-hooks/immutability
-      restFlash.value = withTiming(0, { duration: 400 });
+      restFlash.value = withTiming(0, { duration: durationTokens.slow });
     }
 
     // Audio cue — 3-2-1 countdown tick
@@ -1432,7 +1433,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingVertical: 4,
     paddingHorizontal: 4,
-    borderRadius: 6,
+    borderRadius: radii.md,
     marginBottom: 2,
   },
   colSet: {
@@ -1463,7 +1464,7 @@ const styles = StyleSheet.create({
   circleCheck: {
     width: 28,
     height: 28,
-    borderRadius: 14,
+    borderRadius: radii.xl,
     borderWidth: 2,
     alignItems: "center",
     justifyContent: "center",
@@ -1576,7 +1577,7 @@ const styles = StyleSheet.create({
     paddingBottom: 6,
   },
   notesInput: {
-    fontSize: 13,
+    fontSize: 12,
   },
   suggestionChip: {
     paddingHorizontal: 12,

--- a/app/tools/plates.tsx
+++ b/app/tools/plates.tsx
@@ -25,6 +25,7 @@ import {
   KG_BARS,
   LB_BARS,
 } from "../../lib/plates"
+import { radii } from "../../constants/design-tokens"
 
 const HEIGHT: Record<number, number> = {
   25: 80, 55: 80,
@@ -321,13 +322,13 @@ const plateStyles = StyleSheet.create({
   },
   plate: {
     width: 22,
-    borderRadius: 3,
+    borderRadius: radii.sm,
     marginHorizontal: 1,
   },
   bar: {
     width: 60,
     height: 8,
-    borderRadius: 2,
+    borderRadius: radii.sm,
   },
 })
 

--- a/app/tools/timer.tsx
+++ b/app/tools/timer.tsx
@@ -51,6 +51,7 @@ import {
 } from "../../lib/timer"
 import { getAppSetting, setAppSetting } from "../../lib/db"
 import { hexToRgb } from "../../lib/format"
+import { radii, typography } from "../../constants/design-tokens"
 
 const AnimatedCircle = Animated.createAnimatedComponent(Circle)
 
@@ -643,7 +644,7 @@ const styles = StyleSheet.create({
   stepBtn: {
     width: 56,
     height: 56,
-    borderRadius: 28,
+    borderRadius: radii.pill,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -680,8 +681,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   time: {
-    fontSize: 56,
-    fontWeight: "700",
+    ...typography.display,
     fontVariant: ["tabular-nums"],
     fontFamily: Platform.select({ ios: "Menlo", android: "monospace", default: "monospace" }),
   },
@@ -697,7 +697,7 @@ const styles = StyleSheet.create({
   addRound: {
     minWidth: 160,
     minHeight: 56,
-    borderRadius: 28,
+    borderRadius: radii.pill,
     alignItems: "center",
     justifyContent: "center",
     marginBottom: 16,
@@ -710,7 +710,7 @@ const styles = StyleSheet.create({
   btn: {
     minWidth: 120,
     minHeight: 56,
-    borderRadius: 28,
+    borderRadius: radii.pill,
     alignItems: "center",
     justifyContent: "center",
     paddingHorizontal: 24,

--- a/components/ExercisePickerSheet.tsx
+++ b/components/ExercisePickerSheet.tsx
@@ -29,6 +29,7 @@ import {
   type Category,
   type Exercise,
 } from "../lib/types";
+import { duration as durationTokens, elevation } from "../constants/design-tokens";
 
 type Props = {
   visible: boolean;
@@ -67,18 +68,18 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
         .finally(() => setLoading(false));
 
       translateY.value = withSpring(SNAP_MID, SPRING_CONFIG);
-      backdropOpacity.value = withTiming(1, { duration: 250 });
+      backdropOpacity.value = withTiming(1, { duration: durationTokens.normal });
     } else if (mounted) {
-      translateY.value = withTiming(SCREEN_H, { duration: 200 });
-      backdropOpacity.value = withTiming(0, { duration: 200 }, () => {
+      translateY.value = withTiming(SCREEN_H, { duration: durationTokens.fast });
+      backdropOpacity.value = withTiming(0, { duration: durationTokens.fast }, () => {
         runOnJS(setMounted)(false);
       });
     }
   }, [visible, mounted, translateY, backdropOpacity, SCREEN_H, SNAP_MID]);
 
   const dismiss = useCallback(() => {
-    translateY.value = withTiming(SCREEN_H, { duration: 200 });
-    backdropOpacity.value = withTiming(0, { duration: 200 }, () => {
+    translateY.value = withTiming(SCREEN_H, { duration: durationTokens.fast });
+    backdropOpacity.value = withTiming(0, { duration: durationTokens.fast }, () => {
       runOnJS(onDismiss)();
     });
   }, [translateY, backdropOpacity, onDismiss, SCREEN_H]);
@@ -294,11 +295,7 @@ const styles = StyleSheet.create({
     borderTopLeftRadius: 16,
     borderTopRightRadius: 16,
     overflow: "hidden",
-    elevation: 16,
-    shadowColor: "rgb(0,0,0)",
-    shadowOffset: { width: 0, height: -4 },
-    shadowOpacity: 0.15,
-    shadowRadius: 12,
+    ...elevation.high,
   },
   handleZone: {
     alignItems: "center",

--- a/components/FloatingTabBar.tsx
+++ b/components/FloatingTabBar.tsx
@@ -121,7 +121,7 @@ function CenterButton({
           <MaterialCommunityIcons
             name="arm-flex"
             size={28}
-            color={focused ? "#FFFFFF" : color}
+            color={focused ? theme.colors.onPrimary : color}
           />
         </Pressable>
       </Animated.View>

--- a/components/MuscleMap.tsx
+++ b/components/MuscleMap.tsx
@@ -5,6 +5,7 @@ import Body, { type Slug, type ExtendedBodyPart } from "react-native-body-highli
 import type { MuscleGroup } from "../lib/types";
 import { MUSCLE_LABELS } from "../lib/types";
 import { muscle } from "../constants/theme";
+import { radii } from "../constants/design-tokens";
 
 type Props = {
   primary: MuscleGroup[];
@@ -92,7 +93,7 @@ function MuscleMapInner({ primary, secondary, width: w, gender = "male" }: Props
           side="front"
           scale={scale}
           colors={[c.secondary, c.primary]}
-          border={isDark ? "#555" : "#dfdfdf"}
+          border={isDark ? muscle.dark.outline : muscle.light.outline}
         />
         <Body
           data={data}
@@ -100,7 +101,7 @@ function MuscleMapInner({ primary, secondary, width: w, gender = "male" }: Props
           side="back"
           scale={scale}
           colors={[c.secondary, c.primary]}
-          border={isDark ? "#555" : "#dfdfdf"}
+          border={isDark ? muscle.dark.outline : muscle.light.outline}
         />
       </View>
       <Legend primary={primary} secondary={secondary} isDark={isDark} />
@@ -183,6 +184,6 @@ const styles = StyleSheet.create({
   dot: {
     width: 12,
     height: 12,
-    borderRadius: 6,
+    borderRadius: radii.md,
   },
 });

--- a/components/PhotoGrid.tsx
+++ b/components/PhotoGrid.tsx
@@ -10,6 +10,7 @@ import { Text, useTheme } from "react-native-paper";
 import { FlashList } from "@shopify/flash-list";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import type { ProgressPhoto } from "../lib/db/photos";
+import { radii, scrim } from "../constants/design-tokens";
 
 type Props = {
   photos: ProgressPhoto[];
@@ -89,7 +90,7 @@ export default function PhotoGrid({
             </View>
           )}
           {compareMode && !isSelected && (
-            <View style={[styles.checkbox, { borderColor: theme.colors.onSurface }]} />
+            <View style={[styles.checkbox, { borderColor: theme.colors.onSurface, backgroundColor: theme.colors.backdrop }]} />
           )}
         </Pressable>
       );
@@ -140,7 +141,7 @@ const styles = StyleSheet.create({
     bottom: 0,
     left: 0,
     right: 0,
-    backgroundColor: "rgba(0,0,0,0.55)",
+    backgroundColor: scrim.dark,
     paddingVertical: 2,
     paddingHorizontal: 4,
   },
@@ -152,7 +153,7 @@ const styles = StyleSheet.create({
     position: "absolute",
     top: 4,
     left: 4,
-    borderRadius: 10,
+    borderRadius: radii.lg,
     width: 22,
     height: 22,
     alignItems: "center",
@@ -180,6 +181,5 @@ const styles = StyleSheet.create({
     width: 24,
     height: 24,
     borderWidth: 2,
-    backgroundColor: "rgba(255,255,255,0.5)",
   },
 });

--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -203,7 +203,7 @@ export default function ProfileForm({ initialProfile, onSave, onCancel, onDirtyC
 
       <Text
         variant="titleMedium"
-        style={{ color: theme.colors.onSurface, marginBottom: 16, fontSize: 18 }}
+        style={{ color: theme.colors.onSurface, marginBottom: 16 }}
       >
         Your Profile
       </Text>

--- a/components/SwipeToDelete.tsx
+++ b/components/SwipeToDelete.tsx
@@ -9,6 +9,7 @@ import Animated, {
   runOnJS,
 } from "react-native-reanimated";
 import { IconButton, useTheme } from "react-native-paper";
+import { radii, duration as durationTokens } from "../constants/design-tokens";
 
 interface SwipeToDeleteProps {
   children: React.ReactNode;
@@ -35,7 +36,7 @@ export default function SwipeToDelete({
     })
     .onEnd((e) => {
       if (e.translationX < DISMISS_THRESHOLD) {
-        translateX.value = withTiming(-500, { duration: 200 }, () => {
+        translateX.value = withTiming(-500, { duration: durationTokens.fast }, () => {
           runOnJS(onDelete)();
         });
       } else if (e.translationX < THRESHOLD) {
@@ -89,7 +90,7 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
     justifyContent: "center",
     alignItems: "flex-end",
-    borderRadius: 6,
+    borderRadius: radii.md,
   },
   deleteContent: {
     width: 80,

--- a/components/TrainingModeSelector.tsx
+++ b/components/TrainingModeSelector.tsx
@@ -78,7 +78,7 @@ function TrainingModeSelector({ modes, selected, exercise, onSelect, compact: is
 
       {tooltip && (
         <View style={[styles.tooltip, { backgroundColor: theme.colors.inverseSurface }]}>
-          <Text style={{ color: theme.colors.inverseOnSurface, fontSize: 13 }}>
+          <Text style={{ color: theme.colors.inverseOnSurface, fontSize: 12 }}>
             {tooltip}
           </Text>
         </View>

--- a/components/WeightPicker.tsx
+++ b/components/WeightPicker.tsx
@@ -127,7 +127,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   stepText: {
-    fontSize: 18,
+    fontSize: 16,
     fontWeight: "700",
     lineHeight: 20,
   },
@@ -139,7 +139,7 @@ const styles = StyleSheet.create({
     paddingVertical: 4,
   },
   valueText: {
-    fontSize: 15,
+    fontSize: 16,
     fontWeight: "700",
   },
   unitText: {

--- a/components/WorkoutHeatmap.tsx
+++ b/components/WorkoutHeatmap.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet, View } from "react-native";
 import { Text, useTheme } from "react-native-paper";
 import { useLayout } from "../lib/layout";
 import { withOpacity } from "../lib/format";
+import { radii } from "../constants/design-tokens";
 
 type HeatmapProps = {
   data: Map<string, number>;
@@ -157,7 +158,7 @@ export default function WorkoutHeatmap({ data, weeks = 16, onDayPress }: Heatmap
                   {
                     width: cellSize,
                     height: cellSize,
-                    borderRadius: 3,
+                    borderRadius: radii.sm,
                     backgroundColor: bgColor,
                     margin: gap / 2,
                     opacity: isFuture ? 0.3 : 1,
@@ -183,7 +184,7 @@ export default function WorkoutHeatmap({ data, weeks = 16, onDayPress }: Heatmap
               styles.legendCell,
               {
                 backgroundColor: heatmapColor(level, theme),
-                borderRadius: 3,
+                borderRadius: radii.sm,
               },
             ]}
           >

--- a/constants/design-tokens.ts
+++ b/constants/design-tokens.ts
@@ -127,3 +127,10 @@ export const springConfig = {
 } as const;
 
 export type SpringConfigKey = keyof typeof springConfig;
+
+// ─── Scrim / Overlay ───────────────────────────────────────────────
+
+export const scrim = {
+  light: "rgba(0,0,0,0.5)",
+  dark: "rgba(0,0,0,0.5)",
+} as const;


### PR DESCRIPTION
## Summary

Replace hardcoded colors, border radii, font sizes, and animation durations with design tokens across 23 files. Adds a scrim overlay token and compliance tests to prevent regressions.

## Changes

### Priority 1: Hardcoded Colors
- MuscleMap: `#555`/`#dfdfdf` → `muscle.dark.outline`/`muscle.light.outline`
- PhotoGrid: `rgba(255,255,255,0.5)` → `theme.colors.backdrop`
- ExercisePickerSheet: hardcoded shadow → `elevation.high` token

### Priority 2: Modal Overlay Opacities → 0.5
- Standardized 4 different opacities (0.3, 0.55, 0.6) to 0.5 via new `scrim` token
- Added `scrim` token to `constants/design-tokens.ts`

### Priority 3: borderRadius: 28 → radii.pill
- exercises.tsx, progress.tsx, timer.tsx FABs and pill buttons

### Priority 4: Off-Grid borderRadius Values
- `10` → `radii.lg` (12), `14` → `radii.xl` (16), `6` → `radii.md` (8)

### Priority 5: Progress Bar Radii → radii.sm (4)
- Unified 2, 2.5, 3 values across history, plates, heatmap, achievements, nutrition

### Priority 6: Non-Standard Font Sizes
- `18` → 16 (titleMedium), `15` → 16 (bodyLarge), `13` → 12 (bodySmall)
- `56` → `typography.display`, `32` → `typography.statValue`

### Priority 7: Animation Durations → Tokens
- `250` → `duration.normal`, `200` → `duration.fast`, `400` → `duration.slow`

## Testing

- `npx tsc --noEmit` — 0 errors
- `npm test` — 1319/1319 tests pass (80 suites)
- ESLint — 0 warnings
- Added 4 structural compliance tests for regression prevention

## Issue

Resolves BLD-237