### PR TITLE
feat: swap-exercise fix + long-press exercise delete (BLD-307)

### DIFF
--- a/__tests__/app/session-swap-delete.test.ts
+++ b/__tests__/app/session-swap-delete.test.ts
@@ -44,6 +44,17 @@ describe("BLD-307: Swap exercise + long-press delete", () => {
       expect(sessionSrc).toContain("Long press to remove exercise");
     });
 
+    it("has accessibilityLabel and accessibilityRole on delete pressable", () => {
+      expect(sessionSrc).toContain('accessibilityLabel={`Remove ${group.name}`}');
+      expect(sessionSrc).toContain('accessibilityRole="button"');
+    });
+
+    it("wraps deleteSetsBatch in try/catch for error resilience", () => {
+      // Timeout callback should have try/catch around deleteSetsBatch
+      expect(sessionSrc).toContain("await deleteSetsBatch(setIds)");
+      expect(sessionSrc).toContain("Failed to delete exercise. Restored.");
+    });
+
     it("provides haptic feedback on long-press", () => {
       expect(sessionSrc).toContain("Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)");
     });

--- a/__tests__/app/session-swap-delete.test.ts
+++ b/__tests__/app/session-swap-delete.test.ts
@@ -1,0 +1,105 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Structural tests for BLD-307: Swap-exercise fix + long-press exercise delete.
+ * Verifies the session screen has:
+ * 1. Long-press handler on exercise name for deletion
+ * 2. deleteSetsBatch import for batch deletion
+ * 3. Countdown snackbar pattern for delete with undo
+ * 4. Haptic feedback on long-press
+ * 5. dismissRest on exercise delete
+ */
+
+const sessionSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../app/session/[id].tsx"),
+  "utf-8"
+);
+
+const sessionDbSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../lib/db/sessions.ts"),
+  "utf-8"
+);
+
+const dbIndexSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../lib/db/index.ts"),
+  "utf-8"
+);
+
+describe("BLD-307: Swap exercise + long-press delete", () => {
+  describe("Long-press exercise delete", () => {
+    it("ExerciseGroupCard accepts onDeleteExercise prop", () => {
+      expect(sessionSrc).toContain("onDeleteExercise:");
+      expect(sessionSrc).toContain("onDeleteExercise: (exerciseId: string) => void");
+    });
+
+    it("exercise name has onLongPress for delete", () => {
+      const longPressMatches = sessionSrc.match(/onLongPress=\{.*onDeleteExercise/g);
+      // Should appear in both compact and wide layout
+      expect(longPressMatches).not.toBeNull();
+      expect(longPressMatches!.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("has accessibility hint for long-press delete", () => {
+      expect(sessionSrc).toContain("Long press to remove exercise");
+    });
+
+    it("provides haptic feedback on long-press", () => {
+      expect(sessionSrc).toContain("Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)");
+    });
+
+    it("shows countdown snackbar with exercise name", () => {
+      expect(sessionSrc).toMatch(/Removing \$\{group\.name\}\.\.\. \(\d+s\)/);
+    });
+
+    it("has UNDO action on delete snackbar", () => {
+      expect(sessionSrc).toContain('label: "UNDO"');
+    });
+
+    it("clears rest timer on exercise delete", () => {
+      // The handleDeleteExercise function should call dismissRest
+      expect(sessionSrc).toContain("dismissRest()");
+    });
+
+    it("passes onDeleteExercise to ExerciseGroupCard in FlashList", () => {
+      expect(sessionSrc).toContain("onDeleteExercise={handleDeleteExercise}");
+    });
+
+    it("cleans up delete timers on unmount", () => {
+      expect(sessionSrc).toContain("deleteExerciseTimer.current");
+      expect(sessionSrc).toContain("deleteCountdownInterval.current");
+    });
+  });
+
+  describe("Batch delete in sessions.ts", () => {
+    it("exports deleteSetsBatch function", () => {
+      expect(sessionDbSrc).toContain("export async function deleteSetsBatch");
+    });
+
+    it("deleteSetsBatch uses IN clause for batch delete", () => {
+      expect(sessionDbSrc).toMatch(/DELETE FROM workout_sets WHERE id IN/);
+    });
+
+    it("deleteSetsBatch is exported from db/index.ts", () => {
+      expect(dbIndexSrc).toContain("deleteSetsBatch");
+    });
+  });
+
+  describe("Swap exercise correctness", () => {
+    it("swapExerciseInSession only modifies uncompleted sets", () => {
+      expect(sessionDbSrc).toMatch(/completed = 0/);
+    });
+
+    it("swapExerciseInSession records swapped_from_exercise_id", () => {
+      expect(sessionDbSrc).toContain("swapped_from_exercise_id = ?");
+    });
+
+    it("undoSwapInSession clears swapped_from_exercise_id", () => {
+      expect(sessionDbSrc).toContain("swapped_from_exercise_id = NULL");
+    });
+
+    it("session screen imports deleteSetsBatch", () => {
+      expect(sessionSrc).toContain("deleteSetsBatch");
+    });
+  });
+});

--- a/__tests__/lib/db/session-swap-delete.test.ts
+++ b/__tests__/lib/db/session-swap-delete.test.ts
@@ -1,0 +1,126 @@
+// Unit tests for session swap-exercise and batch delete
+const mockStmt = {
+  executeAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  finalizeAsync: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  getFirstAsync: jest.fn().mockResolvedValue(null),
+  runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+  prepareAsync: jest.fn().mockResolvedValue(mockStmt),
+};
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+}));
+
+import {
+  swapExerciseInSession,
+  undoSwapInSession,
+  deleteSet,
+  deleteSetsBatch,
+} from '../../../lib/db/sessions';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.getAllAsync.mockResolvedValue([]);
+  mockDb.getFirstAsync.mockResolvedValue(null);
+  mockDb.runAsync.mockResolvedValue({ changes: 1 });
+});
+
+// ---- Swap Exercise ----
+
+describe('swapExerciseInSession', () => {
+  it('swaps uncompleted sets to new exercise and records swapped_from', async () => {
+    mockDb.getAllAsync.mockResolvedValue([
+      { id: 'set-1' },
+      { id: 'set-2' },
+    ]);
+
+    const result = await swapExerciseInSession('sess-1', 'old-ex', 'new-ex');
+
+    expect(result).toEqual(['set-1', 'set-2']);
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE workout_sets SET exercise_id = ?, swapped_from_exercise_id = ?'),
+      ['new-ex', 'old-ex', 'set-1', 'set-2']
+    );
+  });
+
+  it('returns empty array when no uncompleted sets found', async () => {
+    mockDb.getAllAsync.mockResolvedValue([]);
+
+    const result = await swapExerciseInSession('sess-1', 'old-ex', 'new-ex');
+
+    expect(result).toEqual([]);
+  });
+
+  it('only selects uncompleted sets (completed = 0)', async () => {
+    mockDb.getAllAsync.mockResolvedValue([{ id: 'set-3' }]);
+
+    await swapExerciseInSession('sess-1', 'old-ex', 'new-ex');
+
+    expect(mockDb.getAllAsync).toHaveBeenCalledWith(
+      expect.stringContaining('completed = 0'),
+      ['sess-1', 'old-ex']
+    );
+  });
+});
+
+describe('undoSwapInSession', () => {
+  it('restores original exercise_id and clears swapped_from', async () => {
+    await undoSwapInSession(['set-1', 'set-2'], 'original-ex');
+
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining('SET exercise_id = ?, swapped_from_exercise_id = NULL'),
+      ['original-ex', 'set-1', 'set-2']
+    );
+  });
+
+  it('does nothing for empty setIds array', async () => {
+    await undoSwapInSession([], 'original-ex');
+
+    expect(mockDb.runAsync).not.toHaveBeenCalled();
+  });
+});
+
+// ---- Delete Sets ----
+
+describe('deleteSet', () => {
+  it('deletes a single set by id', async () => {
+    await deleteSet('set-1');
+
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'DELETE FROM workout_sets WHERE id = ?',
+      ['set-1']
+    );
+  });
+});
+
+describe('deleteSetsBatch', () => {
+  it('deletes multiple sets in a single query', async () => {
+    await deleteSetsBatch(['set-1', 'set-2', 'set-3']);
+
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'DELETE FROM workout_sets WHERE id IN (?,?,?)',
+      ['set-1', 'set-2', 'set-3']
+    );
+  });
+
+  it('does nothing for empty array', async () => {
+    await deleteSetsBatch([]);
+
+    expect(mockDb.runAsync).not.toHaveBeenCalled();
+  });
+
+  it('handles single item', async () => {
+    await deleteSetsBatch(['set-1']);
+
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      'DELETE FROM workout_sets WHERE id IN (?)',
+      ['set-1']
+    );
+  });
+});

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -1324,19 +1324,36 @@ export default function ActiveSession() {
   }, [id, load]);
 
   // --- Long-press exercise delete with countdown ---
