### PR TITLE
fix: Workout screen layout — remove orphaned notes button, add tests (BLD-275)

### DIFF
--- a/__tests__/acceptance/rpe-notes.test.tsx
+++ b/__tests__/acceptance/rpe-notes.test.tsx
@@ -220,28 +220,28 @@ describe('Notes Field in Active Session', () => {
     mockDb.getSessionSets.mockResolvedValue(makeSessionSets('sess-notes'))
   })
 
-  it('renders set notes button with a11y label', async () => {
+  it('renders exercise-level notes button with a11y label', async () => {
     const { findAllByLabelText } = renderScreen(<ActiveSession />)
-    const noteButtons = await findAllByLabelText('Set notes')
+    const noteButtons = await findAllByLabelText('Bench Press notes')
     expect(noteButtons.length).toBeGreaterThan(0)
   })
 
   it('pressing notes button shows notes input', async () => {
     const { findAllByLabelText, getByPlaceholderText } = renderScreen(<ActiveSession />)
-    const noteButtons = await findAllByLabelText('Set notes')
+    const noteButtons = await findAllByLabelText('Bench Press notes')
     fireEvent.press(noteButtons[0])
 
     await waitFor(() => {
-      expect(getByPlaceholderText('Add notes...')).toBeTruthy()
+      expect(getByPlaceholderText('Add exercise notes...')).toBeTruthy()
     })
   })
 
   it('typing in notes field and blurring calls updateSetNotes', async () => {
     const { findAllByLabelText, getByPlaceholderText } = renderScreen(<ActiveSession />)
-    const noteButtons = await findAllByLabelText('Set notes')
+    const noteButtons = await findAllByLabelText('Bench Press notes')
     fireEvent.press(noteButtons[0])
 
-    const input = await waitFor(() => getByPlaceholderText('Add notes...'))
+    const input = await waitFor(() => getByPlaceholderText('Add exercise notes...'))
     fireEvent.changeText(input, 'Felt strong today')
     fireEvent(input, 'blur')
 

--- a/__tests__/acceptance/session-ux.test.tsx
+++ b/__tests__/acceptance/session-ux.test.tsx
@@ -309,4 +309,40 @@ describe('Session UX Acceptance', () => {
       })
     })
   })
+
+  describe('Exercise-level notes (BLD-275)', () => {
+    it('does NOT render a per-set notes button', async () => {
+      setupSession()
+      const { findByText, queryAllByLabelText } = renderScreen(<ActiveSession />)
+      await findByText('Squat')
+      const setNotesButtons = queryAllByLabelText('Set notes')
+      expect(setNotesButtons.length).toBe(0)
+    })
+
+    it('renders an exercise-level notes button in the header', async () => {
+      setupSession()
+      const { findByText, findByLabelText } = renderScreen(<ActiveSession />)
+      await findByText('Squat')
+      const notesBtn = await findByLabelText('Squat notes')
+      expect(notesBtn).toBeTruthy()
+    })
+
+    it('renders only checkbox and delete per set row', async () => {
+      setupSession()
+      const { findByText, getAllByLabelText } = renderScreen(<ActiveSession />)
+      await findByText('Squat')
+      const deleteButtons = getAllByLabelText(/Delete set/)
+      expect(deleteButtons.length).toBe(3)
+    })
+  })
+
+  describe('Column spacing and alignment (BLD-275)', () => {
+    it('renders SET and PREV column headers', async () => {
+      setupSession()
+      const { findByText } = renderScreen(<ActiveSession />)
+      await findByText('Squat')
+      expect(await findByText('SET')).toBeTruthy()
+      expect(await findByText('PREV')).toBeTruthy()
+    })
+  })
 })

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -211,19 +211,6 @@ const SetRow = memo(function SetRow({
             )}
           </Pressable>
           <Pressable
-            onPress={() => onToggleNotes(set.id)}
-            hitSlop={6}
-            style={styles.actionBtn}
-            accessibilityLabel="Set notes"
-            accessibilityRole="button"
-          >
-            <MaterialCommunityIcons
-              name={set.notes ? "note-text" : "note-text-outline"}
-              size={22}
-              color={theme.colors.onSurfaceVariant}
-            />
-          </Pressable>
-          <Pressable
             onPress={() => onDelete(set.id)}
             hitSlop={6}
             style={styles.actionBtn}


### PR DESCRIPTION
## Summary

Completes the exercise-level notes migration by removing the orphaned per-set notes button from the workout session SetRow. The exercise-level notes feature was already migrated to the exercise header in a previous commit, but the old per-set notes button was left behind, wasting horizontal space.

## Changes

- Remove orphaned per-set notes button from SetRow (was referencing removed `onToggleNotes` prop)
- Add 4 acceptance tests for BLD-275 covering:
  - No per-set notes button exists
  - Exercise-level notes button in header
  - Only checkbox and delete per set row
  - SET/PREV column headers render correctly

## Testing

- `npx tsc --noEmit` passes (0 new errors)
- All 45 session tests pass (including 4 new)
- ESLint passes (0 warnings)

## Issue

Resolves BLD-275