### PR TITLE
feat: Template Exercise Editing (BLD-271)

### DIFF
--- a/__tests__/acceptance/template-exercise-editing.acceptance.test.tsx
+++ b/__tests__/acceptance/template-exercise-editing.acceptance.test.tsx
@@ -1,0 +1,213 @@
+jest.setTimeout(10000)
+
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { Keyboard } from 'react-native'
+import { renderScreen } from '../helpers/render'
+import { createExercise, createTemplateExercise, resetIds } from '../helpers/factories'
+import type { TemplateExercise, WorkoutTemplate } from '../../lib/types'
+
+jest.spyOn(Keyboard, 'dismiss').mockImplementation(() => {})
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
+const mockParams = { id: 'tpl-1' }
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    useRouter: () => mockRouter,
+    useLocalSearchParams: () => mockParams,
+    usePathname: () => '/template/tpl-1',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0, horizontalPadding: 16 }) }))
+jest.mock('../../lib/errors', () => ({ logError: jest.fn(), generateReport: jest.fn().mockResolvedValue('{}'), getRecentErrors: jest.fn().mockResolvedValue([]), generateGitHubURL: jest.fn().mockReturnValue('https://github.com') }))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+
+// Mock sheets to avoid Portal issues in test renderer
+jest.mock('../../components/ExercisePickerSheet', () => {
+  const RealReact = require('react')
+  return { __esModule: true, default: ({ visible }: { visible: boolean }) => {
+    if (!visible) return null
+    return RealReact.createElement('View', { testID: 'exercise-picker-sheet' })
+  }}
+})
+
+let mockEditSheetProps: { visible: boolean; exercise: TemplateExercise | null; onSave: (...args: unknown[]) => void; onDismiss: () => void } | null = null
+jest.mock('../../components/EditExerciseSheet', () => {
+  const RealReact = require('react')
+  return { __esModule: true, default: (props: { visible: boolean; exercise: TemplateExercise | null; onSave: (...args: unknown[]) => void; onDismiss: () => void }) => {
+    mockEditSheetProps = props
+    if (!props.visible) return null
+    return RealReact.createElement('View', { testID: 'edit-exercise-sheet' },
+      RealReact.createElement('View', {
+        testID: 'edit-sheet-save',
+        accessibilityLabel: 'Save exercise settings',
+        accessibilityRole: 'button',
+        onPress: () => props.onSave(
+          props.exercise?.target_sets ?? 3,
+          props.exercise?.target_reps ?? '8-12',
+          props.exercise?.rest_seconds ?? 90
+        ),
+      }),
+    )
+  }}
+})
+const mockExercise1 = createExercise({ id: 'ex-1', name: 'Bench Press', category: 'chest' })
+const mockExercise2 = createExercise({ id: 'ex-2', name: 'Squat', category: 'legs_glutes' })
+
+const mockTemplateExercises: TemplateExercise[] = [
+  createTemplateExercise({ id: 'te-1', template_id: 'tpl-1', exercise_id: 'ex-1', position: 0, target_sets: 4, target_reps: '6-8', rest_seconds: 120, exercise: mockExercise1 }),
+  createTemplateExercise({ id: 'te-2', template_id: 'tpl-1', exercise_id: 'ex-2', position: 1, target_sets: 3, target_reps: '10', rest_seconds: 90, exercise: mockExercise2 }),
+]
+
+const mockTemplate: WorkoutTemplate & { exercises: TemplateExercise[] } = {
+  id: 'tpl-1',
+  name: 'Push Day',
+  created_at: Date.now(),
+  updated_at: Date.now(),
+  is_starter: false,
+  exercises: mockTemplateExercises,
+}
+
+const mockGetTemplateById = jest.fn().mockResolvedValue(mockTemplate)
+const mockUpdateTemplateExercise = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('../../lib/db', () => ({
+  getTemplateById: (...args: unknown[]) => mockGetTemplateById(...args),
+  updateTemplateExercise: (...args: unknown[]) => mockUpdateTemplateExercise(...args),
+  addExerciseToTemplate: jest.fn().mockResolvedValue(undefined),
+  removeExerciseFromTemplate: jest.fn().mockResolvedValue(undefined),
+  reorderTemplateExercises: jest.fn().mockResolvedValue(undefined),
+  getTemplateExerciseCount: jest.fn().mockResolvedValue(2),
+  createExerciseLink: jest.fn().mockResolvedValue(undefined),
+  duplicateTemplate: jest.fn().mockResolvedValue('tpl-2'),
+  unlinkExerciseGroup: jest.fn().mockResolvedValue(undefined),
+  unlinkSingleExercise: jest.fn().mockResolvedValue(undefined),
+  getAppSetting: jest.fn().mockResolvedValue(null),
+  getAllExercises: jest.fn().mockResolvedValue([mockExercise1, mockExercise2]),
+}))
+
+import EditTemplate from '../../app/template/[id]'
+
+describe('Template Exercise Editing Acceptance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+    mockGetTemplateById.mockResolvedValue(mockTemplate)
+    mockUpdateTemplateExercise.mockResolvedValue(undefined)
+    mockEditSheetProps = null
+  })
+
+  it('opens edit sheet when tapping an exercise row', async () => {
+    const { findByText, findByTestId } = renderScreen(<EditTemplate />)
+    const benchText = await findByText('Bench Press')
+    // The Pressable parent has the onPress handler - find the closest pressable ancestor
+    fireEvent.press(benchText)
+    expect(await findByTestId('edit-exercise-sheet')).toBeTruthy()
+  })
+
+  it('opens edit sheet when tapping pencil icon', async () => {
+    const { findByText, findByTestId, findAllByLabelText } = renderScreen(<EditTemplate />)
+    await findByText('Bench Press')
+    // Find pencil icon by its accessibility label
+    const editBtns = await findAllByLabelText('Edit Bench Press settings')
+    fireEvent.press(editBtns[0])
+    expect(await findByTestId('edit-exercise-sheet')).toBeTruthy()
+  })
+
+  it('calls updateTemplateExercise with correct args on save', async () => {
+    const { findByText, findByTestId } = renderScreen(<EditTemplate />)
+    const benchText = await findByText('Bench Press')
+    fireEvent.press(benchText)
+
+    await findByTestId('edit-exercise-sheet')
+    if (mockEditSheetProps) {
+      mockEditSheetProps.onSave(5, '3-5', 90)
+    }
+
+    await waitFor(() => {
+      expect(mockUpdateTemplateExercise).toHaveBeenCalledWith('te-1', 'tpl-1', 5, '3-5', 90)
+    })
+  })
+
+  it('shows snackbar on save failure', async () => {
+    mockUpdateTemplateExercise.mockRejectedValueOnce(new Error('DB error'))
+    const { findByText, findByTestId } = renderScreen(<EditTemplate />)
+
+    const benchText = await findByText('Bench Press')
+    fireEvent.press(benchText)
+
+    await findByTestId('edit-exercise-sheet')
+    if (mockEditSheetProps) {
+      mockEditSheetProps.onSave(4, '6-8', 120)
+    }
+
+    expect(await findByText('Failed to update exercise settings')).toBeTruthy()
+  })
+
+  it('refetches template data after successful save', async () => {
+    const { findByText, findByTestId } = renderScreen(<EditTemplate />)
+
+    await waitFor(() => {
+      expect(mockGetTemplateById).toHaveBeenCalledTimes(1)
+    })
+
+    const benchText = await findByText('Bench Press')
+    fireEvent.press(benchText)
+
+    await findByTestId('edit-exercise-sheet')
+    if (mockEditSheetProps) {
+      mockEditSheetProps.onSave(4, '6-8', 120)
+    }
+
+    await waitFor(() => {
+      expect(mockGetTemplateById).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('does not open edit sheet in selection mode', async () => {
+    const { findByText, queryByTestId } = renderScreen(<EditTemplate />)
+    // Long-press to enter selection mode
+    const benchText = await findByText('Bench Press')
+    fireEvent(benchText, 'onLongPress')
+
+    // In selection mode, pressing toggles selection — doesn't open edit
+    fireEvent.press(benchText)
+    expect(queryByTestId('edit-exercise-sheet')).toBeNull()
+  })
+
+  it('preserves link_id when editing linked exercises', async () => {
+    const mockLinkedExercises: TemplateExercise[] = [
+      createTemplateExercise({ id: 'te-1', template_id: 'tpl-1', exercise_id: 'ex-1', position: 0, target_sets: 4, target_reps: '6-8', rest_seconds: 120, link_id: 'link-1', link_label: 'A', exercise: mockExercise1 }),
+      createTemplateExercise({ id: 'te-2', template_id: 'tpl-1', exercise_id: 'ex-2', position: 1, target_sets: 3, target_reps: '10', rest_seconds: 90, link_id: 'link-1', link_label: 'A', exercise: mockExercise2 }),
+    ]
+    mockGetTemplateById.mockResolvedValue({ ...mockTemplate, exercises: mockLinkedExercises })
+
+    const { findByText, findByTestId } = renderScreen(<EditTemplate />)
+    const benchText = await findByText('Bench Press')
+    fireEvent.press(benchText)
+
+    await findByTestId('edit-exercise-sheet')
+    if (mockEditSheetProps) {
+      mockEditSheetProps.onSave(5, '3-5', 60)
+    }
+
+    await waitFor(() => {
+      // Only sets/reps/rest updated, not link_id
+      expect(mockUpdateTemplateExercise).toHaveBeenCalledWith('te-1', 'tpl-1', 5, '3-5', 60)
+    })
+  })
+})

--- a/__tests__/components/EditExerciseSheet.test.tsx
+++ b/__tests__/components/EditExerciseSheet.test.tsx
@@ -17,7 +17,7 @@ const baseExercise: TemplateExercise = {
   rest_seconds: 120,
   link_id: null,
   link_label: '',
-  exercise: { id: 'ex-1', name: 'Bench Press', muscle_group: 'chest', equipment: 'barbell', is_custom: false, created_at: 0, deleted_at: null } as TemplateExercise['exercise'],
+  exercise: { id: 'ex-1', name: 'Bench Press', category: 'chest', primary_muscles: ['chest'], secondary_muscles: ['triceps'], equipment: 'barbell', instructions: '', difficulty: 'intermediate', is_custom: false, deleted_at: null } as TemplateExercise['exercise'],
 }
 
 describe('EditExerciseSheet', () => {

--- a/__tests__/components/EditExerciseSheet.test.tsx
+++ b/__tests__/components/EditExerciseSheet.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react'
+import { fireEvent } from '@testing-library/react-native'
+import { Keyboard } from 'react-native'
+import EditExerciseSheet from '../../components/EditExerciseSheet'
+import { renderScreen } from '../helpers/render'
+import type { TemplateExercise } from '../../lib/types'
+
+jest.spyOn(Keyboard, 'dismiss').mockImplementation(() => {})
+
+const baseExercise: TemplateExercise = {
+  id: 'te-1',
+  template_id: 'tpl-1',
+  exercise_id: 'ex-1',
+  position: 0,
+  target_sets: 4,
+  target_reps: '6-8',
+  rest_seconds: 120,
+  link_id: null,
+  link_label: '',
+  exercise: { id: 'ex-1', name: 'Bench Press', muscle_group: 'chest', equipment: 'barbell', is_custom: false, created_at: 0, deleted_at: null } as TemplateExercise['exercise'],
+}
+
+describe('EditExerciseSheet', () => {
+  const onSave = jest.fn()
+  const onDismiss = jest.fn()
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it('renders nothing when not visible', () => {
+    const { queryByText } = renderScreen(
+      <EditExerciseSheet visible={false} exercise={baseExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    expect(queryByText('Bench Press')).toBeNull()
+  })
+
+  it('renders pre-filled values when visible', () => {
+    const { getByDisplayValue, getByText } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={baseExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    expect(getByText('Bench Press')).toBeTruthy()
+    expect(getByDisplayValue('4')).toBeTruthy()
+    expect(getByDisplayValue('6-8')).toBeTruthy()
+    expect(getByDisplayValue('120')).toBeTruthy()
+  })
+
+  it('uses default fallbacks when exercise has null values', () => {
+    const nullExercise = {
+      ...baseExercise,
+      target_sets: null as unknown as number,
+      target_reps: null as unknown as string,
+      rest_seconds: null as unknown as number,
+    }
+    const { getByDisplayValue } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={nullExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    expect(getByDisplayValue('3')).toBeTruthy()
+    expect(getByDisplayValue('8-12')).toBeTruthy()
+    expect(getByDisplayValue('90')).toBeTruthy()
+  })
+
+  it('uses defaults when exercise is null', () => {
+    const { getByDisplayValue } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={null} onSave={onSave} onDismiss={onDismiss} />
+    )
+    expect(getByDisplayValue('3')).toBeTruthy()
+    expect(getByDisplayValue('8-12')).toBeTruthy()
+    expect(getByDisplayValue('90')).toBeTruthy()
+  })
+
+  it('calls onSave with parsed values and dismisses keyboard', () => {
+    const { getByLabelText } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={baseExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    fireEvent.press(getByLabelText('Save exercise settings'))
+    expect(Keyboard.dismiss).toHaveBeenCalled()
+    expect(onSave).toHaveBeenCalledWith(4, '6-8', 120)
+  })
+
+  it('calls onDismiss when Cancel is pressed', () => {
+    const { getByLabelText } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={baseExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    fireEvent.press(getByLabelText('Cancel editing'))
+    expect(onDismiss).toHaveBeenCalled()
+  })
+
+  it('disables Save when sets is 0', () => {
+    const { getByLabelText } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={baseExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    fireEvent.changeText(getByLabelText('Target sets'), '0')
+    fireEvent.press(getByLabelText('Save exercise settings'))
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('disables Save when reps is empty', () => {
+    const { getByLabelText } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={baseExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    fireEvent.changeText(getByLabelText('Target reps'), '')
+    fireEvent.press(getByLabelText('Save exercise settings'))
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('disables Save when rest is negative', () => {
+    const { getByLabelText } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={baseExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    fireEvent.changeText(getByLabelText('Rest time in seconds'), '-1')
+    fireEvent.press(getByLabelText('Save exercise settings'))
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('allows rest of 0 seconds', () => {
+    const { getByLabelText } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={baseExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    fireEvent.changeText(getByLabelText('Rest time in seconds'), '0')
+    fireEvent.press(getByLabelText('Save exercise settings'))
+    expect(onSave).toHaveBeenCalledWith(4, '6-8', 0)
+  })
+
+  it('allows AMRAP as reps value', () => {
+    const { getByLabelText } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={baseExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    fireEvent.changeText(getByLabelText('Target reps'), 'AMRAP')
+    fireEvent.press(getByLabelText('Save exercise settings'))
+    expect(onSave).toHaveBeenCalledWith(4, 'AMRAP', 120)
+  })
+
+  it('has accessibilityViewIsModal on the sheet', () => {
+    const { getByLabelText } = renderScreen(
+      <EditExerciseSheet visible={true} exercise={baseExercise} onSave={onSave} onDismiss={onDismiss} />
+    )
+    const saveBtn = getByLabelText('Save exercise settings')
+    // Walk up from button to find the modal container
+    let node: { props?: Record<string, unknown>; parent?: unknown } = saveBtn
+    let found = false
+    while (node.parent) {
+      if (node.props?.accessibilityViewIsModal === true) {
+        found = true
+        break
+      }
+      node = node.parent as typeof node
+    }
+    expect(found).toBe(true)
+  })
+})

--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -27,10 +27,12 @@ import {
   reorderTemplateExercises,
   unlinkExerciseGroup,
   unlinkSingleExercise,
+  updateTemplateExercise,
 } from "../../lib/db";
 import type { Exercise, TemplateExercise, WorkoutTemplate } from "../../lib/types";
 import SwipeToDelete from "../../components/SwipeToDelete";
 import ExercisePickerSheet from "../../components/ExercisePickerSheet";
+import EditExerciseSheet from "../../components/EditExerciseSheet";
 
 function linkLabel(exercises: TemplateExercise[], linkId: string, idx: number): string {
   const count = exercises.filter((e) => e.link_id === linkId).length;
@@ -54,6 +56,7 @@ export default function EditTemplate() {
   const [snackbar, setSnackbar] = useState("");
   const [undo, setUndo] = useState<(() => Promise<void>) | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [editing, setEditing] = useState<TemplateExercise | null>(null);
   const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const linkIds = useMemo(() => {
@@ -173,6 +176,17 @@ export default function EditTemplate() {
     await load();
   }, [id, load]);
 
+  const handleEditSave = useCallback(async (sets: number, reps: string, rest: number) => {
+    if (!editing || !id) return;
+    try {
+      await updateTemplateExercise(editing.id, id, sets, reps, rest);
+      setEditing(null);
+      await load();
+    } catch {
+      setSnackbar("Failed to update exercise settings");
+    }
+  }, [editing, id, load]);
+
   const renderItem = useCallback(
     ({ item, index }: { item: TemplateExercise; index: number }) => {
       const linkIdx = item.link_id ? linkIds.indexOf(item.link_id) : -1;
@@ -207,6 +221,13 @@ export default function EditTemplate() {
 
           <SwipeToDelete onDelete={() => remove(item.id)} enabled={!selecting}>
             <Pressable
+              onPress={() => {
+                if (selecting) {
+                  toggleSelect(item.id);
+                } else {
+                  setEditing(item);
+                }
+              }}
               onLongPress={() => {
                 if (!selecting) startSelection(item.id);
               }}
@@ -219,11 +240,11 @@ export default function EditTemplate() {
                   borderLeftColor: color ?? "transparent",
                 },
               ]}
-              accessibilityRole={selecting ? "checkbox" : "none"}
+              accessibilityRole={selecting ? "checkbox" : "button"}
               accessibilityState={selecting ? { selected: selected.has(item.id) } : undefined}
               accessibilityLabel={selecting
                 ? `Select ${item.exercise?.name ?? "exercise"} for superset`
-                : undefined}
+                : `Edit ${item.exercise?.name ?? "exercise"} settings`}
             >
               {selecting && (
                 <Checkbox
@@ -267,6 +288,12 @@ export default function EditTemplate() {
               </View>
               {!selecting && (
                 <View style={styles.actions}>
+                  <IconButton
+                    icon="pencil-outline"
+                    size={16}
+                    onPress={() => setEditing(item)}
+                    accessibilityLabel={`Edit ${item.exercise?.name ?? "exercise"} settings`}
+                  />
                   {item.link_id && (
                     <IconButton
                       icon="link-off"
@@ -506,6 +533,12 @@ export default function EditTemplate() {
         visible={pickerOpen}
         onDismiss={() => setPickerOpen(false)}
         onPick={handlePickExercise}
+      />
+      <EditExerciseSheet
+        visible={!!editing}
+        exercise={editing}
+        onSave={handleEditSave}
+        onDismiss={() => setEditing(null)}
       />
     </>
   );

--- a/app/template/create.tsx
+++ b/app/template/create.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import {
   Alert,
+  Pressable,
   StyleSheet,
   View,
 } from "react-native";
@@ -8,6 +9,7 @@ import { FlashList } from "@shopify/flash-list";
 import {
   Button,
   IconButton,
+  Snackbar,
   Text,
   TextInput,
   useTheme,
@@ -23,9 +25,11 @@ import {
   removeExerciseFromTemplate,
   reorderTemplateExercises,
   updateTemplateName,
+  updateTemplateExercise,
 } from "../../lib/db";
 import type { Exercise, TemplateExercise, WorkoutTemplate } from "../../lib/types";
 import ExercisePickerSheet from "../../components/ExercisePickerSheet";
+import EditExerciseSheet from "../../components/EditExerciseSheet";
 
 export default function CreateTemplate() {
   const theme = useTheme();
@@ -39,6 +43,8 @@ export default function CreateTemplate() {
   const [exercises, setExercises] = useState<TemplateExercise[]>([]);
   const [saving, setSaving] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [editing, setEditing] = useState<TemplateExercise | null>(null);
+  const [snackbar, setSnackbar] = useState("");
 
   useFocusEffect(
     useCallback(() => {
@@ -118,13 +124,27 @@ export default function CreateTemplate() {
     await load();
   }, [template, exercises, load]);
 
+  const handleEditSave = useCallback(async (sets: number, reps: string, rest: number) => {
+    if (!editing || !template) return;
+    try {
+      await updateTemplateExercise(editing.id, template.id, sets, reps, rest);
+      setEditing(null);
+      await load();
+    } catch {
+      setSnackbar("Failed to update exercise settings");
+    }
+  }, [editing, template, load]);
+
   const renderItem = useCallback(
     ({ item, index }: { item: TemplateExercise; index: number }) => (
-      <View
+      <Pressable
+        onPress={() => setEditing(item)}
         style={[
           styles.exerciseRow,
           { backgroundColor: theme.colors.surface, borderBottomColor: theme.colors.outlineVariant },
         ]}
+        accessibilityRole="button"
+        accessibilityLabel={`Edit ${item.exercise?.name ?? "exercise"} settings`}
       >
         <View style={styles.exerciseInfo}>
           <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>
@@ -138,6 +158,12 @@ export default function CreateTemplate() {
           </Text>
         </View>
         <View style={styles.actions}>
+          <IconButton
+            icon="pencil-outline"
+            size={16}
+            onPress={() => setEditing(item)}
+            accessibilityLabel={`Edit ${item.exercise?.name ?? "exercise"} settings`}
+          />
           <IconButton
             icon="arrow-up"
             size={18}
@@ -159,7 +185,7 @@ export default function CreateTemplate() {
             accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"}`}
           />
         </View>
-      </View>
+      </Pressable>
     ),
     [theme, exercises.length, move, remove]
   );
@@ -235,6 +261,20 @@ export default function CreateTemplate() {
         onDismiss={() => setPickerOpen(false)}
         onPick={handlePickExercise}
       />
+      <EditExerciseSheet
+        visible={!!editing}
+        exercise={editing}
+        onSave={handleEditSave}
+        onDismiss={() => setEditing(null)}
+      />
+      <Snackbar
+        visible={!!snackbar}
+        onDismiss={() => setSnackbar("")}
+        duration={4000}
+        accessibilityLiveRegion="polite"
+      >
+        {snackbar}
+      </Snackbar>
     </>
   );
 }

--- a/components/EditExerciseSheet.tsx
+++ b/components/EditExerciseSheet.tsx
@@ -1,0 +1,207 @@
+import { useState } from "react";
+import {
+  Keyboard,
+  Pressable,
+  StyleSheet,
+  View,
+} from "react-native";
+import {
+  Button,
+  Portal,
+  Text,
+  TextInput,
+  useTheme,
+} from "react-native-paper";
+import type { TemplateExercise } from "../lib/types";
+import { elevation } from "../constants/design-tokens";
+
+type Props = {
+  visible: boolean;
+  exercise: TemplateExercise | null;
+  onSave: (sets: number, reps: string, rest: number) => void;
+  onDismiss: () => void;
+};
+
+const DEFAULT_SETS = 3;
+const DEFAULT_REPS = "8-12";
+const DEFAULT_REST = 90;
+
+export default function EditExerciseSheet({
+  visible,
+  exercise,
+  onSave,
+  onDismiss,
+}: Props) {
+  const theme = useTheme();
+  const initialSets = visible ? String((exercise?.target_sets ?? DEFAULT_SETS)) : "";
+  const initialReps = visible ? (exercise?.target_reps ?? DEFAULT_REPS) : "";
+  const initialRest = visible ? String((exercise?.rest_seconds ?? DEFAULT_REST)) : "";
+
+  const [sets, setSets] = useState(initialSets);
+  const [reps, setReps] = useState(initialReps);
+  const [rest, setRest] = useState(initialRest);
+  const [prevVisible, setPrevVisible] = useState(visible);
+
+  // Reset state when sheet opens (derived state pattern)
+  if (visible && !prevVisible) {
+    setSets(String(exercise?.target_sets ?? DEFAULT_SETS));
+    setReps(exercise?.target_reps ?? DEFAULT_REPS);
+    setRest(String(exercise?.rest_seconds ?? DEFAULT_REST));
+  }
+  if (visible !== prevVisible) {
+    setPrevVisible(visible);
+  }
+
+  const parsedSets = parseInt(sets, 10);
+  const parsedRest = parseInt(rest, 10);
+  const setsValid = !isNaN(parsedSets) && parsedSets >= 1;
+  const repsValid = reps.trim().length > 0;
+  const restValid = !isNaN(parsedRest) && parsedRest >= 0;
+  const canSave = setsValid && repsValid && restValid;
+
+  const handleSave = () => {
+    if (!canSave) return;
+    Keyboard.dismiss();
+    onSave(parsedSets, reps.trim(), parsedRest);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <Portal>
+      <Pressable
+        style={StyleSheet.absoluteFill}
+        onPress={onDismiss}
+        accessibilityLabel="Close edit exercise sheet"
+        accessibilityRole="button"
+      >
+        <View
+          style={[StyleSheet.absoluteFill, { backgroundColor: theme.colors.backdrop }]}
+          pointerEvents="none"
+        />
+      </Pressable>
+
+      <View
+        style={[
+          styles.sheet,
+          { backgroundColor: theme.colors.surface },
+        ]}
+        accessibilityViewIsModal={true}
+      >
+        <View style={styles.handle}>
+          <View style={[styles.handleBar, { backgroundColor: theme.colors.onSurfaceVariant }]} />
+        </View>
+
+        <Text
+          variant="titleMedium"
+          style={[styles.title, { color: theme.colors.onSurface }]}
+          numberOfLines={2}
+        >
+          {exercise?.exercise?.name ?? "Edit Exercise"}
+        </Text>
+
+        <TextInput
+          label="Target Sets"
+          value={sets}
+          onChangeText={setSets}
+          keyboardType="numeric"
+          mode="outlined"
+          style={styles.input}
+          accessibilityLabel="Target sets"
+          error={sets.length > 0 && !setsValid}
+        />
+
+        <TextInput
+          label="Target Reps"
+          value={reps}
+          onChangeText={setReps}
+          mode="outlined"
+          style={styles.input}
+          accessibilityLabel="Target reps"
+          placeholder="e.g. 8-12, 5, AMRAP"
+          error={reps.length > 0 && !repsValid}
+        />
+
+        <TextInput
+          label="Rest (seconds)"
+          value={rest}
+          onChangeText={setRest}
+          keyboardType="numeric"
+          mode="outlined"
+          style={styles.input}
+          accessibilityLabel="Rest time in seconds"
+          error={rest.length > 0 && !restValid}
+        />
+
+        <View style={styles.buttons}>
+          <Button
+            mode="text"
+            onPress={onDismiss}
+            style={styles.button}
+            contentStyle={styles.buttonContent}
+            accessibilityLabel="Cancel editing"
+          >
+            Cancel
+          </Button>
+          <Button
+            mode="contained"
+            onPress={handleSave}
+            disabled={!canSave}
+            style={styles.button}
+            contentStyle={styles.buttonContent}
+            accessibilityRole="button"
+            accessibilityLabel="Save exercise settings"
+          >
+            Save
+          </Button>
+        </View>
+      </View>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  sheet: {
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+    right: 0,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingHorizontal: 20,
+    paddingBottom: 32,
+    ...elevation.high,
+  },
+  handle: {
+    alignItems: "center",
+    paddingVertical: 10,
+  },
+  handleBar: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    opacity: 0.4,
+  },
+  title: {
+    marginBottom: 16,
+    fontWeight: "700",
+  },
+  input: {
+    marginBottom: 12,
+    fontSize: 16,
+  },
+  buttons: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    marginTop: 8,
+    gap: 8,
+  },
+  button: {
+    minWidth: 56,
+    minHeight: 56,
+  },
+  buttonContent: {
+    paddingVertical: 8,
+    minHeight: 56,
+  },
+});

--- a/lib/db/templates.ts
+++ b/lib/db/templates.ts
@@ -302,14 +302,22 @@ export async function reorderTemplateExercises(
 
 export async function updateTemplateExercise(
   id: string,
+  templateId: string,
   targetSets: number,
   targetReps: string,
   restSeconds: number
 ): Promise<void> {
-  await execute(
-    "UPDATE template_exercises SET target_sets = ?, target_reps = ?, rest_seconds = ? WHERE id = ?",
-    [targetSets, targetReps, restSeconds, id]
-  );
+  const database = await getDatabase();
+  await database.withTransactionAsync(async () => {
+    await database.runAsync(
+      "UPDATE template_exercises SET target_sets = ?, target_reps = ?, rest_seconds = ? WHERE id = ?",
+      [targetSets, targetReps, restSeconds, id]
+    );
+    await database.runAsync(
+      "UPDATE workout_templates SET updated_at = ? WHERE id = ?",
+      [Date.now(), templateId]
+    );
+  });
 }
 
 export async function getTemplateExerciseCount(


### PR DESCRIPTION
## Summary

Add tap-to-edit functionality for template exercise parameters (target sets, target reps, rest seconds). Users can now tap an exercise row to open an EditExerciseSheet overlay and modify values without removing and re-adding the exercise.

## Changes

- **lib/db/templates.ts**: Fix `updateTemplateExercise()` to accept `templateId` and update `workout_templates.updated_at` in a transaction (bug fix — every other template mutation does this)
- **components/EditExerciseSheet.tsx**: New Portal-based overlay component with three inputs, validation, keyboard dismiss, and `accessibilityViewIsModal`
- **app/template/[id].tsx**: Add tap handler on exercise rows (opens edit sheet when not in selection mode), pencil icon affordance, save handler with try/catch + Snackbar error
- **app/template/create.tsx**: Same edit capability using `updateTemplateExercise()` directly (create screen persists via DB)

## Testing

- 12 unit tests for EditExerciseSheet (validation, defaults, null handling, keyboard dismiss, accessibility)
- 7 acceptance tests for template editing flow (tap-to-edit, save with correct args, error snackbar, selection mode guard, superset preservation, refetch after save)
- All 1507 existing tests pass with zero regressions
- `tsc --noEmit` passes (no new type errors)
- ESLint passes with zero warnings

## Issue

Resolves BLD-271