### PR TITLE
feat: Online Food Search — Open Food Facts Integration (BLD-248)

### DIFF
--- a/__tests__/acceptance/online-food-search.acceptance.test.tsx
+++ b/__tests__/acceptance/online-food-search.acceptance.test.tsx
@@ -1,0 +1,281 @@
+jest.setTimeout(10000)
+
+/**
+ * BLD-248: Online Food Search acceptance tests.
+ * Tests the OnlineTab in the add-nutrition screen: tab rendering,
+ * search flow, dedup+favorite, offline detection, and error states.
+ */
+
+import React from 'react'
+import { fireEvent, waitFor, act } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+import { resetIds } from '../helpers/factories'
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
+const mockParams: Record<string, string> = {}
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    router: { back: jest.fn(), push: jest.fn() },
+    useRouter: () => mockRouter,
+    useLocalSearchParams: () => mockParams,
+    usePathname: () => '/nutrition/add',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
+jest.mock('../../lib/errors', () => ({ logError: jest.fn() }))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn() }))
+
+const mockAddFoodEntry = jest.fn().mockResolvedValue({
+  id: 'fe-1', name: 'Test Food', calories: 200, protein: 10,
+  carbs: 25, fat: 8, serving_size: '1 cup (240ml)', is_favorite: false, created_at: Date.now(),
+})
+const mockAddDailyLog = jest.fn().mockResolvedValue(undefined)
+const mockGetFavoriteFoods = jest.fn().mockResolvedValue([])
+const mockFindDuplicate = jest.fn().mockResolvedValue(null)
+const mockToggleFavorite = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('../../lib/db', () => ({
+  addFoodEntry: (...args: unknown[]) => mockAddFoodEntry(...args),
+  addDailyLog: (...args: unknown[]) => mockAddDailyLog(...args),
+  getFavoriteFoods: (...args: unknown[]) => mockGetFavoriteFoods(...args),
+  findDuplicateFoodEntry: (...args: unknown[]) => mockFindDuplicate(...args),
+  toggleFavorite: (...args: unknown[]) => mockToggleFavorite(...args),
+}))
+
+let mockNetInfoConnected = true
+jest.mock('@react-native-community/netinfo', () => ({
+  __esModule: true,
+  default: {
+    fetch: jest.fn(() => Promise.resolve({ isConnected: mockNetInfoConnected })),
+  },
+}))
+
+const mockFetchWithTimeout = jest.fn()
+jest.mock('../../lib/openfoodfacts', () => ({
+  ...jest.requireActual('../../lib/openfoodfacts'),
+  fetchWithTimeout: (...args: unknown[]) => mockFetchWithTimeout(...args),
+}))
+
+import AddFood from '../../app/nutrition/add'
+
+function renderAddFood() {
+  return renderScreen(<AddFood />)
+}
+
+async function switchToOnline(screen: ReturnType<typeof renderScreen>) {
+  const btn = await screen.findByText('Online')
+  fireEvent.press(btn)
+}
+
+describe('Online Food Search (BLD-248)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    resetIds()
+    Object.keys(mockParams).forEach((k) => delete mockParams[k])
+    mockGetFavoriteFoods.mockResolvedValue([])
+    mockNetInfoConnected = true
+    mockFetchWithTimeout.mockResolvedValue({ ok: true, foods: [] })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('tab rendering', () => {
+    it('shows 4 tabs: New, Favs, Database, Online', async () => {
+      const screen = renderAddFood()
+      await waitFor(() => {
+        expect(screen.getByText('New')).toBeTruthy()
+        expect(screen.getByText('Favs')).toBeTruthy()
+        expect(screen.getByText('Database')).toBeTruthy()
+        expect(screen.getByText('Online')).toBeTruthy()
+      })
+    })
+
+    it('shows search input on Online tab', async () => {
+      const screen = renderAddFood()
+      await switchToOnline(screen)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Search online food database')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('offline detection', () => {
+    it('shows offline message when no network', async () => {
+      mockNetInfoConnected = false
+      const screen = renderAddFood()
+      await switchToOnline(screen)
+      await waitFor(() => {
+        expect(screen.getByText(/offline/i)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('search flow', () => {
+    it('shows hint for queries < 2 chars', async () => {
+      const screen = renderAddFood()
+      await switchToOnline(screen)
+      const input = await screen.findByLabelText('Search online food database')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'a')
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Type at least 2 characters')).toBeTruthy()
+      })
+    })
+
+    it('fires search after debounce for queries >= 2 chars', async () => {
+      mockFetchWithTimeout.mockResolvedValue({
+        ok: true,
+        foods: [{
+          name: 'Chobani — Greek Yogurt',
+          calories: 100, protein: 15, carbs: 6, fat: 2,
+          servingLabel: '1 cup (150g)', isPerServing: true,
+        }],
+      })
+
+      const screen = renderAddFood()
+      await switchToOnline(screen)
+      const input = await screen.findByLabelText('Search online food database')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'yogurt')
+        jest.advanceTimersByTime(500) // past 400ms debounce
+      })
+
+      await waitFor(() => {
+        expect(mockFetchWithTimeout).toHaveBeenCalledWith('yogurt', expect.anything())
+      })
+    })
+
+    it('shows no results message when search returns empty', async () => {
+      mockFetchWithTimeout.mockResolvedValue({ ok: true, foods: [] })
+
+      const screen = renderAddFood()
+      await switchToOnline(screen)
+      const input = await screen.findByLabelText('Search online food database')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'zznonexistent')
+        jest.advanceTimersByTime(500)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(/No foods found/)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('dedup and favorite', () => {
+    it('toggles favorite when dedup reuses unfavorited entry with saveFav=true', async () => {
+      const existingEntry = {
+        id: 'existing-1', name: 'Test Food', calories: 200, protein: 10,
+        carbs: 25, fat: 8, serving_size: '1 cup', is_favorite: false, created_at: Date.now(),
+      }
+      mockFindDuplicate.mockResolvedValue(existingEntry)
+
+      mockFetchWithTimeout.mockResolvedValue({
+        ok: true,
+        foods: [{
+          name: 'Test Food', calories: 200, protein: 10, carbs: 25, fat: 8,
+          servingLabel: '1 cup', isPerServing: true,
+        }],
+      })
+
+      const screen = renderAddFood()
+      await switchToOnline(screen)
+      const input = await screen.findByLabelText('Search online food database')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'test food')
+        jest.advanceTimersByTime(500)
+      })
+
+      // Wait for result to appear and tap to expand
+      await waitFor(() => {
+        expect(screen.getByText('Test Food')).toBeTruthy()
+      })
+
+      const resultCard = screen.getByLabelText(/Test Food, 200 calories/)
+      await act(async () => {
+        fireEvent.press(resultCard)
+      })
+
+      // Toggle favorite
+      await waitFor(() => {
+        expect(screen.getByText('Save as Favorite')).toBeTruthy()
+      })
+      const favChip = screen.getByLabelText('Save as favorite')
+      await act(async () => {
+        fireEvent.press(favChip)
+      })
+
+      // Log food
+      const logBtn = screen.getByLabelText('Log food')
+      await act(async () => {
+        fireEvent.press(logBtn)
+        jest.advanceTimersByTime(100)
+      })
+
+      await waitFor(() => {
+        expect(mockFindDuplicate).toHaveBeenCalled()
+        expect(mockToggleFavorite).toHaveBeenCalledWith('existing-1')
+        expect(mockAddFoodEntry).not.toHaveBeenCalled() // reused existing
+        expect(mockAddDailyLog).toHaveBeenCalledWith('existing-1', expect.any(String), 'snack', 1)
+      })
+    })
+  })
+
+  describe('error states', () => {
+    it('shows timeout error with retry button', async () => {
+      mockFetchWithTimeout.mockResolvedValue({ ok: false, error: 'timeout' })
+
+      const screen = renderAddFood()
+      await switchToOnline(screen)
+      const input = await screen.findByLabelText('Search online food database')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'test')
+        jest.advanceTimersByTime(500)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(/timed out/)).toBeTruthy()
+        expect(screen.getByLabelText('Retry search')).toBeTruthy()
+      })
+    })
+
+    it('shows network error message', async () => {
+      mockFetchWithTimeout.mockResolvedValue({ ok: false, error: 'offline' })
+
+      const screen = renderAddFood()
+      await switchToOnline(screen)
+      const input = await screen.findByLabelText('Search online food database')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'test')
+        jest.advanceTimersByTime(500)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(/Could not reach food database/)).toBeTruthy()
+      })
+    })
+  })
+})

