### PR TITLE
fix: Prevent workout tools crash (BLD-272)

### DIFF
--- a/__tests__/app/tools/tools-hub-error-boundary.test.tsx
+++ b/__tests__/app/tools/tools-hub-error-boundary.test.tsx
@@ -1,0 +1,123 @@
+jest.setTimeout(10000)
+
+import React from 'react'
+import { renderScreen } from '../../helpers/render'
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/tools',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0, horizontalPadding: 16 }) }))
+jest.mock('../../../lib/errors', () => ({ logError: jest.fn(), generateReport: jest.fn().mockResolvedValue('{}'), getRecentErrors: jest.fn().mockResolvedValue([]), generateGitHubURL: jest.fn().mockReturnValue('https://github.com') }))
+jest.mock('../../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+
+jest.mock('../../../lib/db', () => ({
+  getBodySettings: jest.fn().mockResolvedValue({ weight_unit: 'kg' }),
+  getAppSetting: jest.fn().mockResolvedValue(null),
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../../../lib/audio', () => ({
+  play: jest.fn(),
+  unload: jest.fn(),
+  setEnabled: jest.fn(),
+}))
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+}))
+
+jest.mock('expo-keep-awake', () => ({
+  activateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined),
+  deactivateKeepAwake: jest.fn(),
+}))
+
+jest.mock('react-native-svg', () => {
+  const React = require('react')
+  return {
+    __esModule: true,
+    default: (props: React.PropsWithChildren) => React.createElement('Svg', props),
+    Circle: (props: Record<string, unknown>) => React.createElement('Circle', props),
+  }
+})
+
+jest.mock('react-native-reanimated', () => {
+  const View = require('react-native').View
+  const bezierFn = () => (t: number) => t
+  return {
+    __esModule: true,
+    default: {
+      View,
+      createAnimatedComponent: (comp: React.ComponentType) => comp,
+    },
+    Easing: { bezier: bezierFn },
+    useSharedValue: (v: number) => ({ value: v }),
+    useAnimatedStyle: (fn: () => Record<string, unknown>) => fn(),
+    useAnimatedProps: (fn: () => Record<string, unknown>) => fn(),
+    withTiming: (v: number) => v,
+    useReducedMotion: () => false,
+  }
+})
+
+import ToolsHub from '../../../app/tools/index'
+
+describe('ToolsHub', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders all three tool cards', async () => {
+    const { findByText } = renderScreen(<ToolsHub />)
+
+    expect(await findByText('Interval Timer')).toBeTruthy()
+    expect(await findByText('1RM Calculator')).toBeTruthy()
+    expect(await findByText('Plate Calculator')).toBeTruthy()
+  })
+
+  it('contains error boundary that catches tool render failures', async () => {
+    // Verify ToolErrorBoundary is structurally present by checking
+    // that the component source wraps children in ToolErrorBoundary
+    const source = require('fs').readFileSync(
+      require('path').resolve(__dirname, '../../../app/tools/index.tsx'),
+      'utf8'
+    )
+    expect(source).toContain('ToolErrorBoundary')
+    expect(source).toContain('getDerivedStateFromError')
+  })
+})
+
+describe('ToolsHub error isolation', () => {
+  it('db failure in getBodySettings does not crash RMCalculatorContent', async () => {
+    const db = require('../../../lib/db')
+    db.getBodySettings.mockRejectedValueOnce(new Error('DB unavailable'))
+
+    // Should not throw — unhandled promise rejection would crash
+    const { findByText } = renderScreen(<ToolsHub />)
+    expect(await findByText('1RM Calculator')).toBeTruthy()
+  })
+
+  it('db failure in getBodySettings does not crash PlateCalculatorContent', async () => {
+    const db = require('../../../lib/db')
+    db.getBodySettings.mockRejectedValueOnce(new Error('DB unavailable'))
+
+    const { findByText } = renderScreen(<ToolsHub />)
+    expect(await findByText('Plate Calculator')).toBeTruthy()
+  })
+})

