### PR TITLE
chore: release v0.4.0 — Session Rating & UI Polish (BLD-239)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,7 +4,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: "FitForge",
   slug: "fitforge",
-  version: "0.3.1",
+  version: "0.4.0",
   orientation: "default",
   icon: "./assets/icon.png",
   userInterfaceStyle: "automatic",
@@ -23,7 +23,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       backgroundColor: "#ffffff",
     },
     package: "com.anomalyco.fitforge",
-    versionCode: 2,
+    versionCode: 3,
   },
   web: {
     favicon: "./assets/favicon.png",

--- a/fdroid/metadata/com.anomalyco.fitforge.yml
+++ b/fdroid/metadata/com.anomalyco.fitforge.yml
@@ -22,8 +22,10 @@ Description: |
   - Workout history with calendar view
   - Plate calculator and 1RM calculator
   - Interval timers (Tabata, EMOM, AMRAP)
+  - Session rating (1-5 stars) on post-workout summary
+  - Session notes — add text notes to completed workouts
   - CSV export and sharing
   - Dark mode support
 
-CurrentVersion: 0.3.1
-CurrentVersionCode: 6
+CurrentVersion: 0.4.0
+CurrentVersionCode: 7

--- a/fdroid/metadata/com.anomalyco.fitforge/en-US/changelogs/7.txt
+++ b/fdroid/metadata/com.anomalyco.fitforge/en-US/changelogs/7.txt
@@ -1,0 +1,11 @@
+v0.4.0 — Session Rating & UI Polish
+
+New Features:
+* Session rating (1-5 stars) on post-workout summary
+* Session notes — add text notes to completed workouts
+
+Improvements:
+* borderRadius tokens standardized to design system
+* Font sizes aligned to MD3 type scale
+* Modal overlay colors use theme tokens (no hardcoded values)
+* FloatingTabBar colors use theme tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fitforge",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fitforge",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fitforge",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fitforge",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fitforge",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
## Summary

Release v0.4.0 with Session Rating & Save-as-Template features and UI polish improvements merged since v0.3.1.

## Changes

- Bump version from 0.3.1 to 0.4.0 in package.json and app.config.ts
- Bump android versionCode from 2 to 3
- Update F-Droid metadata (CurrentVersion, CurrentVersionCode, feature list)
- Add F-Droid changelog for v0.4.0

## Release Notes (v0.4.0)

**New Features:**
- ⭐ Session Rating (1-5 stars) on post-workout summary
- 📝 Session Notes — add text notes to completed workouts

**Improvements:**
- borderRadius tokens standardized to design system
- Font sizes aligned to MD3 type scale
- Modal overlay colors use theme tokens (no hardcoded values)
- FloatingTabBar colors use theme tokens

## Testing

- `npx tsc --noEmit` passes with zero errors
- `npm test` passes (81 suites, 1323 tests)

## Issue

Resolves BLD-239