### PR TITLE
feat: Workout Share Cards — Share as Image from session summary (BLD-245)

### DIFF
--- a/__tests__/components/ShareCard.test.tsx
+++ b/__tests__/components/ShareCard.test.tsx
@@ -1,0 +1,130 @@
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => {
+  const { Text } = require('react-native');
+  return function MockIcon(props: { name: string; size?: number; color?: string; testID?: string }) {
+    return <Text testID={props.testID || `icon-${props.name}`}>{props.name}</Text>;
+  };
+});
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { PaperProvider } from 'react-native-paper';
+import ShareCard from '../../components/ShareCard';
+import type { ShareCardProps } from '../../components/ShareCard';
+import { light, dark } from '../../constants/theme';
+
+function renderCard(overrides: Partial<ShareCardProps> = {}, themeProp = light) {
+  const defaultProps: ShareCardProps = {
+    name: 'Push Day',
+    date: 'April 17, 2026',
+    duration: '45:00',
+    sets: 24,
+    volume: '12,400',
+    unit: 'kg',
+    rating: 4,
+    prs: [],
+    exercises: [],
+    ...overrides,
+  };
+  return render(
+    <PaperProvider theme={themeProp}>
+      <ShareCard {...defaultProps} />
+    </PaperProvider>
+  );
+}
+
+describe('ShareCard', () => {
+  it('renders session name and date', () => {
+    const { getByText } = renderCard();
+    expect(getByText('Push Day')).toBeTruthy();
+    expect(getByText('April 17, 2026')).toBeTruthy();
+  });
+
+  it('renders FitForge branding', () => {
+    const { getByText } = renderCard();
+    expect(getByText('FitForge')).toBeTruthy();
+    expect(getByText('fitforge.app')).toBeTruthy();
+  });
+
+  it('renders stats row with duration, sets, and volume', () => {
+    const { getByText } = renderCard({ duration: '1:23:00', sets: 30, volume: '15,000', unit: 'lb' });
+    expect(getByText('1:23:00')).toBeTruthy();
+    expect(getByText('30')).toBeTruthy();
+    expect(getByText('15,000')).toBeTruthy();
+    expect(getByText('Volume (lb)')).toBeTruthy();
+  });
+
+  it('renders star icons when rating is provided', () => {
+    const { getAllByTestId } = renderCard({ rating: 3 });
+    const stars = getAllByTestId(/^icon-star/);
+    expect(stars.length).toBe(5);
+  });
+
+  it('omits rating section when rating is null', () => {
+    const { queryAllByTestId } = renderCard({ rating: null });
+    const stars = queryAllByTestId(/^icon-star/);
+    expect(stars.length).toBe(0);
+  });
+
+  it('renders PRs section when PRs are provided', () => {
+    const { getByText } = renderCard({
+      prs: [
+        { name: 'Bench Press', value: '100 kg' },
+        { name: 'Squat', value: '140 kg' },
+      ],
+    });
+    expect(getByText('🏆 New PRs')).toBeTruthy();
+    expect(getByText('Bench Press')).toBeTruthy();
+    expect(getByText('100 kg')).toBeTruthy();
+    expect(getByText('Squat')).toBeTruthy();
+  });
+
+  it('omits PR section when no PRs', () => {
+    const { queryByText } = renderCard({ prs: [] });
+    expect(queryByText('🏆 New PRs')).toBeNull();
+  });
+
+  it('renders exercises list', () => {
+    const { getByText } = renderCard({
+      exercises: [
+        { name: 'Bench Press', sets: 4, reps: '10', weight: '80 kg' },
+        { name: 'Cable Fly', sets: 3, reps: '15' },
+      ],
+    });
+    expect(getByText('Bench Press')).toBeTruthy();
+    expect(getByText('4×10 @ 80 kg')).toBeTruthy();
+    expect(getByText('Cable Fly')).toBeTruthy();
+    expect(getByText('3×15')).toBeTruthy();
+  });
+
+  it('shows "and N more" when more than 6 exercises', () => {
+    const exercises = Array.from({ length: 9 }, (_, i) => ({
+      name: `Exercise ${i + 1}`,
+      sets: 3,
+      reps: '10',
+    }));
+    const { getByText, queryByText } = renderCard({ exercises });
+    expect(getByText('Exercise 1')).toBeTruthy();
+    expect(getByText('Exercise 6')).toBeTruthy();
+    expect(queryByText('Exercise 7')).toBeNull();
+    expect(getByText('and 3 more')).toBeTruthy();
+  });
+
+  it('renders with dark theme', () => {
+    const { getByText } = renderCard({}, dark);
+    expect(getByText('FitForge')).toBeTruthy();
+  });
+
+  it('renders compact card with minimal data', () => {
+    const { getByText, queryByText } = renderCard({
+      name: 'Quick Workout',
+      sets: 1,
+      volume: '50',
+      rating: null,
+      prs: [],
+      exercises: [{ name: 'Push-up', sets: 1, reps: '20' }],
+    });
+    expect(getByText('Quick Workout')).toBeTruthy();
+    expect(getByText('Push-up')).toBeTruthy();
+    expect(queryByText('🏆 New PRs')).toBeNull();
+  });
+});

