### PR TITLE
feat: replace age with birth year in body profile (BLD-296)

### DIFF
--- a/__tests__/app/nutrition/profile.test.tsx
+++ b/__tests__/app/nutrition/profile.test.tsx
@@ -77,7 +77,7 @@ describe("Profile Screen", () => {
     const { findByText, getByLabelText } = renderScreen(<ProfileScreen />);
 
     expect(await findByText("Your Profile")).toBeTruthy();
-    expect(getByLabelText("Age in years")).toBeTruthy();
+    expect(getByLabelText("Birth year")).toBeTruthy();
     expect(getByLabelText("Weight in kg")).toBeTruthy();
     expect(getByLabelText("Height in cm")).toBeTruthy();
     expect(getByLabelText("Calculate and save nutrition targets")).toBeTruthy();
@@ -95,7 +95,7 @@ describe("Profile Screen", () => {
 
   it("loads saved profile data", async () => {
     const savedProfile = JSON.stringify({
-      age: 30,
+      birthYear: 1996,
       weight: 80,
       height: 180,
       sex: "male",
@@ -108,9 +108,9 @@ describe("Profile Screen", () => {
 
     const { findByLabelText } = renderScreen(<ProfileScreen />);
 
-    const ageInput = await findByLabelText("Age in years");
+    const birthYearInput = await findByLabelText("Birth year");
     await waitFor(() => {
-      expect(ageInput.props.value).toBe("30");
+      expect(birthYearInput.props.value).toBe("1996");
     });
   });
 
@@ -122,7 +122,8 @@ describe("Profile Screen", () => {
     const { fireEvent } = require("@testing-library/react-native");
     fireEvent.press(saveBtn);
 
-    expect(await findByText("Enter a valid age (1–120)")).toBeTruthy();
+    const currentYear = new Date().getFullYear();
+    expect(await findByText(`Enter a valid birth year (1900–${currentYear - 1})`)).toBeTruthy();
     expect(await findByText("Enter a valid weight")).toBeTruthy();
     expect(await findByText("Enter a valid height")).toBeTruthy();
     expect(mockSetAppSetting).not.toHaveBeenCalled();

--- a/__tests__/app/nutrition/targets.test.tsx
+++ b/__tests__/app/nutrition/targets.test.tsx
@@ -91,7 +91,7 @@ describe("Targets Screen", () => {
 
   it("shows update profile CTA with summary when profile exists", async () => {
     const profile = JSON.stringify({
-      age: 30,
+      birthYear: 1996,
       weight: 75,
       height: 175,
       sex: "male",
@@ -139,7 +139,7 @@ describe("Targets Screen", () => {
 
   it("resets to profile-calculated values when profile exists", async () => {
     const profile = JSON.stringify({
-      age: 30,
+      birthYear: 1996,
       weight: 75,
       height: 175,
       sex: "male",

--- a/__tests__/components/ProfileForm.test.tsx
+++ b/__tests__/components/ProfileForm.test.tsx
@@ -30,7 +30,7 @@ jest.mock("@react-navigation/native", () => ({
 }));
 
 const mockProfile = {
-  age: 30,
+  birthYear: 1996,
   weight: 75,
   height: 175,
   sex: "male" as const,
@@ -62,7 +62,7 @@ describe("ProfileForm", () => {
       <ProfileForm onSave={jest.fn()} />
     );
     await waitFor(() => {
-      expect(getByLabelText("Age in years")).toBeTruthy();
+      expect(getByLabelText("Birth year")).toBeTruthy();
       expect(getByLabelText("Weight in kg")).toBeTruthy();
       expect(getByLabelText("Height in cm")).toBeTruthy();
     });
@@ -73,7 +73,7 @@ describe("ProfileForm", () => {
       <ProfileForm initialProfile={mockProfile} onSave={jest.fn()} />
     );
     await waitFor(() => {
-      expect(getByLabelText("Age in years").props.value).toBe("30");
+      expect(getByLabelText("Birth year").props.value).toBe("1996");
       expect(getByLabelText("Weight in kg").props.value).toBe("75");
       expect(getByLabelText("Height in cm").props.value).toBe("175");
     });
@@ -85,11 +85,12 @@ describe("ProfileForm", () => {
       <ProfileForm onSave={onSave} />
     );
     await waitFor(() => {
-      expect(getByLabelText("Age in years")).toBeTruthy();
+      expect(getByLabelText("Birth year")).toBeTruthy();
     });
     fireEvent.press(getByText("Calculate & Save"));
+    const currentYear = new Date().getFullYear();
     await waitFor(() => {
-      expect(getByText("Enter a valid age (1–120)")).toBeTruthy();
+      expect(getByText(`Enter a valid birth year (1900–${currentYear - 1})`)).toBeTruthy();
       expect(getByText("Enter a valid weight")).toBeTruthy();
       expect(getByText("Enter a valid height")).toBeTruthy();
     });
@@ -102,7 +103,7 @@ describe("ProfileForm", () => {
       <ProfileForm initialProfile={mockProfile} onSave={onSave} />
     );
     await waitFor(() => {
-      expect(getByLabelText("Age in years").props.value).toBe("30");
+      expect(getByLabelText("Birth year").props.value).toBe("1996");
     });
     fireEvent.press(getByText("Calculate & Save"));
     await waitFor(() => {
@@ -133,9 +134,9 @@ describe("ProfileForm", () => {
       <ProfileForm onSave={jest.fn()} onDirtyChange={onDirtyChange} />
     );
     await waitFor(() => {
-      expect(getByLabelText("Age in years")).toBeTruthy();
+      expect(getByLabelText("Birth year")).toBeTruthy();
     });
-    fireEvent.changeText(getByLabelText("Age in years"), "25");
+    fireEvent.changeText(getByLabelText("Birth year"), "1995");
     await waitFor(() => {
       expect(onDirtyChange).toHaveBeenCalledWith(true);
     });
@@ -147,7 +148,7 @@ describe("ProfileForm", () => {
       <ProfileForm initialProfile={mockProfile} onSave={jest.fn()} />
     );
     await waitFor(() => {
-      expect(getByLabelText("Age in years").props.value).toBe("30");
+      expect(getByLabelText("Birth year").props.value).toBe("1996");
     });
     fireEvent.press(getByText("Calculate & Save"));
     await waitFor(() => {
@@ -170,7 +171,7 @@ describe("BodyProfileCard", () => {
     const { getByText, getByLabelText } = renderScreen(<BodyProfileCard />);
     await waitFor(() => {
       expect(getByText("Body Profile")).toBeTruthy();
-      expect(getByLabelText("Age in years")).toBeTruthy();
+      expect(getByLabelText("Birth year")).toBeTruthy();
       expect(getByLabelText("Weight in kg")).toBeTruthy();
       expect(getByLabelText("Height in cm")).toBeTruthy();
     });
@@ -180,7 +181,7 @@ describe("BodyProfileCard", () => {
     mockGetAppSetting.mockResolvedValue(JSON.stringify(mockProfile));
     const { getByLabelText } = renderScreen(<BodyProfileCard />);
     await waitFor(() => {
-      expect(getByLabelText("Age in years").props.value).toBe("30");
+      expect(getByLabelText("Birth year").props.value).toBe("1996");
       expect(getByLabelText("Weight in kg").props.value).toBe("75");
       expect(getByLabelText("Height in cm").props.value).toBe("175");
     });
@@ -217,10 +218,10 @@ describe("BodyProfileCard", () => {
     mockGetAppSetting.mockResolvedValue(JSON.stringify(mockProfile));
     const { getByLabelText } = renderScreen(<BodyProfileCard />);
     await waitFor(() => {
-      expect(getByLabelText("Age in years").props.value).toBe("30");
+      expect(getByLabelText("Birth year").props.value).toBe("1996");
     });
-    fireEvent.changeText(getByLabelText("Age in years"), "25");
-    fireEvent(getByLabelText("Age in years"), "blur");
+    fireEvent.changeText(getByLabelText("Birth year"), "1995");
+    fireEvent(getByLabelText("Birth year"), "blur");
     await waitFor(() => {
       expect(mockSetAppSetting).toHaveBeenCalledWith(
         "nutrition_profile",
@@ -234,12 +235,13 @@ describe("BodyProfileCard", () => {
     mockGetAppSetting.mockResolvedValue(JSON.stringify(mockProfile));
     const { getByLabelText, getByText } = renderScreen(<BodyProfileCard />);
     await waitFor(() => {
-      expect(getByLabelText("Age in years").props.value).toBe("30");
+      expect(getByLabelText("Birth year").props.value).toBe("1996");
     });
-    fireEvent.changeText(getByLabelText("Age in years"), "");
-    fireEvent(getByLabelText("Age in years"), "blur");
+    fireEvent.changeText(getByLabelText("Birth year"), "");
+    fireEvent(getByLabelText("Birth year"), "blur");
+    const currentYear = new Date().getFullYear();
     await waitFor(() => {
-      expect(getByText("Enter a valid age (1–120)")).toBeTruthy();
+      expect(getByText(`Enter a valid birth year (1900–${currentYear - 1})`)).toBeTruthy();
     });
     expect(mockSetAppSetting).not.toHaveBeenCalled();
   });
@@ -248,7 +250,7 @@ describe("BodyProfileCard", () => {
     mockGetAppSetting.mockResolvedValue(JSON.stringify(mockProfile));
     const { getByText, getByLabelText } = renderScreen(<BodyProfileCard />);
     await waitFor(() => {
-      expect(getByLabelText("Age in years").props.value).toBe("30");
+      expect(getByLabelText("Birth year").props.value).toBe("1996");
     });
     fireEvent.press(getByText("Bulk"));
     await waitFor(() => {

--- a/__tests__/lib/nutrition-calc.test.ts
+++ b/__tests__/lib/nutrition-calc.test.ts
@@ -4,6 +4,7 @@ import {
   calculateMacros,
   calculateFromProfile,
   convertToMetric,
+  migrateProfile,
   type NutritionProfile,
 } from "../../lib/nutrition-calc";
 
@@ -123,8 +124,9 @@ describe("nutrition-calc", () => {
   });
 
   describe("calculateFromProfile", () => {
+    const currentYear = new Date().getFullYear();
     const baseProfile: NutritionProfile = {
-      age: 30,
+      birthYear: currentYear - 30,
       weight: 75,
       height: 175,
       sex: "male",
@@ -174,11 +176,35 @@ describe("nutrition-calc", () => {
 
     it("end-to-end: 30yo 75kg 175cm male, moderately active, maintaining", () => {
       const result = calculateFromProfile(baseProfile);
+      // birthYear = currentYear - 30 → age = 30
       // BMR = 10*75 + 6.25*175 - 5*30 + 5 = 1698.75
       // TDEE = 1698.75 * 1.55 = 2633.06
       // calories = round(2633.06) = 2633
       expect(result.calories).toBe(2633);
       expect(result.protein).toBe(165); // 75 * 2.2
+    });
+  });
+
+  describe("migrateProfile", () => {
+    it("converts legacy age to birthYear", () => {
+      const currentYear = new Date().getFullYear();
+      const legacy = { age: 30, weight: 75, height: 175, sex: "male", activityLevel: "moderately_active", goal: "maintain", weightUnit: "kg", heightUnit: "cm" };
+      const migrated = migrateProfile(legacy);
+      expect(migrated.birthYear).toBe(currentYear - 30);
+      expect((migrated as unknown as Record<string, unknown>).age).toBeUndefined();
+    });
+
+    it("keeps birthYear if already present", () => {
+      const modern = { birthYear: 1990, weight: 75, height: 175, sex: "male", activityLevel: "moderately_active", goal: "maintain", weightUnit: "kg", heightUnit: "cm" };
+      const migrated = migrateProfile(modern);
+      expect(migrated.birthYear).toBe(1990);
+    });
+
+    it("prefers birthYear over age when both present", () => {
+      const both = { birthYear: 1990, age: 50, weight: 75, height: 175, sex: "male", activityLevel: "moderately_active", goal: "maintain", weightUnit: "kg", heightUnit: "cm" };
+      const migrated = migrateProfile(both);
+      expect(migrated.birthYear).toBe(1990);
+      expect((migrated as unknown as Record<string, unknown>).age).toBeUndefined();
     });
   });
 });

--- a/app/nutrition/targets.tsx
+++ b/app/nutrition/targets.tsx
@@ -6,6 +6,7 @@ import { useLayout } from "../../lib/layout";
 import { getAppSetting, getMacroTargets, updateMacroTargets } from "../../lib/db";
 import {
   calculateFromProfile,
+  migrateProfile,
   ACTIVITY_LABELS,
   GOAL_LABELS,
   type NutritionProfile,
@@ -30,7 +31,7 @@ export default function Targets() {
         setFat(String(t.fat));
       });
       getAppSetting("nutrition_profile").then((saved) => {
-        setProfile(saved ? JSON.parse(saved) : null);
+        setProfile(saved ? migrateProfile(JSON.parse(saved)) : null);
       });
     }, [])
   );
@@ -66,7 +67,7 @@ export default function Targets() {
   };
 
   const profileSummary = profile
-    ? profile.age + "yo, " + profile.weight + profile.weightUnit + ", " +
+    ? (new Date().getFullYear() - profile.birthYear) + "yo, " + profile.weight + profile.weightUnit + ", " +
       ACTIVITY_LABELS[profile.activityLevel].toLowerCase() + ", " +
       GOAL_LABELS[profile.goal].toLowerCase()
     : null;

--- a/components/BodyProfileCard.tsx
+++ b/components/BodyProfileCard.tsx
@@ -18,6 +18,7 @@ import {
   ACTIVITY_LABELS,
   GOAL_LABELS,
   calculateFromProfile,
+  migrateProfile,
   type ActivityLevel,
   type Goal,
   type NutritionProfile,
@@ -48,7 +49,7 @@ type CardState = "loading" | "error" | "ready";
 export default function BodyProfileCard() {
   const theme = useTheme();
   const [cardState, setCardState] = useState<CardState>("loading");
-  const [age, setAge] = useState("");
+  const [birthYear, setBirthYear] = useState("");
   const [weight, setWeight] = useState("");
   const [height, setHeight] = useState("");
   const [sex, setSex] = useState<Sex>("male");
@@ -83,8 +84,8 @@ export default function BodyProfileCard() {
       setHeightUnit(hu);
 
       if (saved) {
-        const profile: NutritionProfile = JSON.parse(saved);
-        setAge(String(profile.age));
+        const profile: NutritionProfile = migrateProfile(JSON.parse(saved));
+        setBirthYear(String(profile.birthYear));
         setWeight(String(profile.weight));
         setHeight(String(profile.height));
         setSex(profile.sex);
@@ -107,8 +108,11 @@ export default function BodyProfileCard() {
 
   function validateField(field: string, value: string): string | null {
     const num = parseFloat(value);
-    if (field === "age") {
-      if (!value || isNaN(num) || num < 1 || num > 120) return "Enter a valid age (1–120)";
+    if (field === "birthYear") {
+      const currentYear = new Date().getFullYear();
+      if (!value || isNaN(num) || !Number.isInteger(num) || num < 1900 || num >= currentYear) {
+        return `Enter a valid birth year (1900–${currentYear - 1})`;
+      }
     } else if (field === "weight") {
       if (!value || isNaN(num) || num <= 0) return "Enter a valid weight";
     } else if (field === "height") {
@@ -118,20 +122,20 @@ export default function BodyProfileCard() {
   }
 
   async function saveProfile(
-    ageVal: string, weightVal: string, heightVal: string,
+    birthYearVal: string, weightVal: string, heightVal: string,
     sexVal: Sex, actVal: ActivityLevel, goalVal: Goal,
   ) {
-    const ageErr = validateField("age", ageVal);
+    const birthYearErr = validateField("birthYear", birthYearVal);
     const weightErr = validateField("weight", weightVal);
     const heightErr = validateField("height", heightVal);
 
-    if (ageErr || weightErr || heightErr) {
+    if (birthYearErr || weightErr || heightErr) {
       return;
     }
 
     try {
       const profile: NutritionProfile = {
-        age: parseFloat(ageVal),
+        birthYear: parseInt(birthYearVal, 10),
         weight: parseFloat(weightVal),
         height: parseFloat(heightVal),
         sex: sexVal,
@@ -150,12 +154,12 @@ export default function BodyProfileCard() {
   }
 
   function debouncedSave(
-    ageVal: string, weightVal: string, heightVal: string,
+    birthYearVal: string, weightVal: string, heightVal: string,
     sexVal: Sex, actVal: ActivityLevel, goalVal: Goal,
   ) {
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => {
-      saveProfile(ageVal, weightVal, heightVal, sexVal, actVal, goalVal);
+      saveProfile(birthYearVal, weightVal, heightVal, sexVal, actVal, goalVal);
     }, 300);
   }
 
@@ -171,7 +175,7 @@ export default function BodyProfileCard() {
       return next;
     });
     if (!err) {
-      saveProfile(age, weight, height, sex, activityLevel, goal);
+      saveProfile(birthYear, weight, height, sex, activityLevel, goal);
     }
   }
 
@@ -187,7 +191,7 @@ export default function BodyProfileCard() {
     else if (field === "activityLevel") { newAct = value as ActivityLevel; setActivityLevel(newAct); }
     else if (field === "goal") { newGoal = value as Goal; setGoal(newGoal); }
 
-    debouncedSave(age, weight, height, newSex, newAct, newGoal);
+    debouncedSave(birthYear, weight, height, newSex, newAct, newGoal);
   }
 
   if (cardState === "loading") {
@@ -229,20 +233,21 @@ export default function BodyProfileCard() {
           </Text>
 
           <TextInput
-            label="Age"
-            value={age}
-            onChangeText={setAge}
-            onBlur={() => handleFieldBlur("age", age)}
+            label="Birth Year"
+            value={birthYear}
+            onChangeText={setBirthYear}
+            onBlur={() => handleFieldBlur("birthYear", birthYear)}
             keyboardType="numeric"
             mode="outlined"
             style={styles.input}
-            accessibilityLabel="Age in years"
-            accessibilityHint="Enter your age for calorie calculation"
-            error={!!errors.age}
+            placeholder="1990"
+            accessibilityLabel="Birth year"
+            accessibilityHint="Enter your birth year for calorie calculation"
+            error={!!errors.birthYear}
           />
-          {errors.age ? (
+          {errors.birthYear ? (
             <Text style={[styles.errorText, { color: theme.colors.error }]} accessibilityLiveRegion="polite">
-              {errors.age}
+              {errors.birthYear}
             </Text>
           ) : null}
 

--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -13,6 +13,7 @@ import { getAppSetting, setAppSetting, updateMacroTargets } from "../lib/db";
 import { getBodySettings, getLatestBodyWeight } from "../lib/db/body";
 import {
   calculateFromProfile,
+  migrateProfile,
   ACTIVITY_LABELS,
   GOAL_LABELS,
   type ActivityLevel,
@@ -41,7 +42,7 @@ export interface ProfileFormProps {
 
 export default function ProfileForm({ initialProfile, onSave, onCancel, onDirtyChange }: ProfileFormProps) {
   const theme = useTheme();
-  const [age, setAge] = useState("");
+  const [birthYear, setBirthYear] = useState("");
   const [weight, setWeight] = useState("");
   const [height, setHeight] = useState("");
   const [sex, setSex] = useState<Sex>("male");
@@ -77,15 +78,15 @@ export default function ProfileForm({ initialProfile, onSave, onCancel, onDirtyC
         setHeightUnit(hu);
 
         if (saved) {
-          const profile: NutritionProfile = typeof saved === "string" ? JSON.parse(saved) : saved;
-          setAge(String(profile.age));
+          const profile: NutritionProfile = migrateProfile(typeof saved === "string" ? JSON.parse(saved) : saved);
+          setBirthYear(String(profile.birthYear));
           setWeight(String(profile.weight));
           setHeight(String(profile.height));
           setSex(profile.sex);
           setActivityLevel(profile.activityLevel);
           setGoal(profile.goal);
           initialSnapshot.current = JSON.stringify({
-            age: String(profile.age),
+            birthYear: String(profile.birthYear),
             weight: String(profile.weight),
             height: String(profile.height),
             sex: profile.sex,
@@ -97,7 +98,7 @@ export default function ProfileForm({ initialProfile, onSave, onCancel, onDirtyC
             setWeight(String(latestWeight.weight));
           }
           initialSnapshot.current = JSON.stringify({
-            age: "",
+            birthYear: "",
             weight: latestWeight ? String(latestWeight.weight) : "",
             height: "",
             sex: "male",
@@ -119,18 +120,19 @@ export default function ProfileForm({ initialProfile, onSave, onCancel, onDirtyC
   // Track dirty state
   useEffect(() => {
     if (!loaded || !onDirtyChange) return;
-    const current = JSON.stringify({ age, weight, height, sex, activityLevel, goal });
+    const current = JSON.stringify({ birthYear, weight, height, sex, activityLevel, goal });
     onDirtyChange(current !== initialSnapshot.current);
-  }, [age, weight, height, sex, activityLevel, goal, loaded, onDirtyChange]);
+  }, [birthYear, weight, height, sex, activityLevel, goal, loaded, onDirtyChange]);
 
   function validate(): boolean {
     const e: Record<string, string> = {};
-    const ageNum = parseFloat(age);
+    const birthYearNum = parseInt(birthYear, 10);
     const weightNum = parseFloat(weight);
     const heightNum = parseFloat(height);
+    const currentYear = new Date().getFullYear();
 
-    if (!age || isNaN(ageNum) || ageNum < 1 || ageNum > 120) {
-      e.age = "Enter a valid age (1–120)";
+    if (!birthYear || isNaN(birthYearNum) || birthYearNum < 1900 || birthYearNum >= currentYear) {
+      e.birthYear = `Enter a valid birth year (1900–${currentYear - 1})`;
     }
     if (!weight || isNaN(weightNum) || weightNum <= 0) {
       e.weight = "Enter a valid weight";
@@ -148,7 +150,7 @@ export default function ProfileForm({ initialProfile, onSave, onCancel, onDirtyC
     setSaveError(null);
     try {
       const profile: NutritionProfile = {
-        age: parseFloat(age),
+        birthYear: parseInt(birthYear, 10),
         weight: parseFloat(weight),
         height: parseFloat(height),
         sex,
@@ -203,22 +205,23 @@ export default function ProfileForm({ initialProfile, onSave, onCancel, onDirtyC
       </Text>
 
       <TextInput
-        label="Age"
-        value={age}
-        onChangeText={setAge}
+        label="Birth Year"
+        value={birthYear}
+        onChangeText={setBirthYear}
         keyboardType="numeric"
         mode="outlined"
         style={styles.input}
-        accessibilityLabel="Age in years"
-        accessibilityHint="Enter your age for calorie calculation"
-        error={!!errors.age}
+        placeholder="1990"
+        accessibilityLabel="Birth year"
+        accessibilityHint="Enter your birth year for calorie calculation"
+        error={!!errors.birthYear}
       />
-      {errors.age ? (
+      {errors.birthYear ? (
         <Text
           style={[styles.errorText, { color: theme.colors.error }]}
           accessibilityLiveRegion="polite"
         >
-          {errors.age}
+          {errors.birthYear}
         </Text>
       ) : null}
 

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -414,6 +414,19 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
       return r.changes > 0;
     }
     case "app_settings": {
+      // Migrate nutrition_profile from age to birthYear on import
+      if (row.key === "nutrition_profile" && typeof row.value === "string") {
+        try {
+          const parsed = JSON.parse(row.value);
+          if (parsed.age !== undefined && parsed.birthYear === undefined) {
+            const { migrateProfile } = require("../nutrition-calc");
+            const migrated = migrateProfile(parsed);
+            row = { ...row, value: JSON.stringify(migrated) };
+          }
+        } catch {
+          // Invalid JSON — import as-is
+        }
+      }
       const r = await database.runAsync(
         "INSERT OR IGNORE INTO app_settings (key, value) VALUES (?, ?)",
         [row.key, row.value]

--- a/lib/nutrition-calc.ts
+++ b/lib/nutrition-calc.ts
@@ -22,7 +22,7 @@ export interface MacroTargets {
 }
 
 export interface NutritionProfile {
-  age: number;
+  birthYear: number;
   weight: number;
   height: number;
   sex: Sex;
@@ -94,6 +94,20 @@ export function calculateMacros(
   return { calories, protein, carbs, fat };
 }
 
+/**
+ * Migrate a legacy profile that used `age` to the new `birthYear` format.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- handles legacy profile shape
+export function migrateProfile(raw: any): NutritionProfile {
+  const { age: legacyAge, ...rest } = raw;
+  if (rest.birthYear !== undefined && rest.birthYear !== null) {
+    return rest as NutritionProfile;
+  }
+  const currentYear = new Date().getFullYear();
+  const birthYear = currentYear - (Number(legacyAge) || 0);
+  return { ...rest, birthYear } as NutritionProfile;
+}
+
 export function calculateFromProfile(profile: NutritionProfile): MacroTargets & { belowFloor: boolean } {
   const { weight_kg, height_cm } = convertToMetric(
     profile.weight,
@@ -102,7 +116,8 @@ export function calculateFromProfile(profile: NutritionProfile): MacroTargets & 
     profile.heightUnit
   );
 
-  const bmr = calculateBMR(weight_kg, height_cm, profile.age, profile.sex);
+  const age = new Date().getFullYear() - profile.birthYear;
+  const bmr = calculateBMR(weight_kg, height_cm, age, profile.sex);
   const tdee = calculateTDEE(bmr, profile.activityLevel);
   const rawCalories = tdee + GOAL_ADJUSTMENTS[profile.goal];
   const belowFloor = rawCalories < CALORIE_FLOOR;


### PR DESCRIPTION
## Summary

Replace the age input with a birth year input in the body profile, so users enter a 4-digit year that stays correct over time. The app dynamically computes age for BMR calculation.

## Changes

- **lib/nutrition-calc.ts**: Changed `NutritionProfile.age` to `birthYear`. Added `migrateProfile()` to convert legacy profiles. `calculateFromProfile()` now computes age from birth year.
- **components/BodyProfileCard.tsx**: Birth Year input (1900–current year validation, placeholder '1990'), auto-migrates on load.
- **components/ProfileForm.tsx**: Same birth year input and validation updates.
- **app/nutrition/targets.tsx**: Profile summary shows computed age, uses `migrateProfile()` on load.
- **lib/db/import-export.ts**: Migrates `nutrition_profile` settings from age to birthYear during import.
- **Tests**: All updated — 54 tests passing across 4 suites.

## Testing

- `npx tsc --noEmit` — zero errors
- `npx eslint` — zero warnings
- Jest: 54 tests pass (nutrition-calc, ProfileForm, targets, profile)
- Migration tested: legacy age→birthYear, modern birthYear preserved, both-present prefers birthYear

## Issue

Resolves BLD-296
Closes #161