--- a/__tests__/lib/openfoodfacts.test.ts
+++ b/__tests__/lib/openfoodfacts.test.ts
@@ -1,0 +1,408 @@
+import {
+  isValidProduct,
+  formatProductName,
+  parseProduct,
+  fetchWithTimeout,
+  type OFFProduct,
+} from "../../lib/openfoodfacts";
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function makeProduct(overrides: Partial<OFFProduct> = {}): OFFProduct {
+  return {
+    product_name: "Test Food",
+    brands: "TestBrand",
+    nutriments: {
+      "energy-kcal_100g": 200,
+      proteins_100g: 10,
+      carbohydrates_100g: 25,
+      fat_100g: 8,
+    },
+    serving_size: "1 cup (240ml)",
+    serving_quantity: 240,
+    ...overrides,
+  };
+}
+
+// ── Validation ──────────────────────────────────────────────────
+
+describe("isValidProduct", () => {
+  it("accepts a valid product", () => {
+    expect(isValidProduct(makeProduct())).toBe(true);
+  });
+
+  it("accepts product with all macros = 0 (water)", () => {
+    const water = makeProduct({
+      nutriments: {
+        "energy-kcal_100g": 0,
+        proteins_100g: 0,
+        carbohydrates_100g: 0,
+        fat_100g: 0,
+      },
+    });
+    expect(isValidProduct(water)).toBe(true);
+  });
+
+  it("rejects empty product_name", () => {
+    expect(isValidProduct(makeProduct({ product_name: "" }))).toBe(false);
+    expect(isValidProduct(makeProduct({ product_name: "  " }))).toBe(false);
+  });
+
+  it("rejects negative calories", () => {
+    const p = makeProduct();
+    p.nutriments["energy-kcal_100g"] = -10;
+    expect(isValidProduct(p)).toBe(false);
+  });
+
+  it("rejects absurdly high calories (>2000 per 100g)", () => {
+    const p = makeProduct();
+    p.nutriments["energy-kcal_100g"] = 2001;
+    expect(isValidProduct(p)).toBe(false);
+  });
+
+  it("rejects NaN in protein", () => {
+    const p = makeProduct();
+    p.nutriments.proteins_100g = NaN;
+    expect(isValidProduct(p)).toBe(false);
+  });
+
+  it("rejects Infinity in carbs", () => {
+    const p = makeProduct();
+    p.nutriments.carbohydrates_100g = Infinity;
+    expect(isValidProduct(p)).toBe(false);
+  });
+
+  it("rejects negative fat", () => {
+    const p = makeProduct();
+    p.nutriments.fat_100g = -1;
+    expect(isValidProduct(p)).toBe(false);
+  });
+
+  it("rejects macros > 200 per 100g", () => {
+    const p = makeProduct();
+    p.nutriments.proteins_100g = 201;
+    expect(isValidProduct(p)).toBe(false);
+  });
+
+  it("rejects missing nutriments", () => {
+    const p = makeProduct();
+    (p as Record<string, unknown>).nutriments = undefined;
+    expect(isValidProduct(p)).toBe(false);
+  });
+
+  it("rejects undefined calories", () => {
+    const p = makeProduct();
+    p.nutriments["energy-kcal_100g"] = undefined;
+    expect(isValidProduct(p)).toBe(false);
+  });
+
+  it("accepts exactly 2000 kcal (boundary)", () => {
+    const p = makeProduct();
+    p.nutriments["energy-kcal_100g"] = 2000;
+    expect(isValidProduct(p)).toBe(true);
+  });
+
+  it("accepts exactly 200g protein (boundary)", () => {
+    const p = makeProduct();
+    p.nutriments.proteins_100g = 200;
+    expect(isValidProduct(p)).toBe(true);
+  });
+});
+
+// ── Name formatting ─────────────────────────────────────────────
+
+describe("formatProductName", () => {
+  it("combines brand and product name with em dash", () => {
+    const p = makeProduct({ brands: "Chobani", product_name: "Greek Yogurt" });
+    expect(formatProductName(p)).toBe("Chobani — Greek Yogurt");
+  });
+
+  it("returns product name alone when no brand", () => {
+    const p = makeProduct({ brands: undefined, product_name: "Plain Oats" });
+    expect(formatProductName(p)).toBe("Plain Oats");
+  });
+
+  it("returns product name when brand is empty string", () => {
+    const p = makeProduct({ brands: "", product_name: "Plain Oats" });
+    expect(formatProductName(p)).toBe("Plain Oats");
+  });
+
+  it("returns product name when brand is whitespace", () => {
+    const p = makeProduct({ brands: "   ", product_name: "Plain Oats" });
+    expect(formatProductName(p)).toBe("Plain Oats");
+  });
+
+  it("truncates to 100 chars with ellipsis", () => {
+    const longName = "A".repeat(100);
+    const p = makeProduct({ brands: "Brand", product_name: longName });
+    const result = formatProductName(p);
+    expect(result.length).toBeLessThanOrEqual(100);
+    expect(result.endsWith("...")).toBe(true);
+  });
+
+  it("does not truncate at exactly 100 chars", () => {
+    const p = makeProduct({ brands: "B", product_name: "A".repeat(94) });
+    // "B — " + 94 A's = 98 chars, fits
+    const result = formatProductName(p);
+    expect(result.length).toBeLessThanOrEqual(100);
+    expect(result.endsWith("...")).toBe(false);
+  });
+});
+
+// ── Per-100g vs per-serving conversion ──────────────────────────
+
+describe("parseProduct", () => {
+  it("computes per-serving values when serving_quantity > 0", () => {
+    const p = makeProduct({
+      nutriments: {
+        "energy-kcal_100g": 100,
+        proteins_100g: 10,
+        carbohydrates_100g: 20,
+        fat_100g: 5,
+      },
+      serving_quantity: 200, // 200g serving
+      serving_size: "1 large bowl",
+    });
+    const food = parseProduct(p);
+    // per serving = per_100g × (200/100) = ×2
+    expect(food.calories).toBe(200);
+    expect(food.protein).toBe(20);
+    expect(food.carbs).toBe(40);
+    expect(food.fat).toBe(10);
+    expect(food.servingLabel).toBe("1 large bowl");
+    expect(food.isPerServing).toBe(true);
+  });
+
+  it("uses per-100g when serving_quantity is 0", () => {
+    const p = makeProduct({
+      nutriments: {
+        "energy-kcal_100g": 100,
+        proteins_100g: 10,
+        carbohydrates_100g: 20,
+        fat_100g: 5,
+      },
+      serving_quantity: 0,
+      serving_size: "1 cup",
+    });
+    const food = parseProduct(p);
+    expect(food.calories).toBe(100);
+    expect(food.protein).toBe(10);
+    expect(food.carbs).toBe(20);
+    expect(food.fat).toBe(5);
+    expect(food.servingLabel).toBe("100g");
+    expect(food.isPerServing).toBe(false);
+  });
+
+  it("uses per-100g when serving_quantity is null/undefined", () => {
+    const p = makeProduct({
+      nutriments: {
+        "energy-kcal_100g": 300,
+        proteins_100g: 15,
+        carbohydrates_100g: 30,
+        fat_100g: 12,
+      },
+      serving_quantity: undefined,
+      serving_size: "1 piece",
+    });
+    const food = parseProduct(p);
+    expect(food.calories).toBe(300);
+    expect(food.servingLabel).toBe("100g");
+    expect(food.isPerServing).toBe(false);
+  });
+
+  it("uses per-100g when serving_size is empty", () => {
+    const p = makeProduct({
+      nutriments: {
+        "energy-kcal_100g": 100,
+        proteins_100g: 5,
+        carbohydrates_100g: 10,
+        fat_100g: 3,
+      },
+      serving_quantity: 50,
+      serving_size: "",
+    });
+    const food = parseProduct(p);
+    expect(food.servingLabel).toBe("100g");
+    expect(food.isPerServing).toBe(false);
+  });
+
+  it("truncates long serving_size to 30 chars with ellipsis", () => {
+    const p = makeProduct({
+      serving_size: "A".repeat(40),
+      serving_quantity: 100,
+    });
+    const food = parseProduct(p);
+    expect(food.servingLabel.length).toBeLessThanOrEqual(30);
+    expect(food.servingLabel.endsWith("...")).toBe(true);
+  });
+
+  it("rounds calories to integer, macros to 1 decimal", () => {
+    const p = makeProduct({
+      nutriments: {
+        "energy-kcal_100g": 133,
+        proteins_100g: 7.33,
+        carbohydrates_100g: 14.77,
+        fat_100g: 3.89,
+      },
+      serving_quantity: 50,
+      serving_size: "1 piece",
+    });
+    const food = parseProduct(p);
+    // scale = 50/100 = 0.5
+    expect(food.calories).toBe(67); // Math.round(133 * 0.5) = 67
+    expect(food.protein).toBe(3.7); // Math.round(7.33 * 0.5 * 10) / 10
+    expect(food.carbs).toBe(7.4);
+    expect(food.fat).toBe(1.9); // Math.round(3.89 * 0.5 * 10) / 10
+  });
+
+  it("formats name with brand", () => {
+    const p = makeProduct({ brands: "Chobani", product_name: "Yogurt" });
+    const food = parseProduct(p);
+    expect(food.name).toBe("Chobani — Yogurt");
+  });
+
+  it("handles missing nutriment values (defaults to 0)", () => {
+    const p = makeProduct({
+      nutriments: {
+        "energy-kcal_100g": 0,
+        proteins_100g: 0,
+        carbohydrates_100g: 0,
+        fat_100g: 0,
+      },
+      serving_quantity: undefined,
+    });
+    const food = parseProduct(p);
+    expect(food.calories).toBe(0);
+    expect(food.protein).toBe(0);
+    expect(food.carbs).toBe(0);
+    expect(food.fat).toBe(0);
+  });
+});
+
+// ── fetchWithTimeout ────────────────────────────────────────────
+
+describe("fetchWithTimeout", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns parsed foods on successful response", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          count: 1,
+          products: [
+            {
+              product_name: "Test",
+              brands: "Brand",
+              nutriments: {
+                "energy-kcal_100g": 100,
+                proteins_100g: 5,
+                carbohydrates_100g: 20,
+                fat_100g: 3,
+              },
+              serving_size: "1 cup",
+              serving_quantity: 200,
+            },
+          ],
+        }),
+    });
+
+    const result = await fetchWithTimeout("test");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.foods).toHaveLength(1);
+      expect(result.foods[0].name).toBe("Brand — Test");
+    }
+  });
+
+  it("filters out invalid products", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          count: 2,
+          products: [
+            {
+              product_name: "Valid",
+              nutriments: {
+                "energy-kcal_100g": 100,
+                proteins_100g: 5,
+                carbohydrates_100g: 20,
+                fat_100g: 3,
+              },
+            },
+            {
+              product_name: "",
+              nutriments: {
+                "energy-kcal_100g": 100,
+                proteins_100g: 5,
+                carbohydrates_100g: 20,
+                fat_100g: 3,
+              },
+            },
+          ],
+        }),
+    });
+
+    const result = await fetchWithTimeout("test");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.foods).toHaveLength(1);
+      expect(result.foods[0].name).toBe("Valid");
+    }
+  });
+
+  it("returns offline error on network failure", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new TypeError("Network request failed"));
+
+    const result = await fetchWithTimeout("test");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("offline");
+    }
+  });
+
+  it("returns unknown error on non-ok response", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const result = await fetchWithTimeout("test");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("unknown");
+    }
+  });
+
+  it("handles empty products array", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ count: 0, products: [] }),
+    });
+
+    const result = await fetchWithTimeout("test");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.foods).toHaveLength(0);
+    }
+  });
+
+  it("returns empty foods on aborted request", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    global.fetch = jest.fn().mockRejectedValue(
+      Object.assign(new Error("Aborted"), { name: "AbortError" })
+    );
+
+    const result = await fetchWithTimeout("test", controller.signal);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.foods).toHaveLength(0);
+    }
+  });
+});

