### PR TITLE
feat: enhanced error logging with device diagnostics (BLD-292)

### DIFF
--- a/__mocks__/expo-device.js
+++ b/__mocks__/expo-device.js
@@ -1,0 +1,5 @@
+module.exports = {
+  deviceName: "Test Device",
+  modelName: "Test Model",
+  totalMemory: 4294967296,
+};

--- a/__tests__/lib/db/interaction-log.test.ts
+++ b/__tests__/lib/db/interaction-log.test.ts
@@ -1,0 +1,29 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Structural tests for BLD-292: interaction log limit expanded to 50.
+ */
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../../../lib/db/settings.ts"),
+  "utf-8"
+);
+
+describe("interaction log limits (BLD-292)", () => {
+  it("insertInteraction prunes to 50 entries", () => {
+    expect(src).toMatch(/ORDER BY timestamp DESC LIMIT 50/);
+  });
+
+  it("getInteractions returns up to 50 entries", () => {
+    const match = src.match(/SELECT \* FROM interaction_log ORDER BY timestamp DESC LIMIT (\d+)/);
+    expect(match).not.toBeNull();
+    expect(parseInt(match![1], 10)).toBe(50);
+  });
+
+  it("does NOT use time-based pruning", () => {
+    // Per CEO directive: count-based only, no 60-second window
+    expect(src).not.toMatch(/timestamp\s*<\s*\?.*60/);
+    expect(src).not.toMatch(/strftime.*60/);
+  });
+});

--- a/__tests__/lib/feedback.test.ts
+++ b/__tests__/lib/feedback.test.ts
@@ -259,3 +259,62 @@ describe("generateShareText", () => {
     expect(text).not.toContain("Test error");
   });
 });
+
+describe("device info (BLD-292)", () => {
+  it("buildReportBody includes Device Info section by default", () => {
+    const body = buildReportBody({
+      type: "bug",
+      description: "test",
+      errors: [],
+      interactions: [],
+      includeDiag: true,
+    });
+    expect(body).toContain("## Device Info");
+    expect(body).toContain("Test Model");
+    expect(body).toContain("Test Device");
+    expect(body).toContain("4096 MB");
+  });
+
+  it("buildReportBody excludes Device Info when includeDeviceInfo is false", () => {
+    const body = buildReportBody({
+      type: "bug",
+      description: "test",
+      errors: [],
+      interactions: [],
+      includeDiag: true,
+      includeDeviceInfo: false,
+    });
+    expect(body).not.toContain("## Device Info");
+    expect(body).not.toContain("Test Model");
+  });
+
+  it("generateShareText includes device info", () => {
+    const text = generateShareText({
+      type: "bug",
+      title: "Bug",
+      description: "desc",
+      errors: [],
+      interactions: [],
+      includeDiag: true,
+    });
+    expect(text).toContain("Device Info:");
+    expect(text).toContain("Test Model");
+  });
+
+  it("truncation removes device info first (Phase 0)", () => {
+    const long = "X".repeat(8000);
+    const errors = [makeError()];
+    const interactions = [makeInteraction()];
+    const body = buildReportBody({
+      type: "bug",
+      description: long,
+      errors,
+      interactions,
+      includeDiag: true,
+    });
+    const result = truncateBody(body, errors, interactions, long, "bug", true);
+    expect(result).toContain("[truncated");
+    const url = `https://github.com/alankyshum/fitforge/issues/new?title=x&body=${encodeURIComponent(result)}`;
+    expect(url.length).toBeLessThanOrEqual(8000);
+  });
+});

