### PR TITLE
refactor: replace stale tablet addForm with InlineFoodSearch (BLD-308)

### DIFF
--- a/__tests__/app/nutrition/tablet-inline-search.test.tsx
+++ b/__tests__/app/nutrition/tablet-inline-search.test.tsx
@@ -1,0 +1,114 @@
+jest.setTimeout(10000)
+
+import React from 'react'
+import '@testing-library/react-native'
+import { renderScreen } from '../../helpers/render'
+import { createFoodEntry, createDailyLog, createMacroTargets, resetIds } from '../../helpers/factories'
+import type { DailyLog } from '../../../lib/types'
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
+    useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+    Stack: { Screen: () => null },
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../../lib/errors', () => ({ logError: jest.fn(), generateReport: jest.fn().mockResolvedValue('{}'), getRecentErrors: jest.fn().mockResolvedValue([]), generateGitHubURL: jest.fn().mockReturnValue('https://github.com') }))
+jest.mock('../../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+
+const chicken = createFoodEntry({ id: 'f1', name: 'Chicken Breast', calories: 165, protein: 31, carbs: 0, fat: 3.6 })
+const logs: DailyLog[] = [
+  createDailyLog({ id: 'dl1', food_entry_id: 'f1', meal: 'lunch', servings: 1, food: chicken }),
+]
+const targets = createMacroTargets({ calories: 2000, protein: 150, carbs: 250, fat: 65 })
+
+const mockGetDailyLogs = jest.fn().mockResolvedValue(logs)
+const mockGetDailySummary = jest.fn().mockResolvedValue({ calories: 165, protein: 31, carbs: 0, fat: 3.6 })
+const mockGetMacroTargets = jest.fn().mockResolvedValue(targets)
+const mockDeleteDailyLog = jest.fn().mockResolvedValue(undefined)
+const mockAddDailyLog = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('../../../lib/db', () => ({
+  getDailyLogs: (...args: unknown[]) => mockGetDailyLogs(...args),
+  getDailySummary: (...args: unknown[]) => mockGetDailySummary(...args),
+  getMacroTargets: (...args: unknown[]) => mockGetMacroTargets(...args),
+  deleteDailyLog: (...args: unknown[]) => mockDeleteDailyLog(...args),
+  addDailyLog: (...args: unknown[]) => mockAddDailyLog(...args),
+}))
+
+jest.mock('../../../components/InlineFoodSearch', () => {
+  const RealReact = require('react')
+  return {
+    __esModule: true,
+    default: (props: { dateKey: string }) => {
+      const { View, Text } = require('react-native')
+      return RealReact.createElement(View, { testID: 'inline-food-search' },
+        RealReact.createElement(Text, {}, `InlineFoodSearch:${props.dateKey}`)
+      )
+    },
+  }
+})
+
+// Tablet layout — atLeastMedium: true
+jest.mock('../../../lib/layout', () => ({
+  useLayout: () => ({ wide: true, atLeastMedium: true, width: 800, horizontalPadding: 16, scale: 1.0 }),
+}))
+
+import Nutrition from '../../../app/(tabs)/nutrition'
+
+describe('Nutrition Tab — Tablet Layout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+  })
+
+  it('renders InlineFoodSearch in the tablet right pane instead of the old addForm', async () => {
+    const { findByTestId, queryByText } = renderScreen(<Nutrition />)
+
+    // InlineFoodSearch should be rendered in the tablet pane
+    const search = await findByTestId('inline-food-search')
+    expect(search).toBeTruthy()
+
+    // Old addForm elements should NOT be present
+    expect(queryByText('Add Food')).toBeNull()
+    expect(queryByText('Log Food')).toBeNull()
+    expect(queryByText('Save as favorite')).toBeNull()
+    expect(queryByText('Quick Log Favorites')).toBeNull()
+  })
+
+  it('does not render FAB on tablet layout', async () => {
+    const { findByTestId, queryByLabelText } = renderScreen(<Nutrition />)
+
+    await findByTestId('inline-food-search')
+
+    // FAB is phone-only
+    expect(queryByLabelText('Add food')).toBeNull()
+  })
+
+  it('still shows food log entries in the left pane', async () => {
+    const { findByText } = renderScreen(<Nutrition />)
+
+    expect(await findByText('Chicken Breast')).toBeTruthy()
+    expect(await findByText('Lunch')).toBeTruthy()
+  })
+
+  it('does not call getFavoriteFoods (removed dead code)', async () => {
+    const { findByTestId } = renderScreen(<Nutrition />)
+    await findByTestId('inline-food-search')
+
+    // getFavoriteFoods was removed — verify it's not in the mock
+    const db = require('../../../lib/db')
+    expect(db.getFavoriteFoods).toBeUndefined()
+  })
+})

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -1,17 +1,13 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { LayoutAnimation, SectionList, StyleSheet, View } from "react-native";
-import { FlashList } from "@shopify/flash-list";
 import {
-  Button,
   Card,
-  Chip,
   FAB,
   IconButton,
   MD3Theme,
   ProgressBar,
   Snackbar,
   Text,
-  TextInput,
   useTheme,
 } from "react-native-paper";
 import { router, useFocusEffect } from "expo-router";
