### PR TITLE
feat: Smart Exercise Substitutions (BLD-241)

### DIFF
--- a/__tests__/acceptance/rpe-notes.test.tsx
+++ b/__tests__/acceptance/rpe-notes.test.tsx
@@ -344,3 +344,67 @@ describe('RPE and Notes Combined', () => {
     expect(await findByText('Hard set')).toBeTruthy()
   })
 })
+
+// --- Swapped From Label in Session Detail ---
+
+describe('Swapped From Label in Session Detail', () => {
+  const session = createSession({
+    id: 'sess-swap-detail',
+    name: 'Chest Day',
+    started_at: Date.now() - 3600000,
+    completed_at: Date.now(),
+    duration_seconds: 3600,
+  })
+
+  beforeEach(() => {
+    mockParams.id = 'sess-swap-detail'
+    mockDb.getSessionById.mockResolvedValue(session)
+  })
+
+  it('shows "Swapped from" label when exercise was substituted', async () => {
+    mockDb.getSessionSets.mockResolvedValue([
+      {
+        ...createSet({
+          id: 'set-swap-1',
+          session_id: 'sess-swap-detail',
+          exercise_id: 'ex-new',
+          set_number: 1,
+          weight: 60,
+          reps: 10,
+          completed: true,
+          completed_at: Date.now(),
+          swapped_from_exercise_id: 'ex-original',
+        }),
+        exercise_name: 'Dumbbell Press',
+        exercise_deleted: false,
+        swapped_from_name: 'Bench Press',
+      },
+    ])
+
+    const { findByText } = renderScreen(<SessionDetail />)
+    expect(await findByText('Swapped from Bench Press')).toBeTruthy()
+  })
+
+  it('does not show "Swapped from" label for non-substituted exercises', async () => {
+    mockDb.getSessionSets.mockResolvedValue([
+      {
+        ...createSet({
+          id: 'set-noswap-1',
+          session_id: 'sess-swap-detail',
+          exercise_id: 'ex-1',
+          set_number: 1,
+          weight: 80,
+          reps: 8,
+          completed: true,
+          completed_at: Date.now(),
+        }),
+        exercise_name: 'Bench Press',
+        exercise_deleted: false,
+      },
+    ])
+
+    const { findByText, queryByText } = renderScreen(<SessionDetail />)
+    expect(await findByText('Bench Press')).toBeTruthy()
+    expect(queryByText(/Swapped from/)).toBeNull()
+  })
+})

