### PR TITLE
fix: Owner-reported UX issues batch (BLD-273)

### DIFF
--- a/__tests__/acceptance/owner-ux-batch.acceptance.test.tsx
+++ b/__tests__/acceptance/owner-ux-batch.acceptance.test.tsx
@@ -1,0 +1,108 @@
+jest.setTimeout(10000)
+
+import React from 'react'
+import { waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/test',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0, horizontalPadding: 16 }) }))
+jest.mock('../../lib/errors', () => ({ logError: jest.fn(), generateReport: jest.fn().mockResolvedValue('{}'), getRecentErrors: jest.fn().mockResolvedValue([]), generateGitHubURL: jest.fn().mockReturnValue('https://github.com') }))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+jest.mock('../../lib/db', () => ({
+  getAppSetting: jest.fn().mockResolvedValue(null),
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+  updateMacroTargets: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('../../lib/db/body', () => ({
+  getBodySettings: jest.fn().mockResolvedValue({ weight_unit: 'kg', measurement_unit: 'cm' }),
+  getLatestBodyWeight: jest.fn().mockResolvedValue({ weight: 75 }),
+}))
+
+describe('Issue 1: Barcode scanner header icon', () => {
+  it('nutrition tab _layout.tsx includes barcode-scan icon config', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../app/(tabs)/_layout.tsx'),
+      'utf8'
+    )
+    expect(source).toContain('barcode-scan')
+    expect(source).toContain('/nutrition/add?scan=true')
+    expect(source).toContain('Scan food barcode')
+  })
+
+  it('add.tsx accepts scan query param and auto-opens scanner', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../app/nutrition/add.tsx'),
+      'utf8'
+    )
+    expect(source).toContain('scan?: string')
+    expect(source).toContain('autoScan')
+    expect(source).toContain('setScannerVisible(true)')
+  })
+})
+
+describe('Issue 2: Stat card padding', () => {
+  it('statCard style includes paddingHorizontal', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../app/(tabs)/index.tsx'),
+      'utf8'
+    )
+    expect(source).toMatch(/statCard[\s\S]*?paddingHorizontal/)
+  })
+})
+
+describe('Issue 3: Activity level dropdown', () => {
+  it('ProfileForm uses Menu instead of SegmentedButtons for activity level', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../components/ProfileForm.tsx'),
+      'utf8'
+    )
+    // Should use Menu component for activity level
+    expect(source).toContain('Menu')
+    expect(source).toContain('activityMenuVisible')
+    // Should NOT have truncated labels
+    expect(source).not.toContain('ACTIVITY_LABELS.sedentary.split')
+    // Should show full labels via ACTIVITY_LABELS[key]
+    expect(source).toContain('ACTIVITY_LABELS[activityLevel]')
+  })
+
+  it('ProfileForm renders dropdown for activity level', async () => {
+    const ProfileForm = require('../../components/ProfileForm').default
+    const { findByLabelText } = renderScreen(
+      <ProfileForm onSave={jest.fn()} />
+    )
+
+    // Should show full activity level label in dropdown
+    await waitFor(async () => {
+      const dropdown = await findByLabelText(/Activity level:/)
+      expect(dropdown).toBeTruthy()
+    })
+  })
+})

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -44,6 +44,17 @@ export default function TabLayout() {
         options={{
           title: "Nutrition",
           headerTitle: renderHeaderTitle("food-apple", "Nutrition"),
+          headerRight: () => (
+            <IconButton
+              icon="barcode-scan"
+              size={24}
+              onPress={() => router.push("/nutrition/add?scan=true")}
+              accessibilityLabel="Scan food barcode"
+              accessibilityRole="button"
+              iconColor={theme.colors.onSurface}
+              style={{ minWidth: 48, minHeight: 48 }}
+            />
+          ),
         }}
       />
       <Tabs.Screen

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -907,6 +907,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     paddingVertical: 4,
+    paddingHorizontal: 8,
   },
   nextBanner: {
     marginBottom: 12,

--- a/app/nutrition/add.tsx
+++ b/app/nutrition/add.tsx
@@ -232,7 +232,7 @@ function DatabaseTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: 
   );
 }
 