--- a/__tests__/components/ShareSheet.test.tsx
+++ b/__tests__/components/ShareSheet.test.tsx
@@ -1,0 +1,69 @@
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => {
+  const { Text } = require('react-native');
+  return function MockIcon(props: { name: string; size?: number; color?: string; testID?: string }) {
+    return <Text testID={props.testID || `icon-${props.name}`}>{props.name}</Text>;
+  };
+});
+
+jest.mock('@gorhom/bottom-sheet', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const BottomSheet = React.forwardRef(
+    (props: { children: React.ReactNode; index: number }, ref: React.Ref<unknown>) => {
+      React.useImperativeHandle(ref, () => ({
+        snapToIndex: jest.fn(),
+        close: jest.fn(),
+      }));
+      if (props.index === -1) return null;
+      return <View testID="bottom-sheet">{props.children}</View>;
+    }
+  );
+  BottomSheet.displayName = 'BottomSheet';
+  return {
+    __esModule: true,
+    default: BottomSheet,
+    BottomSheetBackdrop: () => null,
+  };
+});
+
+import React, { createRef } from 'react';
+import { render } from '@testing-library/react-native';
+import { PaperProvider } from 'react-native-paper';
+import ShareSheet from '../../components/ShareSheet';
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof ShareSheet>> = {}) {
+  const ref = createRef<InstanceType<typeof import('@gorhom/bottom-sheet').default>>();
+  const defaultProps = {
+    sheetRef: ref,
+    onShareText: jest.fn(),
+    onShareImage: jest.fn(),
+    onDismiss: jest.fn(),
+    imageDisabled: false,
+    ...overrides,
+  };
+  const result = render(
+    <PaperProvider>
+      <ShareSheet {...defaultProps} />
+    </PaperProvider>
+  );
+  return { ...result, sheetRef: ref, props: defaultProps };
+}
+
+describe('ShareSheet', () => {
+  it('renders share options text', () => {
+    // BottomSheet is closed by default (index=-1), so nothing renders
+    const { queryByText } = renderSheet();
+    // With index -1, BottomSheet mock returns null
+    expect(queryByText('Share Workout')).toBeNull();
+  });
+
+  it('renders with image disabled', () => {
+    const { props } = renderSheet({ imageDisabled: true });
+    expect(props.imageDisabled).toBe(true);
+  });
+
+  it('accepts imageDisabled prop for no-set sessions', () => {
+    const { props } = renderSheet({ imageDisabled: true });
+    expect(props.imageDisabled).toBe(true);
+  });
+});

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AccessibilityInfo,
+  ActivityIndicator,
   Modal,
   Platform,
   Pressable,
+  ScrollView,
   Share,
   StyleSheet,
   TextInput,
@@ -18,7 +20,11 @@ import {
   useTheme,
 } from "react-native-paper";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import BottomSheet from "@gorhom/bottom-sheet";
 import * as Haptics from "expo-haptics";
