### PR TITLE
fix: resolve tsc error in ShareSheet test (BLD-288)

### DIFF
--- a/__tests__/components/ShareSheet.test.tsx
+++ b/__tests__/components/ShareSheet.test.tsx
@@ -29,10 +29,11 @@ jest.mock('@gorhom/bottom-sheet', () => {
 import React, { createRef } from 'react';
 import { render } from '@testing-library/react-native';
 import { PaperProvider } from 'react-native-paper';
+import type BottomSheet from '@gorhom/bottom-sheet';
 import ShareSheet from '../../components/ShareSheet';
 
 function renderSheet(overrides: Partial<React.ComponentProps<typeof ShareSheet>> = {}) {
-  const ref = createRef<InstanceType<typeof import('@gorhom/bottom-sheet').default>>();
+  const ref = createRef<BottomSheet | null>();
   const defaultProps = {
     sheetRef: ref,
     onShareText: jest.fn(),


### PR DESCRIPTION
## Summary

Fix pre-existing TypeScript error in ShareSheet.test.tsx:35 where `InstanceType<typeof import('@gorhom/bottom-sheet').default>` failed because the default export is a `MemoExoticComponent`, not a constructor.

## Changes

- Replace inline `InstanceType<typeof import(...)>` with direct `import type BottomSheet from '@gorhom/bottom-sheet'`
- Use `createRef<BottomSheet | null>()` matching the component's prop type

## Testing

- `npx -p typescript tsc --noEmit` passes with zero errors
- ShareSheet tests pass (3/3)

## Issue

Resolves BLD-288