### PR TITLE
fix: Improve workout reminder toggle UX (BLD-274)

### DIFF
--- a/__tests__/acceptance/settings.test.tsx
+++ b/__tests__/acceptance/settings.test.tsx
@@ -300,6 +300,64 @@ describe('Settings Screen Acceptance', () => {
     })
   })
 
+  it('shows schedule-required snack when no workout days scheduled', async () => {
+    const { getSchedule } = require('../../lib/db')
+    getSchedule.mockResolvedValue([])
+
+    mockGetAppSetting.mockImplementation((key: string) => {
+      if (key === 'reminders_enabled') return Promise.resolve('false')
+      if (key === 'timer_sound_enabled') return Promise.resolve('true')
+      return Promise.resolve(null)
+    })
+
+    const { findByLabelText, findByText } = renderScreen(<Settings />)
+    const toggle = await findByLabelText('Workout Reminders')
+
+    fireEvent(toggle, 'valueChange', true)
+
+    await waitFor(() => {
+      expect(requestPermission).not.toHaveBeenCalled()
+    })
+    expect(await findByText(/Set up a weekly workout schedule/)).toBeTruthy()
+  })
+
+  it('shows permission-denied snack when permission is denied on toggle', async () => {
+    const { getSchedule } = require('../../lib/db')
+    getSchedule.mockResolvedValue([{ day: 1 }, { day: 3 }, { day: 5 }])
+    requestPermission.mockResolvedValue(false)
+
+    mockGetAppSetting.mockImplementation((key: string) => {
+      if (key === 'reminders_enabled') return Promise.resolve('false')
+      if (key === 'timer_sound_enabled') return Promise.resolve('true')
+      return Promise.resolve(null)
+    })
+
+    const { findByLabelText, findByText } = renderScreen(<Settings />)
+    const toggle = await findByLabelText('Workout Reminders')
+
+    fireEvent(toggle, 'valueChange', true)
+
+    await waitFor(() => {
+      expect(requestPermission).toHaveBeenCalled()
+    })
+    expect(await findByText(/Notification permission denied.*Open Settings/)).toBeTruthy()
+  })
+
+  it('shows persistent schedule hint in error color when no schedule exists', async () => {
+    const { getSchedule } = require('../../lib/db')
+    getSchedule.mockResolvedValue([])
+
+    mockGetAppSetting.mockImplementation((key: string) => {
+      if (key === 'reminders_enabled') return Promise.resolve('false')
+      if (key === 'timer_sound_enabled') return Promise.resolve('true')
+      return Promise.resolve(null)
+    })
+
+    const { findByText } = renderScreen(<Settings />)
+    const hint = await findByText(/No workout days scheduled/)
+    expect(hint).toBeTruthy()
+  })
+
   // ── Export Data Button ──────────────────────────────────
 
   it('Export All button is pressable and has accessible label', async () => {

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -387,14 +387,14 @@ export default function Settings() {
               onValueChange={async (val) => {
                 if (val) {
                   if (scheduleCount === 0) {
-                    setSnack("No workout days scheduled — set up your schedule first");
+                    setSnack("Set up a weekly workout schedule in your active program first");
                     return;
                   }
                   try {
                     const granted = await requestPermission();
                     if (!granted) {
                       setPermDenied(true);
-                      setSnack("Notification permission denied");
+                      setSnack("Notification permission denied. Tap 'Open Settings' below to enable.");
                       return;
                     }
                     setPermDenied(false);
@@ -475,8 +475,8 @@ export default function Settings() {
           )}
 
           {!reminders && scheduleCount === 0 && (
-            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant, marginTop: 4 }}>
-              Set a weekly schedule on your active program to enable reminders.
+            <Text variant="bodySmall" style={{ color: theme.colors.error, marginTop: 4 }}>
+              No workout days scheduled. Set a weekly schedule on your active program to enable reminders.
             </Text>
           )}
 


### PR DESCRIPTION
## Summary

Fixes the workout reminder toggle being confusing when it can't be enabled — the user gets a transient snack message they may not notice, and the messages don't differentiate between error states.

## Changes

- **Schedule guard**: Updated snack message to explicitly say "Set up a weekly workout schedule in your active program first"
- **Permission denied**: Updated snack message to reference the 'Open Settings' button below the toggle
- **Schedule hint text**: Changed color from `onSurfaceVariant` to `error` and added "No workout days scheduled" prefix for visibility
- **Tests**: Added 3 acceptance tests covering schedule-required snack, permission-denied snack, and persistent hint display

## Testing

- All 28 settings acceptance tests pass
- `tsc --noEmit` passes (only pre-existing unrelated error)
- ESLint passes via lint-staged

## Issue

Resolves BLD-274
GitHub: https://github.com/alankyshum/fitforge/issues/144