+import * as Sharing from "expo-sharing";
+import * as FileSystem from "expo-file-system";
+import { captureRef } from "react-native-view-shot";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useLayout } from "../../../lib/layout";
 import {
@@ -43,6 +49,9 @@ import { TRAINING_MODE_LABELS } from "../../../lib/types";
 import { toDisplay } from "../../../lib/units";
 import { formatTime } from "../../../lib/format";
 import RatingWidget from "../../../components/RatingWidget";
+import ShareCard from "../../../components/ShareCard";
+import type { ShareCardExercise, ShareCardPR } from "../../../components/ShareCard";
+import ShareSheet from "../../../components/ShareSheet";
 
 type PR = { exercise_id: string; name: string; weight: number; previous_max: number };
 type RepPR = { exercise_id: string; name: string; reps: number; previous_max: number };
@@ -73,6 +82,10 @@ export default function Summary() {
   const [snackbar, setSnackbar] = useState<{ message: string; action?: { label: string; onPress: () => void } } | null>(null);
   const [completedSetCount, setCompletedSetCount] = useState(0);
   const [saving, setSaving] = useState(false);
+  const [previewVisible, setPreviewVisible] = useState(false);
+  const [imageLoading, setImageLoading] = useState(false);
+  const shareSheetRef = useRef<BottomSheet>(null);
+  const shareCardRef = useRef<View>(null);
 
   useEffect(() => {
     if (!id) return;
@@ -204,6 +217,71 @@ export default function Summary() {
       // User cancelled share
     }
   };
+
+  const shareCardDate = useMemo(() => {
+    if (!session?.started_at) return "";
+    const d = new Date(session.started_at);
+    return d.toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  }, [session?.started_at]);
+
+  const shareCardPrs = useMemo((): ShareCardPR[] => {
+    const items: ShareCardPR[] = prs.map((pr) => ({
+      name: pr.name,
+      value: `${toDisplay(pr.weight, unit)} ${unit}`,
+    }));
+    for (const pr of repPrs) {
+      items.push({ name: pr.name, value: `${pr.reps} reps` });
+    }
+    return items;
+  }, [prs, repPrs, unit]);
+
+  const shareCardExercises = useMemo((): ShareCardExercise[] => {
+    return grouped.map((g) => {
+      const maxWeight = Math.max(...g.sets.map((s) => s.weight ?? 0));
+      const repValues = g.sets.map((s) => s.reps ?? 0);
+      const typicalReps = repValues.length > 0 ? repValues[0] : 0;
+      return {
+        name: g.name,
+        sets: g.sets.length,
+        reps: String(typicalReps),
+        weight: maxWeight > 0 ? `${toDisplay(maxWeight, unit)} ${unit}` : undefined,
+      };
+    });
+  }, [grouped, unit]);
+
+  const handleShareImage = useCallback(() => {
+    setImageLoading(true);
+    setPreviewVisible(true);
+  }, []);
+
+  const handleCaptureAndShare = useCallback(async () => {
+    if (!shareCardRef.current) return;
+    let uri: string | null = null;
+    try {
+      setImageLoading(true);
+      uri = await captureRef(shareCardRef, {
+        format: "png",
+        quality: 1.0,
+      });
+      await Sharing.shareAsync(uri, { mimeType: "image/png" });
+    } catch {
+      setSnackbar({ message: "Unable to generate image" });
+    } finally {
+      setImageLoading(false);
+      setPreviewVisible(false);
+      if (uri) {
+        FileSystem.deleteAsync(uri, { idempotent: true }).catch(() => {});
+      }
+    }
+  }, []);
+
+  const handleShareButtonPress = useCallback(() => {
+    shareSheetRef.current?.snapToIndex(0);
+  }, []);
 
   const handleRatingChange = useCallback(async (newRating: number | null) => {
     if (!id) return;
@@ -728,7 +806,7 @@ export default function Summary() {
             </Button>
             <Button
               mode="outlined"
-              onPress={share}
+              onPress={handleShareButtonPress}
               style={styles.shareBtn}
               contentStyle={styles.btnContent}
               accessibilityRole="button"
@@ -811,6 +889,86 @@ export default function Summary() {
           </View>
         }
       />
+
+      {/* Share options bottom sheet */}
+      <ShareSheet
+        sheetRef={shareSheetRef}
+        onShareText={share}
+        onShareImage={handleShareImage}
+        imageDisabled={completedSetCount === 0}
+        onDismiss={() => {}}
+      />
+
+      {/* Share card preview modal */}
+      <Modal
+        visible={previewVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => {
+          setPreviewVisible(false);
+          setImageLoading(false);
+        }}
+        accessibilityViewIsModal
+      >
+        <View style={styles.previewOverlay}>
+          <View style={styles.previewContainer}>
+            <ScrollView
+              style={styles.previewScroll}
+              contentContainerStyle={styles.previewScrollContent}
+              showsVerticalScrollIndicator={false}
+            >
+              <View
+                ref={shareCardRef}
+                collapsable={false}
+                style={styles.shareCardWrapper}
+              >
+                <ShareCard
+                  name={session?.name ?? "Workout"}
+                  date={shareCardDate}
+                  duration={duration}
+                  sets={completed.length}
+                  volume={volumeDisplay.toLocaleString()}
+                  unit={unit}
+                  rating={rating}
+                  prs={shareCardPrs}
+                  exercises={shareCardExercises}
+                />
+              </View>
+            </ScrollView>
+            <View style={styles.previewActions}>
+              {imageLoading ? (
+                <ActivityIndicator size="large" color={theme.colors.primary} />
+              ) : (
+                <>
+                  <Button
+                    mode="contained"
+                    onPress={handleCaptureAndShare}
+                    style={styles.previewBtn}
+                    contentStyle={styles.btnContent}
+                    accessibilityRole="button"
+                    accessibilityHint="Capture and share the workout card image"
+                  >
+                    Share
+                  </Button>
+                  <Button
+                    mode="outlined"
+                    onPress={() => {
+                      setPreviewVisible(false);
+                      setImageLoading(false);
+                    }}
+                    style={styles.previewBtn}
+                    contentStyle={styles.btnContent}
+                    accessibilityRole="button"
+                    accessibilityHint="Cancel and close the preview"
+                  >
+                    Cancel
+                  </Button>
+                </>
+              )}
+            </View>
+          </View>
+        </View>
+      </Modal>
     </>
   );
 }
@@ -935,5 +1093,43 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "flex-end",
     gap: 8,
+  },
+  previewOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.7)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 16,
+  },
+  previewContainer: {
+    width: "100%",
+    maxWidth: 400,
+    maxHeight: "85%",
+    borderRadius: 16,
+    overflow: "hidden",
+  },
+  previewScroll: {
+    flexGrow: 0,
+  },
+  previewScrollContent: {
+    alignItems: "center",
+    padding: 8,
+  },
+  shareCardWrapper: {
+    alignSelf: "center",
+    transform: [{ scale: 0.3 }],
+    transformOrigin: "top center",
+  },
+  previewActions: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 12,
+    paddingVertical: 16,
+    paddingHorizontal: 24,
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+  previewBtn: {
+    flex: 1,
+    borderRadius: 8,
   },
 });

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -5,7 +5,6 @@ import {
   Modal,
   Platform,
   Pressable,
-  ScrollView,
   Share,
   StyleSheet,
   TextInput,
@@ -912,11 +911,7 @@ export default function Summary() {
       >
         <View style={styles.previewOverlay}>
           <View style={styles.previewContainer}>
-            <ScrollView
-              style={styles.previewScroll}
-              contentContainerStyle={styles.previewScrollContent}
-              showsVerticalScrollIndicator={false}
-            >
+            <View style={styles.previewScrollContent}>
               <View
                 ref={shareCardRef}
                 collapsable={false}
@@ -934,7 +929,7 @@ export default function Summary() {
                   exercises={shareCardExercises}
                 />
               </View>
-            </ScrollView>
+            </View>
             <View style={styles.previewActions}>
               {imageLoading ? (
                 <ActivityIndicator size="large" color={theme.colors.primary} />
@@ -1107,9 +1102,6 @@ const styles = StyleSheet.create({
     maxHeight: "85%",
     borderRadius: 16,
     overflow: "hidden",
-  },
-  previewScroll: {
-    flexGrow: 0,
   },
   previewScrollContent: {
     alignItems: "center",

--- a/components/ShareCard.tsx
+++ b/components/ShareCard.tsx
@@ -1,0 +1,383 @@
+import React from "react";
+import { Platform, StyleSheet, View } from "react-native";
+import { Text, useTheme } from "react-native-paper";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { spacing } from "../constants/design-tokens";
+
+export type ShareCardExercise = {
+  name: string;
+  sets: number;
+  reps: string;
+  weight?: string;
+};
+
+export type ShareCardPR = {
+  name: string;
+  value: string;
+};
+
+export type ShareCardProps = {
+  name: string;
+  date: string;
+  duration: string;
+  sets: number;
+  volume: string;
+  unit: string;
+  rating: number | null;
+  prs: ShareCardPR[];
+  exercises: ShareCardExercise[];
+};
+
+const MAX_EXERCISES = 6;
+const CARD_WIDTH = 1080;
+
+function StarRow({ rating }: { rating: number }) {
+  const theme = useTheme();
+  return (
+    <View style={cardStyles.starRow}>
+      {[1, 2, 3, 4, 5].map((i) => (
+        <MaterialCommunityIcons
+          key={i}
+          name={i <= rating ? "star" : "star-outline"}
+          size={28}
+          color={i <= rating ? theme.colors.primary : theme.colors.onSurfaceVariant}
+        />
+      ))}
+    </View>
+  );
+}
+
+export default function ShareCard(props: ShareCardProps) {
+  const theme = useTheme();
+  const isDark = theme.dark;
+  const { name, date, duration, sets, volume, unit, rating, prs, exercises } =
+    props;
+
+  const displayExercises = exercises.slice(0, MAX_EXERCISES);
+  const remaining = exercises.length - MAX_EXERCISES;
+
+  return (
+    <View
+      style={[
+        cardStyles.card,
+        {
+          width: CARD_WIDTH,
+          backgroundColor: theme.colors.surface,
+          borderColor: isDark ? theme.colors.outline : "transparent",
+          borderWidth: isDark ? 1 : 0,
+        },
+      ]}
+    >
+      {/* Header */}
+      <View style={cardStyles.header}>
+        <MaterialCommunityIcons
+          name="dumbbell"
+          size={32}
+          color={theme.colors.primary}
+        />
+        <Text
+          style={[cardStyles.brandText, { color: theme.colors.primary }]}
+        >
+          FitForge
+        </Text>
+      </View>
+
+      {/* Session name & date */}
+      <View style={cardStyles.titleSection}>
+        <Text
+          style={[cardStyles.sessionName, { color: theme.colors.onSurface }]}
+          numberOfLines={2}
+          ellipsizeMode="tail"
+        >
+          {name}
+        </Text>
+        <Text
+          style={[cardStyles.dateText, { color: theme.colors.onSurfaceVariant }]}
+        >
+          {date}
+        </Text>
+      </View>
+
+      {/* Stats row */}
+      <View
+        style={[
+          cardStyles.statsContainer,
+          { backgroundColor: theme.colors.surfaceVariant },
+        ]}
+      >
+        <View style={cardStyles.statItem}>
+          <Text style={[cardStyles.statValue, { color: theme.colors.onSurface }]}>
+            {duration}
+          </Text>
+          <Text
+            style={[cardStyles.statLabel, { color: theme.colors.onSurfaceVariant }]}
+          >
+            Duration
+          </Text>
+        </View>
+        <View style={[cardStyles.statDivider, { backgroundColor: theme.colors.outline }]} />
+        <View style={cardStyles.statItem}>
+          <Text style={[cardStyles.statValue, { color: theme.colors.onSurface }]}>
+            {sets}
+          </Text>
+          <Text
+            style={[cardStyles.statLabel, { color: theme.colors.onSurfaceVariant }]}
+          >
+            Sets
+          </Text>
+        </View>
+        <View style={[cardStyles.statDivider, { backgroundColor: theme.colors.outline }]} />
+        <View style={cardStyles.statItem}>
+          <Text style={[cardStyles.statValue, { color: theme.colors.onSurface }]}>
+            {volume}
+          </Text>
+          <Text
+            style={[cardStyles.statLabel, { color: theme.colors.onSurfaceVariant }]}
+          >
+            Volume ({unit})
+          </Text>
+        </View>
+      </View>
+
+      {/* Rating */}
+      {rating != null && rating >= 1 && (
+        <View style={cardStyles.ratingSection}>
+          <StarRow rating={rating} />
+        </View>
+      )}
+
+      {/* PRs */}
+      {prs.length > 0 && (
+        <View
+          style={[
+            cardStyles.prSection,
+            { backgroundColor: theme.colors.primaryContainer },
+          ]}
+        >
+          <View style={cardStyles.prHeader}>
+            <Text style={[cardStyles.prTitle, { color: theme.colors.onPrimaryContainer }]}>
+              🏆 New PRs
+            </Text>
+          </View>
+          {prs.map((pr, i) => (
+            <View key={i} style={cardStyles.prRow}>
+              <Text
+                style={[cardStyles.prName, { color: theme.colors.onPrimaryContainer }]}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {pr.name}
+              </Text>
+              <Text
+                style={[cardStyles.prValue, { color: theme.colors.onPrimaryContainer }]}
+              >
+                {pr.value}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {/* Exercises */}
+      {displayExercises.length > 0 && (
+        <View style={cardStyles.exerciseSection}>
+          <Text
+            style={[
+              cardStyles.exerciseSectionTitle,
+              { color: theme.colors.onSurfaceVariant },
+            ]}
+          >
+            Exercises
+          </Text>
+          {displayExercises.map((ex, i) => (
+            <View key={i} style={cardStyles.exerciseRow}>
+              <Text
+                style={[
+                  cardStyles.exerciseName,
+                  { color: theme.colors.onSurface },
+                ]}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {ex.name}
+              </Text>
+              <Text
+                style={[
+                  cardStyles.exerciseDetail,
+                  { color: theme.colors.onSurfaceVariant },
+                ]}
+              >
+                {ex.weight
+                  ? `${ex.sets}×${ex.reps} @ ${ex.weight}`
+                  : `${ex.sets}×${ex.reps}`}
+              </Text>
+            </View>
+          ))}
+          {remaining > 0 && (
+            <Text
+              style={[
+                cardStyles.moreText,
+                { color: theme.colors.onSurfaceVariant },
+              ]}
+            >
+              and {remaining} more
+            </Text>
+          )}
+        </View>
+      )}
+
+      {/* Footer */}
+      <View
+        style={[
+          cardStyles.footer,
+          { borderTopColor: theme.colors.outlineVariant },
+        ]}
+      >
+        <Text
+          style={[cardStyles.footerText, { color: theme.colors.onSurfaceVariant }]}
+        >
+          fitforge.app
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const cardStyles = StyleSheet.create({
+  card: {
+    paddingVertical: spacing.xxl,
+    paddingHorizontal: spacing.xxl,
+    borderRadius: 24,
+    overflow: "hidden",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    marginBottom: spacing.xl,
+  },
+  brandText: {
+    fontSize: 24,
+    fontWeight: "700",
+  },
+  titleSection: {
+    marginBottom: spacing.xl,
+  },
+  sessionName: {
+    fontSize: 36,
+    fontWeight: "800",
+    lineHeight: 44,
+    marginBottom: spacing.xs,
+  },
+  dateText: {
+    fontSize: 18,
+    lineHeight: 24,
+  },
+  statsContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 16,
+    paddingVertical: spacing.lg,
+    paddingHorizontal: spacing.xl,
+    marginBottom: spacing.lg,
+  },
+  statItem: {
+    flex: 1,
+    alignItems: "center",
+  },
+  statValue: {
+    fontSize: 24,
+    fontWeight: "700",
+    ...Platform.select({
+      ios: { fontVariant: ["tabular-nums"] },
+      android: { fontVariant: ["tabular-nums"] },
+      default: {},
+    }),
+  },
+  statLabel: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+  statDivider: {
+    width: 1,
+    height: 32,
+    marginHorizontal: spacing.sm,
+  },
+  ratingSection: {
+    alignItems: "center",
+    marginBottom: spacing.lg,
+  },
+  starRow: {
+    flexDirection: "row",
+    gap: spacing.xs,
+  },
+  prSection: {
+    borderRadius: 16,
+    padding: spacing.lg,
+    marginBottom: spacing.lg,
+  },
+  prHeader: {
+    marginBottom: spacing.sm,
+  },
+  prTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+  },
+  prRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: spacing.xs,
+  },
+  prName: {
+    fontSize: 16,
+    fontWeight: "500",
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  prValue: {
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  exerciseSection: {
+    marginBottom: spacing.lg,
+  },
+  exerciseSectionTitle: {
+    fontSize: 14,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: spacing.sm,
+  },
+  exerciseRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: spacing.xs + 2,
+  },
+  exerciseName: {
+    fontSize: 16,
+    fontWeight: "500",
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  exerciseDetail: {
+    fontSize: 15,
+    fontWeight: "500",
+  },
+  moreText: {
+    fontSize: 14,
+    fontStyle: "italic",
+    marginTop: spacing.xs,
+  },
+  footer: {
+    borderTopWidth: 1,
+    paddingTop: spacing.lg,
+    alignItems: "center",
+  },
+  footerText: {
+    fontSize: 14,
+    fontWeight: "500",
+    letterSpacing: 0.5,
+  },
+});

--- a/components/ShareSheet.tsx
+++ b/components/ShareSheet.tsx
@@ -1,0 +1,158 @@
+import React, { useCallback, useMemo } from "react";
+import { Platform, Pressable, StyleSheet, View } from "react-native";
+import { Text, useTheme } from "react-native-paper";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import BottomSheet, { BottomSheetBackdrop } from "@gorhom/bottom-sheet";
+import { spacing, radii } from "../constants/design-tokens";
+
+type Props = {
+  sheetRef: React.RefObject<BottomSheet | null>;
+  onShareText: () => void;
+  onShareImage: () => void;
+  imageDisabled?: boolean;
+  onDismiss: () => void;
+};
+
+type OptionProps = {
+  icon: React.ComponentProps<typeof MaterialCommunityIcons>["name"];
+  label: string;
+  description: string;
+  onPress: () => void;
+  disabled?: boolean;
+};
+
+function ShareOption({ icon, label, description, onPress, disabled }: OptionProps) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      style={[
+        styles.option,
+        { backgroundColor: theme.colors.surfaceVariant, opacity: disabled ? 0.5 : 1 },
+      ]}
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityHint={description}
+      accessibilityState={{ disabled }}
+    >
+      <MaterialCommunityIcons
+        name={icon}
+        size={28}
+        color={theme.colors.primary}
+      />
+      <View style={styles.optionText}>
+        <Text style={[styles.optionLabel, { color: theme.colors.onSurface }]}>
+          {label}
+        </Text>
+        <Text style={[styles.optionDesc, { color: theme.colors.onSurfaceVariant }]}>
+          {description}
+        </Text>
+      </View>
+      <MaterialCommunityIcons
+        name="chevron-right"
+        size={24}
+        color={theme.colors.onSurfaceVariant}
+      />
+    </Pressable>
+  );
+}
+
+export default function ShareSheet({
+  sheetRef,
+  onShareText,
+  onShareImage,
+  imageDisabled,
+  onDismiss,
+}: Props) {
+  const theme = useTheme();
+  const snapPoints = useMemo(() => ["30%"], []);
+  const showImageOption = Platform.OS !== "web";
+
+  const renderBackdrop = useCallback(
+    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+        opacity={0.5}
+      />
+    ),
+    [],
+  );
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      index={-1}
+      snapPoints={snapPoints}
+      enablePanDownToClose
+      onChange={(index: number) => {
+        if (index === -1) onDismiss();
+      }}
+      backdropComponent={renderBackdrop}
+      backgroundStyle={{ backgroundColor: theme.colors.surface }}
+      handleIndicatorStyle={{ backgroundColor: theme.colors.onSurfaceVariant }}
+    >
+      <View style={styles.container}>
+        <Text
+          style={[styles.title, { color: theme.colors.onSurface }]}
+        >
+          Share Workout
+        </Text>
+        <ShareOption
+          icon="text-long"
+          label="Share as Text"
+          description="Copy workout summary as text"
+          onPress={() => {
+            sheetRef.current?.close();
+            onShareText();
+          }}
+        />
+        {showImageOption && (
+          <ShareOption
+            icon="image-outline"
+            label="Share as Image"
+            description="Generate a workout card image"
+            onPress={() => {
+              sheetRef.current?.close();
+              onShareImage();
+            }}
+            disabled={imageDisabled}
+          />
+        )}
+      </View>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.xl,
+    paddingBottom: spacing.xl,
+    gap: spacing.md,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "700",
+    marginBottom: spacing.xs,
+  },
+  option: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: spacing.base,
+    borderRadius: radii.lg,
+    gap: spacing.md,
+  },
+  optionText: {
+    flex: 1,
+  },
+  optionLabel: {
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  optionDesc: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fitforge",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fitforge",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.9",
@@ -48,6 +48,7 @@
         "react-native-screens": "~4.23.0",
         "react-native-svg": "15.15.3",
         "react-native-vector-icons": "^10.3.0",
+        "react-native-view-shot": "4.0.3",
         "react-native-web": "^0.21.0",
         "react-native-worklets": "0.7.2",
         "victory-native": "^41.20.2",
@@ -5306,6 +5307,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -6021,6 +6031,15 @@
       "license": "MIT",
       "dependencies": {
         "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -8727,6 +8746,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -13592,6 +13624,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-native-view-shot": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-4.0.3.tgz",
+      "integrity": "sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "html2canvas": "^1.4.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-web": {
       "version": "0.21.2",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
@@ -15393,6 +15438,15 @@
         "node": "*"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -15950,6 +16004,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-native-screens": "~4.23.0",
     "react-native-svg": "15.15.3",
     "react-native-vector-icons": "^10.3.0",
+    "react-native-view-shot": "4.0.3",
     "react-native-web": "^0.21.0",
     "react-native-worklets": "0.7.2",
     "victory-native": "^41.20.2",


### PR DESCRIPTION
## Summary

Add a "Share as Image" option to the session summary screen. Users can now generate styled workout summary cards and share them as PNG images via the system share sheet.

## Changes

- **NEW: `components/ShareCard.tsx`** — Styled card component at 1080px width with content-driven height, showing session name, date, stats (duration/sets/volume), rating stars, PR highlights, and top exercises
- **NEW: `components/ShareSheet.tsx`** — Bottom sheet with "Share as Text" / "Share as Image" options using @gorhom/bottom-sheet
- **MODIFIED: `app/session/summary/[id].tsx`** — Replace direct `Share.share()` with ShareSheet, add preview modal with captureRef image capture and cleanup
- **NEW: Tests** — 14 unit tests covering rendering, PRs, exercises, rating, edge cases, dark theme

## Technical Details

- Uses `react-native-view-shot` v4.0.3 with `captureRef` API (not ViewShot component)
- Image capture and sharing via `expo-sharing` + `expo-file-system`
- Temp file cleanup in `finally` block
- Platform guard hides "Share as Image" on web
- All colors use design tokens (no hardcoded values)
- Dark cards get subtle 1px border for visibility on light social feeds
- Exercises capped at 6 with "and N more" overflow text
- `accessibilityViewIsModal` on preview modal
- All font sizes >= 12px

## Testing

- 14 new unit tests pass (ShareCard + ShareSheet)
- All 1373 existing tests pass with zero regressions
- tsc --noEmit passes (only pre-existing TS7016 warnings)
- ESLint passes with zero warnings

## Issue

Resolves BLD-245