-function OnlineTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: boolean; onSaving: (v: boolean) => void; dateKey: string }) {
+function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; saving: boolean; onSaving: (v: boolean) => void; dateKey: string; autoScan?: boolean }) {
   const theme = useTheme();
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<ParsedFood[]>([]);
@@ -253,6 +253,15 @@ function OnlineTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: bo
   const barcodeAbortRef = useRef<AbortController | null>(null);
   const cacheRef = useRef<Map<string, ParsedFood[]>>(new Map());
   const today = dateKey;
+
+  // Auto-open scanner when navigated with scan=true
+  const autoScanTriggered = useRef(false);
+  useEffect(() => {
+    if (autoScan && !autoScanTriggered.current && Platform.OS !== "web") {
+      autoScanTriggered.current = true;
+      setScannerVisible(true);
+    }
+  }, [autoScan]);
 
   // Proactive offline detection on mount / tab switch
   useEffect(() => {
@@ -709,9 +718,9 @@ const TAB_BUTTONS = [
 export default function AddFood() {
   const theme = useTheme();
   const layout = useLayout();
-  const params = useLocalSearchParams<{ date?: string }>();
+  const params = useLocalSearchParams<{ date?: string; scan?: string }>();
   const dateKey = params.date || localDateKey();
-  const [tab, setTab] = useState("new");
+  const [tab, setTab] = useState(params.scan === "true" ? "online" : "new");
   const [name, setName] = useState("");
   const [calories, setCalories] = useState("");
   const [protein, setProtein] = useState("");
@@ -791,7 +800,7 @@ export default function AddFood() {
         {tab === "database" ? (
           <DatabaseTab meal={meal} saving={saving} onSaving={setSaving} dateKey={dateKey} />
         ) : (
-          <OnlineTab meal={meal} saving={saving} onSaving={setSaving} dateKey={dateKey} />
+          <OnlineTab meal={meal} saving={saving} onSaving={setSaving} dateKey={dateKey} autoScan={params.scan === "true"} />
         )}
       </View>
     );

--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import {
   Banner,
   Button,
+  Menu,
   SegmentedButtons,
   Text,
   TextInput,
@@ -19,14 +20,6 @@ import {
   type NutritionProfile,
   type Sex,
 } from "../lib/nutrition-calc";
-
-const ACTIVITY_BUTTONS = [
-  { value: "sedentary", label: ACTIVITY_LABELS.sedentary.split(" ")[0], accessibilityLabel: ACTIVITY_LABELS.sedentary, style: { minHeight: 48 } },
-  { value: "lightly_active", label: ACTIVITY_LABELS.lightly_active.split(" ")[0], accessibilityLabel: ACTIVITY_LABELS.lightly_active, style: { minHeight: 48 } },
-  { value: "moderately_active", label: ACTIVITY_LABELS.moderately_active.split(" ")[0], accessibilityLabel: ACTIVITY_LABELS.moderately_active, style: { minHeight: 48 } },
-  { value: "very_active", label: ACTIVITY_LABELS.very_active.split(" ")[0], accessibilityLabel: ACTIVITY_LABELS.very_active, style: { minHeight: 48 } },
-  { value: "extra_active", label: ACTIVITY_LABELS.extra_active.split(" ")[0], accessibilityLabel: ACTIVITY_LABELS.extra_active, style: { minHeight: 48 } },
-] as const;
 
 const GOAL_BUTTONS = [
   { value: "cut", label: GOAL_LABELS.cut, accessibilityLabel: GOAL_LABELS.cut },
@@ -57,6 +50,7 @@ export default function ProfileForm({ initialProfile, onSave, onCancel, onDirtyC
   const [weightUnit, setWeightUnit] = useState<"kg" | "lb">("kg");
   const [heightUnit, setHeightUnit] = useState<"cm" | "in">("cm");
   const [saving, setSaving] = useState(false);
+  const [activityMenuVisible, setActivityMenuVisible] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -287,12 +281,38 @@ export default function ProfileForm({ initialProfile, onSave, onCancel, onDirtyC
       >
         Activity Level
       </Text>
-      <SegmentedButtons
-        value={activityLevel}
-        onValueChange={(v) => setActivityLevel(v as ActivityLevel)}
-        buttons={ACTIVITY_BUTTONS as unknown as Array<{ value: string; label: string; accessibilityLabel: string; style: Record<string, number> }>}
-        style={styles.segmented}
-      />
+      <Menu
+        visible={activityMenuVisible}
+        onDismiss={() => setActivityMenuVisible(false)}
+        anchor={
+          <Pressable
+            onPress={() => setActivityMenuVisible(true)}
+            style={[styles.dropdown, { borderColor: theme.colors.outline, backgroundColor: theme.colors.surface }]}
+            accessibilityLabel={`Activity level: ${ACTIVITY_LABELS[activityLevel]}`}
+            accessibilityRole="button"
+          >
+            <Text variant="bodyLarge" style={{ color: theme.colors.onSurface, flex: 1 }}>
+              {ACTIVITY_LABELS[activityLevel]}
+            </Text>
+            <Text style={{ color: theme.colors.onSurfaceVariant }}>▼</Text>
+          </Pressable>
+        }
+        anchorPosition="bottom"
+        style={{ width: "auto" }}
+      >
+        {(Object.keys(ACTIVITY_LABELS) as ActivityLevel[]).map((key) => (
+          <Menu.Item
+            key={key}
+            title={ACTIVITY_LABELS[key]}
+            onPress={() => {
+              setActivityLevel(key);
+              setActivityMenuVisible(false);
+            }}
+            style={key === activityLevel ? { backgroundColor: theme.colors.primaryContainer } : undefined}
+            accessibilityLabel={ACTIVITY_LABELS[key]}
+          />
+        ))}
+      </Menu>
 
       <Text
         variant="labelLarge"
@@ -339,6 +359,16 @@ const styles = StyleSheet.create({
   input: { marginBottom: 4 },
   fieldLabel: { marginTop: 16, marginBottom: 8, fontSize: 14 },
   segmented: { marginBottom: 8 },
+  dropdown: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderRadius: 4,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    marginBottom: 8,
+    minHeight: 48,
+  },
   btnContent: { paddingVertical: 8, minHeight: 48 },
   errorText: { fontSize: 14, marginBottom: 8 },
   buttonRow: { flexDirection: "row", marginTop: 16 },


### PR DESCRIPTION
## Summary

Three owner-reported UX issues fixed in a single PR.

## Changes

### Issue 1: Barcode Scanner Missing (GitHub #140)
- Added barcode-scan icon to the Nutrition tab header (same pattern as wrench icon on Workouts tab)
- Icon navigates to `/nutrition/add?scan=true`
- Add Food screen accepts `scan` query param: auto-switches to Online tab and opens barcode scanner on mount

### Issue 2: Missing Card Padding on Workout Tab (GitHub #142)
- Added `paddingHorizontal: 8` to `statCard` style for consistent internal spacing on achievement cards (streak, workouts, PRs)

### Issue 3: Activity Level Should Use Dropdown (GitHub #143)
- Replaced `SegmentedButtons` for activity level in `ProfileForm` with a `Menu` dropdown from react-native-paper
- Now shows full activity labels (e.g., "Moderately Active (3-5 days/week)") instead of truncated first words
- Removed unused `ACTIVITY_BUTTONS` constant that was explicitly truncating labels with `.split(' ')[0]`

## Testing

- Added 5 acceptance tests in `owner-ux-batch.acceptance.test.tsx`
- All 27 existing nutrition/ProfileForm tests pass with no regressions
- `tsc --noEmit` passes (pre-existing unrelated error only)

## Issue

Resolves BLD-273 (GitHub #140, #142, #143)