### PR TITLE
fix: repair all starter template data on seed — prevent recurring metadata loss

### DIFF
--- a/__tests__/lib/starter-templates.test.ts
+++ b/__tests__/lib/starter-templates.test.ts
@@ -1,5 +1,6 @@
 import { STARTER_TEMPLATES, STARTER_PROGRAM, STARTER_VERSION } from "../../lib/starter-templates";
 import { DIFFICULTY_LABELS } from "../../lib/types";
+import { seedExercises } from "../../lib/seed";
 
 describe("starter-templates data", () => {
   it("has at least 6 starter templates", () => {
@@ -111,5 +112,45 @@ describe("starter program data", () => {
     expect(STARTER_PROGRAM.days[0].template_id).toBe("starter-tpl-2");
     expect(STARTER_PROGRAM.days[1].template_id).toBe("starter-tpl-3");
     expect(STARTER_PROGRAM.days[2].template_id).toBe("starter-tpl-4");
+  });
+});
+
+// --- Regression: BLD-255 — exercise references must exist in seed data ---
+describe("starter template exercise references (BLD-255 regression)", () => {
+  const allExercises = seedExercises();
+  const exerciseIds = new Set(allExercises.map((e) => e.id));
+
+  it("all starter template exercises reference valid seed exercise IDs", () => {
+    for (const tpl of STARTER_TEMPLATES) {
+      for (const ex of tpl.exercises) {
+        expect(exerciseIds.has(ex.exercise_id)).toBe(true);
+      }
+    }
+  });
+
+  it("every starter template has non-empty exercises array", () => {
+    for (const tpl of STARTER_TEMPLATES) {
+      expect(tpl.exercises.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every starter template exercise has all required fields", () => {
+    for (const tpl of STARTER_TEMPLATES) {
+      for (const ex of tpl.exercises) {
+        expect(ex.id).toBeTruthy();
+        expect(ex.exercise_id).toBeTruthy();
+        expect(ex.target_sets).toBeGreaterThanOrEqual(1);
+        expect(ex.target_reps).toBeTruthy();
+        expect(ex.rest_seconds).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("Founder's Favourite template has exercises and metadata", () => {
+    const founders = STARTER_TEMPLATES.find((t) => t.name === "Founder's Favourite");
+    expect(founders).toBeDefined();
+    expect(founders!.exercises.length).toBeGreaterThanOrEqual(5);
+    expect(founders!.difficulty).toBe("advanced");
+    expect(founders!.duration).toBeTruthy();
   });
 });

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -579,29 +579,44 @@ async function seedStarters(database: SQLite.SQLiteDatabase): Promise<void> {
     );
   }
 
-  // Always repair is_starter flags and names — handles cases where import,
-  // migration, or prior seeding left starters with is_starter=0 or empty names
-  const starterTplIds = STARTER_TEMPLATES.map((t) => t.id);
-  const tplPlaceholders = starterTplIds.map(() => "?").join(",");
-  await database.runAsync(
-    `UPDATE workout_templates SET is_starter = 1 WHERE id IN (${tplPlaceholders}) AND is_starter = 0`,
-    starterTplIds
-  );
-  // Repair names from canonical STARTER_TEMPLATES data
+  // Always repair ALL canonical starter data — handles cases where import,
+  // migration, deletion, or prior incomplete seeding left starters corrupted.
+  // Each repair uses INSERT OR IGNORE (idempotent) to re-create deleted rows,
+  // then UPDATE to fix corrupted columns on existing rows.
+  // This covers: workout_templates, template_exercises, programs, program_days.
+  // See BLD-174, BLD-187, BLD-255 for the history of this recurring regression.
   for (const tpl of STARTER_TEMPLATES) {
     await database.runAsync(
-      "UPDATE workout_templates SET name = ? WHERE id = ? AND (name IS NULL OR name = '')",
+      "INSERT OR IGNORE INTO workout_templates (id, name, created_at, updated_at, is_starter) VALUES (?, ?, 0, 0, 1)",
+      [tpl.id, tpl.name]
+    );
+    await database.runAsync(
+      "UPDATE workout_templates SET is_starter = 1, name = ? WHERE id = ? AND (is_starter = 0 OR name IS NULL OR name = '')",
       [tpl.name, tpl.id]
     );
+    for (let i = 0; i < tpl.exercises.length; i++) {
+      const ex = tpl.exercises[i];
+      await database.runAsync(
+        "INSERT OR IGNORE INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [ex.id, tpl.id, ex.exercise_id, i, ex.target_sets, ex.target_reps, ex.rest_seconds]
+      );
+    }
   }
   await database.runAsync(
-    "UPDATE programs SET is_starter = 1 WHERE id = ? AND is_starter = 0",
-    [STARTER_PROGRAM.id]
+    "INSERT OR IGNORE INTO programs (id, name, description, is_active, current_day_id, created_at, updated_at, is_starter) VALUES (?, ?, ?, 0, NULL, 0, 0, 1)",
+    [STARTER_PROGRAM.id, STARTER_PROGRAM.name, STARTER_PROGRAM.description]
   );
   await database.runAsync(
-    "UPDATE programs SET name = ? WHERE id = ? AND (name IS NULL OR name = '')",
+    "UPDATE programs SET is_starter = 1, name = ? WHERE id = ? AND (is_starter = 0 OR name IS NULL OR name = '')",
     [STARTER_PROGRAM.name, STARTER_PROGRAM.id]
   );
+  for (let i = 0; i < STARTER_PROGRAM.days.length; i++) {
+    const day = STARTER_PROGRAM.days[i];
+    await database.runAsync(
+      "INSERT OR IGNORE INTO program_days (id, program_id, template_id, position, label) VALUES (?, ?, ?, ?, ?)",
+      [day.id, STARTER_PROGRAM.id, day.template_id, i, day.label]
+    );
+  }
 
   if (row && Number(row.value) >= STARTER_VERSION) return;
 


### PR DESCRIPTION
## Summary
Fixes the recurring regression where starter workouts (including 'Founder's Favourite') show no metadata/exercises on the home screen. This is the **third time** this bug has been reported (BLD-174, BLD-187, BLD-255).

## Root Cause
The `seedStarters` repair logic only fixed `is_starter` flags and template names. If `template_exercises` or `program_days` rows were deleted (by import, migration, or cleanup), starter workouts would appear empty with no way to recover.

## Changes
- `lib/db/helpers.ts`: Expanded the repair logic to use INSERT OR IGNORE + UPDATE across all four tables (`workout_templates`, `template_exercises`, `programs`, `program_days`). This is idempotent — re-creates any missing rows on every app startup without duplicating existing data.
- `__tests__/lib/starter-templates.test.ts`: Added regression tests validating exercise reference integrity, non-empty exercises, required fields, and Founder's Favourite template specifically.

## Testing
- All 1433 tests pass (87 suites)
- ESLint passes with zero warnings
- Pre-existing TSC error in ShareSheet.test.tsx (unrelated, exists on main)

## Issue
Refs: BLD-255, BLD-174, BLD-187
Closes https://github.com/alankyshum/fitforge/issues/128