--- a/app/nutrition/add.tsx
+++ b/app/nutrition/add.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import {
+  ActivityIndicator,
   Button,
   Card,
   Chip,
@@ -11,13 +12,19 @@ import {
   useTheme,
 } from "react-native-paper";
 import { router, useFocusEffect, useLocalSearchParams } from "expo-router";
+import NetInfo from "@react-native-community/netinfo";
 import { useLayout } from "../../lib/layout";
 import {
   addFoodEntry,
   addDailyLog,
   getFavoriteFoods,
+  findDuplicateFoodEntry,
 } from "../../lib/db";
 import { searchFoods, getCategories } from "../../lib/foods";
+import {
+  fetchWithTimeout,
+  type ParsedFood,
+} from "../../lib/openfoodfacts";
 import type { FoodEntry, Meal, BuiltinFood, FoodCategory } from "../../lib/types";
 import { MEALS, MEAL_LABELS } from "../../lib/types";
 
@@ -221,10 +228,341 @@ function DatabaseTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: 
   );
 }
 
+function OnlineTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: boolean; onSaving: (v: boolean) => void; dateKey: string }) {
+  const theme = useTheme();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<ParsedFood[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const [multiplier, setMultiplier] = useState("1");
+  const [saveFav, setSaveFav] = useState(false);
+  const [offline, setOffline] = useState(false);
+  const [hint, setHint] = useState<string | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cacheRef = useRef<Map<string, ParsedFood[]>>(new Map());
+  const today = dateKey;
+
+  // Proactive offline detection on mount / tab switch
+  useEffect(() => {
+    let mounted = true;
+    NetInfo.fetch().then((state) => {
+      if (mounted) setOffline(!state.isConnected);
+    });
+    return () => { mounted = false; };
+  }, []);
+
+  // Debounced search
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (abortRef.current) abortRef.current.abort();
+
+    setError(null);
+
+    if (!query.trim()) {
+      setResults([]);
+      setHint(null);
+      return;
+    }
+    if (query.trim().length < 2) {
+      setResults([]);
+      setHint("Type at least 2 characters");
+      return;
+    }
+
+    setHint(null);
+
+    const cached = cacheRef.current.get(query.trim().toLowerCase());
+    if (cached) {
+      setResults(cached);
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setLoading(true);
+
+      fetchWithTimeout(query.trim(), controller.signal).then((result) => {
+        if (controller.signal.aborted) return;
+        setLoading(false);
+        if (result.ok) {
+          setResults(result.foods);
+          // Cache (limit to 10 entries)
+          const cache = cacheRef.current;
+          const key = query.trim().toLowerCase();
+          cache.set(key, result.foods);
+          if (cache.size > 10) {
+            const first = cache.keys().next().value;
+            if (first !== undefined) cache.delete(first);
+          }
+        } else {
+          setResults([]);
+          if (result.error === "timeout") {
+            setError("Search timed out. Please try again.");
+          } else if (result.error === "offline") {
+            setError("Could not reach food database. Check your connection.");
+          } else {
+            setError("Could not reach food database. Check your connection.");
+          }
+        }
+      });
+    }, 400);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query]);
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      if (abortRef.current) abortRef.current.abort();
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const mult = Math.max(0.25, parseFloat(multiplier) || 0);
+  const valid = parseFloat(multiplier) >= 0.25;
+
+  const expand = (idx: number) => {
+    setExpanded(expanded === idx ? null : idx);
+    setMultiplier("1");
+    setSaveFav(false);
+  };
+
+  const retry = () => {
+    setError(null);
+    // Re-trigger search by cycling query
+    const q = query;
+    setQuery("");
+    setTimeout(() => setQuery(q), 0);
+  };
+
+  const log = async (food: ParsedFood) => {
+    if (!valid) return;
+    onSaving(true);
+    try {
+      // Dedup: check if identical food entry already exists
+      const existing = await findDuplicateFoodEntry(
+        food.name,
+        food.calories,
+        food.protein,
+        food.carbs,
+        food.fat
+      );
+      const entry = existing ?? await addFoodEntry(
+        food.name,
+        food.calories,
+        food.protein,
+        food.carbs,
+        food.fat,
+        food.servingLabel,
+        saveFav
+      );
+      // If existing and user wants favorite, update won't happen here —
+      // but that's acceptable for MVP (they can fav from favorites tab)
+      await addDailyLog(entry.id, today, meal, mult);
+      router.back();
+    } finally {
+      onSaving(false);
+    }
+  };
+
+  if (offline) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text
+          variant="bodyMedium"
+          style={{ color: theme.colors.onSurfaceVariant, textAlign: "center", padding: 24 }}
+          accessibilityLiveRegion="polite"
+        >
+          You&apos;re offline. Connect to search online foods.
+        </Text>
+      </View>
+    );
+  }
+
+  const header = () => (
+    <View>
+      <TextInput
+        mode="outlined"
+        placeholder="Search for foods online"
+        value={query}
+        onChangeText={setQuery}
+        left={<TextInput.Icon icon="magnify" />}
+        style={styles.input}
+        accessibilityLabel="Search online food database"
+      />
+      {hint && (
+        <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, paddingHorizontal: 4, marginBottom: 8 }}>
+          {hint}
+        </Text>
+      )}
+      {loading && (
+        <ActivityIndicator
+          style={{ marginVertical: 16 }}
+          accessibilityLabel="Searching..."
+          accessibilityRole="progressbar"
+        />
+      )}
+      {error && (
+        <View style={{ alignItems: "center", padding: 16 }} accessibilityLiveRegion="polite">
+          <Text variant="bodyMedium" style={{ color: theme.colors.error, textAlign: "center", marginBottom: 12 }}>
+            {error}
+          </Text>
+          <Button
+            mode="outlined"
+            onPress={retry}
+            accessibilityLabel="Retry search"
+            accessibilityRole="button"
+            contentStyle={{ minHeight: 48 }}
+          >
+            Retry
+          </Button>
+        </View>
+      )}
+    </View>
+  );
+
+  const renderItem = ({ item, index }: { item: ParsedFood; index: number }) => {
+    const open = expanded === index;
+    const scaled = {
+      calories: (item.calories * mult).toFixed(0),
+      protein: (item.protein * mult).toFixed(1),
+      carbs: (item.carbs * mult).toFixed(1),
+      fat: (item.fat * mult).toFixed(1),
+    };
+
+    return (
+      <Card
+        style={[styles.dbCard, { backgroundColor: theme.colors.surfaceVariant }]}
+        onPress={() => expand(index)}
+        accessibilityLabel={`${item.name}, ${item.calories} calories per ${item.servingLabel}`}
+        accessibilityRole="button"
+      >
+        <Card.Content>
+          <Text
+            variant="titleSmall"
+            numberOfLines={2}
+            style={{ color: theme.colors.onSurface }}
+          >
+            {item.name}
+          </Text>
+          <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
+            {item.calories} cal · {item.protein}p · {item.carbs}c · {item.fat}f · per {item.servingLabel}
+          </Text>
+          {open && (
+            <View style={[styles.detail, { borderTopColor: theme.colors.outlineVariant }]}>
+              <Text variant="labelMedium" style={{ color: theme.colors.onSurfaceVariant, marginBottom: 8 }}>
+                Serving: {item.servingLabel}
+              </Text>
+              <Text variant="labelMedium" style={{ color: theme.colors.onSurface, marginBottom: 4 }}>
+                Multiplier
+              </Text>
+              <View style={styles.multChips}>
+                {["0.5", "1", "1.5", "2"].map((v) => (
+                  <Chip
+                    key={v}
+                    selected={multiplier === v}
+                    onPress={() => setMultiplier(v)}
+                    style={styles.chip}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: multiplier === v }}
+                  >
+                    {v}x
+                  </Chip>
+                ))}
+              </View>
+              <TextInput
+                mode="outlined"
+                label="Custom amount"
+                value={multiplier}
+                onChangeText={setMultiplier}
+                keyboardType="numeric"
+                dense
+                style={styles.multInput}
+                accessibilityLabel={`Serving multiplier: ${multiplier} times`}
+              />
+              {!valid && (
+                <Text variant="bodySmall" style={{ color: theme.colors.error, marginBottom: 4 }}>
+                  Minimum 0.25x
+                </Text>
+              )}
+              <View
+                style={styles.macros}
+                accessibilityLiveRegion="polite"
+              >
+                <Text variant="bodyMedium" style={{ color: theme.colors.onSurface }}>
+                  {scaled.calories} cal · {scaled.protein}p · {scaled.carbs}c · {scaled.fat}f
+                </Text>
+              </View>
+              <Chip
+                selected={saveFav}
+                onPress={() => setSaveFav(!saveFav)}
+                icon={saveFav ? "heart" : "heart-outline"}
+                style={styles.favChip}
+                accessibilityLabel={saveFav ? "Remove from favorites" : "Save as favorite"}
+                accessibilityRole="button"
+                accessibilityState={{ selected: saveFav }}
+              >
+                Save as Favorite
+              </Chip>
+              <Button
+                mode="contained"
+                onPress={() => log(item)}
+                loading={saving}
+                disabled={saving || !valid}
+                style={styles.btn}
+                contentStyle={styles.btnContent}
+                accessibilityLabel="Log food"
+              >
+                Log Food
+              </Button>
+            </View>
+          )}
+        </Card.Content>
+      </Card>
+    );
+  };
+
+  const empty = () => {
+    if (loading || error || !query.trim() || hint) return null;
+    return (
+      <Text
+        variant="bodyMedium"
+        style={{ color: theme.colors.onSurfaceVariant, textAlign: "center", padding: 24 }}
+      >
+        No foods found for &apos;{query.trim()}&apos;. Try different terms or use manual entry.
+      </Text>
+    );
+  };
+
+  return (
+    <FlashList
+      data={results}
+      renderItem={renderItem}
+      keyExtractor={(_item, index) => String(index)}
+      ListHeaderComponent={header}
+      ListEmptyComponent={empty}
+      style={{ backgroundColor: theme.colors.background }}
+    />
+  );
+}
+
 function localDateKey(): string {
   const d = new Date();
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
+
+const TAB_BUTTONS = [
+  { value: "new", label: "New" },
+  { value: "favorites", label: "Favs" },
+  { value: "database", label: "Database" },
+  { value: "online", label: "Online" },
+];
 
 export default function AddFood() {
   const theme = useTheme();
@@ -281,19 +619,16 @@ export default function AddFood() {
     }
   };
 
-  if (tab === "database") {
+  if (tab === "database" || tab === "online") {
     return (
       <View style={[styles.container, { backgroundColor: theme.colors.background, paddingHorizontal: layout.horizontalPadding }]}>
         <View style={styles.header}>
           <SegmentedButtons
             value={tab}
             onValueChange={setTab}
-            buttons={[
-              { value: "new", label: "New Food" },
-              { value: "favorites", label: "Favorites" },
-              { value: "database", label: "Database" },
-            ]}
+            buttons={TAB_BUTTONS}
             style={styles.tabs}
+            density="medium"
           />
           <View style={styles.meals}>
             {MEALS.map((m) => (
@@ -311,7 +646,11 @@ export default function AddFood() {
             ))}
           </View>
         </View>
-        <DatabaseTab meal={meal} saving={saving} onSaving={setSaving} dateKey={dateKey} />
+        {tab === "database" ? (
+          <DatabaseTab meal={meal} saving={saving} onSaving={setSaving} dateKey={dateKey} />
+        ) : (
+          <OnlineTab meal={meal} saving={saving} onSaving={setSaving} dateKey={dateKey} />
+        )}
       </View>
     );
   }
@@ -346,12 +685,9 @@ export default function AddFood() {
           <SegmentedButtons
             value={tab}
             onValueChange={setTab}
-            buttons={[
-              { value: "new", label: "New Food" },
-              { value: "favorites", label: "Favorites" },
-              { value: "database", label: "Database" },
-            ]}
+            buttons={TAB_BUTTONS}
             style={styles.tabs}
+            density="medium"
           />
 
           <View style={styles.meals}>
@@ -486,4 +822,5 @@ const styles = StyleSheet.create({
   multChips: { flexDirection: "row", gap: 6, marginBottom: 8 },
   multInput: { marginBottom: 8 },
   macros: { marginBottom: 12, padding: 8, borderRadius: 8 },
+  emptyContainer: { flex: 1, justifyContent: "center", alignItems: "center" },
 });

--- a/app/nutrition/add.tsx
+++ b/app/nutrition/add.tsx
@@ -19,6 +19,7 @@ import {
   addDailyLog,
   getFavoriteFoods,
   findDuplicateFoodEntry,
+  toggleFavorite,
 } from "../../lib/db";
 import { searchFoods, getCategories } from "../../lib/foods";
 import {
@@ -362,8 +363,10 @@ function OnlineTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: bo
         food.servingLabel,
         saveFav
       );
-      // If existing and user wants favorite, update won't happen here —
-      // but that's acceptable for MVP (they can fav from favorites tab)
+      // If dedup reused an existing entry and user wants favorite, update it
+      if (existing && saveFav && !existing.is_favorite) {
+        await toggleFavorite(existing.id);
+      }
       await addDailyLog(entry.id, today, meal, mult);
       router.back();
     } finally {
@@ -544,7 +547,7 @@ function OnlineTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: bo
     <FlashList
       data={results}
       renderItem={renderItem}
-      keyExtractor={(_item, index) => String(index)}
+      keyExtractor={(item, index) => `${item.name}-${item.calories}-${index}`}
       ListHeaderComponent={header}
       ListEmptyComponent={empty}
       style={{ backgroundColor: theme.colors.background }}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -96,6 +96,7 @@ export {
   getMacroTargets,
   updateMacroTargets,
   getDailySummary,
+  findDuplicateFoodEntry,
 } from "./nutrition";
 
 export {

--- a/lib/db/nutrition.ts
+++ b/lib/db/nutrition.ts
@@ -151,6 +151,20 @@ export async function updateMacroTargets(
   );
 }
 
+export async function findDuplicateFoodEntry(
+  name: string,
+  calories: number,
+  protein: number,
+  carbs: number,
+  fat: number
+): Promise<FoodEntry | null> {
+  const row = await queryOne<FoodRow>(
+    "SELECT * FROM food_entries WHERE LOWER(name) = LOWER(?) AND calories = ? AND protein = ? AND carbs = ? AND fat = ? LIMIT 1",
+    [name, calories, protein, carbs, fat]
+  );
+  return row ? mapFood(row) : null;
+}
+
 export async function getDailySummary(
   date: string
 ): Promise<{ calories: number; protein: number; carbs: number; fat: number }> {

--- a/lib/openfoodfacts.ts
+++ b/lib/openfoodfacts.ts
@@ -1,0 +1,175 @@
+/**
+ * Open Food Facts API client for FitForge.
+ * Queries the free, open-source food database (3M+ products).
+ * No API key required.
+ */
+
+const BASE_URL =
+  "https://world.openfoodfacts.org/cgi/search.pl";
+const USER_AGENT =
+  "FitForge/0.5.0 (https://github.com/alankyshum/fitforge)";
+const TIMEOUT_MS = 5000;
+const PAGE_SIZE = 20;
+const FIELDS =
+  "product_name,brands,nutriments,serving_size,serving_quantity";
+
+export type OFFProduct = {
+  product_name: string;
+  brands?: string;
+  nutriments: {
+    "energy-kcal_100g"?: number;
+    proteins_100g?: number;
+    carbohydrates_100g?: number;
+    fat_100g?: number;
+  };
+  serving_size?: string;
+  serving_quantity?: number;
+};
+
+export type OFFSearchResponse = {
+  count: number;
+  products: OFFProduct[];
+};
+
+export type ParsedFood = {
+  /** Composite key for dedup: lowercased name */
+  name: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  servingLabel: string;
+  /** Whether this is per-serving (true) or per-100g (false) */
+  isPerServing: boolean;
+};
+
+// ── Validation ──────────────────────────────────────────────────
+
+function isFiniteInRange(v: unknown, min: number, max: number): v is number {
+  return typeof v === "number" && Number.isFinite(v) && v >= min && v <= max;
+}
+
+export function isValidProduct(p: OFFProduct): boolean {
+  if (!p.product_name || typeof p.product_name !== "string" || !p.product_name.trim()) {
+    return false;
+  }
+  const n = p.nutriments;
+  if (!n) return false;
+
+  if (!isFiniteInRange(n["energy-kcal_100g"], 0, 2000)) return false;
+  if (!isFiniteInRange(n.proteins_100g, 0, 200)) return false;
+  if (!isFiniteInRange(n.carbohydrates_100g, 0, 200)) return false;
+  if (!isFiniteInRange(n.fat_100g, 0, 200)) return false;
+
+  return true;
+}
+
+// ── Name formatting ─────────────────────────────────────────────
+
+export function formatProductName(p: OFFProduct): string {
+  const brand = p.brands?.trim();
+  const name = p.product_name.trim();
+  const combined = brand ? `${brand} — ${name}` : name;
+  return combined.length > 100 ? combined.slice(0, 97) + "..." : combined;
+}
+
+// ── Serving logic ───────────────────────────────────────────────
+
+function truncateServing(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 3) + "..." : s;
+}
+
+export function parseProduct(p: OFFProduct): ParsedFood {
+  const n = p.nutriments;
+  const hasServing =
+    typeof p.serving_quantity === "number" &&
+    p.serving_quantity > 0 &&
+    typeof p.serving_size === "string" &&
+    p.serving_size.trim().length > 0;
+
+  const servingScale = hasServing ? p.serving_quantity! / 100 : 1;
+  const servingLabel = hasServing
+    ? truncateServing(p.serving_size!.trim(), 30)
+    : "100g";
+
+  return {
+    name: formatProductName(p),
+    calories: Math.round((n["energy-kcal_100g"] ?? 0) * servingScale),
+    protein: Math.round((n.proteins_100g ?? 0) * servingScale * 10) / 10,
+    carbs: Math.round((n.carbohydrates_100g ?? 0) * servingScale * 10) / 10,
+    fat: Math.round((n.fat_100g ?? 0) * servingScale * 10) / 10,
+    servingLabel,
+    isPerServing: hasServing,
+  };
+}
+
+// ── API fetch ───────────────────────────────────────────────────
+
+export type SearchError = "offline" | "timeout" | "unknown";
+
+export type SearchResult =
+  | { ok: true; foods: ParsedFood[] }
+  | { ok: false; error: SearchError };
+
+export async function searchOnlineFoods(
+  query: string,
+  signal?: AbortSignal
+): Promise<SearchResult> {
+  const url = `${BASE_URL}?${new URLSearchParams({
+    search_terms: query,
+    search_simple: "1",
+    action: "process",
+    json: "1",
+    page_size: String(PAGE_SIZE),
+    fields: FIELDS,
+  })}`;
+
+  try {
+    const response = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT },
+      signal,
+    });
+
+    if (!response.ok) {
+      return { ok: false, error: "unknown" };
+    }
+
+    const data: OFFSearchResponse = await response.json();
+    const foods = (data.products ?? [])
+      .filter(isValidProduct)
+      .map(parseProduct);
+
+    return { ok: true, foods };
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === "AbortError") {
+      // Caller cancelled — treat as empty (not an error to display)
+      return { ok: true, foods: [] };
+    }
+    if (err instanceof TypeError) {
+      // Network error (fetch throws TypeError for network failures)
+      return { ok: false, error: "offline" };
+    }
+    return { ok: false, error: "unknown" };
+  }
+}
+
+/**
+ * Creates a fetch with a timeout wrapper.
+ * The caller should use AbortController for cancellation;
+ * this adds an additional timeout safety net.
+ */
+export function fetchWithTimeout(
+  query: string,
+  signal?: AbortSignal
+): Promise<SearchResult> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      resolve({ ok: false, error: "timeout" });
+    }, TIMEOUT_MS);
+
+    searchOnlineFoods(query, signal).then((result) => {
+      clearTimeout(timeout);
+      resolve(result);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds an "Online" tab to the Add Food screen that queries the Open Food Facts API (free, open-source, 3M+ products). Users can search for branded/packaged foods, view per-serving or per-100g macro info, and log with one tap.

## Changes

- **lib/openfoodfacts.ts** — API client with validation, per-serving/per-100g conversion, name formatting, timeout handling, and AbortController support
- **app/nutrition/add.tsx** — New `OnlineTab` component with 400ms debounced search, expand/collapse results, serving multiplier, Save as Favorite toggle, and offline/error states
- **lib/db/nutrition.ts** — `findDuplicateFoodEntry()` for dedup when logging online foods
- **lib/db/index.ts** — Export the new dedup function
- Tab labels shortened to fit 4 tabs: New / Favs / Database / Online

## Key Behaviors

- Per-serving display when `serving_quantity > 0`, fallback to per-100g
- Input validation: filters products with negative/absurd/NaN/Infinity macros
- Dedup: reuses existing FoodEntry if name+macros match (case-insensitive)
- Proactive offline detection via NetInfo on tab switch
- In-memory cache of last 10 search results
- All interactive elements have 48×48dp min touch targets

## Testing

- 33 new unit tests covering: validation, data mapping, per-100g/per-serving conversion, name formatting, fetch error handling
- All 1406 tests pass with zero regressions
- `tsc --noEmit` passes (no new errors)
- ESLint passes

## Issue

Resolves BLD-248