@@ -22,10 +18,8 @@ import {
   getMacroTargets,
   deleteDailyLog,
   addDailyLog,
-  addFoodEntry,
-  getFavoriteFoods,
 } from "../../lib/db";
-import type { DailyLog, FoodEntry, MacroTargets, Meal } from "../../lib/types";
+import type { DailyLog, MacroTargets } from "../../lib/types";
 import { MEALS, MEAL_LABELS } from "../../lib/types";
 import { semantic } from "../../constants/theme";
 import { useLayout } from "../../lib/layout";
@@ -57,18 +51,6 @@ export default function Nutrition() {
   const deleted = useRef<{ log: DailyLog; timer: ReturnType<typeof setTimeout> } | null>(null);
   const [showAddCard, setShowAddCard] = useState(false);
 
-  // Inline add-form state (tablet only)
-  const [name, setName] = useState("");
-  const [calories, setCalories] = useState("");
-  const [protein, setProtein] = useState("");
-  const [carbs, setCarbs] = useState("");
-  const [fat, setFat] = useState("");
-  const [serving, setServing] = useState("1 serving");
-  const [meal, setMeal] = useState<Meal>("snack");
-  const [favorite, setFavorite] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [favorites, setFavorites] = useState<FoodEntry[]>([]);
-
   const load = useCallback(async () => {
     const ds = formatDateKey(date.getTime());
     const [l, s, t] = await Promise.all([
@@ -84,8 +66,7 @@ export default function Nutrition() {
   useFocusEffect(
     useCallback(() => {
       load();
-      if (layout.atLeastMedium) getFavoriteFoods().then(setFavorites);
-    }, [load, layout.atLeastMedium])
+    }, [load])
   );
 
   const prev = () => { setDate((d) => new Date(d.getTime() - DAY_MS)); setShowAddCard(false); };
@@ -113,46 +94,6 @@ export default function Nutrition() {
     setSnack("");
     load();
   }, [load]);
-
-  const inlineSave = async () => {
-    if (!name.trim()) return;
-    setSaving(true);
-    try {
-      const entry = await addFoodEntry(
-        name.trim(),
-        Math.max(0, parseFloat(calories) || 0),
-        Math.max(0, parseFloat(protein) || 0),
-        Math.max(0, parseFloat(carbs) || 0),
-        Math.max(0, parseFloat(fat) || 0),
-        serving.trim() || "1 serving",
-        favorite
-      );
-      await addDailyLog(entry.id, formatDateKey(date.getTime()), meal, 1);
-      setName("");
-      setCalories("");
-      setProtein("");
-      setCarbs("");
-      setFat("");
-      setServing("1 serving");
-      setFavorite(false);
-      load();
-      getFavoriteFoods().then(setFavorites);
-      setSnack("Food logged");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const quickLog = async (food: FoodEntry) => {
-    setSaving(true);
-    try {
-      await addDailyLog(food.id, formatDateKey(date.getTime()), meal, 1);
-      load();
-      setSnack(`${food.name} logged`);
-    } finally {
-      setSaving(false);
-    }
-  };
 
   const sections = useMemo(() =>
     MEALS
@@ -239,93 +180,6 @@ export default function Nutrition() {
     />
   );
 
-  const addForm = (
-    <FlashList
-      data={favorites}
-      keyExtractor={(f) => f.id}
-      contentContainerStyle={[styles.addContent, { paddingBottom: tabBarHeight + 16 }]}
-      renderItem={({ item: f }) => (
-        <Card
-          style={[styles.favCard, { backgroundColor: theme.colors.surfaceVariant }]}
-          onPress={() => quickLog(f)}
-          accessibilityLabel={`Quick log ${f.name}, ${f.calories} calories`}
-          accessibilityRole="button"
-        >
-          <Card.Content>
-            <Text variant="titleSmall" style={{ color: theme.colors.onSurface }}>
-              {f.name}
-            </Text>
-            <Text variant="bodySmall" style={{ color: theme.colors.onSurfaceVariant }}>
-              {f.calories} cal · {f.protein}p · {f.carbs}c · {f.fat}f
-            </Text>
-          </Card.Content>
-        </Card>
-      )}
-      ListHeaderComponent={
-        <>
-          <Text variant="titleMedium" style={{ color: theme.colors.onSurface, marginBottom: 12 }}>
-            Add Food
-          </Text>
-
-          <View style={styles.meals}>
-            {MEALS.map((m) => (
-              <Chip
-                key={m}
-                selected={meal === m}
-                onPress={() => setMeal(m)}
-                accessibilityLabel={`Meal: ${MEAL_LABELS[m]}`}
-                accessibilityRole="button"
-                accessibilityState={{ selected: meal === m }}
-              >
-                {MEAL_LABELS[m]}
-              </Chip>
-            ))}
-          </View>
-
-          <TextInput label="Food name" value={name} onChangeText={setName} mode="outlined" style={styles.input} />
-          <TextInput label="Calories" value={calories} onChangeText={setCalories} keyboardType="numeric" mode="outlined" style={styles.input} />
-          <View style={styles.macroInputRow}>
-            <TextInput label="Protein (g)" value={protein} onChangeText={setProtein} keyboardType="numeric" mode="outlined" style={[styles.input, styles.flex]} />
-            <View style={{ width: 8 }} />
-            <TextInput label="Carbs (g)" value={carbs} onChangeText={setCarbs} keyboardType="numeric" mode="outlined" style={[styles.input, styles.flex]} />
-            <View style={{ width: 8 }} />
-            <TextInput label="Fat (g)" value={fat} onChangeText={setFat} keyboardType="numeric" mode="outlined" style={[styles.input, styles.flex]} />
-          </View>
-          <TextInput label="Serving size" value={serving} onChangeText={setServing} mode="outlined" style={styles.input} />
-
-          <Chip
-            selected={favorite}
-            onPress={() => setFavorite(!favorite)}
-            icon={favorite ? "heart" : "heart-outline"}
-            style={styles.favChip}
-            accessibilityLabel={favorite ? "Remove from favorites" : "Save as favorite"}
-            accessibilityRole="button"
-            accessibilityState={{ selected: favorite }}
-          >
-            Save as favorite
-          </Chip>
-
-          <Button
-            mode="contained"
-            onPress={inlineSave}
-            loading={saving}
-            disabled={saving || !name.trim()}
-            contentStyle={styles.btnContent}
-            accessibilityLabel="Log food"
-          >
-            Log Food
-          </Button>
-
-          {favorites.length > 0 && (
-            <Text variant="titleSmall" style={{ color: theme.colors.onSurfaceVariant, marginTop: 24, marginBottom: 8 }}>
-              Quick Log Favorites
-            </Text>
-          )}
-        </>
-      }
-    />
-  );
-
   const toggleAddCard = useCallback(() => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setShowAddCard((v) => !v);
@@ -358,7 +212,11 @@ export default function Nutrition() {
         <View style={styles.wideRow}>
           <View style={styles.wideLog}>{logContent}</View>
           <View style={[styles.wideAdd, { borderLeftColor: theme.colors.outlineVariant }]}>
-            {addForm}
+            <InlineFoodSearch
+              dateKey={formatDateKey(date.getTime())}
+              onFoodLogged={handleFoodLogged}
+              onSnack={handleSnack}
+            />
           </View>
         </View>
         <Snackbar
@@ -448,7 +306,6 @@ const styles = StyleSheet.create({
   card: { marginBottom: 8 },
   scroll: { flex: 1 },
   scrollContent: { padding: 16, paddingBottom: 80 },
-  addContent: { padding: 16, paddingBottom: 32 },
   empty: { flex: 1, alignItems: "center", justifyContent: "center", paddingTop: 64 },
   section: { marginBottom: 16 },
   foodCard: { marginBottom: 6, borderRadius: 8 },
@@ -461,11 +318,4 @@ const styles = StyleSheet.create({
   wideRow: { flex: 1, flexDirection: "row" },
   wideLog: { flex: 6 },
   wideAdd: { flex: 4, borderLeftWidth: StyleSheet.hairlineWidth },
-  meals: { flexDirection: "row", flexWrap: "wrap", marginBottom: 12, gap: 8 },
-  input: { marginBottom: 12 },
-  macroInputRow: { flexDirection: "row" },
-  flex: { flex: 1 },
-  favChip: { marginBottom: 16 },
-  favCard: { marginBottom: 8, borderRadius: 8 },
-  btnContent: { paddingVertical: 8 },
 });


### PR DESCRIPTION
## Summary

Replace the outdated manual TextInput food entry form in the tablet layout with the modern InlineFoodSearch component, unifying the food-adding experience across phone and tablet.

## Changes

- **Tablet pane**: Replaced `addForm` (FlashList with manual TextInput fields) with `<InlineFoodSearch>` component
- **Removed dead state**: `name`, `calories`, `protein`, `carbs`, `fat`, `serving`, `meal`, `favorite`, `saving`, `favorites`
- **Removed dead functions**: `inlineSave`, `quickLog`
- **Removed dead imports**: `FlashList`, `Button`, `Chip`, `TextInput`, `addFoodEntry`, `getFavoriteFoods`, `FoodEntry`, `Meal`
- **Removed dead styles**: `addContent`, `meals`, `input`, `macroInputRow`, `flex`, `favChip`, `favCard`, `btnContent`
- **Phone layout unchanged**: FAB toggle + InlineFoodSearch overlay remains as-is

## Testing

- `npx tsc --noEmit` — passes with zero errors
- `npx jest --no-coverage` — all 103 suites, 1633 tests pass
- New test: `__tests__/app/nutrition/tablet-inline-search.test.tsx` (4 tests)
- Existing `nutrition.acceptance.test.tsx` — all 7 tests pass
- ESLint pre-commit hook passes

## Issue

Resolves BLD-308