### PR TITLE
fix: responsive exercise header — name always visible on phone viewport

### DIFF
--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -401,44 +401,83 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
 
   const exerciseInfo = (
     <>
-      <View style={styles.groupHeader}>
-        <Text
-          variant="titleMedium"
-          numberOfLines={2}
-          style={[
-            styles.groupTitle,
-            { color: theme.colors.primary },
-            layout.compact && styles.groupTitleCompact,
-          ]}
-        >
-          {group.name}
-        </Text>
-        <Button
-          mode="text"
-          compact
-          icon="information-outline"
-          onPress={() => onShowDetail(group.exercise_id)}
-          accessibilityLabel={`View ${group.name} details`}
-        >
-          Details
-        </Button>
-        <IconButton
-          icon="swap-horizontal"
-          size={24}
-          onPress={() => onSwap(group.exercise_id)}
-          accessibilityLabel={`Swap ${group.name} for alternative`}
-          style={styles.swapBtn}
-        />
-        {group.is_voltra && group.training_modes.length > 1 && (
-          <TrainingModeSelector
-            modes={group.training_modes}
-            selected={modes[group.exercise_id] ?? group.training_modes[0]}
-            exercise={group.name}
-            onSelect={(m) => onModeChange(group.exercise_id, m)}
+      {layout.compact ? (
+        <View style={styles.groupHeaderCompactWrap}>
+          <View style={styles.groupHeaderCompactRow}>
+            <Text
+              variant="titleMedium"
+              numberOfLines={2}
+              ellipsizeMode="tail"
+              style={[styles.groupTitle, { color: theme.colors.primary }]}
+            >
+              {group.name}
+            </Text>
+            <IconButton
+              icon="swap-horizontal"
+              size={24}
+              onPress={() => onSwap(group.exercise_id)}
+              accessibilityLabel={`Swap ${group.name} for alternative`}
+              style={styles.swapBtn}
+            />
+          </View>
+          <View style={styles.groupHeaderCompactRow}>
+            <Button
+              mode="text"
+              compact
+              icon="information-outline"
+              onPress={() => onShowDetail(group.exercise_id)}
+              accessibilityLabel={`View ${group.name} details`}
+            >
+              Details
+            </Button>
+            {group.is_voltra && group.training_modes.length > 1 && (
+              <TrainingModeSelector
+                modes={group.training_modes}
+                selected={modes[group.exercise_id] ?? group.training_modes[0]}
+                exercise={group.name}
+                onSelect={(m) => onModeChange(group.exercise_id, m)}
+                compact
+              />
+            )}
+          </View>
+        </View>
+      ) : (
+        <View style={styles.groupHeader}>
+          <Text
+            variant="titleMedium"
+            numberOfLines={2}
+            ellipsizeMode="tail"
+            style={[styles.groupTitle, { color: theme.colors.primary }]}
+          >
+            {group.name}
+          </Text>
+          <Button
+            mode="text"
             compact
+            icon="information-outline"
+            onPress={() => onShowDetail(group.exercise_id)}
+            accessibilityLabel={`View ${group.name} details`}
+          >
+            Details
+          </Button>
+          <IconButton
+            icon="swap-horizontal"
+            size={24}
+            onPress={() => onSwap(group.exercise_id)}
+            accessibilityLabel={`Swap ${group.name} for alternative`}
+            style={styles.swapBtn}
           />
-        )}
-      </View>
+          {group.is_voltra && group.training_modes.length > 1 && (
+            <TrainingModeSelector
+              modes={group.training_modes}
+              selected={modes[group.exercise_id] ?? group.training_modes[0]}
+              exercise={group.name}
+              onSelect={(m) => onModeChange(group.exercise_id, m)}
+              compact
+            />
+          )}
+        </View>
+      )}
     </>
   );
 
@@ -1516,11 +1555,16 @@ const styles = StyleSheet.create({
   groupTitle: {
     fontWeight: "700",
     flex: 1,
-    minWidth: 0,
+    minWidth: 80,
   },
-  groupTitleCompact: {
-    flexBasis: "100%" as unknown as number,
-    flexGrow: 0,
+  groupHeaderCompactWrap: {
+    gap: 4,
+    marginBottom: 8,
+  },
+  groupHeaderCompactRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
   },
   headerRow: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary
On narrow phone viewports (<600dp), the exercise name in workout session headers was hidden because buttons consumed all available horizontal space. This restructures the header to a two-row layout on compact screens.

## Changes
- `app/session/[id].tsx`: On compact layout (phone), exercise header splits into two rows:
  - **Row 1**: Exercise name (flex, min 80dp, ellipsis overflow) + swap button
  - **Row 2**: Details button + training mode selector
  - On tablet/desktop (≥600dp), the single-row layout is preserved (no regression)
- Removed unused `groupTitleCompact` style
- Added `ellipsizeMode="tail"` for explicit text truncation behavior
- Set `minWidth: 80` on title to guarantee visibility even on 320dp screens

## Testing
- 59/59 session tests pass
- 410/410 acceptance tests pass
- ESLint zero warnings
- TSC clean (pre-existing ShareSheet error only)

## Issue
Refs: BLD-256
Closes https://github.com/alankyshum/fitforge/issues/129