### PR TITLE
fix: import Easing from react-native-reanimated (BLD-254)

### DIFF
--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -64,6 +64,7 @@ jest.mock('react-native-reanimated', () => {
     withTiming: <T,>(v: T) => v,
     interpolateColor: () => '#000',
     createAnimatedComponent: <T,>(c: T) => c,
+    Easing: { bezier: () => (t: number) => t },
   }
 })
 

--- a/__tests__/acceptance/dashboard.test.tsx
+++ b/__tests__/acceptance/dashboard.test.tsx
@@ -60,6 +60,7 @@ jest.mock('react-native-reanimated', () => {
     __esModule: true,
     default: { View, createAnimatedComponent: (c: unknown) => c },
     FadeInDown: { delay: () => ({ duration: () => undefined }) },
+    Easing: { bezier: () => (t: number) => t },
   }
 })
 jest.mock('expo-haptics', () => ({

--- a/__tests__/acceptance/history.acceptance.test.tsx
+++ b/__tests__/acceptance/history.acceptance.test.tsx
@@ -48,6 +48,7 @@ jest.mock('react-native-reanimated', () => {
     useReducedMotion: () => false,
     withTiming: <T,>(v: T) => v,
     createAnimatedComponent: <T,>(c: T) => c,
+    Easing: { bezier: () => (t: number) => t },
   }
 })
 

--- a/constants/design-tokens.ts
+++ b/constants/design-tokens.ts
@@ -1,4 +1,5 @@
-import { Easing, Platform } from "react-native";
+import { Platform } from "react-native";
+import { Easing } from "react-native-reanimated";
 
 // ─── Spacing (4px grid) ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes crash: `[Reanimated] The easing function is not a worklet. Please make sure you import Easing from react-native-reanimated.` This affected every user session.

## Changes

- Changed `constants/design-tokens.ts` to import `Easing` from `react-native-reanimated` instead of `react-native`
- Added `Easing` mock to 3 test suites that mock `react-native-reanimated` (history, dashboard, accessibility)

## Testing

- `npx tsc --noEmit` — passes (only pre-existing ShareSheet error)
- `npx jest` — all 87 suites, 1433 tests pass
- ESLint — passes via lint-staged

## Issue

Closes #124
Resolves BLD-254