### PR TITLE
feat: warm-up set tagging (BLD-267)

### DIFF
--- a/__tests__/helpers/factories.ts
+++ b/__tests__/helpers/factories.ts
@@ -139,6 +139,7 @@ export function createSet(overrides: Partial<WorkoutSet> = {}): WorkoutSet {
     training_mode: null,
     tempo: null,
     swapped_from_exercise_id: null,
+    is_warmup: false,
     ...overrides,
   }
 }

--- a/__tests__/lib/db/import-export.test.ts
+++ b/__tests__/lib/db/import-export.test.ts
@@ -30,10 +30,10 @@ beforeEach(() => {
 // ---- Export v3 Format ----
 
 describe("exportAllData", () => {
-  it("produces v4 format with data wrapper and counts", async () => {
+  it("produces v5 format with data wrapper and counts", async () => {
     mockDb.getAllAsync.mockResolvedValue([]);
     const result = await exportAllData();
-    expect(result.version).toBe(4);
+    expect(result.version).toBe(5);
     expect(result.data).toBeDefined();
     expect(result.counts).toBeDefined();
     expect(result.exported_at).toBeDefined();
@@ -99,11 +99,19 @@ describe("validateBackupData", () => {
     expect(err!.type).toBe("missing_version");
   });
 
-  it("rejects future version (v5+)", () => {
-    const err = validateBackupData({ version: 5, data: { exercises: [{ id: "1" }] } });
+  it("rejects future version (v6+)", () => {
+    const err = validateBackupData({ version: 6, data: { exercises: [{ id: "1" }] } });
     expect(err).not.toBeNull();
     expect(err!.type).toBe("future_version");
     expect(err!.message).toContain("update the app");
+  });
+
+  it("accepts v5 backup", () => {
+    const err = validateBackupData({
+      version: 5,
+      data: { exercises: [{ id: "1", name: "Bench" }] },
+    });
+    expect(err).toBeNull();
   });
 
   it("accepts v4 backup", () => {

--- a/__tests__/lib/db/session-rating.test.ts
+++ b/__tests__/lib/db/session-rating.test.ts
@@ -180,9 +180,9 @@ describe('validateBackupData v4', () => {
     expect(err).toBeNull();
   });
 
-  it('rejects v5 as future version', () => {
+  it('rejects v6 as future version', () => {
     const err = validateBackupData({
-      version: 5,
+      version: 6,
       data: { exercises: [{ id: '1' }] },
     });
     expect(err).not.toBeNull();

--- a/__tests__/lib/db/source-session-sets.test.ts
+++ b/__tests__/lib/db/source-session-sets.test.ts
@@ -36,6 +36,7 @@ describe('getSourceSessionSets', () => {
         training_mode: 'weight',
         tempo: null,
         exercise_exists: 'ex-1',
+        is_warmup: 0,
       },
       {
         exercise_id: 'ex-1',
@@ -46,6 +47,7 @@ describe('getSourceSessionSets', () => {
         training_mode: 'weight',
         tempo: null,
         exercise_exists: 'ex-1',
+        is_warmup: 0,
       },
     ]);
 
@@ -61,6 +63,7 @@ describe('getSourceSessionSets', () => {
       training_mode: 'weight',
       tempo: null,
       exercise_exists: true,
+      is_warmup: false,
     });
     expect(result[1].weight).toBe(85);
     expect(result[1].reps).toBe(8);
@@ -77,6 +80,7 @@ describe('getSourceSessionSets', () => {
         training_mode: null,
         tempo: null,
         exercise_exists: null,
+        is_warmup: 0,
       },
     ]);
 
@@ -97,6 +101,7 @@ describe('getSourceSessionSets', () => {
         training_mode: null,
         tempo: '3-1-2',
         exercise_exists: 'ex-1',
+        is_warmup: 0,
       },
       {
         exercise_id: 'ex-2',
@@ -107,6 +112,7 @@ describe('getSourceSessionSets', () => {
         training_mode: null,
         tempo: null,
         exercise_exists: 'ex-2',
+        is_warmup: 0,
       },
     ]);
 

--- a/__tests__/lib/db/warmup-sets.test.ts
+++ b/__tests__/lib/db/warmup-sets.test.ts
@@ -128,7 +128,7 @@ describe('metric queries exclude warm-ups', () => {
 
   it('getPersonalRecords excludes warm-up sets', async () => {
     mockDb.getAllAsync.mockResolvedValue([]);
-    await getPersonalRecords('ex-1');
+    await getPersonalRecords();
 
     const call = mockDb.getAllAsync.mock.calls[0];
     expect(call[0]).toContain('is_warmup = 0');

--- a/__tests__/lib/db/warmup-sets.test.ts
+++ b/__tests__/lib/db/warmup-sets.test.ts
@@ -1,0 +1,136 @@
+// Unit tests for warm-up set tagging (Phase 45)
+const mockStmt = {
+  executeAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  finalizeAsync: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  getFirstAsync: jest.fn().mockResolvedValue(null),
+  runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+  prepareAsync: jest.fn().mockResolvedValue(mockStmt),
+};
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+}));
+
+import {
+  updateSetWarmup,
+  addSet,
+  getSessionSets,
+  getSessionSetCount,
+  getPersonalRecords,
+} from '../../../lib/db/sessions';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.getAllAsync.mockResolvedValue([]);
+  mockDb.getFirstAsync.mockResolvedValue(null);
+  mockDb.runAsync.mockResolvedValue({ changes: 1 });
+  mockDb.withTransactionAsync.mockImplementation(async (cb: () => Promise<void>) => cb());
+});
+
+// ---- updateSetWarmup ----
+
+describe('updateSetWarmup', () => {
+  it('sets is_warmup = 1 when true', async () => {
+    await updateSetWarmup('set-1', true);
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'UPDATE workout_sets SET is_warmup = ? WHERE id = ?',
+      [1, 'set-1']
+    );
+  });
+
+  it('sets is_warmup = 0 when false', async () => {
+    await updateSetWarmup('set-2', false);
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'UPDATE workout_sets SET is_warmup = ? WHERE id = ?',
+      [0, 'set-2']
+    );
+  });
+});
+
+// ---- addSet includes is_warmup ----
+
+describe('addSet with isWarmup', () => {
+  it('inserts set with is_warmup = 1 when isWarmup is true', async () => {
+    mockDb.getFirstAsync.mockResolvedValue({ next: 2 });
+    const result = await addSet('sess-1', 'ex-1', 1, null, null, null, null, true);
+
+    const insertCall = mockDb.runAsync.mock.calls.find(
+      (c: string[]) => typeof c[0] === 'string' && c[0].includes('INSERT INTO workout_sets')
+    );
+    expect(insertCall).toBeDefined();
+    expect(insertCall![0]).toContain('is_warmup');
+    // Last param should be 1
+    const params = insertCall![1] as unknown[];
+    expect(params[params.length - 1]).toBe(1);
+    expect(result.is_warmup).toBe(true);
+  });
+
+  it('inserts set with is_warmup = 0 by default', async () => {
+    mockDb.getFirstAsync.mockResolvedValue({ next: 1 });
+    const result = await addSet('sess-1', 'ex-1', 1);
+
+    const insertCall = mockDb.runAsync.mock.calls.find(
+      (c: string[]) => typeof c[0] === 'string' && c[0].includes('INSERT INTO workout_sets')
+    );
+    expect(insertCall).toBeDefined();
+    expect(insertCall![0]).toContain('is_warmup');
+    const params = insertCall![1] as unknown[];
+    expect(params[params.length - 1]).toBe(0);
+    expect(result.is_warmup).toBe(false);
+  });
+});
+
+// ---- getSessionSets includes is_warmup (no filter) ----
+
+describe('getSessionSets', () => {
+  it('maps is_warmup from integer to boolean', async () => {
+    mockDb.getAllAsync.mockResolvedValue([
+      {
+        id: 's1', session_id: 'sess-1', exercise_id: 'ex-1',
+        set_number: 1, weight: 100, reps: 5, completed: 1,
+        completed_at: null, rpe: null, notes: null,
+        exercise_name: 'Squat', link_id: null, round: null,
+        training_mode: null, tempo: null,
+        swapped_from_exercise_id: null, is_warmup: 1,
+      },
+      {
+        id: 's2', session_id: 'sess-1', exercise_id: 'ex-1',
+        set_number: 2, weight: 100, reps: 5, completed: 1,
+        completed_at: null, rpe: null, notes: null,
+        exercise_name: 'Squat', link_id: null, round: null,
+        training_mode: null, tempo: null,
+        swapped_from_exercise_id: null, is_warmup: 0,
+      },
+    ]);
+
+    const sets = await getSessionSets('sess-1');
+    expect(sets[0].is_warmup).toBe(true);
+    expect(sets[1].is_warmup).toBe(false);
+  });
+});
+
+// ---- Metric queries exclude warm-ups ----
+
+describe('metric queries exclude warm-ups', () => {
+  it('getSessionSetCount excludes warm-up sets', async () => {
+    mockDb.getFirstAsync.mockResolvedValue({ cnt: 3 });
+    await getSessionSetCount('sess-1');
+
+    const call = mockDb.getFirstAsync.mock.calls[0];
+    expect(call[0]).toContain('is_warmup = 0');
+  });
+
+  it('getPersonalRecords excludes warm-up sets', async () => {
+    mockDb.getAllAsync.mockResolvedValue([]);
+    await getPersonalRecords('ex-1');
+
+    const call = mockDb.getAllAsync.mock.calls[0];
+    expect(call[0]).toContain('is_warmup = 0');
+  });
+});

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -56,8 +56,10 @@ import {
   updateSetRPE,
   updateSetNotes,
   updateSetTrainingMode,
+  updateSetWarmup,
   getExerciseById,
   getAppSetting,
+  setAppSetting,
 } from "../../lib/db";
 import {
   getSessionProgramDayId,
@@ -119,12 +121,13 @@ type SetRowProps = {
   onNotes: (setId: string, text: string) => void;
   onNotesDraftChange: (setId: string, text: string) => void;
   onToggleNotes: (setId: string) => void;
+  onToggleWarmup: (setId: string) => void;
 };
 
 const SetRow = memo(function SetRow({
   set, step, unit, notesOpen, notesDraft, halfStep,
   onUpdate, onCheck, onDelete, onRPE, onHalfStep, onHalfStepClear,
-  onHalfStepOpen, onNotes, onNotesDraftChange, onToggleNotes,
+  onHalfStepOpen, onNotes, onNotesDraftChange, onToggleNotes, onToggleWarmup,
 }: SetRowProps) {
   const theme = useTheme();
 
@@ -138,11 +141,28 @@ const SetRow = memo(function SetRow({
             styles.setRow,
             set.completed && { backgroundColor: theme.colors.primaryContainer + "40" },
             { backgroundColor: theme.colors.background },
+            set.is_warmup && { borderLeftWidth: 3, borderLeftColor: theme.colors.surfaceVariant },
           ]}
         >
-          <Text variant="bodyMedium" style={[styles.colSet, { color: theme.colors.onSurface }]}>
-            {set.round ? `R${set.round}` : set.set_number}
-          </Text>
+          <Pressable
+            onPress={() => onToggleWarmup(set.id)}
+            hitSlop={10}
+            style={styles.colSet}
+            accessibilityRole="switch"
+            accessibilityState={{ checked: set.is_warmup }}
+            accessibilityLabel={`Set ${set.set_number}, ${set.is_warmup ? "warm-up set" : "working set"}`}
+            accessibilityHint="Double tap to toggle between warm-up and working set"
+          >
+            {set.is_warmup ? (
+              <View style={[styles.warmupChip, { backgroundColor: theme.colors.surfaceVariant }]}>
+                <Text style={{ color: theme.colors.onSurfaceVariant, fontSize: 13, fontWeight: "700" }}>W</Text>
+              </View>
+            ) : (
+              <Text variant="bodyMedium" style={{ color: theme.colors.onSurface, textAlign: "center" }}>
+                {set.round ? `R${set.round}` : set.set_number}
+              </Text>
+            )}
+          </Pressable>
           <Text variant="bodySmall" style={[styles.colPrev, { color: theme.colors.onSurfaceVariant }]}>
             {set.previous}
           </Text>
@@ -325,6 +345,7 @@ type GroupCardProps = {
   onNotes: (setId: string, text: string) => void;
   onNotesDraftChange: (setId: string, text: string) => void;
   onToggleNotes: (setId: string) => void;
+  onToggleWarmup: (setId: string) => void;
   onShowDetail: (exerciseId: string) => void;
   onSwap: (exerciseId: string) => void;
 };
@@ -334,7 +355,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
   notesOpenMap, notesDraftMap, halfStep, linkIds, groups, palette,
   onUpdate, onCheck, onDelete, onAddSet, onModeChange,
   onRPE, onHalfStep, onHalfStepClear,
-  onHalfStepOpen, onNotes, onNotesDraftChange, onToggleNotes,
+  onHalfStepOpen, onNotes, onNotesDraftChange, onToggleNotes, onToggleWarmup,
   onShowDetail, onSwap,
 }: GroupCardProps) {
   const theme = useTheme();
@@ -514,6 +535,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
           onNotes={onNotes}
           onNotesDraftChange={onNotesDraftChange}
           onToggleNotes={onToggleNotes}
+          onToggleWarmup={onToggleWarmup}
         />
       ))}
       <Button
@@ -960,6 +982,7 @@ export default function ActiveSession() {
               round: newLinkId ? s.set_number : null,
               trainingMode: (s.training_mode as TrainingMode) ?? null,
               tempo: s.tempo ?? null,
+              isWarmup: s.is_warmup,
             });
           }
           const created = await addSetsBatch(setsToInsert);
@@ -1313,6 +1336,32 @@ export default function ActiveSession() {
     setNotesOpen((prev) => ({ ...prev, [setId]: !prev[setId] }));
   }, []);
 
+  const handleToggleWarmup = useCallback(async (setId: string) => {
+    let newVal = false;
+    setGroups((prev) =>
+      prev.map((g) => ({
+        ...g,
+        sets: g.sets.map((s) => {
+          if (s.id === setId) {
+            newVal = !s.is_warmup;
+            return { ...s, is_warmup: newVal };
+          }
+          return s;
+        }),
+      }))
+    );
+    // Wait for state to settle before DB call (newVal captured in closure)
+    await updateSetWarmup(setId, newVal);
+    Haptics.selectionAsync();
+
+    // First-use tooltip
+    const shown = await getAppSetting("warmup_tooltip_shown");
+    if (!shown) {
+      setSnackbar("Set marked as warm-up. Warm-up sets are excluded from volume and PR tracking.");
+      await setAppSetting("warmup_tooltip_shown", "1");
+    }
+  }, []);
+
   const isPR = (set: SetWithMeta) => {
     if (!set.completed || !set.weight || set.weight <= 0) return false;
     const max = maxes[set.exercise_id];
@@ -1453,6 +1502,7 @@ export default function ActiveSession() {
             onNotes={handleNotes}
             onNotesDraftChange={handleNotesDraftChange}
             onToggleNotes={toggleNotes}
+            onToggleWarmup={handleToggleWarmup}
             onShowDetail={handleShowDetail}
             onSwap={handleSwapOpen}
           />
@@ -1648,6 +1698,16 @@ const styles = StyleSheet.create({
   colSet: {
     width: 36,
     textAlign: "center",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 36,
+  },
+  warmupChip: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
   },
   colPrev: {
     width: 64,

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -465,13 +465,19 @@ export default function SessionDetail() {
               .filter((s) => s.completed)
               .map((set) => (
                 <View key={set.id}>
-                  <View style={styles.setRow}>
+                  <View style={[styles.setRow, set.is_warmup && { borderLeftWidth: 3, borderLeftColor: theme.colors.surfaceVariant, paddingLeft: 5 }]}>
+                    {set.is_warmup ? (
+                      <View style={{ width: 28, height: 28, borderRadius: 14, backgroundColor: theme.colors.surfaceVariant, justifyContent: "center", alignItems: "center", marginRight: 8 }}>
+                        <Text style={{ fontSize: 13, fontWeight: "700", color: theme.colors.onSurfaceVariant }}>W</Text>
+                      </View>
+                    ) : (
                     <Text
                       variant="bodyMedium"
                       style={[styles.setNum, { color: theme.colors.onSurface }]}
                     >
                       {set.round ? `R${set.round}` : `Set ${set.set_number}`}
                     </Text>
+                    )}
                     <Text
                       variant="bodyMedium"
                       style={{ color: theme.colors.onSurface }}

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -158,10 +158,16 @@ export default function Summary() {
   const volume = useMemo(() => {
     let total = 0;
     for (const s of completed) {
-      if (s.weight && s.reps) total += s.weight * s.reps;
+      if (s.weight && s.reps && !s.is_warmup) total += s.weight * s.reps;
     }
     return total;
   }, [completed]);
+
+  const warmupCount = useMemo(
+    () => completed.filter((s) => s.is_warmup).length,
+    [completed],
+  );
+  const workingCount = completed.length - warmupCount;
 
   const duration = session?.duration_seconds
     ? formatTime(session.duration_seconds)
@@ -396,14 +402,14 @@ export default function Summary() {
               </Card>
               <Card
                 style={[styles.stat, { backgroundColor: theme.colors.surface }]}
-                accessibilityLabel={`${completed.length} sets completed`}
+                accessibilityLabel={warmupCount > 0 ? `${workingCount} working sets, ${warmupCount} warm-up sets` : `${completed.length} sets completed`}
               >
                 <Card.Content style={styles.statInner}>
                   <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
                     {completed.length}
                   </Text>
                   <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
-                    Sets
+                    {warmupCount > 0 ? `Sets (${warmupCount}W / ${workingCount})` : "Sets"}
                   </Text>
                 </Card.Content>
               </Card>

--- a/lib/db/achievements.ts
+++ b/lib/db/achievements.ts
@@ -27,12 +27,14 @@ export async function buildAchievementContext(): Promise<AchievementContext> {
        WHERE completed_at IS NOT NULL
        ORDER BY date ASC`
     ),
+    // Warm-up sets excluded from volume/PR achievements but workout-count achievements are session-based, not set-based
     queryOne<{ count: number }>(
       `SELECT COUNT(*) AS count FROM (
         SELECT ws.exercise_id
         FROM workout_sets ws
         JOIN workout_sessions wss ON ws.session_id = wss.id
         WHERE ws.completed = 1
+          AND ws.is_warmup = 0
           AND ws.weight IS NOT NULL
           AND ws.weight > 0
           AND wss.completed_at IS NOT NULL
@@ -43,6 +45,7 @@ export async function buildAchievementContext(): Promise<AchievementContext> {
             WHERE ws2.exercise_id = ws.exercise_id
               AND ws2.session_id != ws.session_id
               AND ws2.completed = 1
+              AND ws2.is_warmup = 0
               AND ws2.weight IS NOT NULL
               AND ws2.weight > 0
               AND wss2.completed_at IS NOT NULL
@@ -57,6 +60,7 @@ export async function buildAchievementContext(): Promise<AchievementContext> {
         FROM workout_sets ws
         JOIN workout_sessions wss ON ws.session_id = wss.id
         WHERE ws.completed = 1
+          AND ws.is_warmup = 0
           AND ws.weight IS NOT NULL
           AND ws.reps IS NOT NULL
           AND wss.completed_at IS NOT NULL
@@ -68,6 +72,7 @@ export async function buildAchievementContext(): Promise<AchievementContext> {
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
+         AND ws.is_warmup = 0
          AND ws.weight IS NOT NULL
          AND ws.reps IS NOT NULL
          AND wss.completed_at IS NOT NULL`

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -337,6 +337,11 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
       "ALTER TABLE workout_sets ADD COLUMN swapped_from_exercise_id TEXT DEFAULT NULL"
     );
   }
+  if (!setNames.has("is_warmup")) {
+    await database.execAsync(
+      "ALTER TABLE workout_sets ADD COLUMN is_warmup INTEGER DEFAULT 0"
+    );
+  }
 
   const exCols = await database.getAllAsync<{ name: string }>(
     "PRAGMA table_info(exercises)"

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -105,7 +105,7 @@ export type BackupV3Data = {
 };
 
 export type BackupV3 = {
-  version: 3 | 4;
+  version: 3 | 4 | 5;
   app_version: string;
   exported_at: string;
   data: BackupV3Data;
@@ -169,7 +169,7 @@ export function validateBackupData(data: unknown): ValidationError | null {
   }
 
   const version = Number(obj.version);
-  if (version >= 5) {
+  if (version >= 6) {
     return { type: "future_version", message: "This backup was created with a newer version of FitForge. Please update the app first." };
   }
 
@@ -286,7 +286,7 @@ export async function exportAllData(
   onProgress?.({ table: "done", tableIndex: tables.length, totalTables: tables.length });
 
   return {
-    version: 4,
+    version: 5,
     app_version: "1.0.0",
     exported_at: new Date().toISOString(),
     data: data as unknown as BackupV3Data,
@@ -450,8 +450,8 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
     }
     case "workout_sets": {
       const r = await database.runAsync(
-        "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, training_mode, tempo) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        [row.id, row.session_id, row.exercise_id, row.set_number, row.weight, row.reps, row.completed, row.completed_at, row.set_rpe ?? row.rpe ?? null, row.set_notes ?? row.notes ?? "", row.link_id ?? null, row.round ?? null, row.training_mode ?? null, row.tempo ?? null]
+        "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, training_mode, tempo, is_warmup) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.session_id, row.exercise_id, row.set_number, row.weight, row.reps, row.completed, row.completed_at, row.set_rpe ?? row.rpe ?? null, row.set_notes ?? row.notes ?? "", row.link_id ?? null, row.round ?? null, row.training_mode ?? null, row.tempo ?? null, row.is_warmup ?? 0]
       );
       return r.changes > 0;
     }

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -51,6 +51,7 @@ export {
   updateSetNotes,
   updateSetTrainingMode,
   updateSetTempo,
+  updateSetWarmup,
   getPreviousSets,
   getSessionSetCount,
   getSessionAvgRPE,

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -21,6 +21,7 @@ type SetRow = {
   exercise_deleted_at: number | null;
   swapped_from_exercise_id: string | null;
   swapped_from_name: string | null;
+  is_warmup: number;
 };
 
 // ---- Sessions ----
@@ -116,6 +117,7 @@ export async function getSessionSets(
     training_mode: (r.training_mode as TrainingMode) ?? null,
     tempo: r.tempo ?? null,
     swapped_from_exercise_id: r.swapped_from_exercise_id ?? null,
+    is_warmup: r.is_warmup === 1,
     exercise_name: r.exercise_name ?? undefined,
     exercise_deleted: r.exercise_deleted_at != null,
     swapped_from_name: r.swapped_from_name ?? undefined,
@@ -139,6 +141,7 @@ export type SourceSessionSet = {
   training_mode: string | null;
   tempo: string | null;
   exercise_exists: boolean;
+  is_warmup: boolean;
 };
 
 export async function getSourceSessionSets(
@@ -153,9 +156,10 @@ export async function getSourceSessionSets(
     training_mode: string | null;
     tempo: string | null;
     exercise_exists: string | null;
+    is_warmup: number;
   }>(
     `SELECT ws.exercise_id, ws.set_number, ws.weight, ws.reps, ws.link_id,
-            ws.training_mode, ws.tempo, e.id AS exercise_exists
+            ws.training_mode, ws.tempo, e.id AS exercise_exists, ws.is_warmup
      FROM workout_sets ws
      LEFT JOIN exercises e ON ws.exercise_id = e.id
      WHERE ws.session_id = ? AND ws.completed = 1
@@ -171,6 +175,7 @@ export async function getSourceSessionSets(
     training_mode: r.training_mode,
     tempo: r.tempo,
     exercise_exists: r.exercise_exists != null,
+    is_warmup: r.is_warmup === 1,
   }));
 }
 
@@ -183,12 +188,13 @@ export async function addSet(
   linkId?: string | null,
   round?: number | null,
   trainingMode?: TrainingMode | null,
-  tempo?: string | null
+  tempo?: string | null,
+  isWarmup?: boolean
 ): Promise<WorkoutSet> {
   const id = uuid();
   await execute(
-    "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-    [id, sessionId, exerciseId, setNumber, linkId ?? null, round ?? null, trainingMode ?? null, tempo ?? null]
+    "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo, is_warmup) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    [id, sessionId, exerciseId, setNumber, linkId ?? null, round ?? null, trainingMode ?? null, tempo ?? null, isWarmup ? 1 : 0]
   );
   return {
     id,
@@ -206,6 +212,7 @@ export async function addSet(
     training_mode: trainingMode ?? null,
     tempo: tempo ?? null,
     swapped_from_exercise_id: null,
+    is_warmup: isWarmup ?? false,
   };
 }
 
@@ -218,6 +225,7 @@ export async function addSetsBatch(
     round?: number | null;
     trainingMode?: TrainingMode | null;
     tempo?: string | null;
+    isWarmup?: boolean;
   }[]
 ): Promise<WorkoutSet[]> {
   const results: WorkoutSet[] = sets.map((s) => ({
@@ -236,16 +244,17 @@ export async function addSetsBatch(
     training_mode: s.trainingMode ?? null,
     tempo: s.tempo ?? null,
     swapped_from_exercise_id: null,
+    is_warmup: s.isWarmup ?? false,
   }));
   await withTransaction(async (db) => {
     const stmt = await db.prepareAsync(
-      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo, is_warmup) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     try {
       for (const r of results) {
         await stmt.executeAsync([
           r.id, r.session_id, r.exercise_id, r.set_number,
-          r.link_id, r.round, r.training_mode, r.tempo,
+          r.link_id, r.round, r.training_mode, r.tempo, r.is_warmup ? 1 : 0,
         ]);
       }
     } finally {
@@ -330,6 +339,13 @@ export async function updateSetTempo(id: string, tempo: string | null): Promise<
   );
 }
 
+export async function updateSetWarmup(id: string, isWarmup: boolean): Promise<void> {
+  await execute(
+    "UPDATE workout_sets SET is_warmup = ? WHERE id = ?",
+    [isWarmup ? 1 : 0, id]
+  );
+}
+
 export async function getPreviousSets(
   exerciseId: string,
   currentSessionId: string
@@ -357,7 +373,7 @@ export async function getSessionSetCount(
   sessionId: string
 ): Promise<number> {
   const row = await queryOne<{ count: number }>(
-    "SELECT COUNT(*) as count FROM workout_sets WHERE session_id = ? AND completed = 1",
+    "SELECT COUNT(*) as count FROM workout_sets WHERE session_id = ? AND completed = 1 AND is_warmup = 0",
     [sessionId]
   );
   return row?.count ?? 0;
@@ -367,7 +383,7 @@ export async function getSessionAvgRPE(
   sessionId: string
 ): Promise<number | null> {
   const row = await queryOne<{ val: number | null }>(
-    "SELECT AVG(rpe) AS val FROM workout_sets WHERE session_id = ? AND completed = 1 AND rpe IS NOT NULL",
+    "SELECT AVG(rpe) AS val FROM workout_sets WHERE session_id = ? AND completed = 1 AND rpe IS NOT NULL AND is_warmup = 0",
     [sessionId]
   );
   return row?.val ?? null;
@@ -481,7 +497,7 @@ export async function getWeeklyVolume(
             COALESCE(SUM(ws.weight * ws.reps), 0) AS volume
      FROM workout_sets ws
      JOIN workout_sessions wss ON ws.session_id = wss.id
-     WHERE ws.completed = 1 AND wss.completed_at IS NOT NULL AND wss.started_at >= ?
+     WHERE ws.completed = 1 AND ws.is_warmup = 0 AND wss.completed_at IS NOT NULL AND wss.started_at >= ?
      GROUP BY week_start
      ORDER BY week_start ASC`,
     [cutoff]
@@ -504,6 +520,7 @@ export async function getPersonalRecords(): Promise<
      LEFT JOIN exercises e ON ws.exercise_id = e.id
      JOIN workout_sessions wss ON ws.session_id = wss.id
      WHERE ws.completed = 1 AND ws.weight IS NOT NULL AND ws.weight > 0
+       AND ws.is_warmup = 0
        AND wss.completed_at IS NOT NULL
      GROUP BY ws.exercise_id
      ORDER BY name ASC`
@@ -541,6 +558,7 @@ export async function getMaxWeightByExercise(
        AND ws.completed = 1
        AND ws.weight IS NOT NULL
        AND ws.weight > 0
+       AND ws.is_warmup = 0
        AND wss.completed_at IS NOT NULL
      GROUP BY ws.exercise_id`,
     [...exerciseIds, excludeSessionId]
@@ -567,6 +585,7 @@ export async function getSessionPRs(
          AND ws.completed = 1
          AND ws.weight IS NOT NULL
          AND ws.weight > 0
+         AND ws.is_warmup = 0
        GROUP BY ws.exercise_id
      ) cur
      JOIN (
@@ -577,6 +596,7 @@ export async function getSessionPRs(
          AND ws.completed = 1
          AND ws.weight IS NOT NULL
          AND ws.weight > 0
+         AND ws.is_warmup = 0
          AND wss.completed_at IS NOT NULL
        GROUP BY ws.exercise_id
      ) hist ON cur.exercise_id = hist.exercise_id
@@ -602,6 +622,7 @@ export async function getRecentPRs(
      WHERE ws.completed = 1
        AND ws.weight IS NOT NULL
        AND ws.weight > 0
+       AND ws.is_warmup = 0
        AND wss.completed_at IS NOT NULL
        AND ws.weight > (SELECT MAX(ws2.weight)
           FROM workout_sets ws2
@@ -611,6 +632,7 @@ export async function getRecentPRs(
             AND ws2.completed = 1
             AND ws2.weight IS NOT NULL
             AND ws2.weight > 0
+            AND ws2.is_warmup = 0
             AND wss2.completed_at IS NOT NULL
             AND wss2.started_at < wss.started_at
          )
@@ -663,6 +685,7 @@ export async function getExerciseHistory(
      JOIN workout_sessions wss ON ws.session_id = wss.id
      WHERE ws.exercise_id = ?
        AND ws.completed = 1
+       AND ws.is_warmup = 0
        AND wss.completed_at IS NOT NULL
      GROUP BY wss.id
      ORDER BY wss.started_at DESC
@@ -676,7 +699,7 @@ export async function getExerciseRecords(exerciseId: string): Promise<ExerciseRe
     `SELECT MAX(ws.weight) AS val
      FROM workout_sets ws
      JOIN workout_sessions wss ON ws.session_id = wss.id
-     WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.weight > 0 AND wss.completed_at IS NOT NULL`,
+     WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.is_warmup = 0 AND ws.weight > 0 AND wss.completed_at IS NOT NULL`,
     [exerciseId]
   );
 
@@ -684,7 +707,7 @@ export async function getExerciseRecords(exerciseId: string): Promise<ExerciseRe
     `SELECT MAX(ws.reps) AS val
      FROM workout_sets ws
      JOIN workout_sessions wss ON ws.session_id = wss.id
-     WHERE ws.exercise_id = ? AND ws.completed = 1 AND wss.completed_at IS NOT NULL`,
+     WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.is_warmup = 0 AND wss.completed_at IS NOT NULL`,
     [exerciseId]
   );
 
@@ -693,7 +716,7 @@ export async function getExerciseRecords(exerciseId: string): Promise<ExerciseRe
        SELECT SUM(ws.weight * ws.reps) AS sv
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
-       WHERE ws.exercise_id = ? AND ws.completed = 1 AND wss.completed_at IS NOT NULL
+       WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.is_warmup = 0 AND wss.completed_at IS NOT NULL
        GROUP BY wss.id
      )`,
     [exerciseId]
@@ -703,7 +726,7 @@ export async function getExerciseRecords(exerciseId: string): Promise<ExerciseRe
     `SELECT MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS val
      FROM workout_sets ws
      JOIN workout_sessions wss ON ws.session_id = wss.id
-     WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.weight > 0 AND ws.reps > 0 AND ws.reps <= 12 AND wss.completed_at IS NOT NULL`,
+     WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.is_warmup = 0 AND ws.weight > 0 AND ws.reps > 0 AND ws.reps <= 12 AND wss.completed_at IS NOT NULL`,
     [exerciseId]
   );
 
@@ -711,7 +734,7 @@ export async function getExerciseRecords(exerciseId: string): Promise<ExerciseRe
     `SELECT COUNT(DISTINCT wss.id) AS val
      FROM workout_sets ws
      JOIN workout_sessions wss ON ws.session_id = wss.id
-     WHERE ws.exercise_id = ? AND ws.completed = 1 AND wss.completed_at IS NOT NULL`,
+     WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.is_warmup = 0 AND wss.completed_at IS NOT NULL`,
     [exerciseId]
   );
 
@@ -746,6 +769,7 @@ export async function getExercise1RMChartData(
          AND ws.weight > 0
          AND ws.reps IS NOT NULL
          AND ws.reps > 0
+         AND ws.is_warmup = 0
          AND wss.completed_at IS NOT NULL
        GROUP BY wss.id
        ORDER BY wss.started_at DESC
@@ -769,6 +793,7 @@ export async function getExerciseChartData(
          AND ws.completed = 1
          AND ws.weight IS NOT NULL
          AND ws.weight > 0
+         AND ws.is_warmup = 0
          AND wss.completed_at IS NOT NULL
        GROUP BY wss.id
        ORDER BY wss.started_at DESC
@@ -788,6 +813,7 @@ export async function getExerciseChartData(
        WHERE ws.exercise_id = ?
          AND ws.completed = 1
          AND wss.completed_at IS NOT NULL
+         AND ws.is_warmup = 0
        GROUP BY wss.id
        ORDER BY wss.started_at DESC
        LIMIT ?
@@ -846,6 +872,7 @@ export async function getBestSet(
      JOIN workout_sessions wss ON ws.session_id = wss.id
      WHERE ws.exercise_id = ?
        AND ws.completed = 1
+       AND ws.is_warmup = 0
        AND ws.weight > 0
        AND ws.reps > 0
        AND ws.reps <= 12
@@ -878,6 +905,7 @@ export async function getMuscleVolumeForWeek(
        AND wss.completed_at >= ?
        AND wss.completed_at < ?
        AND ws.completed = 1
+       AND ws.is_warmup = 0
      GROUP BY ws.exercise_id`,
     [weekStart, end]
   );
@@ -940,6 +968,7 @@ export async function getMuscleVolumeTrend(
        AND wss.completed_at >= ?
        AND wss.completed_at < ?
        AND ws.completed = 1
+       AND ws.is_warmup = 0
      GROUP BY ws.exercise_id, wss.id`,
     [oldest.getTime(), end.getTime()]
   );
@@ -977,6 +1006,7 @@ export async function getSessionRepPRs(
        FROM workout_sets ws
        WHERE ws.session_id = ?
          AND ws.completed = 1
+         AND ws.is_warmup = 0
          AND ws.reps IS NOT NULL
          AND ws.reps > 0
          AND (ws.weight IS NULL OR ws.weight = 0)
@@ -988,6 +1018,7 @@ export async function getSessionRepPRs(
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.session_id != ?
          AND ws.completed = 1
+         AND ws.is_warmup = 0
          AND ws.reps IS NOT NULL
          AND ws.reps > 0
          AND (ws.weight IS NULL OR ws.weight = 0)
@@ -1025,7 +1056,7 @@ export async function getSessionComparison(
     const row = await queryOne<{ vol: number; cnt: number }>(
       `SELECT COALESCE(SUM(CASE WHEN weight IS NOT NULL AND reps IS NOT NULL THEN weight * reps ELSE 0 END), 0) AS vol,
               COUNT(*) AS cnt
-       FROM workout_sets WHERE session_id = ? AND completed = 1`,
+       FROM workout_sets WHERE session_id = ? AND completed = 1 AND is_warmup = 0`,
       [sid]
     );
     return { volume: row?.vol ?? 0, sets: row?.cnt ?? 0 };
@@ -1060,6 +1091,7 @@ export async function getSessionWeightIncreases(
      LEFT JOIN exercises e ON ws.exercise_id = e.id
      WHERE ws.session_id = ?
        AND ws.completed = 1
+       AND ws.is_warmup = 0
        AND ws.weight IS NOT NULL
        AND ws.weight > 0
      GROUP BY ws.exercise_id`,
@@ -1085,6 +1117,7 @@ export async function getSessionWeightIncreases(
          AND wss.id != ?
          AND wss.completed_at IS NOT NULL
          AND ws.completed = 1
+         AND ws.is_warmup = 0
          AND ws.weight > 0
          AND wss.started_at = (
            SELECT MAX(wss2.started_at)

--- a/lib/db/weekly-summary.ts
+++ b/lib/db/weekly-summary.ts
@@ -97,7 +97,7 @@ export async function getWeeklyWorkouts(
         `SELECT COALESCE(SUM(ws.weight * ws.reps), 0) AS volume
          FROM workout_sets ws
          JOIN workout_sessions wss ON ws.session_id = wss.id
-         WHERE ws.completed = 1 AND wss.completed_at IS NOT NULL
+         WHERE ws.completed = 1 AND ws.is_warmup = 0 AND wss.completed_at IS NOT NULL
            AND wss.started_at >= ? AND wss.started_at < ?`,
         [start, end]
       ),
@@ -111,7 +111,7 @@ export async function getWeeklyWorkouts(
         `SELECT COALESCE(SUM(ws.weight * ws.reps), 0) AS volume
          FROM workout_sets ws
          JOIN workout_sessions wss ON ws.session_id = wss.id
-         WHERE ws.completed = 1 AND wss.completed_at IS NOT NULL
+         WHERE ws.completed = 1 AND ws.is_warmup = 0 AND wss.completed_at IS NOT NULL
            AND wss.started_at >= ? AND wss.started_at < ?`,
         [prevStart, start]
       ),
@@ -162,6 +162,7 @@ export async function getWeeklyPRs(weekStartMs: number): Promise<WeeklyPR[]> {
      LEFT JOIN exercises e ON ws.exercise_id = e.id
      JOIN workout_sessions wss ON ws.session_id = wss.id
      WHERE ws.completed = 1 AND ws.weight IS NOT NULL AND ws.weight > 0
+       AND ws.is_warmup = 0
        AND wss.completed_at IS NOT NULL
        AND wss.started_at >= ? AND wss.started_at < ?
      GROUP BY ws.exercise_id`,
@@ -178,6 +179,7 @@ export async function getWeeklyPRs(weekStartMs: number): Promise<WeeklyPR[]> {
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1 AND ws.weight IS NOT NULL AND ws.weight > 0
+         AND ws.is_warmup = 0
          AND wss.completed_at IS NOT NULL
          AND ws.exercise_id = ?
          AND wss.started_at < ?`,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -210,6 +210,7 @@ export type WorkoutSet = {
   training_mode: TrainingMode | null;
   tempo: string | null;
   swapped_from_exercise_id: string | null;
+  is_warmup: boolean;
 };
 
 export const TRAINING_MODE_LABELS: Record<TrainingMode, { label: string; short: string; description: string }> = {


### PR DESCRIPTION
## Summary

Add `is_warmup` boolean to workout sets, allowing users to tag sets as warm-up. Warm-up sets are excluded from all volume, PR, and metric calculations while remaining visible in the session UI.

## Changes

### Database & Types
- Schema migration: `ALTER TABLE workout_sets ADD COLUMN is_warmup INTEGER DEFAULT 0`
- `WorkoutSet` type: added `is_warmup: boolean`
- New `updateSetWarmup()` function
- `addSet()` and `addSetsBatch()`: accept `isWarmup` parameter
- Import/export: version 4→5, backward-compatible with `row.is_warmup ?? 0`

### Query Filtering (~20 queries)
- All metric/PR/volume queries in sessions.ts, weekly-summary.ts, achievements.ts now filter `AND ws.is_warmup = 0`
- Display queries (getSessionSets, getSourceSessionSets) intentionally do NOT filter — they show all sets

### Session Screen (app/session/[id].tsx)
- Tap set number to toggle warm-up state
- Warm-up sets show circular "W" chip (28dp, surfaceVariant colors)
- Warm-up rows get 3dp left border accent
- `accessibilityRole='switch'` with proper state/labels
- Haptic feedback on toggle
- First-use education snackbar via app_settings
- Warm-up tags preserved when repeating workouts (sourceSessionId flow)

### Summary Screen (app/session/summary/[id].tsx)
- Volume calculation excludes warm-up sets
- Stats card shows "Sets (NW / M)" breakdown when warm-ups exist

### Detail Screen (app/session/detail/[id].tsx)
- Historical warm-up sets display W chip and left border accent

## Testing
- 7 new unit tests in warmup-sets.test.ts
- Updated 4 existing test files for version/schema changes
- All 1474 tests pass across 92 suites
- TypeScript `tsc --noEmit` passes (only pre-existing BottomSheet error)
- ESLint passes via lint-staged on all commits

## Issue

Resolves BLD-267