### PR TITLE
fix: workout session layout — details alignment, column spacing, header baseline (BLD-293)

### DIFF
--- a/__tests__/app/session-layout-fixes.test.ts
+++ b/__tests__/app/session-layout-fixes.test.ts
@@ -14,20 +14,21 @@ const src = fs.readFileSync(
 
 describe("workout session layout fixes (BLD-293)", () => {
   describe("Fix 1: Details button left alignment", () => {
-    it("detailsBtn has marginLeft of -16 or more negative", () => {
+    it("detailsBtn has marginLeft to align text with exercise name", () => {
       const match = src.match(/detailsBtn:\s*\{[^}]*marginLeft:\s*(-?\d+)/);
       expect(match).not.toBeNull();
       const margin = parseInt(match![1], 10);
-      expect(margin).toBeLessThanOrEqual(-12);
+      expect(margin).toBeLessThanOrEqual(-8);
+      expect(margin).toBeGreaterThanOrEqual(-16);
     });
   });
 
   describe("Fix 2: Weight/Reps picker column spacing", () => {
-    it("pickerCol has marginHorizontal of at least 6", () => {
+    it("pickerCol has marginHorizontal of at least 12", () => {
       const match = src.match(/pickerCol:\s*\{[^}]*marginHorizontal:\s*(\d+)/);
       expect(match).not.toBeNull();
       const margin = parseInt(match![1], 10);
-      expect(margin).toBeGreaterThanOrEqual(6);
+      expect(margin).toBeGreaterThanOrEqual(12);
     });
 
     it("colLabel marginHorizontal matches pickerCol spacing", () => {
@@ -48,6 +49,12 @@ describe("workout session layout fixes (BLD-293)", () => {
 
     it("SetRow Pressable has minHeight: 36 inline for touch target", () => {
       expect(src).toMatch(/style=\{\[styles\.colSet,\s*\{\s*minHeight:\s*36\s*\}\]/);
+    });
+
+    it("headerRow has minHeight for consistent label alignment", () => {
+      const match = src.match(/headerRow:\s*\{[^}]*minHeight:\s*(\d+)/);
+      expect(match).not.toBeNull();
+      expect(parseInt(match![1], 10)).toBeGreaterThanOrEqual(24);
     });
   });
 });

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -1801,6 +1801,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingVertical: 4,
     paddingHorizontal: 4,
+    minHeight: 28,
   },
   setRow: {
     flexDirection: "row",
@@ -1831,13 +1832,13 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    marginHorizontal: 8,
+    marginHorizontal: 12,
   },
   colLabel: {
     flex: 1,
     textAlign: "center",
     fontSize: 12,
-    marginHorizontal: 8,
+    marginHorizontal: 12,
   },
   colCheck: {
     width: 32,
@@ -1885,7 +1886,8 @@ const styles = StyleSheet.create({
     margin: 0,
   },
   detailsBtn: {
-    marginLeft: -16,
+    marginLeft: -12,
+    marginRight: -8,
   },
   divider: {
     marginTop: 8,


### PR DESCRIPTION
## Summary

Fixes three UI layout issues on the workout session screen reported in GitHub #147.

## Changes

**Fix 1: Details button left alignment**
- Adjusted `detailsBtn` marginLeft from -16 to -12, added marginRight -8
- Text now aligns closer to exercise name above it

**Fix 2: Weight/Reps column spacing**
- Increased `pickerCol` marginHorizontal from 8 to 12 for better visual separation
- Updated `colLabel` to match (8 → 12) keeping header labels aligned with columns

**Fix 3: SET/PREV header baseline alignment**
- Added `minHeight: 28` to `headerRow` for consistent vertical centering of all column labels

## Testing

- `npx -p typescript tsc --noEmit` — passes
- All 6 structural layout tests pass (`session-layout-fixes.test.ts`)
- All 14 BottomSheet session tests pass
- No tablet layout changes (compact layout only)

## Issue

Resolves BLD-293 (GitHub #147)