### PR TITLE
fix: gender-based body anatomy display (BLD-257)

### DIFF
--- a/__tests__/lib/useProfileGender.test.ts
+++ b/__tests__/lib/useProfileGender.test.ts
@@ -1,3 +1,16 @@
+// Mock useFocusEffect as useEffect so it fires immediately in tests
+jest.mock("@react-navigation/native", () => {
+  const RealReact = require("react");
+  return {
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb();
+        return typeof cleanup === "function" ? cleanup : undefined;
+      }, []);
+    },
+  };
+});
+
 // Mock getAppSetting directly
 const mockGetAppSetting = jest.fn<Promise<string | null>, [string]>();
 jest.mock("../../lib/db", () => ({

--- a/lib/useProfileGender.ts
+++ b/lib/useProfileGender.ts
@@ -1,32 +1,36 @@
-import { useState, useEffect } from "react";
+import { useState, useCallback } from "react";
+import { useFocusEffect } from "@react-navigation/native";
 import { getAppSetting } from "./db";
 import type { Sex } from "./nutrition-calc";
 
 /**
  * Returns the user's sex/gender from their nutrition profile.
+ * Re-reads on every screen focus so changes in settings propagate immediately.
  * Defaults to "male" if no profile is saved or the field is missing.
  */
 export function useProfileGender(): Sex {
   const [gender, setGender] = useState<Sex>("male");
 
-  useEffect(() => {
-    getAppSetting("nutrition_profile")
-      .then((saved) => {
-        if (saved) {
-          try {
-            const profile = JSON.parse(saved);
-            if (profile.sex === "male" || profile.sex === "female") {
-              setGender(profile.sex);
+  useFocusEffect(
+    useCallback(() => {
+      getAppSetting("nutrition_profile")
+        .then((saved) => {
+          if (saved) {
+            try {
+              const profile = JSON.parse(saved);
+              if (profile.sex === "male" || profile.sex === "female") {
+                setGender(profile.sex);
+              }
+            } catch {
+              // Invalid JSON — keep default
             }
-          } catch {
-            // Invalid JSON — keep default
           }
-        }
-      })
-      .catch(() => {
-        // DB error — keep default
-      });
-  }, []);
+        })
+        .catch(() => {
+          // DB error — keep default
+        });
+    }, [])
+  );
 
   return gender;
 }


### PR DESCRIPTION
## Summary

Fixes the muscle map not updating to show female anatomy after changing gender in profile settings. The `useProfileGender` hook was using `useEffect` with an empty dependency array, which only reads the setting once on mount. Switching to `useFocusEffect` ensures the gender re-reads every time the screen gains focus.

## Changes

- `lib/useProfileGender.ts`: Replace `useEffect` with `useFocusEffect` from `@react-navigation/native` so the gender setting is re-read on every screen focus
- `__tests__/lib/useProfileGender.test.ts`: Add mock for `useFocusEffect` (mapped to `useEffect` for tests)

## Testing

- All 6 existing `useProfileGender` unit tests pass
- TypeScript type check passes (zero new errors)
- ESLint lint-staged passes

## Issue

Resolves BLD-257
Closes https://github.com/alankyshum/fitforge/issues/127