### PR TITLE
fix: post-merge review fixes — a11y state, console.warn guards (BLD-276)

### DIFF
--- a/__tests__/components/ProfileForm.test.tsx
+++ b/__tests__/components/ProfileForm.test.tsx
@@ -81,7 +81,7 @@ describe("ProfileForm", () => {
 
   it("shows validation errors for empty fields", async () => {
     const onSave = jest.fn();
-    const { getByLabelText } = renderScreen(
+    const { getByLabelText, getByText } = renderScreen(
       <ProfileForm onSave={onSave} />
     );
     await waitFor(() => {
@@ -98,7 +98,7 @@ describe("ProfileForm", () => {
 
   it("saves profile and calls onSave on valid input", async () => {
     const onSave = jest.fn();
-    const { getByLabelText } = renderScreen(
+    const { getByLabelText, getByText } = renderScreen(
       <ProfileForm initialProfile={mockProfile} onSave={onSave} />
     );
     await waitFor(() => {
@@ -143,7 +143,7 @@ describe("ProfileForm", () => {
 
   it("shows save error on failure", async () => {
     mockSetAppSetting.mockRejectedValue(new Error("DB error"));
-    const { getByLabelText } = renderScreen(
+    const { getByLabelText, getByText } = renderScreen(
       <ProfileForm initialProfile={mockProfile} onSave={jest.fn()} />
     );
     await waitFor(() => {
@@ -232,7 +232,7 @@ describe("BodyProfileCard", () => {
 
   it("shows validation error on blur with invalid input", async () => {
     mockGetAppSetting.mockResolvedValue(JSON.stringify(mockProfile));
-    const { getByLabelText } = renderScreen(<BodyProfileCard />);
+    const { getByLabelText, getByText } = renderScreen(<BodyProfileCard />);
     await waitFor(() => {
       expect(getByLabelText("Age in years").props.value).toBe("30");
     });

--- a/__tests__/components/ProfileForm.test.tsx
+++ b/__tests__/components/ProfileForm.test.tsx
@@ -81,7 +81,7 @@ describe("ProfileForm", () => {
 
   it("shows validation errors for empty fields", async () => {
     const onSave = jest.fn();
-    const { getByLabelText, getByText } = renderScreen(
+    const { getByLabelText } = renderScreen(
       <ProfileForm onSave={onSave} />
     );
     await waitFor(() => {
@@ -98,7 +98,7 @@ describe("ProfileForm", () => {
 
   it("saves profile and calls onSave on valid input", async () => {
     const onSave = jest.fn();
-    const { getByLabelText, getByText } = renderScreen(
+    const { getByLabelText } = renderScreen(
       <ProfileForm initialProfile={mockProfile} onSave={onSave} />
     );
     await waitFor(() => {
@@ -143,7 +143,7 @@ describe("ProfileForm", () => {
 
   it("shows save error on failure", async () => {
     mockSetAppSetting.mockRejectedValue(new Error("DB error"));
-    const { getByLabelText, getByText } = renderScreen(
+    const { getByLabelText } = renderScreen(
       <ProfileForm initialProfile={mockProfile} onSave={jest.fn()} />
     );
     await waitFor(() => {
@@ -232,7 +232,7 @@ describe("BodyProfileCard", () => {
 
   it("shows validation error on blur with invalid input", async () => {
     mockGetAppSetting.mockResolvedValue(JSON.stringify(mockProfile));
-    const { getByLabelText, getByText } = renderScreen(<BodyProfileCard />);
+    const { getByLabelText } = renderScreen(<BodyProfileCard />);
     await waitFor(() => {
       expect(getByLabelText("Age in years").props.value).toBe("30");
     });
@@ -256,6 +256,19 @@ describe("BodyProfileCard", () => {
         "nutrition_profile",
         expect.any(String)
       );
+    });
+  });
+});
+
+describe("ProfileForm accessibility", () => {
+  it("activity dropdown has accessibilityState with expanded property", async () => {
+    const { getByLabelText } = renderScreen(
+      <ProfileForm onSave={jest.fn()} />
+    );
+    await waitFor(() => {
+      const dropdown = getByLabelText(/Activity level:/);
+      expect(dropdown.props.accessibilityState).toBeDefined();
+      expect(dropdown.props.accessibilityState).toHaveProperty("expanded");
     });
   });
 });

--- a/app/progress/achievements.tsx
+++ b/app/progress/achievements.tsx
@@ -105,7 +105,7 @@ export default function AchievementsScreen() {
           );
           setEarnedCount(earnedMap.size);
         } catch (e) {
-          console.warn("Achievement evaluation failed:", e);
+          if (__DEV__) console.warn("Achievement evaluation failed:", e);
           if (!cancelled) setError("Could not load achievements. Please try again later.");
         } finally {
           if (!cancelled) setLoading(false);

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -1028,7 +1028,7 @@ export default function ActiveSession() {
       }
       // Load all exercises for substitution sheet
       getAllExercises().then(setAllExercises).catch((err) => {
-        console.warn("Failed to load exercises for substitution:", err);
+        if (__DEV__) console.warn("Failed to load exercises for substitution:", err);
       });
     }, [id, load])
   );

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -133,7 +133,7 @@ export default function Summary() {
           }
         }
       } catch (e) {
-        console.warn("Achievement evaluation failed:", e);
+        if (__DEV__) console.warn("Achievement evaluation failed:", e);
       }
 
       AccessibilityInfo.announceForAccessibility("Workout Complete!");

--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -290,6 +290,7 @@ export default function ProfileForm({ initialProfile, onSave, onCancel, onDirtyC
             style={[styles.dropdown, { borderColor: theme.colors.outline, backgroundColor: theme.colors.surface }]}
             accessibilityLabel={`Activity level: ${ACTIVITY_LABELS[activityLevel]}`}
             accessibilityRole="button"
+            accessibilityState={{ expanded: activityMenuVisible }}
           >
             <Text variant="bodyLarge" style={{ color: theme.colors.onSurface, flex: 1 }}>
               {ACTIVITY_LABELS[activityLevel]}


### PR DESCRIPTION
## Summary

Post-merge review findings from BLD-273 (PR #146). Adds missing accessibility state to ProfileForm activity dropdown and guards console.warn calls with `__DEV__` check.

## Changes

- **Fix 1 (MAJOR)**: Add `accessibilityState={{ expanded: activityMenuVisible }}` to ProfileForm activity dropdown trigger
- **Fix 2 (MINOR)**: Wrap 3 `console.warn` calls in `__DEV__` check:
  - `app/session/summary/[id].tsx` — Achievement evaluation
  - `app/session/[id].tsx` — Substitution exercise load
  - `app/progress/achievements.tsx` — Achievement evaluation
- **Fix 3 (MINOR)**: N/A — WeeklySummary has no setInterval; useEffect already has proper cleanup

## Testing

- `npx tsc --noEmit` passes (only pre-existing ShareSheet TS2344)
- 16/16 ProfileForm tests pass (including new accessibility test)
- 34/34 combined test run passes
- ESLint passes (lint-staged verified on commit)

## Issue

Resolves BLD-276