-  const deleteExerciseRef = useRef<{ exerciseId: string; setIds: string[]; removedGroup: ExerciseGroup } | null>(null);
+  const deleteExerciseRef = useRef<{ exerciseId: string; setIds: string[]; removedGroup: ExerciseGroup; originalIndex: number } | null>(null);
   const deleteExerciseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const deleteCountdownInterval = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // Commit a pending delete immediately (used when a second delete starts before first finishes)
+  const commitPendingDelete = useCallback(async () => {
+    if (!deleteExerciseRef.current) return;
+    const { setIds } = deleteExerciseRef.current;
+    deleteExerciseRef.current = null;
+    if (deleteExerciseTimer.current) {
+      clearTimeout(deleteExerciseTimer.current);
+      deleteExerciseTimer.current = null;
+    }
+    if (deleteCountdownInterval.current) {
+      clearInterval(deleteCountdownInterval.current);
+      deleteCountdownInterval.current = null;
+    }
+    await deleteSetsBatch(setIds);
+  }, []);
+
   const handleDeleteExerciseUndo = useCallback(() => {
     if (!deleteExerciseRef.current) return;
-    const { removedGroup } = deleteExerciseRef.current;
-    // Restore the group back into state
+    const { removedGroup, originalIndex } = deleteExerciseRef.current;
     setGroups((prev) => {
-      // Re-insert in original position or at end
       const exists = prev.some((g) => g.exercise_id === removedGroup.exercise_id);
       if (exists) return prev;
-      return [...prev, removedGroup];
+      // Restore at original position
+      const next = [...prev];
+      next.splice(Math.min(originalIndex, next.length), 0, removedGroup);
+      return next;
     });
     deleteExerciseRef.current = null;
     if (deleteExerciseTimer.current) {
@@ -1352,12 +1369,16 @@ export default function ActiveSession() {
   }, []);
 
   const handleDeleteExercise = useCallback((exerciseId: string) => {
-    const group = groups.find((g) => g.exercise_id === exerciseId);
-    if (!group) return;
+    const groupIndex = groups.findIndex((g) => g.exercise_id === exerciseId);
+    if (groupIndex === -1) return;
+    const group = groups[groupIndex];
 
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 
     const setIds = group.sets.map((s) => s.id);
+
+    // Commit any pending delete before starting a new one (prevents UI/DB desync)
+    commitPendingDelete();
 
     // Optimistically remove the group from UI
     setGroups((prev) => prev.filter((g) => g.exercise_id !== exerciseId));
@@ -1365,12 +1386,8 @@ export default function ActiveSession() {
     // Clear rest timer if it was running for this exercise
     dismissRest();
 
-    // Store undo info
-    deleteExerciseRef.current = { exerciseId, setIds, removedGroup: group };
-
-    // Clear any existing delete countdown
-    if (deleteExerciseTimer.current) clearTimeout(deleteExerciseTimer.current);
-    if (deleteCountdownInterval.current) clearInterval(deleteCountdownInterval.current);
+    // Store undo info with original position for correct restore
+    deleteExerciseRef.current = { exerciseId, setIds, removedGroup: group, originalIndex: groupIndex };
 
     // Start 5s countdown
     let remaining = 5;
@@ -1399,7 +1416,7 @@ export default function ActiveSession() {
       // Actually delete from DB
       await deleteSetsBatch(setIds);
     }, 5000);
-  }, [groups, dismissRest, handleDeleteExerciseUndo]);
+  }, [groups, dismissRest, handleDeleteExerciseUndo, commitPendingDelete]);
 
   const handleRPE = useCallback(async (set: SetWithMeta, val: number) => {
     const next = set.rpe === val ? null : val;

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -35,6 +35,7 @@ import {
   addSetsBatch,
   cancelSession,
   deleteSet,
+  deleteSetsBatch,
   completeSession,
   completeSet,
   getBodySettings,
@@ -326,6 +327,7 @@ type GroupCardProps = {
   onLongPressSetType: (setId: string) => void;
   onShowDetail: (exerciseId: string) => void;
   onSwap: (exerciseId: string) => void;
+  onDeleteExercise: (exerciseId: string) => void;
 };
 
 const ExerciseGroupCard = memo(function ExerciseGroupCard({
@@ -334,7 +336,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
   onUpdate, onCheck, onDelete, onAddSet, onModeChange,
   onRPE, onHalfStep, onHalfStepClear,
   onHalfStepOpen, onExerciseNotes, onExerciseNotesDraftChange, onToggleExerciseNotes, onCycleSetType, onLongPressSetType,
-  onShowDetail, onSwap,
+  onShowDetail, onSwap, onDeleteExercise,
 }: GroupCardProps) {
   const theme = useTheme();
   const layout = useLayout();
@@ -412,14 +414,21 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
       {layout.compact ? (
         <View style={styles.groupHeaderCompactWrap}>
           <View style={styles.groupHeaderCompactRow}>
-            <Text
-              variant="titleMedium"
-              numberOfLines={2}
-              ellipsizeMode="tail"
-              style={[styles.groupTitle, { color: theme.colors.primary }]}
+            <Pressable
+              onLongPress={() => onDeleteExercise(group.exercise_id)}
+              delayLongPress={500}
+              style={{ flex: 1 }}
+              accessibilityHint="Long press to remove exercise"
             >
-              {group.name}
-            </Text>
+              <Text
+                variant="titleMedium"
+                numberOfLines={2}
+                ellipsizeMode="tail"
+                style={[styles.groupTitle, { color: theme.colors.primary }]}
+              >
+                {group.name}
+              </Text>
+            </Pressable>
             <IconButton
               icon="swap-horizontal"
               size={24}
@@ -459,14 +468,21 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
         </View>
       ) : (
         <View style={styles.groupHeader}>
-          <Text
-            variant="titleMedium"
-            numberOfLines={2}
-            ellipsizeMode="tail"
-            style={[styles.groupTitle, { color: theme.colors.primary }]}
+          <Pressable
+            onLongPress={() => onDeleteExercise(group.exercise_id)}
+            delayLongPress={500}
+            style={{ flex: 1 }}
+            accessibilityHint="Long press to remove exercise"
           >
-            {group.name}
-          </Text>
+            <Text
+              variant="titleMedium"
+              numberOfLines={2}
+              ellipsizeMode="tail"
+              style={[styles.groupTitle, { color: theme.colors.primary }]}
+            >
+              {group.name}
+            </Text>
+          </Pressable>
           <Button
             mode="text"
             compact
@@ -1112,11 +1128,11 @@ export default function ActiveSession() {
     }, 1000);
   }, []);
 
-  const dismissRest = () => {
+  const dismissRest = useCallback(() => {
     if (restRef.current) clearInterval(restRef.current);
     restRef.current = null;
     setRest(0);
-  };
+  }, []);
 
   const prevRest = useRef(0);
   useEffect(() => {
@@ -1154,6 +1170,8 @@ export default function ActiveSession() {
       if (hintTimer.current) clearTimeout(hintTimer.current);
       for (const t of restHapticTimers.current) clearTimeout(t);
       if (swapUndoTimer.current) clearTimeout(swapUndoTimer.current);
+      if (deleteExerciseTimer.current) clearTimeout(deleteExerciseTimer.current);
+      if (deleteCountdownInterval.current) clearInterval(deleteCountdownInterval.current);
     };
   }, []);
 
@@ -1304,6 +1322,84 @@ export default function ActiveSession() {
     }
     await load();
   }, [id, load]);
+
+  // --- Long-press exercise delete with countdown ---
+  const deleteExerciseRef = useRef<{ exerciseId: string; setIds: string[]; removedGroup: ExerciseGroup } | null>(null);
+  const deleteExerciseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const deleteCountdownInterval = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const handleDeleteExerciseUndo = useCallback(() => {
+    if (!deleteExerciseRef.current) return;
+    const { removedGroup } = deleteExerciseRef.current;
+    // Restore the group back into state
+    setGroups((prev) => {
+      // Re-insert in original position or at end
+      const exists = prev.some((g) => g.exercise_id === removedGroup.exercise_id);
+      if (exists) return prev;
+      return [...prev, removedGroup];
+    });
+    deleteExerciseRef.current = null;
+    if (deleteExerciseTimer.current) {
+      clearTimeout(deleteExerciseTimer.current);
+      deleteExerciseTimer.current = null;
+    }
+    if (deleteCountdownInterval.current) {
+      clearInterval(deleteCountdownInterval.current);
+      deleteCountdownInterval.current = null;
+    }
+    setSnackbar("");
+    setSnackbarAction(undefined);
+  }, []);
+
+  const handleDeleteExercise = useCallback((exerciseId: string) => {
+    const group = groups.find((g) => g.exercise_id === exerciseId);
+    if (!group) return;
+
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+
+    const setIds = group.sets.map((s) => s.id);
+
+    // Optimistically remove the group from UI
+    setGroups((prev) => prev.filter((g) => g.exercise_id !== exerciseId));
+
+    // Clear rest timer if it was running for this exercise
+    dismissRest();
+
+    // Store undo info
+    deleteExerciseRef.current = { exerciseId, setIds, removedGroup: group };
+
+    // Clear any existing delete countdown
+    if (deleteExerciseTimer.current) clearTimeout(deleteExerciseTimer.current);
+    if (deleteCountdownInterval.current) clearInterval(deleteCountdownInterval.current);
+
+    // Start 5s countdown
+    let remaining = 5;
+    setSnackbar(`Removing ${group.name}... (5s)`);
+    setSnackbarAction({ label: "UNDO", onPress: () => handleDeleteExerciseUndo() });
+
+    deleteCountdownInterval.current = setInterval(() => {
+      remaining -= 1;
+      if (remaining <= 0) {
+        if (deleteCountdownInterval.current) {
+          clearInterval(deleteCountdownInterval.current);
+          deleteCountdownInterval.current = null;
+        }
+      } else {
+        setSnackbar(`Removing ${group.name}... (${remaining}s)`);
+      }
+    }, 1000);
+
+    deleteExerciseTimer.current = setTimeout(async () => {
+      deleteExerciseTimer.current = null;
+      deleteExerciseRef.current = null;
+      if (deleteCountdownInterval.current) {
+        clearInterval(deleteCountdownInterval.current);
+        deleteCountdownInterval.current = null;
+      }
+      // Actually delete from DB
+      await deleteSetsBatch(setIds);
+    }, 5000);
+  }, [groups, dismissRest, handleDeleteExerciseUndo]);
 
   const handleRPE = useCallback(async (set: SetWithMeta, val: number) => {
     const next = set.rpe === val ? null : val;
@@ -1581,6 +1677,7 @@ export default function ActiveSession() {
             onLongPressSetType={handleLongPressSetType}
             onShowDetail={handleShowDetail}
             onSwap={handleSwapOpen}
+            onDeleteExercise={handleDeleteExercise}
           />
         )}
         keyExtractor={(item) => item.exercise_id}

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -418,6 +418,8 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
               onLongPress={() => onDeleteExercise(group.exercise_id)}
               delayLongPress={500}
               style={{ flex: 1 }}
+              accessibilityLabel={`Remove ${group.name}`}
+              accessibilityRole="button"
               accessibilityHint="Long press to remove exercise"
             >
               <Text
@@ -472,6 +474,8 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
             onLongPress={() => onDeleteExercise(group.exercise_id)}
             delayLongPress={500}
             style={{ flex: 1 }}
+            accessibilityLabel={`Remove ${group.name}`}
+            accessibilityRole="button"
             accessibilityHint="Long press to remove exercise"
           >
             <Text
@@ -1341,7 +1345,11 @@ export default function ActiveSession() {
       clearInterval(deleteCountdownInterval.current);
       deleteCountdownInterval.current = null;
     }
-    await deleteSetsBatch(setIds);
+    try {
+      await deleteSetsBatch(setIds);
+    } catch {
+      // Best-effort: pending delete failed but UI already moved on
+    }
   }, []);
 
   const handleDeleteExerciseUndo = useCallback(() => {
@@ -1414,7 +1422,19 @@ export default function ActiveSession() {
         deleteCountdownInterval.current = null;
       }
       // Actually delete from DB
-      await deleteSetsBatch(setIds);
+      try {
+        await deleteSetsBatch(setIds);
+      } catch {
+        // Restore group on DB failure
+        setGroups((prev) => {
+          const exists = prev.some((g) => g.exercise_id === group.exercise_id);
+          if (exists) return prev;
+          const next = [...prev];
+          next.splice(Math.min(groupIndex, next.length), 0, group as ExerciseGroup);
+          return next;
+        });
+        setSnackbar('Failed to delete exercise. Restored.');
+      }
     }, 5000);
   }, [groups, dismissRest, handleDeleteExerciseUndo, commitPendingDelete]);
 

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -47,6 +47,7 @@ export {
   completeSet,
   uncompleteSet,
   deleteSet,
+  deleteSetsBatch,
   updateSetRPE,
   updateSetNotes,
   updateSetTrainingMode,

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -325,6 +325,12 @@ export async function deleteSet(id: string): Promise<void> {
   await execute("DELETE FROM workout_sets WHERE id = ?", [id]);
 }
 
+export async function deleteSetsBatch(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const placeholders = ids.map(() => "?").join(",");
+  await execute(`DELETE FROM workout_sets WHERE id IN (${placeholders})`, ids);
+}
+
 export async function updateSetRPE(id: string, rpe: number | null): Promise<void> {
   await execute(
     "UPDATE workout_sets SET rpe = ? WHERE id = ?",


### PR DESCRIPTION
## Summary

Fix swap-exercise data flow and add long-press exercise delete with 5-second countdown undo on the active workout session screen.

## Changes

- **Swap exercise verified**: Investigated swap logic — correctly only updates uncompleted sets, preserving completed sets with original exercise data. No code changes needed.
- **Long-press exercise delete**: Added onLongPress handler on exercise name (both compact and wide layouts) with haptic feedback, 5-second countdown snackbar with UNDO, and batch deletion.
- **deleteSetsBatch**: New batch delete function in lib/db/sessions.ts using SQL IN clause.
- **dismissRest**: Wrapped in useCallback for stable reference.

## Testing

- tsc --noEmit: zero errors
- jest: 1662 tests pass (106 suites)
- ESLint: zero warnings
- Added 25 new tests (16 structural + 9 unit)

## Issue

Resolves BLD-307