--- a/__tests__/acceptance/rpe-notes.test.tsx
+++ b/__tests__/acceptance/rpe-notes.test.tsx
@@ -32,6 +32,9 @@ jest.mock('../../lib/db', () => ({
   updateSession: jest.fn().mockResolvedValue(undefined),
   getSessionSetCount: jest.fn().mockResolvedValue(0),
   createTemplateFromSession: jest.fn().mockResolvedValue('new-template-id'),
+  getAllExercises: jest.fn().mockResolvedValue([]),
+  swapExerciseInSession: jest.fn().mockResolvedValue([]),
+  undoSwapInSession: jest.fn().mockResolvedValue(undefined),
 }))
 
 jest.mock('../../lib/programs', () => ({

--- a/__tests__/acceptance/session-ux.test.tsx
+++ b/__tests__/acceptance/session-ux.test.tsx
@@ -27,6 +27,9 @@ jest.mock('../../lib/db', () => ({
   getSessionWeightIncreases: jest.fn().mockResolvedValue([]),
   getSessionComparison: jest.fn().mockResolvedValue(null),
   deleteSet: jest.fn().mockResolvedValue(undefined),
+  getAllExercises: jest.fn().mockResolvedValue([]),
+  swapExerciseInSession: jest.fn().mockResolvedValue([]),
+  undoSwapInSession: jest.fn().mockResolvedValue(undefined),
 }))
 
 jest.mock('../../lib/programs', () => ({

--- a/__tests__/acceptance/supersets.test.tsx
+++ b/__tests__/acceptance/supersets.test.tsx
@@ -37,6 +37,9 @@ jest.mock('../../lib/db', () => ({
   createExerciseLink: jest.fn().mockResolvedValue('link-new'),
   unlinkExerciseGroup: jest.fn().mockResolvedValue(undefined),
   unlinkSingleExercise: jest.fn().mockResolvedValue(undefined),
+  getAllExercises: jest.fn().mockResolvedValue([]),
+  swapExerciseInSession: jest.fn().mockResolvedValue([]),
+  undoSwapInSession: jest.fn().mockResolvedValue(undefined),
 }))
 
 jest.mock('../../lib/programs', () => ({
@@ -210,6 +213,7 @@ beforeEach(() => {
   mockDb.getRestSecondsForExercise.mockResolvedValue(90)
   mockDb.getRestSecondsForLink.mockResolvedValue(30)
   mockDb.getAppSetting.mockResolvedValue('true')
+  mockDb.getAllExercises.mockResolvedValue([exerciseA, exerciseB, exerciseC])
   mockDb.getSessionPRs.mockResolvedValue([])
   mockDb.getSessionRepPRs.mockResolvedValue([])
   mockDb.getSessionWeightIncreases.mockResolvedValue([])

--- a/__tests__/acceptance/workout-session.acceptance.test.tsx
+++ b/__tests__/acceptance/workout-session.acceptance.test.tsx
@@ -32,6 +32,9 @@ jest.mock('../../lib/db', () => ({
   buildAchievementContext: jest.fn().mockResolvedValue({}),
   getEarnedAchievementIds: jest.fn().mockResolvedValue([]),
   saveEarnedAchievements: jest.fn().mockResolvedValue(undefined),
+  getAllExercises: jest.fn().mockResolvedValue([]),
+  swapExerciseInSession: jest.fn().mockResolvedValue([]),
+  undoSwapInSession: jest.fn().mockResolvedValue(undefined),
 }))
 
 jest.mock('../../lib/programs', () => ({

--- a/__tests__/helpers/factories.ts
+++ b/__tests__/helpers/factories.ts
@@ -138,6 +138,7 @@ export function createSet(overrides: Partial<WorkoutSet> = {}): WorkoutSet {
     round: null,
     training_mode: null,
     tempo: null,
+    swapped_from_exercise_id: null,
     ...overrides,
   }
 }

--- a/__tests__/lib/exercise-substitutions.test.ts
+++ b/__tests__/lib/exercise-substitutions.test.ts
@@ -1,0 +1,249 @@
+import {
+  scoreSubstitution,
+  scoreSubstitutionDetailed,
+  findSubstitutions,
+} from "../../lib/exercise-substitutions";
+import type { Exercise } from "../../lib/types";
+
+function makeExercise(overrides: Partial<Exercise> = {}): Exercise {
+  return {
+    id: "ex-1",
+    name: "Bench Press",
+    category: "chest",
+    primary_muscles: ["chest", "triceps"],
+    secondary_muscles: ["shoulders"],
+    equipment: "barbell",
+    instructions: "",
+    difficulty: "intermediate",
+    is_custom: false,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+describe("exercise-substitutions", () => {
+  describe("scoreSubstitutionDetailed", () => {
+    it("returns perfect score for identical exercises (except id)", () => {
+      const source = makeExercise({ id: "a" });
+      const candidate = makeExercise({ id: "b" });
+      const details = scoreSubstitutionDetailed(source, candidate);
+      expect(details.primaryOverlap).toBe(50);
+      expect(details.secondaryOverlap).toBe(20);
+      expect(details.equipmentMatch).toBe(15);
+      expect(details.categoryMatch).toBe(10);
+      expect(details.difficultyProx).toBe(5);
+    });
+
+    it("scores primary muscle overlap proportionally", () => {
+      const source = makeExercise({ primary_muscles: ["chest", "triceps"] });
+      const candidate = makeExercise({
+        id: "b",
+        primary_muscles: ["chest", "shoulders"],
+      });
+      const details = scoreSubstitutionDetailed(source, candidate);
+      // intersection: [chest] = 1, union: [chest, triceps, shoulders] = 3
+      // 1/3 * 50 = ~17
+      expect(details.primaryOverlap).toBe(17);
+    });
+
+    it("scores secondary muscle overlap proportionally", () => {
+      const source = makeExercise({
+        secondary_muscles: ["shoulders", "core"],
+      });
+      const candidate = makeExercise({
+        id: "b",
+        secondary_muscles: ["shoulders", "biceps"],
+      });
+      const details = scoreSubstitutionDetailed(source, candidate);
+      // intersection: [shoulders] = 1, union: [shoulders, core, biceps] = 3
+      // 1/3 * 20 = ~7
+      expect(details.secondaryOverlap).toBe(7);
+    });
+
+    it("gives 15 pts for same equipment", () => {
+      const source = makeExercise({ equipment: "barbell" });
+      const candidate = makeExercise({ id: "b", equipment: "barbell" });
+      expect(scoreSubstitutionDetailed(source, candidate).equipmentMatch).toBe(15);
+    });
+
+    it("gives 8 pts for same equipment group (free weights)", () => {
+      const source = makeExercise({ equipment: "barbell" });
+      const candidate = makeExercise({ id: "b", equipment: "dumbbell" });
+      expect(scoreSubstitutionDetailed(source, candidate).equipmentMatch).toBe(8);
+    });
+
+    it("gives 8 pts for same equipment group (machines)", () => {
+      const source = makeExercise({ equipment: "machine" });
+      const candidate = makeExercise({ id: "b", equipment: "cable" });
+      expect(scoreSubstitutionDetailed(source, candidate).equipmentMatch).toBe(8);
+    });
+
+    it("gives 0 pts for different equipment group", () => {
+      const source = makeExercise({ equipment: "barbell" });
+      const candidate = makeExercise({ id: "b", equipment: "bodyweight" });
+      expect(scoreSubstitutionDetailed(source, candidate).equipmentMatch).toBe(0);
+    });
+
+    it("gives 10 pts for same category", () => {
+      const source = makeExercise({ category: "chest" });
+      const candidate = makeExercise({ id: "b", category: "chest" });
+      expect(scoreSubstitutionDetailed(source, candidate).categoryMatch).toBe(10);
+    });
+
+    it("gives 0 pts for different category", () => {
+      const source = makeExercise({ category: "chest" });
+      const candidate = makeExercise({ id: "b", category: "back" });
+      expect(scoreSubstitutionDetailed(source, candidate).categoryMatch).toBe(0);
+    });
+
+    it("gives 5 pts for same difficulty", () => {
+      const source = makeExercise({ difficulty: "intermediate" });
+      const candidate = makeExercise({ id: "b", difficulty: "intermediate" });
+      expect(scoreSubstitutionDetailed(source, candidate).difficultyProx).toBe(5);
+    });
+
+    it("gives 3 pts for ±1 difficulty", () => {
+      const source = makeExercise({ difficulty: "intermediate" });
+      const candidate = makeExercise({ id: "b", difficulty: "beginner" });
+      expect(scoreSubstitutionDetailed(source, candidate).difficultyProx).toBe(3);
+    });
+
+    it("gives 1 pt for ±2 difficulty", () => {
+      const source = makeExercise({ difficulty: "beginner" });
+      const candidate = makeExercise({ id: "b", difficulty: "advanced" });
+      expect(scoreSubstitutionDetailed(source, candidate).difficultyProx).toBe(1);
+    });
+
+    it("handles empty primary muscles", () => {
+      const source = makeExercise({ primary_muscles: [] });
+      const candidate = makeExercise({ id: "b", primary_muscles: ["chest"] });
+      expect(scoreSubstitutionDetailed(source, candidate).primaryOverlap).toBe(0);
+    });
+
+    it("handles empty secondary muscles", () => {
+      const source = makeExercise({ secondary_muscles: [] });
+      const candidate = makeExercise({ id: "b", secondary_muscles: [] });
+      expect(scoreSubstitutionDetailed(source, candidate).secondaryOverlap).toBe(0);
+    });
+  });
+
+  describe("scoreSubstitution", () => {
+    it("returns sum of all detail scores", () => {
+      const source = makeExercise({ id: "a" });
+      const candidate = makeExercise({ id: "b" });
+      expect(scoreSubstitution(source, candidate)).toBe(100);
+    });
+  });
+
+  describe("findSubstitutions", () => {
+    it("returns empty array when source has no primary muscles", () => {
+      const source = makeExercise({ primary_muscles: [] });
+      const candidates = [makeExercise({ id: "b" })];
+      expect(findSubstitutions(source, candidates)).toEqual([]);
+    });
+
+    it("excludes source exercise from results", () => {
+      const source = makeExercise({ id: "a" });
+      const candidates = [
+        makeExercise({ id: "a" }),
+        makeExercise({ id: "b" }),
+      ];
+      const results = findSubstitutions(source, candidates);
+      expect(results.every((r) => r.exercise.id !== "a")).toBe(true);
+    });
+
+    it("excludes deleted exercises from results", () => {
+      const source = makeExercise({ id: "a" });
+      const candidates = [
+        makeExercise({ id: "b", deleted_at: Date.now() }),
+        makeExercise({ id: "c" }),
+      ];
+      const results = findSubstitutions(source, candidates);
+      expect(results.every((r) => r.exercise.id !== "b")).toBe(true);
+      expect(results.length).toBe(1);
+    });
+
+    it("filters out exercises below minimum threshold (20)", () => {
+      const source = makeExercise({
+        id: "a",
+        primary_muscles: ["chest"],
+        secondary_muscles: [],
+        category: "chest",
+        equipment: "barbell",
+      });
+      const lowScoreCandidate = makeExercise({
+        id: "b",
+        primary_muscles: ["calves"],
+        secondary_muscles: [],
+        category: "legs_glutes",
+        equipment: "bodyweight",
+        difficulty: "advanced",
+      });
+      const results = findSubstitutions(source, [lowScoreCandidate]);
+      // calves vs chest = 0 overlap, different category, different equipment, different difficulty
+      expect(results.length).toBe(0);
+    });
+
+    it("sorts by score descending", () => {
+      const source = makeExercise({ id: "a", primary_muscles: ["chest", "triceps"] });
+      const perfect = makeExercise({ id: "b" }); // same muscles
+      const partial = makeExercise({
+        id: "c",
+        primary_muscles: ["chest"],
+        secondary_muscles: [],
+        equipment: "dumbbell",
+      });
+      const results = findSubstitutions(source, [partial, perfect]);
+      expect(results[0].exercise.id).toBe("b");
+      expect(results[1].exercise.id).toBe("c");
+    });
+
+    it("limits results to specified limit", () => {
+      const source = makeExercise({ id: "a" });
+      const candidates = Array.from({ length: 30 }, (_, i) =>
+        makeExercise({ id: `ex-${i}` })
+      );
+      const results = findSubstitutions(source, candidates, 5);
+      expect(results.length).toBe(5);
+    });
+
+    it("defaults to max 20 results", () => {
+      const source = makeExercise({ id: "a" });
+      const candidates = Array.from({ length: 30 }, (_, i) =>
+        makeExercise({ id: `ex-${i}` })
+      );
+      const results = findSubstitutions(source, candidates);
+      expect(results.length).toBe(20);
+    });
+
+    it("exercises with same primary muscles score >80%", () => {
+      const source = makeExercise({
+        id: "a",
+        primary_muscles: ["chest", "triceps"],
+        secondary_muscles: ["shoulders"],
+        equipment: "barbell",
+        category: "chest",
+        difficulty: "intermediate",
+      });
+      const sameMuscleDiffEquip = makeExercise({
+        id: "b",
+        primary_muscles: ["chest", "triceps"],
+        secondary_muscles: ["shoulders"],
+        equipment: "dumbbell",
+        category: "chest",
+        difficulty: "intermediate",
+      });
+      const results = findSubstitutions(source, [sameMuscleDiffEquip]);
+      expect(results.length).toBe(1);
+      // 50 (primary) + 20 (secondary) + 8 (same group) + 10 (category) + 5 (difficulty) = 93
+      expect(results[0].score).toBeGreaterThan(80);
+    });
+
+    it("includes custom exercises", () => {
+      const source = makeExercise({ id: "a" });
+      const custom = makeExercise({ id: "custom-1", is_custom: true });
+      const results = findSubstitutions(source, [custom]);
+      expect(results.length).toBe(1);
+    });
+  });
+});

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -886,7 +886,9 @@ export default function ActiveSession() {
         load();
       }
       // Load all exercises for substitution sheet
-      getAllExercises().then(setAllExercises).catch(() => {});
+      getAllExercises().then(setAllExercises).catch((err) => {
+        console.warn("Failed to load exercises for substitution:", err);
+      });
     }, [id, load])
   );
 

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -38,6 +38,7 @@ import {
   completeSession,
   completeSet,
   getBodySettings,
+  getAllExercises,
   getMaxWeightByExercise,
   getRecentExerciseSets,
   getSessionById,
@@ -46,6 +47,8 @@ import {
   getPreviousSets,
   getRestSecondsForExercise,
   getRestSecondsForLink,
+  swapExerciseInSession,
+  undoSwapInSession,
   uncompleteSet,
   updateSet,
   updateSetsBatch,
@@ -73,6 +76,7 @@ import { useLayout } from "../../lib/layout";
 import { confirmAction } from "../../lib/confirm";
 import WeightPicker from "../../components/WeightPicker";
 import ExercisePickerSheet from "../../components/ExercisePickerSheet";
+import SubstitutionSheet from "../../components/SubstitutionSheet";
 import { radii, duration as durationTokens } from "../../constants/design-tokens";
 
 type SetWithMeta = WorkoutSet & {
@@ -317,6 +321,7 @@ type GroupCardProps = {
   onNotesDraftChange: (setId: string, text: string) => void;
   onToggleNotes: (setId: string) => void;
   onShowDetail: (exerciseId: string) => void;
+  onSwap: (exerciseId: string) => void;
 };
 
 const ExerciseGroupCard = memo(function ExerciseGroupCard({
@@ -325,7 +330,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
   onUpdate, onCheck, onDelete, onAddSet, onModeChange,
   onRPE, onHalfStep, onHalfStepClear,
   onHalfStepOpen, onNotes, onNotesDraftChange, onToggleNotes,
-  onShowDetail,
+  onShowDetail, onSwap,
 }: GroupCardProps) {
   const theme = useTheme();
   const layout = useLayout();
@@ -417,6 +422,13 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
         >
           Details
         </Button>
+        <IconButton
+          icon="swap-horizontal"
+          size={24}
+          onPress={() => onSwap(group.exercise_id)}
+          accessibilityLabel={`Swap ${group.name} for alternative`}
+          style={styles.swapBtn}
+        />
         {group.is_voltra && group.training_modes.length > 1 && (
           <TrainingModeSelector
             modes={group.training_modes}
@@ -674,6 +686,7 @@ export default function ActiveSession() {
   const prevExerciseIds = useRef<string>("");
   const prHapticFired = useRef<Set<string>>(new Set());
   const [snackbar, setSnackbar] = useState("");
+  const [snackbarAction, setSnackbarAction] = useState<{ label: string; onPress: () => void } | undefined>();
   const [notesOpen, setNotesOpen] = useState<Record<string, boolean>>({});
   const [notesDraft, setNotesDraft] = useState<Record<string, string>>({});
   const [halfStep, setHalfStep] = useState<{ setId: string; base: number } | null>(null);
@@ -705,6 +718,12 @@ export default function ActiveSession() {
   const [detailExercise, setDetailExercise] = useState<Exercise | null>(null);
   const detailSheetRef = useRef<BottomSheet>(null);
   const detailSnapPoints = useMemo(() => ["40%", "90%"], []);
+
+  // Substitution state
+  const [allExercises, setAllExercises] = useState<Exercise[]>([]);
+  const [swapSource, setSwapSource] = useState<Exercise | null>(null);
+  const swapSheetRef = useRef<BottomSheet>(null);
+  const swapUndoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const linkIds = useMemo(() => {
     const ids: string[] = [];
@@ -866,6 +885,8 @@ export default function ActiveSession() {
       if (initialized.current && id) {
         load();
       }
+      // Load all exercises for substitution sheet
+      getAllExercises().then(setAllExercises).catch(() => {});
     }, [id, load])
   );
 
@@ -989,6 +1010,7 @@ export default function ActiveSession() {
       if (restRef.current) clearInterval(restRef.current);
       if (hintTimer.current) clearTimeout(hintTimer.current);
       for (const t of restHapticTimers.current) clearTimeout(t);
+      if (swapUndoTimer.current) clearTimeout(swapUndoTimer.current);
     };
   }, []);
 
@@ -1066,6 +1088,70 @@ export default function ActiveSession() {
     setDetailExercise(ex);
     detailSheetRef.current?.snapToIndex(0);
   }, []);
+
+  const handleSwapOpen = useCallback(async (exerciseId: string) => {
+    // Check if all sets are completed
+    const group = groups.find((g) => g.exercise_id === exerciseId);
+    if (group && group.sets.every((s) => s.completed)) {
+      setSnackbar("All sets completed — nothing to swap");
+      return;
+    }
+    const ex = await getExerciseById(exerciseId);
+    if (!ex) return;
+    setSwapSource(ex);
+    swapSheetRef.current?.snapToIndex(0);
+  }, [groups]);
+
+  const swapUndoRef = useRef<{ setIds: string[]; originalExerciseId: string } | null>(null);
+
+  const handleSwapUndo = useCallback(async () => {
+    if (!swapUndoRef.current) return;
+    try {
+      await undoSwapInSession(swapUndoRef.current.setIds, swapUndoRef.current.originalExerciseId);
+      swapUndoRef.current = null;
+      if (swapUndoTimer.current) {
+        clearTimeout(swapUndoTimer.current);
+        swapUndoTimer.current = null;
+      }
+      setSnackbar("");
+      setSnackbarAction(undefined);
+      await load();
+    } catch {
+      setSnackbar("Failed to undo swap");
+    }
+  }, [load]);
+
+  const handleSwapSelect = useCallback(async (newExercise: Exercise) => {
+    if (!id || !swapSource) return;
+    try {
+      const modifiedIds = await swapExerciseInSession(id, swapSource.id, newExercise.id);
+      if (modifiedIds.length === 0) {
+        setSnackbar("All sets completed — nothing to swap");
+        setSwapSource(null);
+        return;
+      }
+      const originalId = swapSource.id;
+      setSwapSource(null);
+      await load();
+
+      // Start rest timer with new exercise rest seconds
+      startRest(newExercise.id);
+
+      // Store undo info in ref for the snackbar action
+      swapUndoRef.current = { setIds: modifiedIds, originalExerciseId: originalId };
+
+      // Undo snackbar (5s)
+      if (swapUndoTimer.current) clearTimeout(swapUndoTimer.current);
+      setSnackbar(`Swapped to ${newExercise.name}`);
+      setSnackbarAction({ label: "UNDO", onPress: () => handleSwapUndo() });
+      swapUndoTimer.current = setTimeout(() => {
+        swapUndoTimer.current = null;
+        swapUndoRef.current = null;
+      }, 5000);
+    } catch {
+      setSnackbar("Failed to swap exercise");
+    }
+  }, [id, swapSource, load, startRest, handleSwapUndo]);
 
   const handlePickExercise = useCallback(async (exercise: { id: string }) => {
     if (!id) return;
@@ -1262,6 +1348,7 @@ export default function ActiveSession() {
             onNotesDraftChange={handleNotesDraftChange}
             onToggleNotes={toggleNotes}
             onShowDetail={handleShowDetail}
+            onSwap={handleSwapOpen}
           />
         )}
         keyExtractor={(item) => item.exercise_id}
@@ -1338,8 +1425,12 @@ export default function ActiveSession() {
       </KeyboardAvoidingView>
       <Snackbar
         visible={!!snackbar}
-        onDismiss={() => setSnackbar("")}
-        duration={3000}
+        onDismiss={() => {
+          setSnackbar("");
+          setSnackbarAction(undefined);
+        }}
+        duration={snackbarAction ? 5000 : 3000}
+        action={snackbarAction}
         accessibilityLiveRegion="polite"
       >
         {snackbar}
@@ -1379,6 +1470,13 @@ export default function ActiveSession() {
           </>
         )}
       </BottomSheet>
+      <SubstitutionSheet
+        sheetRef={swapSheetRef}
+        sourceExercise={swapSource}
+        allExercises={allExercises}
+        onSelect={handleSwapSelect}
+        onDismiss={() => setSwapSource(null)}
+      />
     </>
   );
 }
@@ -1488,6 +1586,11 @@ const styles = StyleSheet.create({
   addSetBtn: {
     alignSelf: "flex-start",
     marginTop: 4,
+  },
+  swapBtn: {
+    width: 56,
+    height: 56,
+    margin: 0,
   },
   divider: {
     marginTop: 8,

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -19,13 +19,14 @@ import { rpeColor, rpeText } from "../../../lib/rpe";
 import { formatDuration, formatDateShort } from "../../../lib/format";
 import RatingWidget from "../../../components/RatingWidget";
 
-type SetWithName = WorkoutSet & { exercise_name?: string; exercise_deleted?: boolean };
+type SetWithName = WorkoutSet & { exercise_name?: string; exercise_deleted?: boolean; swapped_from_name?: string };
 
 type ExerciseGroup = {
   exercise_id: string;
   name: string;
   sets: SetWithName[];
   link_id: string | null;
+  swapped_from_name: string | null;
 };
 
 export default function SessionDetail() {
@@ -83,6 +84,7 @@ export default function SessionDetail() {
             name: (s.exercise_name ?? "Unknown") + (s.exercise_deleted ? " (removed)" : ""),
             sets: [],
             link_id: s.link_id ?? null,
+            swapped_from_name: (s as SetWithName).swapped_from_name ?? null,
           });
         }
         map.get(s.exercise_id)!.sets.push(s);
@@ -400,6 +402,15 @@ export default function SessionDetail() {
             >
               {group.name}
             </Text>
+            {group.swapped_from_name && (
+              <Text
+                variant="bodySmall"
+                style={{ color: theme.colors.onSurfaceVariant, fontStyle: "italic", marginBottom: 4, marginTop: -2 }}
+                accessibilityLabel={`Swapped from ${group.swapped_from_name}`}
+              >
+                Swapped from {group.swapped_from_name}
+              </Text>
+            )}
             {group.sets
               .filter((s) => s.completed)
               .map((set) => (

--- a/components/SubstitutionSheet.tsx
+++ b/components/SubstitutionSheet.tsx
@@ -347,7 +347,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   muscleText: {
-    fontSize: 11,
+    fontSize: 12,
     lineHeight: 16,
   },
   filterRow: {
@@ -398,7 +398,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   equipText: {
-    fontSize: 11,
+    fontSize: 12,
   },
   emptyState: {
     paddingVertical: 48,

--- a/components/SubstitutionSheet.tsx
+++ b/components/SubstitutionSheet.tsx
@@ -1,0 +1,407 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { Alert, Platform, Pressable, StyleSheet, View } from "react-native";
+import { Chip, Text, useTheme } from "react-native-paper";
+import BottomSheet, {
+  BottomSheetBackdrop,
+  BottomSheetFlatList,
+} from "@gorhom/bottom-sheet";
+import type { Exercise, Equipment } from "../lib/types";
+import { EQUIPMENT_LABELS, DIFFICULTY_LABELS, MUSCLE_LABELS } from "../lib/types";
+import {
+  findSubstitutions,
+  type SubstitutionScore,
+} from "../lib/exercise-substitutions";
+import { radii } from "../constants/design-tokens";
+
+type Props = {
+  sheetRef: React.RefObject<BottomSheet | null>;
+  sourceExercise: Exercise | null;
+  allExercises: Exercise[];
+  onSelect: (exercise: Exercise) => void;
+  onDismiss: () => void;
+};
+
+function matchColor(score: number): string {
+  if (score >= 80) return "#2e7d32";
+  if (score >= 60) return "#f57f17";
+  return "#c62828";
+}
+
+function matchBgColor(score: number): string {
+  if (score >= 80) return "#e8f5e9";
+  if (score >= 60) return "#fff8e1";
+  return "#ffebee";
+}
+
+function SubstitutionItem({
+  item,
+  onPress,
+}: {
+  item: SubstitutionScore;
+  onPress: (exercise: Exercise) => void;
+}) {
+  const theme = useTheme();
+  const ex = item.exercise;
+
+  return (
+    <Pressable
+      style={[styles.item, { backgroundColor: theme.colors.surface }]}
+      onPress={() => onPress(ex)}
+      accessibilityRole="button"
+      accessibilityLabel={`${ex.name}, ${item.score}% match, ${EQUIPMENT_LABELS[ex.equipment]}, ${DIFFICULTY_LABELS[ex.difficulty]}`}
+    >
+      <View style={styles.itemHeader}>
+        <Text
+          variant="titleSmall"
+          numberOfLines={1}
+          style={[styles.itemName, { color: theme.colors.onSurface }]}
+        >
+          {ex.name}
+        </Text>
+        <View
+          style={[
+            styles.matchBadge,
+            { backgroundColor: matchBgColor(item.score) },
+          ]}
+        >
+          <Text style={[styles.matchText, { color: matchColor(item.score) }]}>
+            {item.score}%
+          </Text>
+        </View>
+      </View>
+      <View style={styles.itemMeta}>
+        <View
+          style={[
+            styles.equipBadge,
+            { backgroundColor: theme.colors.surfaceVariant },
+          ]}
+        >
+          <Text
+            style={[styles.equipText, { color: theme.colors.onSurfaceVariant }]}
+          >
+            {EQUIPMENT_LABELS[ex.equipment]}
+          </Text>
+        </View>
+        <View
+          style={[
+            styles.equipBadge,
+            { backgroundColor: theme.colors.surfaceVariant },
+          ]}
+        >
+          <Text
+            style={[styles.equipText, { color: theme.colors.onSurfaceVariant }]}
+          >
+            {DIFFICULTY_LABELS[ex.difficulty]}
+          </Text>
+        </View>
+      </View>
+      {ex.primary_muscles.length > 0 && (
+        <View style={styles.muscleRow}>
+          {ex.primary_muscles.map((m) => (
+            <View
+              key={m}
+              style={[
+                styles.muscleChip,
+                { backgroundColor: theme.colors.secondaryContainer },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.muscleText,
+                  { color: theme.colors.onSecondaryContainer },
+                ]}
+              >
+                {MUSCLE_LABELS[m]}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+export default function SubstitutionSheet({
+  sheetRef,
+  sourceExercise,
+  allExercises,
+  onSelect,
+  onDismiss,
+}: Props) {
+  const theme = useTheme();
+  const snapPoints = useMemo(() => ["50%", "90%"], []);
+  const [equipmentFilter, setEquipmentFilter] = useState<Equipment | null>(null);
+
+  const scored = useMemo(() => {
+    if (!sourceExercise) return [];
+    return findSubstitutions(sourceExercise, allExercises);
+  }, [sourceExercise, allExercises]);
+
+  const filtered = useMemo(() => {
+    if (!equipmentFilter) return scored;
+    return scored.filter((s) => s.exercise.equipment === equipmentFilter);
+  }, [scored, equipmentFilter]);
+
+  const availableEquipment = useMemo(() => {
+    const set = new Set<Equipment>();
+    for (const s of scored) set.add(s.exercise.equipment);
+    return [...set];
+  }, [scored]);
+
+  const handleSelect = useCallback(
+    (exercise: Exercise) => {
+      if (!sourceExercise) return;
+      if (exercise.id === sourceExercise.id) {
+        sheetRef.current?.close();
+        return;
+      }
+
+      const doSwap = () => {
+        onSelect(exercise);
+        sheetRef.current?.close();
+        setEquipmentFilter(null);
+      };
+
+      if (Platform.OS === "web") {
+        if (
+          window.confirm(
+            `Replace ${sourceExercise.name} with ${exercise.name}?`
+          )
+        ) {
+          doSwap();
+        }
+      } else {
+        Alert.alert(
+          `Replace ${sourceExercise.name} with ${exercise.name}?`,
+          undefined,
+          [
+            { text: "Cancel", style: "cancel" },
+            { text: "Replace", onPress: doSwap },
+          ]
+        );
+      }
+    },
+    [sourceExercise, onSelect, sheetRef]
+  );
+
+  const handleClose = useCallback(() => {
+    setEquipmentFilter(null);
+    onDismiss();
+  }, [onDismiss]);
+
+  const noMuscleData =
+    sourceExercise &&
+    (!sourceExercise.primary_muscles ||
+      sourceExercise.primary_muscles.length === 0);
+
+  const renderItem = useCallback(
+    ({ item }: { item: SubstitutionScore }) => (
+      <SubstitutionItem item={item} onPress={handleSelect} />
+    ),
+    [handleSelect]
+  );
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      index={-1}
+      snapPoints={snapPoints}
+      enablePanDownToClose
+      enableDynamicSizing={false}
+      onClose={handleClose}
+      backdropComponent={(props) => (
+        <BottomSheetBackdrop
+          {...props}
+          disappearsOnIndex={-1}
+          appearsOnIndex={0}
+          pressBehavior="close"
+        />
+      )}
+      backgroundStyle={{ backgroundColor: theme.colors.surface }}
+      handleIndicatorStyle={{ backgroundColor: theme.colors.onSurfaceVariant }}
+    >
+      {sourceExercise && (
+        <View style={styles.container}>
+          <Text
+            variant="titleMedium"
+            style={[styles.header, { color: theme.colors.onSurface }]}
+          >
+            Alternatives for {sourceExercise.name}
+          </Text>
+
+          {sourceExercise.primary_muscles.length > 0 && (
+            <View style={styles.muscleRow}>
+              {sourceExercise.primary_muscles.map((m) => (
+                <View
+                  key={m}
+                  style={[
+                    styles.muscleChip,
+                    { backgroundColor: theme.colors.primaryContainer },
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.muscleText,
+                      { color: theme.colors.onPrimaryContainer },
+                    ]}
+                  >
+                    {MUSCLE_LABELS[m]}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          )}
+
+          {noMuscleData ? (
+            <View style={styles.emptyState}>
+              <Text
+                variant="bodyMedium"
+                style={{ color: theme.colors.onSurfaceVariant, textAlign: "center" }}
+              >
+                No muscle data — cannot suggest alternatives
+              </Text>
+            </View>
+          ) : (
+            <>
+              {availableEquipment.length > 1 && (
+                <View style={styles.filterRow} accessibilityRole="toolbar" accessibilityLabel="Equipment filter">
+                  <Chip
+                    selected={equipmentFilter === null}
+                    onPress={() => setEquipmentFilter(null)}
+                    compact
+                    style={styles.filterChip}
+                    accessibilityLabel="Show all equipment"
+                  >
+                    All
+                  </Chip>
+                  {availableEquipment.map((eq) => (
+                    <Chip
+                      key={eq}
+                      selected={equipmentFilter === eq}
+                      onPress={() =>
+                        setEquipmentFilter(equipmentFilter === eq ? null : eq)
+                      }
+                      compact
+                      style={styles.filterChip}
+                      accessibilityLabel={`Filter by ${EQUIPMENT_LABELS[eq]}`}
+                    >
+                      {EQUIPMENT_LABELS[eq]}
+                    </Chip>
+                  ))}
+                </View>
+              )}
+
+              {scored.length === 0 ? (
+                <View style={styles.emptyState}>
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: theme.colors.onSurfaceVariant, textAlign: "center" }}
+                  >
+                    No alternatives found. Try adding the exercise manually.
+                  </Text>
+                </View>
+              ) : filtered.length === 0 && equipmentFilter ? (
+                <View style={styles.emptyState}>
+                  <Text
+                    variant="bodyMedium"
+                    style={{ color: theme.colors.onSurfaceVariant, textAlign: "center" }}
+                  >
+                    No alternatives with this equipment. Try removing the
+                    filter.
+                  </Text>
+                </View>
+              ) : (
+                <BottomSheetFlatList
+                  data={filtered}
+                  keyExtractor={(item) => item.exercise.id}
+                  renderItem={renderItem}
+                  contentContainerStyle={styles.listContent}
+                />
+              )}
+            </>
+          )}
+        </View>
+      )}
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: 16,
+  },
+  header: {
+    fontWeight: "700",
+    marginBottom: 8,
+  },
+  muscleRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 4,
+    marginBottom: 8,
+  },
+  muscleChip: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 12,
+  },
+  muscleText: {
+    fontSize: 11,
+    lineHeight: 16,
+  },
+  filterRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+    marginBottom: 12,
+  },
+  filterChip: {
+    marginBottom: 2,
+  },
+  listContent: {
+    paddingBottom: 32,
+  },
+  item: {
+    padding: 12,
+    borderRadius: radii.md,
+    marginBottom: 8,
+  },
+  itemHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 4,
+  },
+  itemName: {
+    flex: 1,
+    fontWeight: "600",
+    marginRight: 8,
+  },
+  matchBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+  },
+  matchText: {
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  itemMeta: {
+    flexDirection: "row",
+    gap: 6,
+    marginBottom: 4,
+  },
+  equipBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  equipText: {
+    fontSize: 11,
+  },
+  emptyState: {
+    paddingVertical: 48,
+    paddingHorizontal: 24,
+  },
+});

--- a/components/SubstitutionSheet.tsx
+++ b/components/SubstitutionSheet.tsx
@@ -64,7 +64,7 @@ function SubstitutionItem({
             { backgroundColor: matchBgColor(item.score) },
           ]}
         >
-          <Text style={[styles.matchText, { color: matchColor(item.score) }]}>
+          <Text variant="labelSmall" style={[styles.matchText, { color: matchColor(item.score) }]}>
             {item.score}%
           </Text>
         </View>
@@ -76,7 +76,7 @@ function SubstitutionItem({
             { backgroundColor: theme.colors.surfaceVariant },
           ]}
         >
-          <Text
+          <Text variant="labelSmall"
             style={[styles.equipText, { color: theme.colors.onSurfaceVariant }]}
           >
             {EQUIPMENT_LABELS[ex.equipment]}
@@ -88,7 +88,7 @@ function SubstitutionItem({
             { backgroundColor: theme.colors.surfaceVariant },
           ]}
         >
-          <Text
+          <Text variant="labelSmall"
             style={[styles.equipText, { color: theme.colors.onSurfaceVariant }]}
           >
             {DIFFICULTY_LABELS[ex.difficulty]}
@@ -105,7 +105,7 @@ function SubstitutionItem({
                 { backgroundColor: theme.colors.secondaryContainer },
               ]}
             >
-              <Text
+              <Text variant="labelSmall"
                 style={[
                   styles.muscleText,
                   { color: theme.colors.onSecondaryContainer },
@@ -239,7 +239,7 @@ export default function SubstitutionSheet({
                     { backgroundColor: theme.colors.primaryContainer },
                   ]}
                 >
-                  <Text
+                  <Text variant="labelSmall"
                     style={[
                       styles.muscleText,
                       { color: theme.colors.onPrimaryContainer },
@@ -347,7 +347,6 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   muscleText: {
-    fontSize: 12,
     lineHeight: 16,
   },
   filterRow: {
@@ -384,7 +383,6 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   matchText: {
-    fontSize: 12,
     fontWeight: "700",
   },
   itemMeta: {
@@ -398,7 +396,6 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   equipText: {
-    fontSize: 12,
   },
   emptyState: {
     paddingVertical: 48,

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -332,6 +332,12 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
     });
   }
 
+  if (!setNames.has("swapped_from_exercise_id")) {
+    await database.execAsync(
+      "ALTER TABLE workout_sets ADD COLUMN swapped_from_exercise_id TEXT DEFAULT NULL"
+    );
+  }
+
   const exCols = await database.getAllAsync<{ name: string }>(
     "PRAGMA table_info(exercises)"
   );

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -80,6 +80,8 @@ export {
   getTotalSessionCount,
   updateSession,
   createTemplateFromSession,
+  swapExerciseInSession,
+  undoSwapInSession,
 } from "./sessions";
 export type { ExerciseSession, ExerciseRecords } from "./sessions";
 

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -19,6 +19,8 @@ type SetRow = {
   tempo: string | null;
   exercise_name: string | null;
   exercise_deleted_at: number | null;
+  swapped_from_exercise_id: string | null;
+  swapped_from_name: string | null;
 };
 
 // ---- Sessions ----
@@ -89,9 +91,11 @@ export async function getSessionSets(
   sessionId: string
 ): Promise<(WorkoutSet & { exercise_name?: string; exercise_deleted?: boolean })[]> {
   const rows = await query<SetRow>(
-    `SELECT ws.*, e.name AS exercise_name, e.deleted_at AS exercise_deleted_at
+    `SELECT ws.*, e.name AS exercise_name, e.deleted_at AS exercise_deleted_at,
+            sf.name AS swapped_from_name
      FROM workout_sets ws
      LEFT JOIN exercises e ON ws.exercise_id = e.id
+     LEFT JOIN exercises sf ON ws.swapped_from_exercise_id = sf.id
      WHERE ws.session_id = ?
      ORDER BY ws.exercise_id, ws.set_number ASC`,
     [sessionId]
@@ -111,8 +115,10 @@ export async function getSessionSets(
     round: r.round ?? null,
     training_mode: (r.training_mode as TrainingMode) ?? null,
     tempo: r.tempo ?? null,
+    swapped_from_exercise_id: r.swapped_from_exercise_id ?? null,
     exercise_name: r.exercise_name ?? undefined,
     exercise_deleted: r.exercise_deleted_at != null,
+    swapped_from_name: r.swapped_from_name ?? undefined,
   }));
 }
 
@@ -153,6 +159,7 @@ export async function addSet(
     round: round ?? null,
     training_mode: trainingMode ?? null,
     tempo: tempo ?? null,
+    swapped_from_exercise_id: null,
   };
 }
 
@@ -182,6 +189,7 @@ export async function addSetsBatch(
     round: s.round ?? null,
     training_mode: s.trainingMode ?? null,
     tempo: s.tempo ?? null,
+    swapped_from_exercise_id: null,
   }));
   await withTransaction(async (db) => {
     const stmt = await db.prepareAsync(
@@ -1177,8 +1185,8 @@ export async function swapExerciseInSession(
 
   const placeholders = setIds.map(() => "?").join(",");
   await execute(
-    `UPDATE workout_sets SET exercise_id = ? WHERE id IN (${placeholders})`,
-    [newExerciseId, ...setIds]
+    `UPDATE workout_sets SET exercise_id = ?, swapped_from_exercise_id = ? WHERE id IN (${placeholders})`,
+    [newExerciseId, oldExerciseId, ...setIds]
   );
 
   return setIds;
@@ -1191,7 +1199,7 @@ export async function undoSwapInSession(
   if (setIds.length === 0) return;
   const placeholders = setIds.map(() => "?").join(",");
   await execute(
-    `UPDATE workout_sets SET exercise_id = ? WHERE id IN (${placeholders})`,
+    `UPDATE workout_sets SET exercise_id = ?, swapped_from_exercise_id = NULL WHERE id IN (${placeholders})`,
     [originalExerciseId, ...setIds]
   );
 }

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -1158,3 +1158,40 @@ export async function createTemplateFromSession(
 
   return newTemplateId;
 }
+
+// ---- Exercise Swap ----
+
+export async function swapExerciseInSession(
+  sessionId: string,
+  oldExerciseId: string,
+  newExerciseId: string
+): Promise<string[]> {
+  const rows = await query<{ id: string }>(
+    `SELECT id FROM workout_sets
+     WHERE session_id = ? AND exercise_id = ? AND completed = 0`,
+    [sessionId, oldExerciseId]
+  );
+
+  const setIds = rows.map((r) => r.id);
+  if (setIds.length === 0) return [];
+
+  const placeholders = setIds.map(() => "?").join(",");
+  await execute(
+    `UPDATE workout_sets SET exercise_id = ? WHERE id IN (${placeholders})`,
+    [newExerciseId, ...setIds]
+  );
+
+  return setIds;
+}
+
+export async function undoSwapInSession(
+  setIds: string[],
+  originalExerciseId: string
+): Promise<void> {
+  if (setIds.length === 0) return;
+  const placeholders = setIds.map(() => "?").join(",");
+  await execute(
+    `UPDATE workout_sets SET exercise_id = ? WHERE id IN (${placeholders})`,
+    [originalExerciseId, ...setIds]
+  );
+}

--- a/lib/exercise-substitutions.ts
+++ b/lib/exercise-substitutions.ts
@@ -1,0 +1,114 @@
+import type { Exercise, Equipment, Difficulty } from "./types";
+
+export type MatchDetails = {
+  primaryOverlap: number;
+  secondaryOverlap: number;
+  equipmentMatch: number;
+  categoryMatch: number;
+  difficultyProx: number;
+};
+
+export type SubstitutionScore = {
+  exercise: Exercise;
+  score: number;
+  matchDetails: MatchDetails;
+};
+
+const EQUIPMENT_GROUPS: Record<string, Equipment[]> = {
+  free_weights: ["barbell", "dumbbell", "kettlebell"],
+  machines: ["machine", "cable"],
+  bodyweight: ["bodyweight"],
+  accessories: ["band", "other"],
+};
+
+function getEquipmentGroup(eq: Equipment): string {
+  for (const [group, members] of Object.entries(EQUIPMENT_GROUPS)) {
+    if (members.includes(eq)) return group;
+  }
+  return "other";
+}
+
+function setIntersection<T>(a: T[], b: T[]): T[] {
+  return a.filter((v) => b.includes(v));
+}
+
+function setUnion<T>(a: T[], b: T[]): T[] {
+  return [...new Set([...a, ...b])];
+}
+
+const DIFFICULTY_RANK: Record<Difficulty, number> = {
+  beginner: 0,
+  intermediate: 1,
+  advanced: 2,
+};
+
+export function scoreSubstitution(source: Exercise, candidate: Exercise): number {
+  const details = scoreSubstitutionDetailed(source, candidate);
+  return details.primaryOverlap + details.secondaryOverlap +
+    details.equipmentMatch + details.categoryMatch + details.difficultyProx;
+}
+
+export function scoreSubstitutionDetailed(source: Exercise, candidate: Exercise): MatchDetails {
+  // Primary muscle overlap: 50 pts max
+  const pUnion = setUnion(source.primary_muscles, candidate.primary_muscles);
+  const pIntersect = setIntersection(source.primary_muscles, candidate.primary_muscles);
+  const primaryOverlap = pUnion.length > 0
+    ? Math.round((pIntersect.length / pUnion.length) * 50)
+    : 0;
+
+  // Secondary muscle overlap: 20 pts max
+  const sUnion = setUnion(source.secondary_muscles, candidate.secondary_muscles);
+  const sIntersect = setIntersection(source.secondary_muscles, candidate.secondary_muscles);
+  const secondaryOverlap = sUnion.length > 0
+    ? Math.round((sIntersect.length / sUnion.length) * 20)
+    : 0;
+
+  // Equipment match: 15 pts max
+  let equipmentMatch = 0;
+  if (source.equipment === candidate.equipment) {
+    equipmentMatch = 15;
+  } else if (getEquipmentGroup(source.equipment) === getEquipmentGroup(candidate.equipment)) {
+    equipmentMatch = 8;
+  }
+
+  // Category match: 10 pts max
+  const categoryMatch = source.category === candidate.category ? 10 : 0;
+
+  // Difficulty proximity: 5 pts max
+  const diff = Math.abs(DIFFICULTY_RANK[source.difficulty] - DIFFICULTY_RANK[candidate.difficulty]);
+  const difficultyProx = diff === 0 ? 5 : diff === 1 ? 3 : diff === 2 ? 1 : 0;
+
+  return { primaryOverlap, secondaryOverlap, equipmentMatch, categoryMatch, difficultyProx };
+}
+
+const MIN_SCORE = 20;
+const MAX_RESULTS = 20;
+
+export function findSubstitutions(
+  source: Exercise,
+  allExercises: Exercise[],
+  limit: number = MAX_RESULTS
+): SubstitutionScore[] {
+  if (!source.primary_muscles || source.primary_muscles.length === 0) {
+    return [];
+  }
+
+  const scored: SubstitutionScore[] = [];
+
+  for (const candidate of allExercises) {
+    // Exclude source exercise and deleted exercises
+    if (candidate.id === source.id) continue;
+    if (candidate.deleted_at) continue;
+
+    const matchDetails = scoreSubstitutionDetailed(source, candidate);
+    const score = matchDetails.primaryOverlap + matchDetails.secondaryOverlap +
+      matchDetails.equipmentMatch + matchDetails.categoryMatch + matchDetails.difficultyProx;
+
+    if (score >= MIN_SCORE) {
+      scored.push({ exercise: candidate, score, matchDetails });
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, limit);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -209,6 +209,7 @@ export type WorkoutSet = {
   round: number | null;
   training_mode: TrainingMode | null;
   tempo: string | null;
+  swapped_from_exercise_id: string | null;
 };
 
 export const TRAINING_MODE_LABELS: Record<TrainingMode, { label: string; short: string; description: string }> = {


### PR DESCRIPTION
## Summary

Add a swap flow to the active workout screen that ranks alternative exercises by muscle/equipment/difficulty similarity. When a gym machine is occupied, users can now find equivalent exercises in 2 taps instead of browsing the full library.

## Changes

- **`lib/exercise-substitutions.ts`** — Pure scoring algorithm (0-100 pts) with 5 factors: primary muscle overlap (50), secondary muscle overlap (20), equipment match (15), category match (10), difficulty proximity (5). Equipment grouping: free weights, machines, bodyweight, accessories. Min threshold 20 pts, max 20 results.
- **`components/SubstitutionSheet.tsx`** — Bottom sheet with ranked alternatives showing match % badges (green/amber/red), equipment filter chips, and three empty states (no muscles, no alternatives, no filter matches).
- **`lib/db/sessions.ts`** — `swapExerciseInSession()` updates only uncompleted sets preserving weight/reps; `undoSwapInSession()` reverts specified sets.
- **`app/session/[id].tsx`** — Swap icon button (56×56dp) on each exercise card header, confirmation dialog, undo snackbar (5s), rest timer uses new exercise's rest seconds.

## Testing

- 24 unit tests for scoring algorithm covering all 5 factors, edge cases, and boundary conditions
- Updated 4 existing acceptance test files with new DB mock functions
- Full test suite passes (1348 tests, 0 failures)
- TypeScript compiles with zero errors (`tsc --noEmit`)
- ESLint passes with zero warnings

## Issue

Resolves BLD-241