--- a/__tests__/lib/interactions.test.ts
+++ b/__tests__/lib/interactions.test.ts
@@ -69,7 +69,7 @@ describe("insertInteraction", () => {
     // Second call: DELETE (FIFO prune)
     const deleteCall = mockDb.runAsync.mock.calls[1];
     expect(deleteCall[0]).toContain("DELETE FROM interaction_log");
-    expect(deleteCall[0]).toContain("LIMIT 10");
+    expect(deleteCall[0]).toContain("LIMIT 50");
   });
 
   it("stores detail when provided", async () => {
@@ -84,7 +84,7 @@ describe("insertInteraction", () => {
 });
 
 describe("getInteractions", () => {
-  it("returns rows ordered by timestamp DESC, limited to 10", async () => {
+  it("returns rows ordered by timestamp DESC, limited to 50", async () => {
     await initDb();
     const rows = [
       { id: "1", action: "navigate", screen: "Home", detail: null, timestamp: 1000 },
@@ -95,7 +95,7 @@ describe("getInteractions", () => {
     const result = await db.getInteractions();
     expect(result).toEqual(rows);
     expect(mockDb.getAllAsync).toHaveBeenCalledWith(
-      "SELECT * FROM interaction_log ORDER BY timestamp DESC LIMIT 10"
+      "SELECT * FROM interaction_log ORDER BY timestamp DESC LIMIT 50"
     );
   });
 });

--- a/lib/db/settings.ts
+++ b/lib/db/settings.ts
@@ -123,7 +123,7 @@ export async function insertInteraction(
     );
     await database.runAsync(
       `DELETE FROM interaction_log WHERE id NOT IN (
-        SELECT id FROM interaction_log ORDER BY timestamp DESC LIMIT 10
+        SELECT id FROM interaction_log ORDER BY timestamp DESC LIMIT 50
       )`
     );
   });
@@ -133,7 +133,7 @@ export async function getInteractions(): Promise<
   { id: string; action: string; screen: string; detail: string | null; timestamp: number }[]
 > {
   return query(
-    "SELECT * FROM interaction_log ORDER BY timestamp DESC LIMIT 10"
+    "SELECT * FROM interaction_log ORDER BY timestamp DESC LIMIT 50"
   );
 }
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,5 +1,6 @@
 import { Platform } from "react-native";
 import Constants from "expo-constants";
+import * as Device from "expo-device";
 import { getDatabase } from "./db";
 import { recent as recentInteractions } from "./interactions";
 import { getRecentConsoleLogs, formatConsoleLogs } from "./console-log-buffer";
@@ -92,12 +93,26 @@ export async function generateReport(): Promise<string> {
   const errors = await getRecentErrors(MAX_ERRORS);
   const interactions = await recentInteractions();
   const consoleLogs = getRecentConsoleLogs();
+
+  let deviceInfo: Record<string, string | number | null> = {};
+  try {
+    deviceInfo = {
+      deviceName: Device.deviceName ?? "unknown",
+      modelName: Device.modelName ?? "unknown",
+      totalMemory: Device.totalMemory ?? null,
+      executionEnvironment: Constants.executionEnvironment ?? "unknown",
+    };
+  } catch {
+    deviceInfo = { error: "Device info unavailable" };
+  }
+
   return JSON.stringify(
     {
       generated_at: new Date().toISOString(),
       app_version: Constants.expoConfig?.version ?? "unknown",
       platform: Platform.OS,
       os_version: String(Platform.Version),
+      device: deviceInfo,
       error_count: errors.length,
       errors,
       interactions,
@@ -130,6 +145,19 @@ function formatErrors(items: ErrorEntry[]): string {
     .join("\n");
 }
 
+function getDeviceInfo(): string {
+  try {
+    const lines: string[] = [];
+    lines.push(`- Device: ${Device.modelName ?? "unknown"}`);
+    lines.push(`- Device Name: ${Device.deviceName ?? "unknown"}`);
+    lines.push(`- Total Memory: ${Device.totalMemory != null ? `${Math.round(Device.totalMemory / 1024 / 1024)} MB` : "unknown"}`);
+    lines.push(`- Execution Environment: ${Constants.executionEnvironment ?? "unknown"}`);
+    return lines.join("\n");
+  } catch {
+    return "- Device info unavailable";
+  }
+}
+
 export function buildReportBody(opts: {
   type: ReportType;
   description: string;
@@ -137,6 +165,7 @@ export function buildReportBody(opts: {
   interactions: Interaction[];
   consoleLogs?: ConsoleLogEntry[];
   includeDiag: boolean;
+  includeDeviceInfo?: boolean;
 }): string {
   const version = Constants.expoConfig?.version ?? "unknown";
   const parts: string[] = [];
@@ -150,6 +179,12 @@ export function buildReportBody(opts: {
   parts.push(`- Platform: ${Platform.OS}`);
   parts.push(`- OS Version: ${String(Platform.Version)}`);
   parts.push("");
+
+  if (opts.includeDeviceInfo !== false) {
+    parts.push("## Device Info\n");
+    parts.push(getDeviceInfo());
+    parts.push("");
+  }
 
   if (opts.includeDiag) {
     parts.push("## Recent Interactions\n");
@@ -179,7 +214,19 @@ export function truncateBody(body: string, errors: ErrorEntry[], interactions: I
 
   if (check(body) <= MAX_URL) return body;
 
-  // Phase 0: remove console logs first (they're supplementary)
+  // Phase 0: remove device info first (least valuable for debugging)
+  const noDeviceInfo = buildReportBody({
+    type,
+    description: desc,
+    errors,
+    interactions,
+    consoleLogs,
+    includeDiag,
+    includeDeviceInfo: false,
+  });
+  if (check(noDeviceInfo) <= MAX_URL) return noDeviceInfo + "\n\n[truncated — share full report for details]";
+
+  // Phase 1: also remove console logs
   const noConsoleLogs = buildReportBody({
     type,
     description: desc,
@@ -187,30 +234,33 @@ export function truncateBody(body: string, errors: ErrorEntry[], interactions: I
     interactions,
     consoleLogs: [],
     includeDiag,
+    includeDeviceInfo: false,
   });
   if (check(noConsoleLogs) <= MAX_URL) return noConsoleLogs + "\n\n[truncated — share full report for details]";
 
-  // Phase 1: remove stack traces from errors
+  // Phase 2: remove stack traces from errors
   const noStacks = buildReportBody({
     type,
     description: desc,
     errors: errors.map((e) => ({ ...e, stack: null })),
     interactions,
     includeDiag,
+    includeDeviceInfo: false,
   });
   if (check(noStacks) <= MAX_URL) return noStacks + "\n\n[truncated — share full report for details]";
 
-  // Phase 2: remove errors entirely
+  // Phase 3: remove errors entirely
   const noErrors = buildReportBody({
     type,
     description: desc,
     errors: [],
     interactions,
     includeDiag,
+    includeDeviceInfo: false,
   });
   if (check(noErrors) <= MAX_URL) return noErrors + "\n\n[truncated — share full report for details]";
 
-  // Phase 3: trim interactions
+  // Phase 4: trim interactions
   let trimmed = interactions;
   while (trimmed.length > 0) {
     trimmed = trimmed.slice(0, -1);
@@ -220,11 +270,12 @@ export function truncateBody(body: string, errors: ErrorEntry[], interactions: I
       errors: [],
       interactions: trimmed,
       includeDiag,
+      includeDeviceInfo: false,
     });
     if (check(attempt) <= MAX_URL) return attempt + "\n\n[truncated — share full report for details]";
   }
 
-  // Phase 4: truncate description
+  // Phase 5: truncate description
   let short = desc;
   while (short.length > 20) {
     short = short.slice(0, Math.floor(short.length * 0.7));
@@ -234,11 +285,12 @@ export function truncateBody(body: string, errors: ErrorEntry[], interactions: I
       errors: [],
       interactions: [],
       includeDiag,
+      includeDeviceInfo: false,
     });
     if (check(attempt) <= MAX_URL) return attempt + "\n\n[truncated — share full report for details]";
   }
 
-  return buildReportBody({ type, description: "...", errors: [], interactions: [], includeDiag }) +
+  return buildReportBody({ type, description: "...", errors: [], interactions: [], includeDiag, includeDeviceInfo: false }) +
     "\n\n[truncated — share full report for details]";
 }
 
@@ -281,6 +333,9 @@ export function generateShareText(opts: {
   lines.push(`Date: ${new Date().toISOString()}`);
   lines.push(`App Version: ${version}`);
   lines.push(`Platform: ${Platform.OS} ${String(Platform.Version)}`);
+  lines.push("");
+  lines.push("Device Info:");
+  lines.push(getDeviceInfo());
   lines.push("");
   lines.push("Description:");
   lines.push(opts.description || "(none)");

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "expo-constants": "~55.0.14",
         "expo-crypto": "~55.0.14",
         "expo-dev-client": "~55.0.27",
+        "expo-device": "~55.0.15",
         "expo-document-picker": "~55.0.13",
         "expo-file-system": "~55.0.16",
         "expo-haptics": "~55.0.14",
@@ -7604,6 +7605,44 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-device": {
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-55.0.15.tgz",
+      "integrity": "sha512-vXy4U/IeYI+zHGG45Ap6J7EuyQmkstyo8I+/5YGr5q2zmqLBo6SWE62wii8i9hLHheHn6AtF9UPrSWAREJrE8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ua-parser-js": "^0.7.33"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-device/node_modules/ua-parser-js": {
+      "version": "0.7.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
+      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/expo-document-picker": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "expo-constants": "~55.0.14",
     "expo-crypto": "~55.0.14",
     "expo-dev-client": "~55.0.27",
+    "expo-device": "~55.0.15",
     "expo-document-picker": "~55.0.13",
     "expo-file-system": "~55.0.16",
     "expo-haptics": "~55.0.14",


### PR DESCRIPTION
## Summary

Expands interaction logging from 10 to 50 entries and adds device diagnostics (model, memory, execution environment) to feedback reports using expo-device. Updates truncation cascade so device info is removed first when report exceeds URL length limit.

## Changes

- **lib/db/settings.ts**: Increased interaction log limit from 10 to 50 entries (both insert pruning and select queries)
- **lib/errors.ts**: Added `getDeviceInfo()` function using expo-device and expo-constants; added Device Info section to report output; updated truncation cascade (device info → console logs → error stacks → errors → interactions → description)
- **package.json**: Added expo-device dependency
- **New tests**: `__tests__/lib/feedback.test.ts` for device info and report formatting, updated `__tests__/lib/interactions.test.ts` for 50-entry limit

## Testing

- `npx -p typescript tsc --noEmit` — passes with zero errors
- `npx jest` — all 21 tests pass
- Device info APIs wrapped in try/catch with 'unknown' fallback

## Issue

Resolves BLD-292 (GitHub #149)