### PR TITLE
feat: Dropset & Set Type Annotation (BLD-269)

### DIFF
--- a/__tests__/helpers/factories.ts
+++ b/__tests__/helpers/factories.ts
@@ -140,6 +140,7 @@ export function createSet(overrides: Partial<WorkoutSet> = {}): WorkoutSet {
     tempo: null,
     swapped_from_exercise_id: null,
     is_warmup: false,
+    set_type: 'normal',
     ...overrides,
   }
 }

--- a/__tests__/lib/db/import-export.test.ts
+++ b/__tests__/lib/db/import-export.test.ts
@@ -30,10 +30,10 @@ beforeEach(() => {
 // ---- Export v3 Format ----
 
 describe("exportAllData", () => {
-  it("produces v5 format with data wrapper and counts", async () => {
+  it("produces v6 format with data wrapper and counts", async () => {
     mockDb.getAllAsync.mockResolvedValue([]);
     const result = await exportAllData();
-    expect(result.version).toBe(5);
+    expect(result.version).toBe(6);
     expect(result.data).toBeDefined();
     expect(result.counts).toBeDefined();
     expect(result.exported_at).toBeDefined();
@@ -99,11 +99,19 @@ describe("validateBackupData", () => {
     expect(err!.type).toBe("missing_version");
   });
 
-  it("rejects future version (v6+)", () => {
-    const err = validateBackupData({ version: 6, data: { exercises: [{ id: "1" }] } });
+  it("rejects future version (v7+)", () => {
+    const err = validateBackupData({ version: 7, data: { exercises: [{ id: "1" }] } });
     expect(err).not.toBeNull();
     expect(err!.type).toBe("future_version");
     expect(err!.message).toContain("update the app");
+  });
+
+  it("accepts v6 backup", () => {
+    const err = validateBackupData({
+      version: 6,
+      data: { exercises: [{ id: "1", name: "Squat" }] },
+    });
+    expect(err).toBeNull();
   });
 
   it("accepts v5 backup", () => {

--- a/__tests__/lib/db/session-rating.test.ts
+++ b/__tests__/lib/db/session-rating.test.ts
@@ -180,13 +180,21 @@ describe('validateBackupData v4', () => {
     expect(err).toBeNull();
   });
 
-  it('rejects v6 as future version', () => {
+  it('rejects v7 as future version', () => {
     const err = validateBackupData({
-      version: 6,
+      version: 7,
       data: { exercises: [{ id: '1' }] },
     });
     expect(err).not.toBeNull();
     expect(err!.type).toBe('future_version');
+  });
+
+  it('accepts v6 backup (set_type support)', () => {
+    const err = validateBackupData({
+      version: 6,
+      data: { exercises: [{ id: '1', name: 'Bench' }] },
+    });
+    expect(err).toBeNull();
   });
 
   it('accepts v3 backup (backward compatible)', () => {

--- a/__tests__/lib/db/source-session-sets.test.ts
+++ b/__tests__/lib/db/source-session-sets.test.ts
@@ -64,6 +64,7 @@ describe('getSourceSessionSets', () => {
       tempo: null,
       exercise_exists: true,
       is_warmup: false,
+      set_type: 'normal',
     });
     expect(result[1].weight).toBe(85);
     expect(result[1].reps).toBe(8);

--- a/__tests__/lib/db/warmup-sets.test.ts
+++ b/__tests__/lib/db/warmup-sets.test.ts
@@ -1,4 +1,4 @@
-// Unit tests for warm-up set tagging (Phase 45)
+// Unit tests for warm-up set tagging (Phase 45) and set type annotation (Phase 46)
 const mockStmt = {
   executeAsync: jest.fn().mockResolvedValue({ changes: 1 }),
   finalizeAsync: jest.fn().mockResolvedValue(undefined),
@@ -19,11 +19,16 @@ jest.mock('expo-sqlite', () => ({
 
 import {
   updateSetWarmup,
+  updateSetType,
   addSet,
+  addSetsBatch,
   getSessionSets,
   getSessionSetCount,
   getPersonalRecords,
 } from '../../../lib/db/sessions';
+
+import { SET_TYPE_CYCLE } from '../../../lib/types';
+import type { SetType } from '../../../lib/types';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -33,45 +38,83 @@ beforeEach(() => {
   mockDb.withTransactionAsync.mockImplementation(async (cb: () => Promise<void>) => cb());
 });
 
-// ---- updateSetWarmup ----
+// ---- updateSetWarmup (dual-writes both columns) ----
 
 describe('updateSetWarmup', () => {
-  it('sets is_warmup = 1 when true', async () => {
+  it('sets is_warmup = 1 and set_type = warmup when true', async () => {
     await updateSetWarmup('set-1', true);
     expect(mockDb.runAsync).toHaveBeenCalledWith(
-      'UPDATE workout_sets SET is_warmup = ? WHERE id = ?',
-      [1, 'set-1']
+      'UPDATE workout_sets SET is_warmup = ?, set_type = ? WHERE id = ?',
+      [1, 'warmup', 'set-1']
     );
   });
 
-  it('sets is_warmup = 0 when false', async () => {
+  it('sets is_warmup = 0 and set_type = normal when false', async () => {
     await updateSetWarmup('set-2', false);
     expect(mockDb.runAsync).toHaveBeenCalledWith(
-      'UPDATE workout_sets SET is_warmup = ? WHERE id = ?',
-      [0, 'set-2']
+      'UPDATE workout_sets SET is_warmup = ?, set_type = ? WHERE id = ?',
+      [0, 'normal', 'set-2']
     );
   });
 });
 
-// ---- addSet includes is_warmup ----
+// ---- updateSetType (dual-writes both columns) ----
 
-describe('addSet with isWarmup', () => {
-  it('inserts set with is_warmup = 1 when isWarmup is true', async () => {
+describe('updateSetType', () => {
+  it('sets set_type and is_warmup = 1 for warmup', async () => {
+    await updateSetType('set-1', 'warmup');
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'UPDATE workout_sets SET set_type = ?, is_warmup = ? WHERE id = ?',
+      ['warmup', 1, 'set-1']
+    );
+  });
+
+  it('sets set_type = dropset and is_warmup = 0', async () => {
+    await updateSetType('set-2', 'dropset');
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'UPDATE workout_sets SET set_type = ?, is_warmup = ? WHERE id = ?',
+      ['dropset', 0, 'set-2']
+    );
+  });
+
+  it('sets set_type = failure and is_warmup = 0', async () => {
+    await updateSetType('set-3', 'failure');
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'UPDATE workout_sets SET set_type = ?, is_warmup = ? WHERE id = ?',
+      ['failure', 0, 'set-3']
+    );
+  });
+
+  it('sets set_type = normal and is_warmup = 0', async () => {
+    await updateSetType('set-4', 'normal');
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'UPDATE workout_sets SET set_type = ?, is_warmup = ? WHERE id = ?',
+      ['normal', 0, 'set-4']
+    );
+  });
+});
+
+// ---- addSet includes set_type ----
+
+describe('addSet with setType', () => {
+  it('inserts set with set_type = dropset and is_warmup = 0', async () => {
     mockDb.getFirstAsync.mockResolvedValue({ next: 2 });
-    const result = await addSet('sess-1', 'ex-1', 1, null, null, null, null, true);
+    const result = await addSet('sess-1', 'ex-1', 1, null, null, null, null, false, 'dropset');
 
     const insertCall = mockDb.runAsync.mock.calls.find(
       (c: string[]) => typeof c[0] === 'string' && c[0].includes('INSERT INTO workout_sets')
     );
     expect(insertCall).toBeDefined();
-    expect(insertCall![0]).toContain('is_warmup');
-    // Last param should be 1
+    expect(insertCall![0]).toContain('set_type');
     const params = insertCall![1] as unknown[];
-    expect(params[params.length - 1]).toBe(1);
-    expect(result.is_warmup).toBe(true);
+    // is_warmup should be 0, set_type should be 'dropset'
+    expect(params[params.length - 2]).toBe(0); // is_warmup
+    expect(params[params.length - 1]).toBe('dropset'); // set_type
+    expect(result.set_type).toBe('dropset');
+    expect(result.is_warmup).toBe(false);
   });
 
-  it('inserts set with is_warmup = 0 by default', async () => {
+  it('defaults to set_type = normal when no type provided', async () => {
     mockDb.getFirstAsync.mockResolvedValue({ next: 1 });
     const result = await addSet('sess-1', 'ex-1', 1);
 
@@ -79,17 +122,63 @@ describe('addSet with isWarmup', () => {
       (c: string[]) => typeof c[0] === 'string' && c[0].includes('INSERT INTO workout_sets')
     );
     expect(insertCall).toBeDefined();
-    expect(insertCall![0]).toContain('is_warmup');
     const params = insertCall![1] as unknown[];
-    expect(params[params.length - 1]).toBe(0);
+    expect(params[params.length - 2]).toBe(0); // is_warmup
+    expect(params[params.length - 1]).toBe('normal'); // set_type
+    expect(result.set_type).toBe('normal');
     expect(result.is_warmup).toBe(false);
+  });
+
+  it('resolves setType from isWarmup when setType not provided', async () => {
+    mockDb.getFirstAsync.mockResolvedValue({ next: 2 });
+    const result = await addSet('sess-1', 'ex-1', 1, null, null, null, null, true);
+
+    const insertCall = mockDb.runAsync.mock.calls.find(
+      (c: string[]) => typeof c[0] === 'string' && c[0].includes('INSERT INTO workout_sets')
+    );
+    const params = insertCall![1] as unknown[];
+    expect(params[params.length - 2]).toBe(1); // is_warmup
+    expect(params[params.length - 1]).toBe('warmup'); // set_type
+    expect(result.set_type).toBe('warmup');
+    expect(result.is_warmup).toBe(true);
   });
 });
 
-// ---- getSessionSets includes is_warmup (no filter) ----
+// ---- addSetsBatch with set types ----
+
+describe('addSetsBatch with setType', () => {
+  it('creates batch with mixed set types', async () => {
+    const sets = [
+      { sessionId: 's1', exerciseId: 'e1', setNumber: 1, setType: 'normal' as SetType },
+      { sessionId: 's1', exerciseId: 'e1', setNumber: 2, setType: 'dropset' as SetType },
+      { sessionId: 's1', exerciseId: 'e1', setNumber: 3, setType: 'failure' as SetType },
+    ];
+    const result = await addSetsBatch(sets);
+
+    expect(result).toHaveLength(3);
+    expect(result[0].set_type).toBe('normal');
+    expect(result[0].is_warmup).toBe(false);
+    expect(result[1].set_type).toBe('dropset');
+    expect(result[1].is_warmup).toBe(false);
+    expect(result[2].set_type).toBe('failure');
+    expect(result[2].is_warmup).toBe(false);
+  });
+
+  it('batch resolves warmup from isWarmup when setType not provided', async () => {
+    const sets = [
+      { sessionId: 's1', exerciseId: 'e1', setNumber: 1, isWarmup: true },
+    ];
+    const result = await addSetsBatch(sets);
+
+    expect(result[0].set_type).toBe('warmup');
+    expect(result[0].is_warmup).toBe(true);
+  });
+});
+
+// ---- getSessionSets includes set_type ----
 
 describe('getSessionSets', () => {
-  it('maps is_warmup from integer to boolean', async () => {
+  it('maps is_warmup and set_type from row data', async () => {
     mockDb.getAllAsync.mockResolvedValue([
       {
         id: 's1', session_id: 'sess-1', exercise_id: 'ex-1',
@@ -97,7 +186,7 @@ describe('getSessionSets', () => {
         completed_at: null, rpe: null, notes: null,
         exercise_name: 'Squat', link_id: null, round: null,
         training_mode: null, tempo: null,
-        swapped_from_exercise_id: null, is_warmup: 1,
+        swapped_from_exercise_id: null, is_warmup: 1, set_type: 'warmup',
       },
       {
         id: 's2', session_id: 'sess-1', exercise_id: 'ex-1',
@@ -105,17 +194,59 @@ describe('getSessionSets', () => {
         completed_at: null, rpe: null, notes: null,
         exercise_name: 'Squat', link_id: null, round: null,
         training_mode: null, tempo: null,
-        swapped_from_exercise_id: null, is_warmup: 0,
+        swapped_from_exercise_id: null, is_warmup: 0, set_type: 'dropset',
+      },
+      {
+        id: 's3', session_id: 'sess-1', exercise_id: 'ex-1',
+        set_number: 3, weight: 80, reps: 8, completed: 1,
+        completed_at: null, rpe: null, notes: null,
+        exercise_name: 'Squat', link_id: null, round: null,
+        training_mode: null, tempo: null,
+        swapped_from_exercise_id: null, is_warmup: 0, set_type: 'failure',
       },
     ]);
 
     const sets = await getSessionSets('sess-1');
     expect(sets[0].is_warmup).toBe(true);
+    expect(sets[0].set_type).toBe('warmup');
     expect(sets[1].is_warmup).toBe(false);
+    expect(sets[1].set_type).toBe('dropset');
+    expect(sets[2].set_type).toBe('failure');
+  });
+
+  it('defaults set_type to normal when missing from DB', async () => {
+    mockDb.getAllAsync.mockResolvedValue([
+      {
+        id: 's1', session_id: 'sess-1', exercise_id: 'ex-1',
+        set_number: 1, weight: 100, reps: 5, completed: 1,
+        completed_at: null, rpe: null, notes: null,
+        exercise_name: 'Squat', link_id: null, round: null,
+        training_mode: null, tempo: null,
+        swapped_from_exercise_id: null, is_warmup: 0,
+        // set_type intentionally missing
+      },
+    ]);
+
+    const sets = await getSessionSets('sess-1');
+    expect(sets[0].set_type).toBe('normal');
   });
 });
 
-// ---- Metric queries exclude warm-ups ----
+// ---- SET_TYPE_CYCLE order ----
+
+describe('SET_TYPE_CYCLE', () => {
+  it('has correct cycle order: normal → warmup → dropset → failure', () => {
+    expect(SET_TYPE_CYCLE).toEqual(['normal', 'warmup', 'dropset', 'failure']);
+  });
+
+  it('cycles back to normal after failure', () => {
+    const failureIdx = SET_TYPE_CYCLE.indexOf('failure');
+    const next = SET_TYPE_CYCLE[(failureIdx + 1) % SET_TYPE_CYCLE.length];
+    expect(next).toBe('normal');
+  });
+});
+
+// ---- Metric queries exclude warm-ups (unchanged) ----
 
 describe('metric queries exclude warm-ups', () => {
   it('getSessionSetCount excludes warm-up sets', async () => {

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -56,7 +56,7 @@ import {
   updateSetRPE,
   updateSetNotes,
   updateSetTrainingMode,
-  updateSetWarmup,
+  updateSetType,
   getExerciseById,
   getAppSetting,
   setAppSetting,
@@ -66,8 +66,8 @@ import {
   getProgramDayById,
   advanceProgram,
 } from "../../lib/programs";
-import type { WorkoutSession, WorkoutSet, TrainingMode, Exercise } from "../../lib/types";
-import { CATEGORY_LABELS, ATTACHMENT_LABELS } from "../../lib/types";
+import type { WorkoutSession, WorkoutSet, TrainingMode, Exercise, SetType } from "../../lib/types";
+import { CATEGORY_LABELS, ATTACHMENT_LABELS, SET_TYPE_CYCLE, SET_TYPE_LABELS } from "../../lib/types";
 import { rpeColor, rpeText } from "../../lib/rpe";
 import { difficultyText, DIFFICULTY_COLORS } from "../../constants/theme";
 import { MuscleMap } from "../../components/MuscleMap";
@@ -121,18 +121,32 @@ type SetRowProps = {
   onNotes: (setId: string, text: string) => void;
   onNotesDraftChange: (setId: string, text: string) => void;
   onToggleNotes: (setId: string) => void;
-  onToggleWarmup: (setId: string) => void;
+  onCycleSetType: (setId: string) => void;
+  onLongPressSetType: (setId: string) => void;
 };
 
 const SetRow = memo(function SetRow({
   set, step, unit, notesOpen, notesDraft, halfStep,
   onUpdate, onCheck, onDelete, onRPE, onHalfStep, onHalfStepClear,
-  onHalfStepOpen, onNotes, onNotesDraftChange, onToggleNotes, onToggleWarmup,
+  onHalfStepOpen, onNotes, onNotesDraftChange, onToggleNotes, onCycleSetType, onLongPressSetType,
 }: SetRowProps) {
   const theme = useTheme();
 
   const onWeightChange = useCallback((v: number) => onUpdate(set.id, "weight", String(v)), [set.id, onUpdate]);
   const onRepsChange = useCallback((v: number) => onUpdate(set.id, "reps", String(v)), [set.id, onUpdate]);
+
+  const chipStyle = useMemo(() => {
+    switch (set.set_type) {
+      case "warmup": return { bg: theme.colors.surfaceVariant, fg: theme.colors.onSurfaceVariant };
+      case "dropset": return { bg: theme.colors.tertiaryContainer, fg: theme.colors.onTertiaryContainer };
+      case "failure": return { bg: theme.colors.errorContainer, fg: theme.colors.onErrorContainer };
+      default: return null;
+    }
+  }, [set.set_type, theme]);
+
+  const borderColor = chipStyle?.bg;
+  const chipLabel = SET_TYPE_LABELS[set.set_type]?.short;
+  const typeLabel = set.set_type === "normal" ? "working set" : `${set.set_type} set`;
 
   return (
     <View>
@@ -141,21 +155,22 @@ const SetRow = memo(function SetRow({
             styles.setRow,
             set.completed && { backgroundColor: theme.colors.primaryContainer + "40" },
             { backgroundColor: theme.colors.background },
-            set.is_warmup && { borderLeftWidth: 3, borderLeftColor: theme.colors.surfaceVariant },
+            borderColor ? { borderLeftWidth: 3, borderLeftColor: borderColor } : undefined,
           ]}
         >
           <Pressable
-            onPress={() => onToggleWarmup(set.id)}
+            onPress={() => onCycleSetType(set.id)}
+            onLongPress={() => onLongPressSetType(set.id)}
             hitSlop={10}
             style={styles.colSet}
-            accessibilityRole="switch"
-            accessibilityState={{ checked: set.is_warmup }}
-            accessibilityLabel={`Set ${set.set_number}, ${set.is_warmup ? "warm-up set" : "working set"}`}
-            accessibilityHint="Double tap to toggle between warm-up and working set"
+            accessibilityRole="button"
+            accessibilityLabel={`Set ${set.set_number}, ${typeLabel}`}
+            accessibilityHint="Double tap to cycle set type. Long press for direct selection."
+            accessibilityLiveRegion="polite"
           >
-            {set.is_warmup ? (
-              <View style={[styles.warmupChip, { backgroundColor: theme.colors.surfaceVariant }]}>
-                <Text style={{ color: theme.colors.onSurfaceVariant, fontSize: 13, fontWeight: "700" }}>W</Text>
+            {chipLabel ? (
+              <View style={[styles.warmupChip, { backgroundColor: chipStyle!.bg }]}>
+                <Text style={{ color: chipStyle!.fg, fontSize: 13, fontWeight: "700" }}>{chipLabel}</Text>
               </View>
             ) : (
               <Text variant="bodyMedium" style={{ color: theme.colors.onSurface, textAlign: "center" }}>
@@ -345,7 +360,8 @@ type GroupCardProps = {
   onNotes: (setId: string, text: string) => void;
   onNotesDraftChange: (setId: string, text: string) => void;
   onToggleNotes: (setId: string) => void;
-  onToggleWarmup: (setId: string) => void;
+  onCycleSetType: (setId: string) => void;
+  onLongPressSetType: (setId: string) => void;
   onShowDetail: (exerciseId: string) => void;
   onSwap: (exerciseId: string) => void;
 };
@@ -355,7 +371,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
   notesOpenMap, notesDraftMap, halfStep, linkIds, groups, palette,
   onUpdate, onCheck, onDelete, onAddSet, onModeChange,
   onRPE, onHalfStep, onHalfStepClear,
-  onHalfStepOpen, onNotes, onNotesDraftChange, onToggleNotes, onToggleWarmup,
+  onHalfStepOpen, onNotes, onNotesDraftChange, onToggleNotes, onCycleSetType, onLongPressSetType,
   onShowDetail, onSwap,
 }: GroupCardProps) {
   const theme = useTheme();
@@ -535,7 +551,8 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
           onNotes={onNotes}
           onNotesDraftChange={onNotesDraftChange}
           onToggleNotes={onToggleNotes}
-          onToggleWarmup={onToggleWarmup}
+          onCycleSetType={onCycleSetType}
+          onLongPressSetType={onLongPressSetType}
         />
       ))}
       <Button
@@ -983,6 +1000,7 @@ export default function ActiveSession() {
               trainingMode: (s.training_mode as TrainingMode) ?? null,
               tempo: s.tempo ?? null,
               isWarmup: s.is_warmup,
+              setType: s.set_type,
             });
           }
           const created = await addSetsBatch(setsToInsert);
@@ -1336,31 +1354,67 @@ export default function ActiveSession() {
     setNotesOpen((prev) => ({ ...prev, [setId]: !prev[setId] }));
   }, []);
 
-  const handleToggleWarmup = useCallback(async (setId: string) => {
-    let newVal = false;
+  const handleCycleSetType = useCallback(async (setId: string) => {
+    let newType = "normal" as SetType;
     setGroups((prev) =>
       prev.map((g) => ({
         ...g,
         sets: g.sets.map((s) => {
           if (s.id === setId) {
-            newVal = !s.is_warmup;
-            return { ...s, is_warmup: newVal };
+            const idx = SET_TYPE_CYCLE.indexOf(s.set_type);
+            newType = SET_TYPE_CYCLE[(idx + 1) % SET_TYPE_CYCLE.length];
+            return { ...s, set_type: newType, is_warmup: newType === "warmup" };
           }
           return s;
         }),
       }))
     );
-    // Wait for state to settle before DB call (newVal captured in closure)
-    await updateSetWarmup(setId, newVal);
+    await updateSetType(setId, newType);
     Haptics.selectionAsync();
 
-    // First-use tooltip
-    const shown = await getAppSetting("warmup_tooltip_shown");
-    if (!shown) {
-      setSnackbar("Set marked as warm-up. Warm-up sets are excluded from volume and PR tracking.");
-      await setAppSetting("warmup_tooltip_shown", "1");
+    // First-use tooltip for non-warmup types
+    if (newType === "dropset" || newType === "failure") {
+      const shown = await getAppSetting("set_type_tooltip_shown");
+      if (!shown) {
+        setSnackbar("Dropsets count toward volume. Failure sets help track intensity.");
+        await setAppSetting("set_type_tooltip_shown", "1");
+      }
+    }
+    // Keep warmup first-use tooltip as well
+    if (newType === "warmup") {
+      const shown = await getAppSetting("warmup_tooltip_shown");
+      if (!shown) {
+        setSnackbar("Set marked as warm-up. Warm-up sets are excluded from volume and PR tracking.");
+        await setAppSetting("warmup_tooltip_shown", "1");
+      }
     }
   }, []);
+
+  const [setTypeSheetSetId, setSetTypeSheetSetId] = useState<string | null>(null);
+
+  const handleLongPressSetType = useCallback((setId: string) => {
+    Haptics.selectionAsync();
+    setSetTypeSheetSetId(setId);
+  }, []);
+
+  const handleSelectSetType = useCallback(async (type: SetType) => {
+    const setId = setTypeSheetSetId;
+    if (!setId) return;
+    setSetTypeSheetSetId(null);
+    setGroups((prev) =>
+      prev.map((g) => ({
+        ...g,
+        sets: g.sets.map((s) => {
+          if (s.id === setId) {
+            return { ...s, set_type: type, is_warmup: type === "warmup" };
+          }
+          return s;
+        }),
+      }))
+    );
+    await updateSetType(setId, type);
+    Haptics.selectionAsync();
+  }, [setTypeSheetSetId]);
 
   const isPR = (set: SetWithMeta) => {
     if (!set.completed || !set.weight || set.weight <= 0) return false;
@@ -1502,7 +1556,8 @@ export default function ActiveSession() {
             onNotes={handleNotes}
             onNotesDraftChange={handleNotesDraftChange}
             onToggleNotes={toggleNotes}
-            onToggleWarmup={handleToggleWarmup}
+            onCycleSetType={handleCycleSetType}
+            onLongPressSetType={handleLongPressSetType}
             onShowDetail={handleShowDetail}
             onSwap={handleSwapOpen}
           />
@@ -1579,6 +1634,66 @@ export default function ActiveSession() {
         }
       />
       </KeyboardAvoidingView>
+      {!!setTypeSheetSetId && (
+        <Pressable
+          style={[StyleSheet.absoluteFill, styles.setTypeOverlay]}
+          onPress={() => setSetTypeSheetSetId(null)}
+        >
+          <View style={[styles.setTypeSheet, { backgroundColor: theme.colors.surface }]}>
+            <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
+              Set Type
+            </Text>
+            {SET_TYPE_CYCLE.map((type) => {
+              const label = SET_TYPE_LABELS[type];
+              const isSelected = (() => {
+                if (!setTypeSheetSetId) return false;
+                for (const g of groups) {
+                  for (const s of g.sets) {
+                    if (s.id === setTypeSheetSetId) return s.set_type === type;
+                  }
+                }
+                return false;
+              })();
+              return (
+                <Pressable
+                  key={type}
+                  style={[
+                    styles.setTypeOption,
+                    { backgroundColor: isSelected ? theme.colors.primaryContainer : "transparent" },
+                  ]}
+                  onPress={() => handleSelectSetType(type)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${label.label} set`}
+                  accessibilityState={{ selected: isSelected }}
+                >
+                  {label.short ? (
+                    <View style={[styles.setTypeChipPreview, {
+                      backgroundColor: type === "warmup" ? theme.colors.surfaceVariant
+                        : type === "dropset" ? theme.colors.tertiaryContainer
+                        : type === "failure" ? theme.colors.errorContainer
+                        : theme.colors.surfaceDisabled,
+                    }]}>
+                      <Text style={{
+                        fontSize: 13, fontWeight: "700",
+                        color: type === "warmup" ? theme.colors.onSurfaceVariant
+                          : type === "dropset" ? theme.colors.onTertiaryContainer
+                          : theme.colors.onErrorContainer,
+                      }}>{label.short}</Text>
+                    </View>
+                  ) : (
+                    <View style={[styles.setTypeChipPreview, { backgroundColor: theme.colors.surfaceDisabled }]}>
+                      <Text style={{ fontSize: 13, fontWeight: "700", color: theme.colors.onSurface }}>—</Text>
+                    </View>
+                  )}
+                  <Text variant="bodyLarge" style={{ color: theme.colors.onSurface, marginLeft: 12 }}>
+                    {label.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </Pressable>
+      )}
       <Snackbar
         visible={!!snackbar}
         onDismiss={() => {
@@ -1904,5 +2019,31 @@ const styles = StyleSheet.create({
   },
   detailSection: {
     marginBottom: 16,
+  },
+  setTypeOverlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0,0,0,0.4)",
+  },
+  setTypeSheet: {
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    padding: 20,
+    paddingBottom: 32,
+  },
+  setTypeOption: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 14,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    marginBottom: 4,
+  },
+  setTypeChipPreview: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
   },
 });

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -16,7 +16,7 @@ import {
   updateSession,
 } from "../../../lib/db";
 import type { WorkoutSession, WorkoutSet } from "../../../lib/types";
-import { TRAINING_MODE_LABELS } from "../../../lib/types";
+import { TRAINING_MODE_LABELS, SET_TYPE_LABELS } from "../../../lib/types";
 import { rpeColor, rpeText } from "../../../lib/rpe";
 import { formatDuration, formatDateShort } from "../../../lib/format";
 import RatingWidget from "../../../components/RatingWidget";
@@ -465,19 +465,37 @@ export default function SessionDetail() {
               .filter((s) => s.completed)
               .map((set) => (
                 <View key={set.id}>
-                  <View style={[styles.setRow, set.is_warmup && { borderLeftWidth: 3, borderLeftColor: theme.colors.surfaceVariant, paddingLeft: 5 }]}>
-                    {set.is_warmup ? (
-                      <View style={{ width: 28, height: 28, borderRadius: 14, backgroundColor: theme.colors.surfaceVariant, justifyContent: "center", alignItems: "center", marginRight: 8 }}>
-                        <Text style={{ fontSize: 13, fontWeight: "700", color: theme.colors.onSurfaceVariant }}>W</Text>
-                      </View>
-                    ) : (
-                    <Text
-                      variant="bodyMedium"
-                      style={[styles.setNum, { color: theme.colors.onSurface }]}
-                    >
-                      {set.round ? `R${set.round}` : `Set ${set.set_number}`}
-                    </Text>
-                    )}
+                  <View style={[styles.setRow, (() => {
+                    const st = set.set_type ?? (set.is_warmup ? "warmup" : "normal");
+                    if (st === "warmup") return { borderLeftWidth: 3, borderLeftColor: theme.colors.surfaceVariant, paddingLeft: 5 };
+                    if (st === "dropset") return { borderLeftWidth: 3, borderLeftColor: theme.colors.tertiaryContainer, paddingLeft: 5 };
+                    if (st === "failure") return { borderLeftWidth: 3, borderLeftColor: theme.colors.errorContainer, paddingLeft: 5 };
+                    return {};
+                  })()]}>
+                    {(() => {
+                      const st = set.set_type ?? (set.is_warmup ? "warmup" : "normal");
+                      const label = SET_TYPE_LABELS[st];
+                      if (label.short) {
+                        const chipColors = st === "warmup"
+                          ? { bg: theme.colors.surfaceVariant, fg: theme.colors.onSurfaceVariant }
+                          : st === "dropset"
+                          ? { bg: theme.colors.tertiaryContainer, fg: theme.colors.onTertiaryContainer }
+                          : { bg: theme.colors.errorContainer, fg: theme.colors.onErrorContainer };
+                        return (
+                          <View style={{ width: 28, height: 28, borderRadius: 14, backgroundColor: chipColors.bg, justifyContent: "center", alignItems: "center", marginRight: 8 }}>
+                            <Text style={{ fontSize: 13, fontWeight: "700", color: chipColors.fg }}>{label.short}</Text>
+                          </View>
+                        );
+                      }
+                      return (
+                        <Text
+                          variant="bodyMedium"
+                          style={[styles.setNum, { color: theme.colors.onSurface }]}
+                        >
+                          {set.round ? `R${set.round}` : `Set ${set.set_number}`}
+                        </Text>
+                      );
+                    })()}
                     <Text
                       variant="bodyMedium"
                       style={{ color: theme.colors.onSurface }}

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -163,11 +163,28 @@ export default function Summary() {
     return total;
   }, [completed]);
 
-  const warmupCount = useMemo(
-    () => completed.filter((s) => s.is_warmup).length,
-    [completed],
-  );
-  const workingCount = completed.length - warmupCount;
+  const setTypeCounts = useMemo(() => {
+    const counts = { normal: 0, warmup: 0, dropset: 0, failure: 0 };
+    for (const s of completed) {
+      const t = (s as { set_type?: string }).set_type ?? (s.is_warmup ? "warmup" : "normal");
+      if (t in counts) counts[t as keyof typeof counts]++;
+    }
+    return counts;
+  }, [completed]);
+
+  const warmupCount = setTypeCounts.warmup;
+  const workingCount = setTypeCounts.normal;
+  const dropsetCount = setTypeCounts.dropset;
+  const failureCount = setTypeCounts.failure;
+
+  const setsBreakdown = useMemo(() => {
+    const parts: string[] = [];
+    if (workingCount > 0) parts.push(`${workingCount} working`);
+    if (warmupCount > 0) parts.push(`${warmupCount} warm-up`);
+    if (dropsetCount > 0) parts.push(`${dropsetCount} dropset`);
+    if (failureCount > 0) parts.push(`${failureCount} failure`);
+    return parts.join(" · ");
+  }, [workingCount, warmupCount, dropsetCount, failureCount]);
 
   const duration = session?.duration_seconds
     ? formatTime(session.duration_seconds)
@@ -402,14 +419,14 @@ export default function Summary() {
               </Card>
               <Card
                 style={[styles.stat, { backgroundColor: theme.colors.surface }]}
-                accessibilityLabel={warmupCount > 0 ? `${workingCount} working sets, ${warmupCount} warm-up sets` : `${completed.length} sets completed`}
+                accessibilityLabel={setsBreakdown ? `${completed.length} sets: ${setsBreakdown}` : `${completed.length} sets completed`}
               >
                 <Card.Content style={styles.statInner}>
                   <Text variant="headlineSmall" style={{ color: theme.colors.primary }}>
                     {completed.length}
                   </Text>
                   <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
-                    {warmupCount > 0 ? `Sets (${warmupCount}W / ${workingCount})` : "Sets"}
+                    {setsBreakdown ? `Sets (${setsBreakdown})` : "Sets"}
                   </Text>
                 </Card.Content>
               </Card>

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -342,6 +342,19 @@ async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
       "ALTER TABLE workout_sets ADD COLUMN is_warmup INTEGER DEFAULT 0"
     );
   }
+  if (!setNames.has("set_type")) {
+    await database.withTransactionAsync(async () => {
+      await database.execAsync(
+        "ALTER TABLE workout_sets ADD COLUMN set_type TEXT DEFAULT 'normal'"
+      );
+      await database.execAsync(
+        "UPDATE workout_sets SET set_type = 'warmup' WHERE is_warmup = 1"
+      );
+      await database.execAsync(
+        "UPDATE workout_sets SET set_type = 'normal' WHERE is_warmup = 0 OR is_warmup IS NULL"
+      );
+    });
+  }
 
   const exCols = await database.getAllAsync<{ name: string }>(
     "PRAGMA table_info(exercises)"

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -105,7 +105,7 @@ export type BackupV3Data = {
 };
 
 export type BackupV3 = {
-  version: 3 | 4 | 5;
+  version: 3 | 4 | 5 | 6;
   app_version: string;
   exported_at: string;
   data: BackupV3Data;
@@ -169,7 +169,7 @@ export function validateBackupData(data: unknown): ValidationError | null {
   }
 
   const version = Number(obj.version);
-  if (version >= 6) {
+  if (version >= 7) {
     return { type: "future_version", message: "This backup was created with a newer version of FitForge. Please update the app first." };
   }
 
@@ -286,7 +286,7 @@ export async function exportAllData(
   onProgress?.({ table: "done", tableIndex: tables.length, totalTables: tables.length });
 
   return {
-    version: 5,
+    version: 6,
     app_version: "1.0.0",
     exported_at: new Date().toISOString(),
     data: data as unknown as BackupV3Data,
@@ -449,9 +449,10 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
       return r.changes > 0;
     }
     case "workout_sets": {
+      const setType = row.set_type ?? (row.is_warmup ? "warmup" : "normal");
       const r = await database.runAsync(
-        "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, training_mode, tempo, is_warmup) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        [row.id, row.session_id, row.exercise_id, row.set_number, row.weight, row.reps, row.completed, row.completed_at, row.set_rpe ?? row.rpe ?? null, row.set_notes ?? row.notes ?? "", row.link_id ?? null, row.round ?? null, row.training_mode ?? null, row.tempo ?? null, row.is_warmup ?? 0]
+        "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, training_mode, tempo, is_warmup, set_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.session_id, row.exercise_id, row.set_number, row.weight, row.reps, row.completed, row.completed_at, row.set_rpe ?? row.rpe ?? null, row.set_notes ?? row.notes ?? "", row.link_id ?? null, row.round ?? null, row.training_mode ?? null, row.tempo ?? null, row.is_warmup ?? 0, setType]
       );
       return r.changes > 0;
     }

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -52,6 +52,7 @@ export {
   updateSetTrainingMode,
   updateSetTempo,
   updateSetWarmup,
+  updateSetType,
   getPreviousSets,
   getSessionSetCount,
   getSessionAvgRPE,

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -1,4 +1,4 @@
-import type { WorkoutSession, WorkoutSet, TrainingMode, MuscleGroup } from "../types";
+import type { WorkoutSession, WorkoutSet, TrainingMode, MuscleGroup, SetType } from "../types";
 import { uuid } from "../uuid";
 import { query, queryOne, execute, getDatabase, withTransaction } from "./helpers";
 
@@ -22,6 +22,7 @@ type SetRow = {
   swapped_from_exercise_id: string | null;
   swapped_from_name: string | null;
   is_warmup: number;
+  set_type: string;
 };
 
 // ---- Sessions ----
@@ -118,6 +119,7 @@ export async function getSessionSets(
     tempo: r.tempo ?? null,
     swapped_from_exercise_id: r.swapped_from_exercise_id ?? null,
     is_warmup: r.is_warmup === 1,
+    set_type: (r.set_type as SetType) ?? "normal",
     exercise_name: r.exercise_name ?? undefined,
     exercise_deleted: r.exercise_deleted_at != null,
     swapped_from_name: r.swapped_from_name ?? undefined,
@@ -142,6 +144,7 @@ export type SourceSessionSet = {
   tempo: string | null;
   exercise_exists: boolean;
   is_warmup: boolean;
+  set_type: SetType;
 };
 
 export async function getSourceSessionSets(
@@ -157,9 +160,10 @@ export async function getSourceSessionSets(
     tempo: string | null;
     exercise_exists: string | null;
     is_warmup: number;
+    set_type: string;
   }>(
     `SELECT ws.exercise_id, ws.set_number, ws.weight, ws.reps, ws.link_id,
-            ws.training_mode, ws.tempo, e.id AS exercise_exists, ws.is_warmup
+            ws.training_mode, ws.tempo, e.id AS exercise_exists, ws.is_warmup, ws.set_type
      FROM workout_sets ws
      LEFT JOIN exercises e ON ws.exercise_id = e.id
      WHERE ws.session_id = ? AND ws.completed = 1
@@ -176,6 +180,7 @@ export async function getSourceSessionSets(
     tempo: r.tempo,
     exercise_exists: r.exercise_exists != null,
     is_warmup: r.is_warmup === 1,
+    set_type: (r.set_type as SetType) ?? "normal",
   }));
 }
 
@@ -189,12 +194,15 @@ export async function addSet(
   round?: number | null,
   trainingMode?: TrainingMode | null,
   tempo?: string | null,
-  isWarmup?: boolean
+  isWarmup?: boolean,
+  setType?: SetType
 ): Promise<WorkoutSet> {
   const id = uuid();
+  const resolvedType: SetType = setType ?? (isWarmup ? "warmup" : "normal");
+  const resolvedWarmup = resolvedType === "warmup" ? 1 : 0;
   await execute(
-    "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo, is_warmup) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-    [id, sessionId, exerciseId, setNumber, linkId ?? null, round ?? null, trainingMode ?? null, tempo ?? null, isWarmup ? 1 : 0]
+    "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo, is_warmup, set_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    [id, sessionId, exerciseId, setNumber, linkId ?? null, round ?? null, trainingMode ?? null, tempo ?? null, resolvedWarmup, resolvedType]
   );
   return {
     id,
@@ -212,7 +220,8 @@ export async function addSet(
     training_mode: trainingMode ?? null,
     tempo: tempo ?? null,
     swapped_from_exercise_id: null,
-    is_warmup: isWarmup ?? false,
+    is_warmup: resolvedWarmup === 1,
+    set_type: resolvedType,
   };
 }
 
@@ -226,35 +235,40 @@ export async function addSetsBatch(
     trainingMode?: TrainingMode | null;
     tempo?: string | null;
     isWarmup?: boolean;
+    setType?: SetType;
   }[]
 ): Promise<WorkoutSet[]> {
-  const results: WorkoutSet[] = sets.map((s) => ({
-    id: uuid(),
-    session_id: s.sessionId,
-    exercise_id: s.exerciseId,
-    set_number: s.setNumber,
-    weight: null,
-    reps: null,
-    completed: false,
-    completed_at: null,
-    rpe: null,
-    notes: "",
-    link_id: s.linkId ?? null,
-    round: s.round ?? null,
-    training_mode: s.trainingMode ?? null,
-    tempo: s.tempo ?? null,
-    swapped_from_exercise_id: null,
-    is_warmup: s.isWarmup ?? false,
-  }));
+  const results: WorkoutSet[] = sets.map((s) => {
+    const resolvedType: SetType = s.setType ?? (s.isWarmup ? "warmup" : "normal");
+    return {
+      id: uuid(),
+      session_id: s.sessionId,
+      exercise_id: s.exerciseId,
+      set_number: s.setNumber,
+      weight: null,
+      reps: null,
+      completed: false,
+      completed_at: null,
+      rpe: null,
+      notes: "",
+      link_id: s.linkId ?? null,
+      round: s.round ?? null,
+      training_mode: s.trainingMode ?? null,
+      tempo: s.tempo ?? null,
+      swapped_from_exercise_id: null,
+      is_warmup: resolvedType === "warmup",
+      set_type: resolvedType,
+    };
+  });
   await withTransaction(async (db) => {
     const stmt = await db.prepareAsync(
-      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo, is_warmup) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo, is_warmup, set_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     try {
       for (const r of results) {
         await stmt.executeAsync([
           r.id, r.session_id, r.exercise_id, r.set_number,
-          r.link_id, r.round, r.training_mode, r.tempo, r.is_warmup ? 1 : 0,
+          r.link_id, r.round, r.training_mode, r.tempo, r.is_warmup ? 1 : 0, r.set_type,
         ]);
       }
     } finally {
@@ -340,9 +354,18 @@ export async function updateSetTempo(id: string, tempo: string | null): Promise<
 }
 
 export async function updateSetWarmup(id: string, isWarmup: boolean): Promise<void> {
+  const setType = isWarmup ? "warmup" : "normal";
   await execute(
-    "UPDATE workout_sets SET is_warmup = ? WHERE id = ?",
-    [isWarmup ? 1 : 0, id]
+    "UPDATE workout_sets SET is_warmup = ?, set_type = ? WHERE id = ?",
+    [isWarmup ? 1 : 0, setType, id]
+  );
+}
+
+export async function updateSetType(id: string, type: SetType): Promise<void> {
+  const isWarmup = type === "warmup" ? 1 : 0;
+  await execute(
+    "UPDATE workout_sets SET set_type = ?, is_warmup = ? WHERE id = ?",
+    [type, isWarmup, id]
   );
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -194,6 +194,17 @@ export type WorkoutSession = {
   rating: number | null;
 };
 
+export type SetType = "normal" | "warmup" | "dropset" | "failure";
+
+export const SET_TYPE_CYCLE: SetType[] = ["normal", "warmup", "dropset", "failure"];
+
+export const SET_TYPE_LABELS: Record<SetType, { label: string; short: string }> = {
+  normal: { label: "Normal", short: "" },
+  warmup: { label: "Warm-up", short: "W" },
+  dropset: { label: "Dropset", short: "D" },
+  failure: { label: "Failure", short: "F" },
+};
+
 export type WorkoutSet = {
   id: string;
   session_id: string;
@@ -211,6 +222,7 @@ export type WorkoutSet = {
   tempo: string | null;
   swapped_from_exercise_id: string | null;
   is_warmup: boolean;
+  set_type: SetType;
 };
 
 export const TRAINING_MODE_LABELS: Record<TrainingMode, { label: string; short: string; description: string }> = {


### PR DESCRIPTION
## Summary

Extends the warm-up set tagging (Phase 45) with full set type annotation: normal, warmup, dropset, and failure. Users can now classify sets with advanced training techniques, providing accurate analytics context.

## Changes

- **Schema**: `ALTER TABLE workout_sets ADD COLUMN set_type TEXT DEFAULT 'normal'` with transactional backfill from `is_warmup`
- **Data layer**: Extended `addSet`/`addSetsBatch` with `setType` param, new `updateSetType()`, dual-write both `is_warmup` and `set_type`
- **Session UI**: Tap-to-cycle toggle (normal → warmup → dropset → failure), long-press overlay for direct selection
- **Type chips**: W (surfaceVariant), D (tertiaryContainer), F (errorContainer) with left border accents
- **Summary**: Set breakdown shows 'X working · Y warm-up · Z dropset · W failure' (non-zero only)
- **Detail view**: Type-specific badges matching session screen styling
- **Export/Import**: Format version bumped to v6, backward-compatible import with fallback from `is_warmup`
- **A11y**: `accessibilityRole=button`, `accessibilityLiveRegion=polite`, descriptive labels
- **Query strategy**: All 46+ existing `is_warmup` queries left unchanged (dropsets/failure have `is_warmup=0`, so volume/PR calculations are correct)
- **Repeat workout**: Set types carry over to new sessions

## Testing

- 17 new set type unit tests (cycle logic, dual-write, batch, import/export)
- Updated existing warmup tests for dual-write compatibility
- All 1486 tests pass with zero regressions
- `tsc --noEmit` passes (no new TS errors)
- ESLint passes with zero warnings

## Issue

Resolves BLD-269