### PR TITLE
fix: Template button overridden by nextWorkout logic (BLD-277)

### DIFF
--- a/__tests__/acceptance/dashboard.test.tsx
+++ b/__tests__/acceptance/dashboard.test.tsx
@@ -443,4 +443,68 @@ describe('Dashboard Acceptance', () => {
       })
     })
   })
+
+  describe('Segment switching with nextWorkout (BLD-277)', () => {
+    const nextWorkoutFixture = {
+      program: { id: 'prog-1', name: 'Push Pull Legs' },
+      day: { id: 'day-1', template_id: 'tpl-1', template_name: 'Push Day', label: 'Day 1' },
+    }
+
+    it('defaults to programs when nextWorkout exists', async () => {
+      mockGetNextWorkout.mockResolvedValue(nextWorkoutFixture)
+
+      const { getByLabelText, queryByLabelText } = renderScreen(<Dashboard />)
+
+      await waitFor(() => {
+        expect(getByLabelText('Create new program')).toBeTruthy()
+      })
+      expect(queryByLabelText('Create new template')).toBeNull()
+    })
+
+    it('allows switching to templates when nextWorkout exists', async () => {
+      mockGetNextWorkout.mockResolvedValue(nextWorkoutFixture)
+
+      const { getByLabelText } = renderScreen(<Dashboard />)
+
+      await waitFor(() => {
+        expect(getByLabelText('Create new program')).toBeTruthy()
+      })
+
+      fireEvent.press(getByLabelText('Templates tab'))
+
+      await waitFor(() => {
+        expect(getByLabelText('Create new template')).toBeTruthy()
+      })
+    })
+
+    it('defaults to templates when no nextWorkout', async () => {
+      mockGetNextWorkout.mockResolvedValue(null)
+
+      const { getByLabelText } = renderScreen(<Dashboard />)
+
+      await waitFor(() => {
+        expect(getByLabelText('Create new template')).toBeTruthy()
+      })
+    })
+
+    it('can freely switch segments with active program', async () => {
+      mockGetNextWorkout.mockResolvedValue(nextWorkoutFixture)
+
+      const { getByLabelText } = renderScreen(<Dashboard />)
+
+      await waitFor(() => {
+        expect(getByLabelText('Create new program')).toBeTruthy()
+      })
+
+      fireEvent.press(getByLabelText('Templates tab'))
+      await waitFor(() => {
+        expect(getByLabelText('Create new template')).toBeTruthy()
+      })
+
+      fireEvent.press(getByLabelText('Programs tab'))
+      await waitFor(() => {
+        expect(getByLabelText('Create new program')).toBeTruthy()
+      })
+    })
+  })
 })

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -112,7 +112,7 @@ export default function Workouts() {
   const { showSnack } = useSnackbar();
   const layout = useLayout();
   const tabBarHeight = useFloatingTabBarHeight();
-  const [segment, setSegment] = useState("templates");
+  const [userSegment, setUserSegment] = useState<string | null>(null);
   const [menu, setMenu] = useState<string | null>(null);
 
   const { data } = useQuery({
@@ -132,11 +132,10 @@ export default function Workouts() {
   const recentPRs = data?.recentPRs ?? [];
   const avgRPEs = data?.avgRPEs ?? {};
   const nextWorkout = data?.nextWorkout ?? null;
+  const segment = userSegment ?? (nextWorkout ? "programs" : "templates");
   const todaySchedule = data?.todaySchedule ?? null;
   const todayDone = data?.todayDone ?? false;
   const adherence = data?.adherence ?? [];
-
-  const effectiveSegment = nextWorkout && segment === "templates" ? "programs" : segment;
 
   const reload = () => queryClient.invalidateQueries({ queryKey: ["home"] });
 
@@ -459,8 +458,8 @@ export default function Workouts() {
 
       {/* Segmented Control */}
       <SegmentedButtons
-        value={effectiveSegment}
-        onValueChange={setSegment}
+        value={segment}
+        onValueChange={setUserSegment}
         buttons={[
           {
             value: "templates",
@@ -476,7 +475,7 @@ export default function Workouts() {
         style={styles.segmented}
       />
 
-      {effectiveSegment === "templates" ? (
+      {segment === "templates" ? (
         <>
           {/* User Templates */}
           <View style={styles.section}>


### PR DESCRIPTION
## Summary

Fixes the Templates segmented button on the workout tab not working when a user has an active program with a next workout.

## Root Cause

`effectiveSegment` override on every render silently replaced "templates" with "programs" when `nextWorkout` was truthy, making the Templates button non-functional.

## Fix

Replace the continuous override with a derived segment: `userSegment ?? (nextWorkout ? "programs" : "templates")`. This defaults to programs when nextWorkout exists but lets users switch freely once they tap a segment.

## Changes

- `app/(tabs)/index.tsx`: Remove `effectiveSegment` override, use derived `segment` from `userSegment` state + `nextWorkout` data
- `__tests__/acceptance/dashboard.test.tsx`: Add 4 acceptance tests for segment switching behavior

## Testing

- 26/26 dashboard acceptance tests pass (4 new)
- `tsc --noEmit` passes (no new errors)
- ESLint passes with zero warnings

## Issue

Resolves BLD-277
Fixes https://github.com/alankyshum/fitforge/issues/148