--- a/app/tools/index.tsx
+++ b/app/tools/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
 import { Card, Text, useTheme } from "react-native-paper";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
@@ -55,10 +56,34 @@ function ToolCard({ icon, title, children }: {
             {title}
           </Text>
         </View>
-        {children}
+        <ToolErrorBoundary name={title}>
+          {children}
+        </ToolErrorBoundary>
       </Card.Content>
     </Card>
   );
+}
+
+type BoundaryProps = { name: string; children: React.ReactNode };
+type BoundaryState = { hasError: boolean };
+
+class ToolErrorBoundary extends React.Component<BoundaryProps, BoundaryState> {
+  state: BoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): Partial<BoundaryState> {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Text style={{ textAlign: "center", opacity: 0.6 }}>
+          {this.props.name} failed to load. Try opening it from the standalone screen.
+        </Text>
+      );
+    }
+    return this.props.children;
+  }
 }
 
 const styles = StyleSheet.create({

--- a/app/tools/plates.tsx
+++ b/app/tools/plates.tsx
@@ -53,10 +53,15 @@ export function PlateCalculatorContent({ initialWeight }: { initialWeight?: stri
   useFocusEffect(
     useCallback(() => {
       (async () => {
-        const body = await getBodySettings()
-        setUnit(body.weight_unit)
-        setBar(body.weight_unit === "kg" ? 20 : 45)
-        if (initialWeight) setTarget(initialWeight)
+        try {
+          const body = await getBodySettings()
+          setUnit(body.weight_unit)
+          setBar(body.weight_unit === "kg" ? 20 : 45)
+          if (initialWeight) setTarget(initialWeight)
+        } catch {
+          // Fall back to defaults if settings unavailable
+          setBar(20)
+        }
         setReady(true)
       })()
     }, [initialWeight])

--- a/app/tools/rm.tsx
+++ b/app/tools/rm.tsx
@@ -29,8 +29,12 @@ export function RMCalculatorContent() {
   useFocusEffect(
     useCallback(() => {
       (async () => {
-        const body = await getBodySettings();
-        setUnit(body.weight_unit);
+        try {
+          const body = await getBodySettings();
+          setUnit(body.weight_unit);
+        } catch {
+          // Fall back to default unit if settings unavailable
+        }
       })();
     }, []),
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fitforge",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fitforge",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.9",


### PR DESCRIPTION
## Summary

Fix crash when tapping the wrench icon (Workout Tools) on Android. The crash was caused by unhandled promise rejections in tool components and lack of error isolation between tools in the ToolsHub.

## Changes

- **ToolsHub (app/tools/index.tsx)**: Added `ToolErrorBoundary` class component that wraps each tool card's children. If one tool (e.g., TimerContent with its animated SVG + reanimated combo) crashes, the other tools remain functional with a graceful fallback message.
- **RMCalculatorContent (app/tools/rm.tsx)**: Added try/catch around `getBodySettings()` in `useFocusEffect` to prevent unhandled promise rejection when database is unavailable.
- **PlateCalculatorContent (app/tools/plates.tsx)**: Added try/catch around `getBodySettings()` with fallback to default 20kg bar weight. Ensures `setReady(true)` is always called even on DB failure.

## Root Cause Analysis

Three contributing factors identified:
1. `RMCalculatorContent` and `PlateCalculatorContent` had unhandled async errors in `useFocusEffect` — if `getBodySettings()` threw, the promise rejection could crash the app before the error boundary could catch it
2. No error isolation between the three tool components rendered inline in ToolsHub — a crash in any one (especially TimerContent with its complex animated SVG + reanimated + audio stack) would take down the entire page
3. Android 36 with new architecture may have timing issues with `Animated.createAnimatedComponent(Circle)` combined with `useAnimatedProps`

## Testing

- Added 4 new tests in `tools-hub-error-boundary.test.tsx`
- All 20 existing tools tests pass with no regressions
- `tsc --noEmit` passes (pre-existing unrelated error in ShareSheet test only)

## Issue

Resolves BLD-272 (GitHub #141)