### PR TITLE
feat: BNA UI foundation — theme system, components, color mapping (BLD-310)

### DIFF
--- a/components/ui/Chip.tsx
+++ b/components/ui/Chip.tsx
@@ -1,0 +1,95 @@
+import { Pressable, StyleSheet, type ViewStyle, type TextStyle } from "react-native";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+} from "react-native-reanimated";
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { Colors } from "@/theme/colors";
+import { BORDER_RADIUS, FONT_SIZE } from "@/theme/globals";
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+type ChipProps = {
+  children: React.ReactNode;
+  selected?: boolean;
+  onPress?: () => void;
+  icon?: React.ReactNode;
+  compact?: boolean;
+  style?: ViewStyle;
+  textStyle?: TextStyle;
+};
+
+export function Chip({
+  children,
+  selected = false,
+  onPress,
+  icon,
+  compact = false,
+  style,
+  textStyle,
+}: ChipProps) {
+  const rawScheme = useColorScheme() ?? "light";
+  const scheme = rawScheme === "dark" ? "dark" as const : "light" as const;
+  const colors = Colors[scheme];
+  const scale = useSharedValue(1);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  return (
+    <AnimatedPressable
+      onPressIn={() => {
+        scale.value = withTiming(0.95, { duration: 100 });
+      }}
+      onPressOut={() => {
+        scale.value = withTiming(1, { duration: 100 });
+      }}
+      onPress={onPress}
+      style={[
+        styles.chip,
+        compact && styles.compact,
+        selected
+          ? { backgroundColor: colors.primary, borderColor: colors.primary }
+          : { backgroundColor: "transparent", borderColor: colors.border },
+        animatedStyle,
+        style,
+      ]}
+    >
+      {icon && <>{icon}</>}
+      <Animated.Text
+        style={[
+          styles.text,
+          selected
+            ? { color: colors.primaryForeground, fontWeight: "600" }
+            : { color: colors.foreground },
+          textStyle,
+        ]}
+        numberOfLines={1}
+      >
+        {children}
+      </Animated.Text>
+    </AnimatedPressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: BORDER_RADIUS,
+    borderWidth: 1,
+    gap: 6,
+  },
+  compact: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  text: {
+    fontSize: FONT_SIZE - 3,
+    flexShrink: 0,
+  },
+});

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,0 +1,176 @@
+/* eslint-disable */
+import { Icon } from '@/components/ui/icon';
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { ChevronRight } from 'lucide-react-native';
+import React, { createContext, useContext, useState } from 'react';
+import { TouchableOpacity } from 'react-native';
+
+// Context for accordion state
+interface AccordionContextType {
+  type: 'single' | 'multiple';
+  collapsible?: boolean;
+  value?: string | string[];
+  onValueChange?: (value: string | string[]) => void;
+}
+
+const AccordionContext = createContext<AccordionContextType | null>(null);
+
+// Main Accordion component
+interface AccordionProps {
+  type: 'single' | 'multiple';
+  collapsible?: boolean;
+  defaultValue?: string | string[];
+  value?: string | string[];
+  onValueChange?: (value: string | string[]) => void;
+  children: React.ReactNode;
+}
+
+export function Accordion({
+  type,
+  collapsible = false,
+  defaultValue,
+  value: controlledValue,
+  onValueChange,
+  children,
+}: AccordionProps) {
+  const [internalValue, setInternalValue] = useState<string | string[]>(
+    defaultValue || (type === 'multiple' ? [] : '')
+  );
+
+  const value = controlledValue !== undefined ? controlledValue : internalValue;
+
+  const handleValueChange = (newValue: string | string[]) => {
+    if (controlledValue === undefined) {
+      setInternalValue(newValue);
+    }
+    onValueChange?.(newValue);
+  };
+
+  return (
+    <AccordionContext.Provider
+      value={{
+        type,
+        collapsible,
+        value,
+        onValueChange: handleValueChange,
+      }}
+    >
+      <View style={{ width: '100%' }}>{children}</View>
+    </AccordionContext.Provider>
+  );
+}
+
+// AccordionItem component
+interface AccordionItemProps {
+  value: string;
+  children: React.ReactNode;
+}
+
+export function AccordionItem({ value, children }: AccordionItemProps) {
+  const context = useContext(AccordionContext);
+  if (!context) {
+    throw new Error('AccordionItem must be used within an Accordion');
+  }
+
+  const isOpen = Array.isArray(context.value)
+    ? context.value.includes(value)
+    : context.value === value;
+
+  const toggle = () => {
+    if (!context.onValueChange) return;
+
+    if (context.type === 'single') {
+      const newValue = isOpen && context.collapsible ? '' : value;
+      context.onValueChange(newValue);
+    } else {
+      const currentValues = Array.isArray(context.value) ? context.value : [];
+      const newValue = isOpen
+        ? currentValues.filter((v) => v !== value)
+        : [...currentValues, value];
+      context.onValueChange(newValue);
+    }
+  };
+
+  return (
+    <AccordionItemContext.Provider value={{ value, isOpen, toggle }}>
+      <View>{children}</View>
+    </AccordionItemContext.Provider>
+  );
+}
+
+// Context for accordion item
+interface AccordionItemContextType {
+  value: string;
+  isOpen: boolean;
+  toggle: () => void;
+}
+
+const AccordionItemContext = createContext<AccordionItemContextType | null>(
+  null
+);
+
+// AccordionTrigger component
+interface AccordionTriggerProps {
+  children: React.ReactNode;
+}
+
+export function AccordionTrigger({ children }: AccordionTriggerProps) {
+  const context = useContext(AccordionItemContext);
+  if (!context) {
+    throw new Error('AccordionTrigger must be used within an AccordionItem');
+  }
+
+  return (
+    <TouchableOpacity
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingVertical: 6,
+      }}
+      onPress={context.toggle}
+      activeOpacity={0.8}
+    >
+      <Text variant='subtitle'>{children}</Text>
+      <Icon
+        name={ChevronRight}
+        size={18}
+        style={{
+          transform: [{ rotate: context.isOpen ? '90deg' : '0deg' }],
+        }}
+      />
+    </TouchableOpacity>
+  );
+}
+
+// AccordionContent component
+interface AccordionContentProps {
+  children: React.ReactNode;
+  style?: object;
+}
+
+export function AccordionContent({ children, style }: AccordionContentProps) {
+  const context = useContext(AccordionItemContext);
+  if (!context) {
+    throw new Error('AccordionContent must be used within an AccordionItem');
+  }
+
+  if (!context.isOpen) {
+    return null;
+  }
+
+  return (
+    <View
+      style={[
+        {
+          paddingBottom: 16,
+          paddingLeft: 0,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,196 @@
+/* eslint-disable */
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useColor } from '@/hooks/useColor';
+import React, { useEffect } from 'react';
+import {
+  Modal,
+  StyleSheet,
+  TouchableWithoutFeedback,
+  View,
+  ViewStyle,
+} from 'react-native';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+export type AlertDialogProps = {
+  isVisible: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+  children?: React.ReactNode;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  dismissible?: boolean;
+  showCancelButton?: boolean;
+  style?: ViewStyle;
+};
+
+// A simple card-like dialog overlay with fade-in animation similar to BottomSheet's backdrop
+export function AlertDialog({
+  isVisible,
+  onClose,
+  title,
+  description,
+  children,
+  confirmText = 'OK',
+  cancelText = 'Cancel',
+  onConfirm,
+  onCancel,
+  dismissible = true,
+  showCancelButton = true,
+  style,
+}: AlertDialogProps) {
+  const cardColor = useColor('card');
+
+  const [modalVisible, setModalVisible] = React.useState(false);
+  const backdropOpacity = useSharedValue(0);
+  const cardOpacity = useSharedValue(0);
+
+  useEffect(() => {
+    if (isVisible) {
+      setModalVisible(true);
+      backdropOpacity.value = withTiming(1, { duration: 250 });
+      cardOpacity.value = withTiming(1, { duration: 200 });
+    } else {
+      backdropOpacity.value = withTiming(0, { duration: 250 }, (finished) => {
+        if (finished) {
+          runOnJS(setModalVisible)(false);
+        }
+      });
+      cardOpacity.value = withTiming(0, { duration: 200 });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isVisible]);
+
+  const rBackdropStyle = useAnimatedStyle(() => ({
+    opacity: backdropOpacity.value,
+  }));
+
+  const rCardFadeStyle = useAnimatedStyle(() => ({
+    opacity: cardOpacity.value,
+  }));
+
+  const animateClose = () => {
+    'worklet';
+    backdropOpacity.value = withTiming(0, { duration: 300 }, (finished) => {
+      if (finished) {
+        runOnJS(onClose)();
+      }
+    });
+    cardOpacity.value = withTiming(0, { duration: 200 });
+  };
+
+  const handleBackdropPress = () => {
+    if (dismissible) {
+      animateClose();
+      if (onCancel) onCancel();
+    }
+  };
+
+  const handleCancel = () => {
+    if (onCancel) onCancel();
+    animateClose();
+  };
+
+  const handleConfirm = () => {
+    if (onConfirm) onConfirm();
+    animateClose();
+  };
+
+  return (
+    <Modal
+      visible={modalVisible}
+      transparent
+      statusBarTranslucent
+      animationType='none'
+    >
+      <Animated.View style={[styles.backdrop, rBackdropStyle]}>
+        <TouchableWithoutFeedback onPress={handleBackdropPress}>
+          <Animated.View style={styles.backdropTouchableArea} />
+        </TouchableWithoutFeedback>
+
+        {/* Non-animated outer wrapper: handles rounded corners and clipping */}
+        <View
+          style={[styles.roundedWrapper, { backgroundColor: cardColor }, style]}
+        >
+          {/* Only fade the inner content */}
+          <Animated.View style={[styles.innerContent, rCardFadeStyle]}>
+            <Card
+              // Card has no rounded corners, background or shadow (delegated to wrapper)
+              style={{ backgroundColor: 'transparent', elevation: 0 }}
+            >
+              {(title || description) && (
+                <CardHeader>
+                  {title ? <CardTitle>{title}</CardTitle> : null}
+                  {description ? (
+                    <CardDescription>{description}</CardDescription>
+                  ) : null}
+                </CardHeader>
+              )}
+              {children ? <CardContent>{children}</CardContent> : null}
+              <CardFooter>
+                {showCancelButton && (
+                  <Button variant='outline' onPress={handleCancel}>
+                    {cancelText}
+                  </Button>
+                )}
+                <Button style={{ flex: 1 }} onPress={handleConfirm}>
+                  {confirmText}
+                </Button>
+              </CardFooter>
+            </Card>
+          </Animated.View>
+        </View>
+      </Animated.View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.8)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  backdropTouchableArea: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  // Rounded corners and clipping consolidated here (non-animated)
+  roundedWrapper: {
+    width: '100%',
+    borderRadius: 16,
+    overflow: 'hidden',
+  },
+  // Inner content can render freely (only opacity is animated)
+  innerContent: {
+    width: '100%',
+  },
+});
+
+export function useAlertDialog() {
+  const [isVisible, setIsVisible] = React.useState(false);
+  const open = React.useCallback(() => setIsVisible(true), []);
+  const close = React.useCallback(() => setIsVisible(false), []);
+  const toggle = React.useCallback(() => setIsVisible((v) => !v), []);
+  return { isVisible, open, close, toggle };
+}

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,209 @@
+/* eslint-disable */
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS } from '@/theme/globals';
+import React from 'react';
+import { Alert as RNAlert, TextStyle, ViewStyle } from 'react-native';
+
+type AlertVariant = 'default' | 'destructive';
+
+interface AlertProps {
+  children: React.ReactNode;
+  variant?: AlertVariant;
+  style?: ViewStyle;
+}
+
+// Visual Alert Component (existing functionality)
+export function Alert({ children, variant = 'default', style }: AlertProps) {
+  const borderColor = useColor('border');
+  const destructiveColor = useColor('destructive');
+  const backgroundColor = useColor('card');
+
+  return (
+    <View
+      style={[
+        {
+          padding: BORDER_RADIUS,
+          borderRadius: BORDER_RADIUS,
+          backgroundColor: backgroundColor,
+          borderWidth: 1,
+          borderColor:
+            variant === 'destructive' ? destructiveColor : borderColor,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}
+
+interface AlertTitleProps {
+  children: React.ReactNode;
+  style?: TextStyle;
+}
+
+export function AlertTitle({ children, style }: AlertTitleProps) {
+  return (
+    <Text variant='title' style={[style]}>
+      {children}
+    </Text>
+  );
+}
+
+interface AlertDescriptionProps {
+  children: React.ReactNode;
+  style?: TextStyle;
+}
+
+export function AlertDescription({ children, style }: AlertDescriptionProps) {
+  return (
+    <Text
+      variant='caption'
+      style={[
+        {
+          marginTop: 8,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </Text>
+  );
+}
+
+// Native Alert Functions
+interface AlertButton {
+  text: string;
+  onPress?: () => void;
+  style?: 'default' | 'cancel' | 'destructive';
+}
+
+interface NativeAlertOptions {
+  title: string;
+  message?: string;
+  buttons?: AlertButton[];
+  cancelable?: boolean;
+}
+
+// Two-button native alert
+export const createTwoButtonAlert = (options: NativeAlertOptions) => {
+  const { title, message, buttons } = options;
+
+  const defaultButtons: AlertButton[] = [
+    {
+      text: 'Cancel',
+      onPress: () => console.log('Cancel Pressed'),
+      style: 'cancel',
+    },
+    {
+      text: 'OK',
+      onPress: () => console.log('OK Pressed'),
+    },
+  ];
+
+  RNAlert.alert(title, message, buttons || defaultButtons);
+};
+
+// Three-button native alert
+export const createThreeButtonAlert = (options: NativeAlertOptions) => {
+  const { title, message, buttons } = options;
+
+  const defaultButtons: AlertButton[] = [
+    {
+      text: 'Ask me later',
+      onPress: () => console.log('Ask me later pressed'),
+    },
+    {
+      text: 'Cancel',
+      onPress: () => console.log('Cancel Pressed'),
+      style: 'cancel',
+    },
+    {
+      text: 'OK',
+      onPress: () => console.log('OK Pressed'),
+    },
+  ];
+
+  RNAlert.alert(title, message, buttons || defaultButtons);
+};
+
+// Generic native alert function
+export const showNativeAlert = (options: NativeAlertOptions) => {
+  const { title, message, buttons, cancelable = true } = options;
+
+  if (!buttons || buttons.length === 0) {
+    // Simple alert with just OK button
+    RNAlert.alert(title, message, [
+      {
+        text: 'OK',
+        onPress: () => console.log('OK Pressed'),
+      },
+    ]);
+  } else {
+    RNAlert.alert(title, message, buttons, { cancelable });
+  }
+};
+
+// Convenience functions for common alert types
+export const showSuccessAlert = (
+  title: string,
+  message?: string,
+  onOk?: () => void
+) => {
+  showNativeAlert({
+    title,
+    message,
+    buttons: [
+      {
+        text: 'OK',
+        onPress: onOk || (() => console.log('Success acknowledged')),
+      },
+    ],
+  });
+};
+
+export const showErrorAlert = (
+  title: string,
+  message?: string,
+  onOk?: () => void
+) => {
+  showNativeAlert({
+    title,
+    message,
+    buttons: [
+      {
+        text: 'OK',
+        onPress: onOk || (() => console.log('Error acknowledged')),
+        style: 'destructive',
+      },
+    ],
+  });
+};
+
+export const showConfirmAlert = (
+  title: string,
+  message?: string,
+  onConfirm?: () => void,
+  onCancel?: () => void
+) => {
+  showNativeAlert({
+    title,
+    message,
+    buttons: [
+      {
+        text: 'Cancel',
+        onPress: onCancel || (() => console.log('Cancelled')),
+        style: 'cancel',
+      },
+      {
+        text: 'Confirm',
+        onPress: onConfirm || (() => console.log('Confirmed')),
+      },
+    ],
+  });
+};
+
+// Export the React Native Alert for direct use
+export { RNAlert as NativeAlert };

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable */
+import { Image } from '@/components/ui/image';
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { FONT_SIZE } from '@/theme/globals';
+import { ImageProps, ImageSource } from 'expo-image';
+import { TextStyle, ViewStyle } from 'react-native';
+
+interface AvatarProps {
+  children: React.ReactNode;
+  size?: number;
+  style?: ViewStyle;
+}
+
+export function Avatar({ children, size = 40, style }: AvatarProps) {
+  return (
+    <View
+      style={[
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          overflow: 'hidden',
+          position: 'relative',
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}
+
+interface AvatarImageProps {
+  source: ImageSource;
+  style?: ImageProps['style'];
+}
+
+export function AvatarImage({ source, style }: AvatarImageProps) {
+  return <Image source={source} style={[style]} />;
+}
+
+interface AvatarFallbackProps {
+  children: React.ReactNode;
+  style?: ViewStyle;
+  textStyle?: TextStyle;
+}
+
+export function AvatarFallback({
+  children,
+  style,
+  textStyle,
+}: AvatarFallbackProps) {
+  const mutedColor = useColor('muted');
+  const mutedForegroundColor = useColor('mutedForeground');
+
+  return (
+    <View
+      style={[
+        {
+          width: '100%',
+          height: '100%',
+          backgroundColor: mutedColor,
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        style,
+      ]}
+    >
+      <Text
+        style={[
+          {
+            color: mutedForegroundColor,
+            fontSize: FONT_SIZE,
+            fontWeight: '500',
+          },
+          textStyle,
+        ]}
+      >
+        {children}
+      </Text>
+    </View>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,89 @@
+/* eslint-disable */
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { CORNERS } from '@/theme/globals';
+import { TextStyle, ViewStyle } from 'react-native';
+
+type BadgeVariant =
+  | 'default'
+  | 'secondary'
+  | 'destructive'
+  | 'outline'
+  | 'success';
+
+interface BadgeProps {
+  children: React.ReactNode;
+  variant?: BadgeVariant;
+  style?: ViewStyle;
+  textStyle?: TextStyle;
+}
+
+export function Badge({
+  children,
+  variant = 'default',
+  style,
+  textStyle,
+}: BadgeProps) {
+  const primaryColor = useColor('primary');
+  const primaryForegroundColor = useColor('primaryForeground');
+  const secondaryColor = useColor('secondary');
+  const secondaryForegroundColor = useColor('secondaryForeground');
+  const destructiveColor = useColor('destructive');
+  const destructiveForegroundColor = useColor('destructiveForeground');
+  const borderColor = useColor('border');
+  const successColor = useColor('green');
+
+  const getBadgeStyle = (): ViewStyle => {
+    const baseStyle: ViewStyle = {
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: 6,
+      paddingHorizontal: 12,
+      borderRadius: CORNERS,
+    };
+
+    switch (variant) {
+      case 'secondary':
+        return { ...baseStyle, backgroundColor: secondaryColor };
+      case 'destructive':
+        return { ...baseStyle, backgroundColor: destructiveColor };
+      case 'success':
+        return { ...baseStyle, backgroundColor: successColor };
+      case 'outline':
+        return {
+          ...baseStyle,
+          backgroundColor: 'transparent',
+          borderWidth: 1,
+          borderColor,
+        };
+      default:
+        return { ...baseStyle, backgroundColor: primaryColor };
+    }
+  };
+
+  const getTextStyle = (): TextStyle => {
+    const baseTextStyle: TextStyle = {
+      fontSize: 15,
+      fontWeight: '500',
+      textAlign: 'center',
+    };
+
+    switch (variant) {
+      case 'secondary':
+        return { ...baseTextStyle, color: secondaryForegroundColor };
+      case 'destructive':
+        return { ...baseTextStyle, color: destructiveForegroundColor };
+      case 'outline':
+        return { ...baseTextStyle, color: primaryColor };
+      default:
+        return { ...baseTextStyle, color: primaryForegroundColor };
+    }
+  };
+
+  return (
+    <View style={[getBadgeStyle(), style]}>
+      <Text style={[getTextStyle(), textStyle]}>{children}</Text>
+    </View>
+  );
+}

--- a/components/ui/bna-toast.tsx
+++ b/components/ui/bna-toast.tsx
@@ -1,0 +1,457 @@
+/* eslint-disable */
+import { Text } from '@/components/ui/text';
+import { AlertCircle, Check, Info, X } from 'lucide-react-native';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import {
+  Dimensions,
+  Platform,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native';
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+} from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+export type ToastVariant = 'default' | 'success' | 'error' | 'warning' | 'info';
+
+export interface ToastData {
+  id: string;
+  title?: string;
+  description?: string;
+  variant?: ToastVariant;
+  duration?: number;
+  action?: {
+    label: string;
+    onPress: () => void;
+  };
+}
+
+interface ToastProps extends ToastData {
+  onDismiss: (id: string) => void;
+  index: number;
+}
+
+const { width: screenWidth } = Dimensions.get('window');
+const DYNAMIC_ISLAND_HEIGHT = 37;
+const EXPANDED_HEIGHT = 85;
+const TOAST_MARGIN = 8;
+const DYNAMIC_ISLAND_WIDTH = 126;
+const EXPANDED_WIDTH = screenWidth - 32;
+
+// Reanimated spring configuration
+const SPRING_CONFIG = {
+  stiffness: 120,
+  damping: 8,
+};
+
+export function Toast({
+  id,
+  title,
+  description,
+  variant = 'default',
+  onDismiss,
+  index,
+  action,
+}: ToastProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Reanimated shared values
+  const translateY = useSharedValue(-100);
+  const translateX = useSharedValue(0);
+  const opacity = useSharedValue(0);
+  const scale = useSharedValue(0.8);
+  const width = useSharedValue(DYNAMIC_ISLAND_WIDTH);
+  const height = useSharedValue(DYNAMIC_ISLAND_HEIGHT);
+  const borderRadius = useSharedValue(18.5);
+  const contentOpacity = useSharedValue(0);
+
+  // Dynamic Island colors (dark theme optimized)
+  const backgroundColor = '#1C1C1E'; // iOS Dynamic Island background
+  const mutedTextColor = '#8E8E93'; // iOS secondary text color
+
+  useEffect(() => {
+    const hasContentToShow = Boolean(title || description || action);
+
+    if (hasContentToShow) {
+      // If there's content, start directly with expanded state
+      width.value = EXPANDED_WIDTH;
+      height.value = EXPANDED_HEIGHT;
+      borderRadius.value = 20;
+      setIsExpanded(true);
+
+      // Animate in expanded toast
+      translateY.value = withSpring(0, SPRING_CONFIG);
+      opacity.value = withTiming(1, { duration: 300 });
+      scale.value = withSpring(1, SPRING_CONFIG);
+      // CORRECTED LINE: Use withDelay to wrap withTiming
+      contentOpacity.value = withDelay(100, withTiming(1, { duration: 300 }));
+    } else {
+      // If no content, show compact Dynamic Island with icon only
+      setIsExpanded(false);
+
+      // Animate in compact toast
+      translateY.value = withSpring(0, SPRING_CONFIG);
+      opacity.value = withTiming(1, { duration: 200 });
+      scale.value = withSpring(1, SPRING_CONFIG);
+    }
+  }, []); // This effect should only run once when the toast mounts
+
+  const getVariantColor = () => {
+    switch (variant) {
+      case 'success':
+        return '#30D158'; // iOS green
+      case 'error':
+        return '#FF453A'; // iOS red
+      case 'warning':
+        return '#FF9F0A'; // iOS orange
+      case 'info':
+        return '#007AFF'; // iOS blue
+      default:
+        return '#8E8E93'; // iOS gray
+    }
+  };
+
+  const getIcon = () => {
+    const iconProps = { size: 16, color: getVariantColor() };
+
+    switch (variant) {
+      case 'success':
+        return <Check {...iconProps} />;
+      case 'error':
+        return <X {...iconProps} />;
+      case 'warning':
+        return <AlertCircle {...iconProps} />;
+      case 'info':
+        return <Info {...iconProps} />;
+      default:
+        return null;
+    }
+  };
+
+  const dismiss = useCallback(() => {
+    // This function will be called from the UI thread
+    const onDismissAction = () => {
+      'worklet';
+      runOnJS(onDismiss)(id);
+    };
+
+    translateY.value = withSpring(-100, SPRING_CONFIG);
+    opacity.value = withTiming(0, { duration: 250 }, (finished) => {
+      if (finished) {
+        onDismissAction();
+      }
+    });
+    scale.value = withSpring(0.8, SPRING_CONFIG);
+  }, [id, onDismiss]);
+
+  const panGesture = Gesture.Pan()
+    .onUpdate((event) => {
+      translateX.value = event.translationX;
+    })
+    .onEnd((event) => {
+      const { translationX, velocityX } = event;
+
+      if (
+        Math.abs(translationX) > screenWidth * 0.25 ||
+        Math.abs(velocityX) > 800
+      ) {
+        // Dismiss action to be called from the UI thread
+        const onDismissAction = () => {
+          'worklet';
+          runOnJS(onDismiss)(id);
+        };
+
+        // Animate out horizontally
+        translateX.value = withTiming(
+          translationX > 0 ? screenWidth : -screenWidth,
+          { duration: 250 }
+        );
+        opacity.value = withTiming(0, { duration: 250 }, (finished) => {
+          if (finished) {
+            onDismissAction();
+          }
+        });
+      } else {
+        // Snap back with spring animation
+        translateX.value = withSpring(0, SPRING_CONFIG);
+      }
+    });
+
+  const getTopPosition = () => {
+    const statusBarHeight = Platform.OS === 'ios' ? 59 : 20;
+    return statusBarHeight + index * (EXPANDED_HEIGHT + TOAST_MARGIN);
+  };
+
+  // Animated styles
+  const animatedContainerStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [
+      { translateY: translateY.value },
+      { translateX: translateX.value },
+      { scale: scale.value },
+    ],
+  }));
+
+  const animatedIslandStyle = useAnimatedStyle(() => ({
+    width: width.value,
+    height: height.value,
+    borderRadius: borderRadius.value,
+    backgroundColor,
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+  }));
+
+  const animatedContentStyle = useAnimatedStyle(() => ({
+    opacity: contentOpacity.value,
+  }));
+
+  const toastStyle: ViewStyle = {
+    position: 'absolute',
+    top: getTopPosition(),
+    alignSelf: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.25,
+    shadowRadius: 20,
+    elevation: 10,
+    zIndex: 1000 + index,
+  };
+
+  return (
+    <GestureDetector gesture={panGesture}>
+      <Animated.View style={[toastStyle, animatedContainerStyle]}>
+        <Animated.View style={animatedIslandStyle}>
+          {/* Compact state - just icon or indicator */}
+          {!isExpanded && (
+            <View style={{ justifyContent: 'center', alignItems: 'center' }}>
+              {getIcon()}
+            </View>
+          )}
+
+          {/* Expanded state - full content */}
+          {isExpanded && (
+            <Animated.View
+              style={[
+                {
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  paddingHorizontal: 16,
+                  paddingVertical: 12,
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                },
+                animatedContentStyle,
+              ]}
+            >
+              {getIcon() && (
+                <View style={{ marginRight: 12 }}>{getIcon()}</View>
+              )}
+
+              <View style={{ flex: 1, minWidth: 0 }}>
+                {title && (
+                  <Text
+                    variant='subtitle'
+                    style={{
+                      color: '#FFFFFF',
+                      fontSize: 15,
+                      fontWeight: '600',
+                      marginBottom: description ? 2 : 0,
+                    }}
+                    numberOfLines={1}
+                    ellipsizeMode='tail'
+                  >
+                    {title}
+                  </Text>
+                )}
+                {description && (
+                  <Text
+                    variant='caption'
+                    style={{
+                      color: mutedTextColor,
+                      fontSize: 13,
+                      fontWeight: '400',
+                    }}
+                    numberOfLines={2}
+                    ellipsizeMode='tail'
+                  >
+                    {description}
+                  </Text>
+                )}
+              </View>
+
+              {action && (
+                <TouchableOpacity
+                  onPress={action.onPress}
+                  style={{
+                    marginLeft: 12,
+                    paddingHorizontal: 12,
+                    paddingVertical: 6,
+                    backgroundColor: getVariantColor(),
+                    borderRadius: 12,
+                  }}
+                >
+                  <Text
+                    variant='caption'
+                    style={{
+                      color: '#FFFFFF',
+                      fontSize: 12,
+                      fontWeight: '600',
+                    }}
+                  >
+                    {action.label}
+                  </Text>
+                </TouchableOpacity>
+              )}
+
+              <TouchableOpacity
+                onPress={dismiss}
+                style={{ marginLeft: 8, padding: 4, borderRadius: 8 }}
+              >
+                <X size={14} color={mutedTextColor} />
+              </TouchableOpacity>
+            </Animated.View>
+          )}
+        </Animated.View>
+      </Animated.View>
+    </GestureDetector>
+  );
+}
+
+interface ToastContextType {
+  toast: (toast: Omit<ToastData, 'id'>) => void;
+  success: (title: string, description?: string) => void;
+  error: (title: string, description?: string) => void;
+  warning: (title: string, description?: string) => void;
+  info: (title: string, description?: string) => void;
+  dismiss: (id: string) => void;
+  dismissAll: () => void;
+}
+
+const ToastContext = createContext<ToastContextType | null>(null);
+
+interface ToastProviderProps {
+  children: React.ReactNode;
+  maxToasts?: number;
+}
+
+export function ToastProvider({ children, maxToasts = 3 }: ToastProviderProps) {
+  const [toasts, setToasts] = useState<ToastData[]>([]);
+
+  const generateId = () => Math.random().toString(36).substr(2, 9);
+
+  const addToast = useCallback(
+    (toastData: Omit<ToastData, 'id'>) => {
+      const id = generateId();
+      const newToast: ToastData = {
+        ...toastData,
+        id,
+        duration: toastData.duration ?? 4000,
+      };
+
+      setToasts((prev) => {
+        const updated = [newToast, ...prev];
+        return updated.slice(0, maxToasts);
+      });
+
+      // Auto dismiss after duration
+      if (newToast.duration && newToast.duration > 0) {
+        setTimeout(() => {
+          dismissToast(id);
+        }, newToast.duration);
+      }
+    },
+    [maxToasts]
+  );
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  const dismissAll = useCallback(() => {
+    setToasts([]);
+  }, []);
+
+  const createVariantToast = useCallback(
+    (variant: ToastVariant, title: string, description?: string) => {
+      addToast({
+        title,
+        description,
+        variant,
+      });
+    },
+    [addToast]
+  );
+
+  const contextValue: ToastContextType = {
+    toast: addToast,
+    success: (title, description) =>
+      createVariantToast('success', title, description),
+    error: (title, description) =>
+      createVariantToast('error', title, description),
+    warning: (title, description) =>
+      createVariantToast('warning', title, description),
+    info: (title, description) =>
+      createVariantToast('info', title, description),
+    dismiss: dismissToast,
+    dismissAll,
+  };
+
+  const containerStyle: ViewStyle = {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 1000,
+    pointerEvents: 'box-none',
+  };
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        {children}
+        <View style={containerStyle} pointerEvents='box-none'>
+          {toasts.map((toast, index) => (
+            <Toast
+              key={toast.id}
+              {...toast}
+              index={index}
+              onDismiss={dismissToast}
+            />
+          ))}
+        </View>
+      </GestureHandlerRootView>
+    </ToastContext.Provider>
+  );
+}
+
+// Hook to use toast
+export function useToast() {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+
+  return context;
+}

--- a/components/ui/bottom-sheet.tsx
+++ b/components/ui/bottom-sheet.tsx
@@ -1,0 +1,353 @@
+/* eslint-disable */
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useKeyboardHeight } from '@/hooks/useKeyboardHeight'; // Make sure this path is correct
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS } from '@/theme/globals';
+import React, { useEffect } from 'react';
+import {
+  Dimensions,
+  Modal,
+  ScrollView,
+  TouchableWithoutFeedback,
+  ViewStyle,
+} from 'react-native';
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+} from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated';
+
+const { height: SCREEN_HEIGHT } = Dimensions.get('window');
+const MAX_TRANSLATE_Y = -SCREEN_HEIGHT + 50;
+
+type BottomSheetContentProps = {
+  children: React.ReactNode;
+  title?: string;
+  style?: ViewStyle;
+  rBottomSheetStyle: any;
+  cardColor: string;
+  mutedColor: string;
+  onHandlePress?: () => void;
+};
+
+// Component for the bottom sheet content
+// It now includes a ScrollView by default for better form handling.
+const BottomSheetContent = ({
+  children,
+  title,
+  style,
+  rBottomSheetStyle,
+  cardColor,
+  mutedColor,
+  onHandlePress,
+}: BottomSheetContentProps) => {
+  return (
+    <Animated.View
+      style={[
+        {
+          height: SCREEN_HEIGHT,
+          width: '100%',
+          position: 'absolute',
+          top: SCREEN_HEIGHT,
+          backgroundColor: cardColor,
+          borderTopLeftRadius: BORDER_RADIUS,
+          borderTopRightRadius: BORDER_RADIUS,
+        },
+        rBottomSheetStyle,
+        style,
+      ]}
+    >
+      {/* Handle */}
+      <TouchableWithoutFeedback onPress={onHandlePress}>
+        <View
+          style={{
+            width: '100%',
+            paddingVertical: 12,
+            alignItems: 'center',
+          }}
+        >
+          <View
+            style={{
+              width: 64,
+              height: 6,
+              backgroundColor: mutedColor,
+              borderRadius: 999,
+            }}
+          />
+        </View>
+      </TouchableWithoutFeedback>
+
+      {/* Title */}
+      {title && (
+        <View
+          style={{
+            marginHorizontal: 16,
+            marginTop: 16,
+            paddingBottom: 8,
+          }}
+        >
+          <Text variant='title' style={{ textAlign: 'center' }}>
+            {title}
+          </Text>
+        </View>
+      )}
+
+      {/* Content now wrapped in a ScrollView */}
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ padding: 16, paddingBottom: 40 }}
+        keyboardShouldPersistTaps='handled'
+        showsVerticalScrollIndicator={false}
+      >
+        {children}
+      </ScrollView>
+    </Animated.View>
+  );
+};
+
+type BottomSheetProps = {
+  isVisible: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  snapPoints?: number[];
+  enableBackdropDismiss?: boolean;
+  title?: string;
+  style?: ViewStyle;
+  disablePanGesture?: boolean;
+};
+
+export function BottomSheet({
+  isVisible,
+  onClose,
+  children,
+  snapPoints = [0.3, 0.6, 0.9],
+  enableBackdropDismiss = true,
+  title,
+  style,
+  disablePanGesture = false,
+}: BottomSheetProps) {
+  const cardColor = useColor('card');
+  const mutedColor = useColor('muted');
+  const { keyboardHeight, isKeyboardVisible } = useKeyboardHeight();
+
+  const translateY = useSharedValue(0);
+  const context = useSharedValue({ y: 0 });
+  const opacity = useSharedValue(0);
+  const currentSnapIndex = useSharedValue(0);
+  // Shared value to hold keyboard height for use in worklets
+  const keyboardHeightSV = useSharedValue(0);
+
+  const snapPointsHeights = snapPoints.map((point) => -SCREEN_HEIGHT * point);
+  const defaultHeight = snapPointsHeights[0];
+
+  const [modalVisible, setModalVisible] = React.useState(false);
+
+  // Effect to handle opening and closing the bottom sheet
+  useEffect(() => {
+    if (isVisible) {
+      setModalVisible(true);
+      translateY.value = withSpring(defaultHeight, {
+        damping: 50,
+        stiffness: 400,
+      });
+      opacity.value = withTiming(1, { duration: 300 });
+      currentSnapIndex.value = 0;
+    } else {
+      translateY.value = withSpring(0, { damping: 50, stiffness: 400 });
+      opacity.value = withTiming(0, { duration: 300 }, (finished) => {
+        if (finished) {
+          runOnJS(setModalVisible)(false);
+        }
+      });
+    }
+  }, [isVisible, defaultHeight]);
+
+  // Function to animate the sheet to a specific destination
+  const scrollTo = (destination: number) => {
+    'worklet';
+    translateY.value = withSpring(destination, { damping: 50, stiffness: 400 });
+  };
+
+  // --- START: NEW KEYBOARD HANDLING LOGIC ---
+  useEffect(() => {
+    // Update the shared value whenever keyboardHeight changes
+    keyboardHeightSV.value = keyboardHeight;
+
+    // Only adjust position if the sheet is currently visible
+    if (isVisible) {
+      const currentSnapHeight = snapPointsHeights[currentSnapIndex.value];
+      let destination: number;
+
+      if (isKeyboardVisible) {
+        // Keyboard is open, move sheet up by keyboard height
+        destination = currentSnapHeight - keyboardHeight;
+      } else {
+        // Keyboard is closed, return to original snap point
+        destination = currentSnapHeight;
+      }
+      scrollTo(destination);
+    }
+  }, [keyboardHeight, isKeyboardVisible, isVisible]);
+  // --- END: NEW KEYBOARD HANDLING LOGIC ---
+
+  const findClosestSnapPoint = (currentY: number) => {
+    'worklet';
+    // Adjust the currentY by the keyboard height to find the original snap point
+    const adjustedY = currentY + keyboardHeightSV.value;
+
+    let closest = snapPointsHeights[0];
+    let minDistance = Math.abs(adjustedY - closest);
+    let closestIndex = 0;
+
+    for (let i = 0; i < snapPointsHeights.length; i++) {
+      const snapPoint = snapPointsHeights[i];
+      const distance = Math.abs(adjustedY - snapPoint);
+      if (distance < minDistance) {
+        minDistance = distance;
+        closest = snapPoint;
+        closestIndex = i;
+      }
+    }
+    currentSnapIndex.value = closestIndex;
+    return closest;
+  };
+
+  const handlePress = () => {
+    const nextIndex = (currentSnapIndex.value + 1) % snapPointsHeights.length;
+    currentSnapIndex.value = nextIndex;
+    const destination = snapPointsHeights[nextIndex] - keyboardHeightSV.value;
+    scrollTo(destination);
+  };
+
+  const animateClose = () => {
+    'worklet';
+    translateY.value = withSpring(0, { damping: 50, stiffness: 400 });
+    opacity.value = withTiming(0, { duration: 300 }, (finished) => {
+      if (finished) {
+        runOnJS(onClose)();
+      }
+    });
+  };
+
+  const gesture = Gesture.Pan()
+    .onStart(() => {
+      context.value = { y: translateY.value };
+    })
+    .onUpdate((event) => {
+      const newY = context.value.y + event.translationY;
+      if (newY <= 0 && newY >= MAX_TRANSLATE_Y) {
+        translateY.value = newY;
+      }
+    })
+    .onEnd((event) => {
+      const currentY = translateY.value;
+      const velocity = event.velocityY;
+
+      if (velocity > 500 && currentY > -SCREEN_HEIGHT * 0.2) {
+        animateClose();
+        return;
+      }
+
+      // Find the closest original snap point
+      const closestSnapPoint = findClosestSnapPoint(currentY);
+      // Calculate the final destination, accounting for the keyboard height
+      const finalDestination = closestSnapPoint - keyboardHeightSV.value;
+      scrollTo(finalDestination);
+    });
+
+  const rBottomSheetStyle = useAnimatedStyle(() => {
+    return {
+      transform: [{ translateY: translateY.value }],
+    };
+  });
+
+  const rBackdropStyle = useAnimatedStyle(() => {
+    return {
+      opacity: opacity.value,
+    };
+  });
+
+  const handleBackdropPress = () => {
+    if (enableBackdropDismiss) {
+      animateClose();
+    }
+  };
+
+  return (
+    <Modal
+      visible={modalVisible}
+      transparent
+      statusBarTranslucent
+      animationType='none'
+    >
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <Animated.View
+          style={[
+            { flex: 1, backgroundColor: 'rgba(0, 0, 0, 0.8)' },
+            rBackdropStyle,
+          ]}
+        >
+          <TouchableWithoutFeedback onPress={handleBackdropPress}>
+            <Animated.View style={{ flex: 1 }} />
+          </TouchableWithoutFeedback>
+
+          {disablePanGesture ? (
+            <BottomSheetContent
+              children={children}
+              title={title}
+              style={style}
+              rBottomSheetStyle={rBottomSheetStyle}
+              cardColor={cardColor}
+              mutedColor={mutedColor}
+              onHandlePress={() => runOnJS(handlePress)()}
+            />
+          ) : (
+            <GestureDetector gesture={gesture}>
+              <BottomSheetContent
+                children={children}
+                title={title}
+                style={style}
+                rBottomSheetStyle={rBottomSheetStyle}
+                cardColor={cardColor}
+                mutedColor={mutedColor}
+                onHandlePress={() => runOnJS(handlePress)()}
+              />
+            </GestureDetector>
+          )}
+        </Animated.View>
+      </GestureHandlerRootView>
+    </Modal>
+  );
+}
+
+// Hook for managing bottom sheet state
+export function useBottomSheet() {
+  const [isVisible, setIsVisible] = React.useState(false);
+
+  const open = React.useCallback(() => {
+    setIsVisible(true);
+  }, []);
+
+  const close = React.useCallback(() => {
+    setIsVisible(false);
+  }, []);
+
+  const toggle = React.useCallback(() => {
+    setIsVisible((prev) => !prev);
+  }, []);
+
+  return {
+    isVisible,
+    open,
+    close,
+    toggle,
+  };
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,393 @@
+/* eslint-disable */
+import { Icon } from '@/components/ui/icon';
+import { ButtonSpinner, SpinnerVariant } from '@/components/ui/spinner';
+import { Text } from '@/components/ui/text';
+import { useColor } from '@/hooks/useColor';
+import { CORNERS, FONT_SIZE, HEIGHT } from '@/theme/globals';
+import * as Haptics from 'expo-haptics';
+import { LucideProps } from 'lucide-react-native';
+import { forwardRef } from 'react';
+import {
+  Pressable,
+  TextStyle,
+  TouchableOpacity,
+  TouchableOpacityProps,
+  View,
+  ViewStyle,
+} from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
+
+export type ButtonVariant =
+  | 'default'
+  | 'destructive'
+  | 'success'
+  | 'outline'
+  | 'secondary'
+  | 'ghost'
+  | 'link';
+
+export type ButtonSize = 'default' | 'sm' | 'lg' | 'icon';
+
+export interface ButtonProps extends Omit<TouchableOpacityProps, 'style'> {
+  label?: string;
+  children?: React.ReactNode;
+  animation?: boolean;
+  haptic?: boolean;
+  icon?: React.ComponentType<LucideProps>;
+  onPress?: () => void;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  disabled?: boolean;
+  loading?: boolean;
+  loadingVariant?: SpinnerVariant;
+  style?: ViewStyle | ViewStyle[];
+  textStyle?: TextStyle;
+}
+
+export const Button = forwardRef<View, ButtonProps>(
+  (
+    {
+      children,
+      icon,
+      onPress,
+      variant = 'default',
+      size = 'default',
+      disabled = false,
+      loading = false,
+      animation = true,
+      haptic = true,
+      loadingVariant = 'default',
+      style,
+      textStyle,
+      ...props
+    },
+    ref
+  ) => {
+    const primaryColor = useColor('primary');
+    const primaryForegroundColor = useColor('primaryForeground');
+    const secondaryColor = useColor('secondary');
+    const secondaryForegroundColor = useColor('secondaryForeground');
+    const destructiveColor = useColor('red');
+    const destructiveForegroundColor = useColor('destructiveForeground');
+    const greenColor = useColor('green');
+    const borderColor = useColor('border');
+
+    // Animation values for liquid glass effect
+    const scale = useSharedValue(1);
+    const brightness = useSharedValue(1);
+
+    const getButtonStyle = (): ViewStyle => {
+      const baseStyle: ViewStyle = {
+        borderRadius: CORNERS,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+      };
+
+      // Size variants
+      switch (size) {
+        case 'sm':
+          Object.assign(baseStyle, { height: 44, paddingHorizontal: 24 });
+          break;
+        case 'lg':
+          Object.assign(baseStyle, { height: 54, paddingHorizontal: 36 });
+          break;
+        case 'icon':
+          Object.assign(baseStyle, {
+            height: HEIGHT,
+            width: HEIGHT,
+            paddingHorizontal: 0,
+          });
+          break;
+        default:
+          Object.assign(baseStyle, { height: HEIGHT, paddingHorizontal: 32 });
+      }
+
+      // Variant styles
+      switch (variant) {
+        case 'destructive':
+          return { ...baseStyle, backgroundColor: destructiveColor };
+        case 'success':
+          return { ...baseStyle, backgroundColor: greenColor };
+        case 'outline':
+          return {
+            ...baseStyle,
+            backgroundColor: 'transparent',
+            borderWidth: 1,
+            borderColor,
+          };
+        case 'secondary':
+          return { ...baseStyle, backgroundColor: secondaryColor };
+        case 'ghost':
+          return { ...baseStyle, backgroundColor: 'transparent' };
+        case 'link':
+          return {
+            ...baseStyle,
+            backgroundColor: 'transparent',
+            height: 'auto',
+            paddingHorizontal: 0,
+          };
+        default:
+          return { ...baseStyle, backgroundColor: primaryColor };
+      }
+    };
+
+    const getButtonTextStyle = (): TextStyle => {
+      const baseTextStyle: TextStyle = {
+        fontSize: FONT_SIZE,
+        fontWeight: '500',
+      };
+
+      switch (variant) {
+        case 'destructive':
+          return { ...baseTextStyle, color: destructiveForegroundColor };
+        case 'success':
+          return { ...baseTextStyle, color: destructiveForegroundColor };
+        case 'outline':
+          return { ...baseTextStyle, color: primaryColor };
+        case 'secondary':
+          return { ...baseTextStyle, color: secondaryForegroundColor };
+        case 'ghost':
+          return { ...baseTextStyle, color: primaryColor };
+        case 'link':
+          return {
+            ...baseTextStyle,
+            color: primaryColor,
+            textDecorationLine: 'underline',
+          };
+        default:
+          return { ...baseTextStyle, color: primaryForegroundColor };
+      }
+    };
+
+    const getColor = (): string => {
+      switch (variant) {
+        case 'destructive':
+          return destructiveForegroundColor;
+        case 'success':
+          return destructiveForegroundColor;
+        case 'outline':
+          return primaryColor;
+        case 'secondary':
+          return secondaryForegroundColor;
+        case 'ghost':
+          return primaryColor;
+        case 'link':
+          return primaryColor;
+        default:
+          return primaryForegroundColor;
+      }
+    };
+
+    // Helper function to get icon size based on button size
+    const getIconSize = (): number => {
+      switch (size) {
+        case 'sm':
+          return 16;
+        case 'lg':
+          return 24;
+        case 'icon':
+          return 20;
+        default:
+          return 18;
+      }
+    };
+
+    // Trigger haptic feedback
+    const triggerHapticFeedback = () => {
+      if (haptic && !disabled && !loading) {
+        if (process.env.EXPO_OS === 'ios') {
+          Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        }
+      }
+    };
+
+    // Improved animation handlers for liquid glass effect
+    const handlePressIn = (ev?: any) => {
+      'worklet';
+      // Trigger haptic feedback
+      triggerHapticFeedback();
+
+      // Scale up with bouncy spring animation
+      scale.value = withSpring(1.05, {
+        damping: 15,
+        stiffness: 400,
+        mass: 0.5,
+      });
+
+      // Slight brightness increase for glass effect
+      brightness.value = withSpring(1.1, {
+        damping: 20,
+        stiffness: 300,
+      });
+
+      // Call original onPressIn if provided
+      props.onPressIn?.(ev);
+    };
+
+    const handlePressOut = (ev?: any) => {
+      'worklet';
+      // Return to original size with smooth spring
+      scale.value = withSpring(1, {
+        damping: 20,
+        stiffness: 400,
+        mass: 0.8,
+        overshootClamping: false,
+      });
+
+      // Return brightness to normal
+      brightness.value = withSpring(1, {
+        damping: 20,
+        stiffness: 300,
+      });
+
+      // Call original onPressOut if provided
+      props.onPressOut?.(ev);
+    };
+
+    // Handle actual press action
+    const handlePress = () => {
+      if (onPress && !disabled && !loading) {
+        onPress();
+      }
+    };
+
+    // Handle press for TouchableOpacity (non-animated version)
+    const handleTouchablePress = () => {
+      triggerHapticFeedback();
+      handlePress();
+    };
+
+    // Animated styles using useAnimatedStyle
+    const animatedStyle = useAnimatedStyle(() => {
+      return {
+        transform: [{ scale: scale.value }],
+        opacity: brightness.value * (disabled ? 0.5 : 1),
+      };
+    });
+
+    // Extract flex value from style prop
+    const getFlexFromStyle = () => {
+      if (!style) return null;
+
+      const styleArray = Array.isArray(style) ? style : [style];
+
+      // Find the last occurrence of flex (in case of multiple styles with flex)
+      for (let i = styleArray.length - 1; i >= 0; i--) {
+        const s = styleArray[i];
+        if (s && typeof s === 'object' && 'flex' in s) {
+          return s.flex;
+        }
+      }
+      return null;
+    };
+
+    // Alternative simpler solution - replace flex with alignSelf
+    const getPressableStyle = (): ViewStyle => {
+      const flexValue = getFlexFromStyle();
+      // If flex: 1 is applied, use alignSelf: 'stretch' instead to only affect width
+      return flexValue === 1
+        ? {
+            flex: 1,
+            alignSelf: 'stretch',
+          }
+        : flexValue !== null
+        ? {
+            flex: flexValue,
+            maxHeight: size === 'sm' ? 44 : size === 'lg' ? 54 : HEIGHT,
+          }
+        : {};
+    };
+
+    // Updated getStyleWithoutFlex function
+    const getStyleWithoutFlex = () => {
+      if (!style) return style;
+
+      const styleArray = Array.isArray(style) ? style : [style];
+      return styleArray.map((s) => {
+        if (s && typeof s === 'object' && 'flex' in s) {
+          const { flex, ...restStyle } = s;
+          return restStyle;
+        }
+        return s;
+      });
+    };
+
+    const buttonStyle = getButtonStyle();
+    const finalTextStyle = getButtonTextStyle();
+    const contentColor = getColor();
+    const iconSize = getIconSize();
+    const styleWithoutFlex = getStyleWithoutFlex();
+
+    return animation ? (
+      <Pressable
+        ref={ref}
+        onPress={handlePress}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        disabled={disabled || loading}
+        style={getPressableStyle()}
+        {...props}
+      >
+        <Animated.View style={[animatedStyle, buttonStyle, styleWithoutFlex]}>
+          {loading ? (
+            <ButtonSpinner
+              size={size}
+              variant={loadingVariant}
+              color={contentColor}
+            />
+          ) : typeof children === 'string' ? (
+            <View
+              style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+            >
+              {icon && (
+                <Icon name={icon} color={contentColor} size={iconSize} />
+              )}
+              <Text style={[finalTextStyle, textStyle]}>{children}</Text>
+            </View>
+          ) : (
+            <View
+              style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+            >
+              {icon && (
+                <Icon name={icon} color={contentColor} size={iconSize} />
+              )}
+              {children}
+            </View>
+          )}
+        </Animated.View>
+      </Pressable>
+    ) : (
+      <TouchableOpacity
+        ref={ref}
+        style={[buttonStyle, disabled && { opacity: 0.5 }, styleWithoutFlex]}
+        onPress={handleTouchablePress}
+        disabled={disabled || loading}
+        activeOpacity={0.8}
+        {...props}
+      >
+        {loading ? (
+          <ButtonSpinner
+            size={size}
+            variant={loadingVariant}
+            color={contentColor}
+          />
+        ) : typeof children === 'string' ? (
+          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+            {icon && <Icon name={icon} color={contentColor} size={iconSize} />}
+            <Text style={[finalTextStyle, textStyle]}>{children}</Text>
+          </View>
+        ) : (
+          children
+        )}
+      </TouchableOpacity>
+    );
+  }
+);
+
+// Add display name for better debugging
+Button.displayName = 'Button';

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,111 @@
+/* eslint-disable */
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS } from '@/theme/globals';
+import { TextStyle, ViewStyle } from 'react-native';
+
+interface CardProps {
+  children: React.ReactNode;
+  style?: ViewStyle;
+}
+
+export function Card({ children, style }: CardProps) {
+  const cardColor = useColor('card');
+  const foregroundColor = useColor('foreground');
+
+  return (
+    <View
+      style={[
+        {
+          width: '100%',
+          backgroundColor: cardColor,
+          borderRadius: BORDER_RADIUS,
+          padding: 18,
+          shadowColor: foregroundColor,
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.05,
+          shadowRadius: 3,
+          elevation: 2,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}
+
+interface CardHeaderProps {
+  children: React.ReactNode;
+  style?: ViewStyle;
+}
+
+export function CardHeader({ children, style }: CardHeaderProps) {
+  return <View style={[{ marginBottom: 8 }, style]}>{children}</View>;
+}
+
+interface CardTitleProps {
+  children: React.ReactNode;
+  style?: TextStyle;
+}
+
+export function CardTitle({ children, style }: CardTitleProps) {
+  return (
+    <Text
+      variant='title'
+      style={[
+        {
+          marginBottom: 4,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </Text>
+  );
+}
+
+interface CardDescriptionProps {
+  children: React.ReactNode;
+  style?: TextStyle;
+}
+
+export function CardDescription({ children, style }: CardDescriptionProps) {
+  return (
+    <Text variant='caption' style={[style]}>
+      {children}
+    </Text>
+  );
+}
+
+interface CardContentProps {
+  children: React.ReactNode;
+  style?: ViewStyle;
+}
+
+export function CardContent({ children, style }: CardContentProps) {
+  return <View style={[style]}>{children}</View>;
+}
+
+interface CardFooterProps {
+  children: React.ReactNode;
+  style?: ViewStyle;
+}
+
+export function CardFooter({ children, style }: CardFooterProps) {
+  return (
+    <View
+      style={[
+        {
+          marginTop: 16,
+          flexDirection: 'row',
+          gap: 8,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable */
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS } from '@/theme/globals';
+import { Check } from 'lucide-react-native';
+import React from 'react';
+import { TextStyle, TouchableOpacity } from 'react-native';
+
+interface CheckboxProps {
+  checked: boolean;
+  label?: string;
+  error?: string;
+  disabled?: boolean;
+  labelStyle?: TextStyle;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+export function Checkbox({
+  checked,
+  error,
+  disabled = false,
+  label,
+  labelStyle,
+  onCheckedChange,
+}: CheckboxProps) {
+  const primary = useColor('primary');
+  const primaryForegroundColor = useColor('primaryForeground');
+  const danger = useColor('red');
+  const borderColor = useColor('border');
+
+  return (
+    <TouchableOpacity
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        opacity: disabled ? 0.5 : 1,
+        paddingVertical: 4,
+      }}
+      onPress={() => !disabled && onCheckedChange(!checked)}
+      disabled={disabled}
+    >
+      <View
+        style={{
+          width: BORDER_RADIUS,
+          height: BORDER_RADIUS,
+          borderRadius: BORDER_RADIUS,
+          borderWidth: 1.5,
+          borderColor: checked ? primary : borderColor,
+          backgroundColor: checked ? primary : 'transparent',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginRight: label ? 8 : 0,
+        }}
+      >
+        {checked && (
+          <Check
+            size={16}
+            color={primaryForegroundColor}
+            strokeWidth={3}
+            strokeLinecap='round'
+          />
+        )}
+      </View>
+      {label && (
+        <Text
+          variant='caption'
+          numberOfLines={1}
+          ellipsizeMode='tail'
+          style={[
+            {
+              color: error ? danger : primary,
+            },
+            labelStyle,
+          ]}
+          pointerEvents='none'
+        >
+          {label}
+        </Text>
+      )}
+    </TouchableOpacity>
+  );
+}

--- a/components/ui/icon.tsx
+++ b/components/ui/icon.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable */
+import { useColor } from '@/hooks/useColor';
+import { LucideProps } from 'lucide-react-native';
+import React from 'react';
+
+export type Props = LucideProps & {
+  lightColor?: string;
+  darkColor?: string;
+  name: React.ComponentType<LucideProps>;
+};
+
+export function Icon({
+  lightColor,
+  darkColor,
+  name: IconComponent,
+  color,
+  size = 24,
+  strokeWidth = 1.8,
+  ...rest
+}: Props) {
+  const themedColor = useColor('icon', { light: lightColor, dark: darkColor });
+
+  // Use provided color prop if available, otherwise use themed color
+  const iconColor = color || themedColor;
+
+  return (
+    <IconComponent
+      color={iconColor}
+      size={size}
+      strokeWidth={strokeWidth}
+      strokeLinecap='round'
+      {...rest}
+    />
+  );
+}

--- a/components/ui/image.tsx
+++ b/components/ui/image.tsx
@@ -1,0 +1,175 @@
+/* eslint-disable */
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS, CORNERS } from '@/theme/globals';
+import {
+  Image as ExpoImage,
+  ImageProps as ExpoImageProps,
+  ImageSource,
+} from 'expo-image';
+import { forwardRef, useState } from 'react';
+import { ActivityIndicator, StyleSheet } from 'react-native';
+
+export interface ImageProps extends Omit<ExpoImageProps, 'style'> {
+  variant?: 'rounded' | 'circle' | 'default';
+  source: ImageSource;
+  style?: ExpoImageProps['style'];
+  containerStyle?: any;
+  showLoadingIndicator?: boolean;
+  showErrorFallback?: boolean;
+  errorFallbackText?: string;
+  loadingIndicatorSize?: 'small' | 'large';
+  loadingIndicatorColor?: string;
+  aspectRatio?: number;
+  width?: number | string;
+  height?: number | string;
+}
+
+export const Image = forwardRef<ExpoImage, ImageProps>(
+  (
+    {
+      variant = 'rounded',
+      source,
+      style,
+      containerStyle,
+      showLoadingIndicator = true,
+      showErrorFallback = true,
+      errorFallbackText = 'Failed to load image',
+      loadingIndicatorSize = 'small',
+      loadingIndicatorColor,
+      aspectRatio,
+      width,
+      height,
+      contentFit = 'cover',
+      transition = 200,
+      ...props
+    },
+    ref
+  ) => {
+    const [isLoading, setIsLoading] = useState(true);
+    const [hasError, setHasError] = useState(false);
+
+    // Theme colors
+    const backgroundColor = useColor('muted');
+    const textColor = useColor('mutedForeground');
+    const primaryColor = useColor('primary');
+
+    // Get border radius based on variant
+    const getBorderRadius = () => {
+      switch (variant) {
+        case 'circle':
+          return CORNERS;
+        case 'rounded':
+          return BORDER_RADIUS;
+        case 'default':
+          return 0;
+        default:
+          return BORDER_RADIUS;
+      }
+    };
+
+    const borderRadius = getBorderRadius();
+
+    // Container dimensions - fill container by default, or use provided dimensions
+    const containerDimensions =
+      width || height || aspectRatio
+        ? {
+            ...(width ? { width } : {}),
+            ...(height ? { height } : {}),
+            ...(aspectRatio ? { aspectRatio } : {}),
+          }
+        : { width: '100%', height: '100%' };
+
+    // Image styles - always fill the container
+    const imageStyles = [
+      { width: '100%', height: '100%', borderRadius },
+      style,
+    ].filter(Boolean) as ExpoImageProps['style'];
+
+    const containerStyles = [
+      styles.container,
+      containerDimensions,
+      { borderRadius, backgroundColor },
+      containerStyle,
+    ];
+
+    const handleLoadStart = () => {
+      setIsLoading(true);
+      setHasError(false);
+    };
+
+    const handleLoadEnd = () => {
+      setIsLoading(false);
+    };
+
+    const handleError = () => {
+      setIsLoading(false);
+      setHasError(true);
+    };
+
+    return (
+      <View style={containerStyles}>
+        <ExpoImage
+          ref={ref}
+          source={source}
+          style={imageStyles}
+          contentFit={contentFit}
+          transition={transition}
+          onLoadStart={handleLoadStart}
+          onLoadEnd={handleLoadEnd}
+          onError={handleError}
+          {...props}
+        />
+
+        {/* Loading indicator */}
+        {isLoading && showLoadingIndicator && (
+          <View style={styles.overlay}>
+            <ActivityIndicator
+              size={loadingIndicatorSize}
+              color={loadingIndicatorColor || primaryColor}
+            />
+          </View>
+        )}
+
+        {/* Error fallback */}
+        {hasError && showErrorFallback && (
+          <View style={[styles.overlay, styles.errorContainer]}>
+            <Text
+              variant='caption'
+              style={[styles.errorText, { color: textColor }]}
+              numberOfLines={2}
+            >
+              {errorFallbackText}
+            </Text>
+          </View>
+        )}
+      </View>
+    );
+  }
+);
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  errorContainer: {
+    padding: 8,
+  },
+  errorText: {
+    textAlign: 'center',
+    fontSize: 12,
+  },
+});
+
+Image.displayName = 'Image';

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,608 @@
+/* eslint-disable */
+import { Icon } from '@/components/ui/icon';
+import { Text } from '@/components/ui/text';
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS, CORNERS, FONT_SIZE, HEIGHT } from '@/theme/globals';
+import { LucideProps } from 'lucide-react-native';
+import React, { forwardRef, ReactElement, useState } from 'react';
+import {
+  Pressable,
+  TextInput,
+  TextInputProps,
+  TextStyle,
+  View,
+  ViewStyle,
+} from 'react-native';
+
+export interface InputProps extends Omit<TextInputProps, 'style'> {
+  label?: string;
+  error?: string;
+  icon?: React.ComponentType<LucideProps>;
+  rightComponent?: React.ReactNode | (() => React.ReactNode);
+  containerStyle?: ViewStyle;
+  inputStyle?: TextStyle;
+  labelStyle?: TextStyle;
+  errorStyle?: TextStyle;
+  variant?: 'filled' | 'outline';
+  disabled?: boolean;
+  type?: 'input' | 'textarea';
+  placeholder?: string;
+  rows?: number; // Only used when type="textarea"
+}
+
+export const Input = forwardRef<TextInput, InputProps>(
+  (
+    {
+      label,
+      error,
+      icon,
+      rightComponent,
+      containerStyle,
+      inputStyle,
+      labelStyle,
+      errorStyle,
+      variant = 'filled',
+      disabled = false,
+      type = 'input',
+      rows = 4,
+      onFocus,
+      onBlur,
+      placeholder,
+      ...props
+    },
+    ref
+  ) => {
+    const [isFocused, setIsFocused] = useState(false);
+
+    // Theme colors
+    const cardColor = useColor('card');
+    const textColor = useColor('text');
+    const muted = useColor('textMuted');
+    const borderColor = useColor('border');
+    const primary = useColor('primary');
+    const danger = useColor('red');
+
+    const isTextarea = type === 'textarea';
+
+    // Calculate height based on type
+    const getHeight = () => {
+      if (isTextarea) {
+        return rows * 20 + 32; // Approximate line height + padding
+      }
+      return HEIGHT;
+    };
+
+    // Variant styles
+    const getVariantStyle = (): ViewStyle => {
+      const baseStyle: ViewStyle = {
+        borderRadius: isTextarea ? BORDER_RADIUS : CORNERS,
+        flexDirection: isTextarea ? 'column' : 'row',
+        alignItems: isTextarea ? 'stretch' : 'center',
+        minHeight: getHeight(),
+        paddingHorizontal: 16,
+        paddingVertical: isTextarea ? 12 : 0,
+      };
+
+      switch (variant) {
+        case 'outline':
+          return {
+            ...baseStyle,
+            borderWidth: 1,
+            borderColor: error ? danger : isFocused ? primary : borderColor,
+            backgroundColor: 'transparent',
+          };
+        case 'filled':
+        default:
+          return {
+            ...baseStyle,
+            borderWidth: 1,
+            borderColor: error ? danger : cardColor,
+            backgroundColor: disabled ? muted + '20' : cardColor,
+          };
+      }
+    };
+
+    const getInputStyle = (): TextStyle => ({
+      flex: 1,
+      fontSize: FONT_SIZE,
+      lineHeight: isTextarea ? 20 : undefined,
+      color: disabled ? muted : error ? danger : textColor,
+      paddingVertical: 0, // Remove default padding
+      textAlignVertical: isTextarea ? 'top' : 'center',
+    });
+
+    const handleFocus = (e: any) => {
+      setIsFocused(true);
+      onFocus?.(e);
+    };
+
+    const handleBlur = (e: any) => {
+      setIsFocused(false);
+      onBlur?.(e);
+    };
+
+    // Render right component - supports both direct components and functions
+    const renderRightComponent = () => {
+      if (!rightComponent) return null;
+
+      // If it's a function, call it. Otherwise, render directly
+      return typeof rightComponent === 'function'
+        ? rightComponent()
+        : rightComponent;
+    };
+
+    const renderInputContent = () => (
+      <View style={containerStyle}>
+        {/* Input Container */}
+        <Pressable
+          style={[getVariantStyle(), disabled && { opacity: 0.6 }]}
+          onPress={() => {
+            if (!disabled && ref && 'current' in ref && ref.current) {
+              ref.current.focus();
+            }
+          }}
+          disabled={disabled}
+        >
+          {isTextarea ? (
+            // Textarea Layout (Column)
+            <>
+              {/* Header section with icon, label, and right component */}
+              {(icon || label || rightComponent) && (
+                <View
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    marginBottom: 8,
+                    gap: 8,
+                  }}
+                >
+                  {/* Left section - Icon + Label */}
+                  <View
+                    style={{
+                      flex: 1,
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      gap: 8,
+                    }}
+                    pointerEvents='none'
+                  >
+                    {icon && (
+                      <Icon
+                        name={icon}
+                        size={16}
+                        color={error ? danger : muted}
+                      />
+                    )}
+                    {label && (
+                      <Text
+                        variant='caption'
+                        numberOfLines={1}
+                        ellipsizeMode='tail'
+                        style={[
+                          {
+                            color: error ? danger : muted,
+                          },
+                          labelStyle,
+                        ]}
+                        pointerEvents='none'
+                      >
+                        {label}
+                      </Text>
+                    )}
+                  </View>
+
+                  {/* Right Component */}
+                  {renderRightComponent()}
+                </View>
+              )}
+
+              {/* TextInput section */}
+              <TextInput
+                ref={ref}
+                multiline
+                numberOfLines={rows}
+                style={[getInputStyle(), inputStyle]}
+                placeholderTextColor={error ? danger + '99' : muted}
+                placeholder={placeholder || 'Type your message...'}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+                editable={!disabled}
+                selectionColor={primary}
+                {...props}
+              />
+            </>
+          ) : (
+            // Input Layout (Row)
+            <View
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              {/* Left section - Icon + Label (fixed width to simulate grid column) */}
+              <View
+                style={{
+                  width: label ? 120 : 'auto',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 8,
+                }}
+                pointerEvents='none'
+              >
+                {icon && (
+                  <Icon name={icon} size={16} color={error ? danger : muted} />
+                )}
+                {label && (
+                  <Text
+                    variant='caption'
+                    numberOfLines={1}
+                    ellipsizeMode='tail'
+                    style={[
+                      {
+                        color: error ? danger : muted,
+                      },
+                      labelStyle,
+                    ]}
+                    pointerEvents='none'
+                  >
+                    {label}
+                  </Text>
+                )}
+              </View>
+
+              {/* TextInput section - takes remaining space */}
+              <View style={{ flex: 1 }}>
+                <TextInput
+                  ref={ref}
+                  style={[getInputStyle(), inputStyle]}
+                  placeholderTextColor={error ? danger + 99 : muted}
+                  onFocus={handleFocus}
+                  onBlur={handleBlur}
+                  editable={!disabled}
+                  placeholder={placeholder}
+                  selectionColor={primary}
+                  {...props}
+                />
+              </View>
+
+              {/* Right Component */}
+              {renderRightComponent()}
+            </View>
+          )}
+        </Pressable>
+
+        {/* Error Message */}
+        {error && (
+          <Text
+            style={[
+              {
+                marginLeft: 14,
+                marginTop: 4,
+                fontSize: 14,
+                color: danger,
+              },
+              errorStyle,
+            ]}
+          >
+            {error}
+          </Text>
+        )}
+      </View>
+    );
+
+    return renderInputContent();
+  }
+);
+
+export interface GroupedInputProps {
+  children: React.ReactNode;
+  containerStyle?: ViewStyle;
+  title?: string;
+  titleStyle?: TextStyle;
+}
+
+export const GroupedInput = ({
+  children,
+  containerStyle,
+  title,
+  titleStyle,
+}: GroupedInputProps) => {
+  const border = useColor('border');
+  const background = useColor('card');
+  const danger = useColor('red');
+
+  const childrenArray = React.Children.toArray(children);
+
+  const errors = childrenArray
+    .filter(
+      (child): child is ReactElement<any> =>
+        React.isValidElement(child) && !!(child.props as any).error
+    )
+    .map((child) => child.props.error);
+
+  const renderGroupedContent = () => (
+    <View style={containerStyle}>
+      {!!title && (
+        <Text
+          variant='title'
+          style={[{ marginBottom: 8, marginLeft: 8 }, titleStyle]}
+        >
+          {title}
+        </Text>
+      )}
+
+      <View
+        style={{
+          backgroundColor: background,
+          borderColor: border,
+          borderWidth: 1,
+          borderRadius: BORDER_RADIUS,
+          overflow: 'hidden',
+        }}
+      >
+        {childrenArray.map((child, index) => (
+          <View
+            key={index}
+            style={{
+              minHeight: HEIGHT,
+              paddingVertical: 12,
+              paddingHorizontal: 16,
+              justifyContent: 'center',
+              borderBottomWidth: index !== childrenArray.length - 1 ? 1 : 0,
+              borderColor: border,
+            }}
+          >
+            {child}
+          </View>
+        ))}
+      </View>
+
+      {errors.length > 0 && (
+        <View style={{ marginTop: 6 }}>
+          {errors.map((error, i) => (
+            <Text
+              key={i}
+              style={{
+                fontSize: 14,
+                color: danger,
+                marginTop: i === 0 ? 0 : 1,
+                marginLeft: 8,
+              }}
+            >
+              {error}
+            </Text>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+
+  return renderGroupedContent();
+};
+
+export interface GroupedInputItemProps extends Omit<TextInputProps, 'style'> {
+  label?: string;
+  error?: string;
+  icon?: React.ComponentType<LucideProps>;
+  rightComponent?: React.ReactNode | (() => React.ReactNode);
+  inputStyle?: TextStyle;
+  labelStyle?: TextStyle;
+  errorStyle?: TextStyle;
+  disabled?: boolean;
+  type?: 'input' | 'textarea';
+  rows?: number; // Only used when type="textarea"
+}
+
+export const GroupedInputItem = forwardRef<TextInput, GroupedInputItemProps>(
+  (
+    {
+      label,
+      error,
+      icon,
+      rightComponent,
+      inputStyle,
+      labelStyle,
+      errorStyle,
+      disabled,
+      type = 'input',
+      rows = 3,
+      onFocus,
+      onBlur,
+      placeholder,
+      ...props
+    },
+    ref
+  ) => {
+    const [isFocused, setIsFocused] = useState(false);
+
+    const text = useColor('text');
+    const muted = useColor('textMuted');
+    const primary = useColor('primary');
+    const danger = useColor('red');
+
+    const isTextarea = type === 'textarea';
+
+    const handleFocus = (e: any) => {
+      setIsFocused(true);
+      onFocus?.(e);
+    };
+
+    const handleBlur = (e: any) => {
+      setIsFocused(false);
+      onBlur?.(e);
+    };
+
+    const renderRightComponent = () => {
+      if (!rightComponent) return null;
+      return typeof rightComponent === 'function'
+        ? rightComponent()
+        : rightComponent;
+    };
+
+    const renderItemContent = () => (
+      <Pressable
+        onPress={() => ref && 'current' in ref && ref.current?.focus()}
+        disabled={disabled}
+        style={{ opacity: disabled ? 0.6 : 1 }}
+      >
+        <View
+          style={{
+            flexDirection: isTextarea ? 'column' : 'row',
+            alignItems: isTextarea ? 'stretch' : 'center',
+            backgroundColor: 'transparent',
+          }}
+        >
+          {isTextarea ? (
+            // Textarea Layout (Column)
+            <>
+              {/* Header section with icon, label, and right component */}
+              {(icon || label || rightComponent) && (
+                <View
+                  style={{
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    marginBottom: 8,
+                    gap: 8,
+                  }}
+                >
+                  {/* Icon & Label */}
+                  <View
+                    style={{
+                      flex: 1,
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      gap: 8,
+                    }}
+                    pointerEvents='none'
+                  >
+                    {icon && (
+                      <Icon
+                        name={icon}
+                        size={16}
+                        color={error ? danger : muted}
+                      />
+                    )}
+                    {label && (
+                      <Text
+                        variant='caption'
+                        numberOfLines={1}
+                        ellipsizeMode='tail'
+                        style={[
+                          {
+                            color: error ? danger : muted,
+                          },
+                          labelStyle,
+                        ]}
+                        pointerEvents='none'
+                      >
+                        {label}
+                      </Text>
+                    )}
+                  </View>
+
+                  {/* Right Component */}
+                  {renderRightComponent()}
+                </View>
+              )}
+
+              {/* Textarea Input */}
+              <TextInput
+                ref={ref}
+                multiline
+                numberOfLines={rows}
+                style={[
+                  {
+                    fontSize: FONT_SIZE,
+                    lineHeight: 20,
+                    color: disabled ? muted : error ? danger : text,
+                    textAlignVertical: 'top',
+                    paddingVertical: 0,
+                    minHeight: rows * 20,
+                  },
+                  inputStyle,
+                ]}
+                placeholderTextColor={error ? danger + '99' : muted}
+                placeholder={placeholder || 'Type your message...'}
+                editable={!disabled}
+                selectionColor={primary}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+                {...props}
+              />
+            </>
+          ) : (
+            // Input Layout (Row)
+            <View
+              style={{
+                flex: 1,
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              {/* Icon & Label */}
+              <View
+                style={{
+                  width: label ? 120 : 'auto',
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 8,
+                }}
+                pointerEvents='none'
+              >
+                {icon && (
+                  <Icon name={icon} size={16} color={error ? danger : muted} />
+                )}
+                {label && (
+                  <Text
+                    variant='caption'
+                    numberOfLines={1}
+                    ellipsizeMode='tail'
+                    style={[
+                      {
+                        color: error ? danger : muted,
+                      },
+                      labelStyle,
+                    ]}
+                    pointerEvents='none'
+                  >
+                    {label}
+                  </Text>
+                )}
+              </View>
+
+              {/* Input */}
+              <View style={{ flex: 1 }}>
+                <TextInput
+                  ref={ref}
+                  style={[
+                    {
+                      flex: 1,
+                      fontSize: FONT_SIZE,
+                      color: disabled ? muted : error ? danger : text,
+                      paddingVertical: 0,
+                    },
+                    inputStyle,
+                  ]}
+                  placeholder={placeholder}
+                  placeholderTextColor={error ? danger + '99' : muted}
+                  editable={!disabled}
+                  selectionColor={primary}
+                  onFocus={handleFocus}
+                  onBlur={handleBlur}
+                  {...props}
+                />
+              </View>
+
+              {/* Right Component */}
+              {renderRightComponent()}
+            </View>
+          )}
+        </View>
+      </Pressable>
+    );
+
+    return renderItemContent();
+  }
+);

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,0 +1,160 @@
+/* eslint-disable */
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { HEIGHT } from '@/theme/globals';
+import React, { useEffect } from 'react';
+import { ViewStyle } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+interface ProgressProps {
+  value: number; // 0-100
+  style?: ViewStyle;
+  height?: number;
+  onValueChange?: (value: number) => void;
+  onSeekStart?: () => void;
+  onSeekEnd?: () => void;
+  interactive?: boolean;
+}
+
+export function Progress({
+  value,
+  style,
+  height = HEIGHT,
+  onValueChange,
+  onSeekStart,
+  onSeekEnd,
+  interactive = false,
+}: ProgressProps) {
+  const primaryColor = useColor('primary');
+  const mutedColor = useColor('muted');
+
+  const clampedValue = Math.max(0, Math.min(100, value));
+  const progressWidth = useSharedValue(clampedValue);
+  const containerWidth = useSharedValue(200); // Default width, will be updated
+  const isDragging = useSharedValue(false);
+
+  // Update animation when value prop changes (only if not dragging)
+  useEffect(() => {
+    if (!isDragging.value) {
+      progressWidth.value = withTiming(clampedValue, { duration: 300 });
+    }
+  }, [clampedValue]);
+
+  const updateValue = (newValue: number) => {
+    const clamped = Math.max(0, Math.min(100, newValue));
+    onValueChange?.(clamped);
+  };
+
+  const handleSeekStart = () => {
+    isDragging.value = true;
+    onSeekStart?.();
+  };
+
+  const handleSeekEnd = () => {
+    isDragging.value = false;
+    onSeekEnd?.();
+  };
+
+  // Create pan gesture using the new Gesture API
+  const panGesture = Gesture.Pan()
+    .onStart(() => {
+      if (!interactive) return;
+      runOnJS(handleSeekStart)();
+    })
+    .onUpdate((event) => {
+      if (!interactive) return;
+
+      // Calculate new progress based on gesture position
+      const newProgress = (event.x / containerWidth.value) * 100;
+      const clampedProgress = Math.max(0, Math.min(100, newProgress));
+
+      progressWidth.value = clampedProgress;
+      runOnJS(updateValue)(clampedProgress);
+    })
+    .onEnd(() => {
+      if (!interactive) return;
+      runOnJS(handleSeekEnd)();
+    });
+
+  // Create tap gesture for direct seeking
+  const tapGesture = Gesture.Tap().onStart((event) => {
+    if (!interactive) return;
+
+    runOnJS(handleSeekStart)();
+
+    // Calculate progress based on tap position
+    const newProgress = (event.x / containerWidth.value) * 100;
+    const clampedProgress = Math.max(0, Math.min(100, newProgress));
+
+    progressWidth.value = withTiming(clampedProgress, { duration: 200 });
+    runOnJS(updateValue)(clampedProgress);
+
+    setTimeout(() => {
+      runOnJS(handleSeekEnd)();
+    }, 200);
+  });
+
+  // Combine gestures
+  const combinedGesture = Gesture.Race(panGesture, tapGesture);
+
+  const animatedProgressStyle = useAnimatedStyle(() => {
+    return {
+      width: `${progressWidth.value}%`,
+    };
+  });
+
+  const containerStyle: ViewStyle[] = [
+    {
+      height: height,
+      width: '100%' as const,
+      backgroundColor: mutedColor,
+      borderRadius: height / 2,
+      overflow: 'hidden' as const,
+    },
+    ...(style ? [style] : []),
+  ];
+
+  const onLayout = (event: any) => {
+    containerWidth.value = event.nativeEvent.layout.width;
+  };
+
+  if (interactive) {
+    return (
+      <GestureDetector gesture={combinedGesture}>
+        <Animated.View style={containerStyle} onLayout={onLayout}>
+          <Animated.View
+            style={[
+              {
+                height: '100%' as const,
+                backgroundColor: primaryColor,
+                borderRadius: height / 2,
+              },
+              animatedProgressStyle,
+            ]}
+          />
+        </Animated.View>
+      </GestureDetector>
+    );
+  }
+
+  return (
+    <View style={containerStyle} onLayout={onLayout}>
+      <Animated.View
+        style={[
+          {
+            height: '100%' as const,
+            backgroundColor: primaryColor,
+            borderRadius: height / 2,
+          },
+          animatedProgressStyle,
+        ]}
+      />
+    </View>
+  );
+}

--- a/components/ui/radio.tsx
+++ b/components/ui/radio.tsx
@@ -1,0 +1,134 @@
+/* eslint-disable */
+import { Text } from '@/components/ui/text';
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS, CORNERS, FONT_SIZE } from '@/theme/globals';
+import React from 'react';
+import { TextStyle, TouchableOpacity, View, ViewStyle } from 'react-native';
+
+export interface RadioOption {
+  label: string;
+  value: string;
+  disabled?: boolean;
+}
+
+interface RadioGroupProps {
+  options: RadioOption[];
+  value?: string;
+  onValueChange?: (value: string) => void;
+  disabled?: boolean;
+  orientation?: 'vertical' | 'horizontal';
+  style?: ViewStyle;
+  optionStyle?: ViewStyle;
+  labelStyle?: TextStyle;
+}
+
+interface RadioButtonProps {
+  option: RadioOption;
+  selected: boolean;
+  onPress: () => void;
+  disabled?: boolean;
+  style?: ViewStyle;
+  labelStyle?: TextStyle;
+}
+
+export function RadioButton({
+  option,
+  selected,
+  onPress,
+  disabled = false,
+  style,
+  labelStyle,
+}: RadioButtonProps) {
+  const primaryColor = useColor('primary');
+  const borderColor = useColor('border');
+  const textColor = useColor('text');
+  const mutedColor = useColor('textMuted');
+
+  const isDisabled = disabled || option.disabled;
+
+  const radioButtonStyle: ViewStyle = {
+    width: BORDER_RADIUS,
+    height: BORDER_RADIUS,
+    borderRadius: CORNERS,
+    borderWidth: 1.5,
+    borderColor: selected ? primaryColor : borderColor,
+    backgroundColor: 'transparent',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: 12,
+  };
+
+  const innerCircleStyle: ViewStyle = {
+    width: 16,
+    height: 16,
+    borderRadius: CORNERS,
+    backgroundColor: selected ? primaryColor : 'transparent',
+  };
+
+  const containerStyle: ViewStyle = {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+    paddingHorizontal: 4,
+    opacity: isDisabled ? 0.5 : 1,
+  };
+
+  const textStyle: TextStyle = {
+    color: isDisabled ? mutedColor : textColor,
+    fontSize: FONT_SIZE,
+    fontWeight: '400',
+    lineHeight: 24,
+  };
+
+  return (
+    <TouchableOpacity
+      style={[containerStyle, style]}
+      onPress={onPress}
+      disabled={isDisabled}
+      activeOpacity={0.7}
+    >
+      <View style={radioButtonStyle}>
+        <View style={innerCircleStyle} />
+      </View>
+      <Text style={[textStyle, labelStyle]}>{option.label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+export function RadioGroup({
+  options,
+  value,
+  onValueChange,
+  disabled = false,
+  orientation = 'vertical',
+  style,
+  optionStyle,
+  labelStyle,
+}: RadioGroupProps) {
+  const containerStyle: ViewStyle = {
+    flexDirection: orientation === 'horizontal' ? 'row' : 'column',
+    gap: orientation === 'horizontal' ? 16 : 4,
+  };
+
+  const handlePress = (optionValue: string) => {
+    if (onValueChange && !disabled) {
+      onValueChange(optionValue);
+    }
+  };
+
+  return (
+    <View style={[containerStyle, style]}>
+      {options.map((option) => (
+        <RadioButton
+          key={option.value}
+          option={option}
+          selected={value === option.value}
+          onPress={() => handlePress(option.value)}
+          disabled={disabled}
+          style={optionStyle}
+          labelStyle={labelStyle}
+        />
+      ))}
+    </View>
+  );
+}

--- a/components/ui/scroll-view.tsx
+++ b/components/ui/scroll-view.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable */
+import { forwardRef } from 'react';
+import { ScrollView as RNScrollView, ScrollViewProps } from 'react-native';
+
+export const ScrollView = forwardRef<RNScrollView, ScrollViewProps>(
+  ({ style, ...otherProps }, ref) => {
+    return (
+      <RNScrollView
+        ref={ref}
+        style={[{ backgroundColor: 'transparent' }, style]}
+        {...otherProps}
+      />
+    );
+  }
+);

--- a/components/ui/searchbar.tsx
+++ b/components/ui/searchbar.tsx
@@ -1,0 +1,242 @@
+/* eslint-disable */
+import { Icon } from '@/components/ui/icon';
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { CORNERS, FONT_SIZE, HEIGHT } from '@/theme/globals';
+import { Search, X } from 'lucide-react-native';
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  TextInput,
+  TextInputProps,
+  TextStyle,
+  TouchableOpacity,
+  ViewStyle,
+} from 'react-native';
+
+interface SearchBarProps extends Omit<TextInputProps, 'style'> {
+  loading?: boolean;
+  onSearch?: (query: string) => void;
+  onClear?: () => void;
+  showClearButton?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  containerStyle?: ViewStyle | ViewStyle[];
+  inputStyle?: TextStyle | TextStyle[];
+  debounceMs?: number;
+}
+
+export function SearchBar({
+  loading = false,
+  onSearch,
+  onClear,
+  showClearButton = true,
+  leftIcon,
+  rightIcon,
+  containerStyle,
+  inputStyle,
+  debounceMs = 300,
+  placeholder = 'Search...',
+  value,
+  onChangeText,
+  ...props
+}: SearchBarProps) {
+  const [internalValue, setInternalValue] = useState(value || '');
+  const debounceRef = useRef<NodeJS.Timeout | null>(null);
+  const inputRef = useRef<TextInput>(null);
+
+  // Theme colors
+  const cardColor = useColor('card');
+  const textColor = useColor('text');
+  const muted = useColor('textMuted');
+  const icon = useColor('icon');
+
+  // Handle text change with debouncing
+  const handleTextChange = useCallback(
+    (text: string) => {
+      setInternalValue(text);
+      onChangeText?.(text);
+
+      if (onSearch && debounceMs > 0) {
+        if (debounceRef.current) {
+          clearTimeout(debounceRef.current);
+        }
+        (debounceRef.current as any) = setTimeout(() => {
+          onSearch(text);
+        }, debounceMs);
+      } else if (onSearch) {
+        onSearch(text);
+      }
+    },
+    [onChangeText, onSearch, debounceMs]
+  );
+
+  // Handle clear button press
+  const handleClear = useCallback(() => {
+    setInternalValue('');
+    onChangeText?.('');
+    onClear?.();
+    onSearch?.('');
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+  }, [onChangeText, onClear, onSearch]);
+
+  // Get container style based on variant and size
+  const baseStyle: ViewStyle = {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: cardColor,
+    height: HEIGHT,
+    paddingHorizontal: 16,
+    borderRadius: CORNERS,
+  };
+
+  const baseInputStyle = {
+    flex: 1,
+    fontSize: FONT_SIZE,
+    color: textColor,
+    marginHorizontal: 8,
+  };
+
+  const displayValue = value !== undefined ? value : internalValue;
+  const showClear = showClearButton && displayValue.length > 0;
+
+  return (
+    <View style={[baseStyle, containerStyle]}>
+      {/* Left Icon */}
+      {leftIcon || <Icon name={Search} size={16} color={muted} />}
+
+      {/* Text Input */}
+      <TextInput
+        ref={inputRef}
+        style={[baseInputStyle, inputStyle]}
+        placeholder={placeholder}
+        placeholderTextColor={muted}
+        value={displayValue}
+        onChangeText={handleTextChange}
+        {...props}
+      />
+
+      {/* Loading Indicator */}
+      {loading && (
+        <ActivityIndicator
+          size='small'
+          color={muted}
+          style={{ marginRight: 4 }}
+        />
+      )}
+
+      {/* Clear Button */}
+      {showClear && !loading && (
+        <TouchableOpacity
+          onPress={handleClear}
+          style={{
+            backgroundColor: icon,
+            padding: 4,
+            borderRadius: CORNERS,
+            opacity: 0.6,
+          }}
+          activeOpacity={0.7}
+        >
+          <Icon name={X} size={16} color={cardColor} strokeWidth={2} />
+        </TouchableOpacity>
+      )}
+
+      {/* Right Icon */}
+      {rightIcon && !showClear && !loading && rightIcon}
+    </View>
+  );
+}
+
+// SearchBar with suggestions dropdown
+interface SearchBarWithSuggestionsProps extends SearchBarProps {
+  suggestions?: string[];
+  onSuggestionPress?: (suggestion: string) => void;
+  maxSuggestions?: number;
+  showSuggestions?: boolean;
+}
+
+export function SearchBarWithSuggestions({
+  suggestions = [],
+  onSuggestionPress,
+  maxSuggestions = 5,
+  showSuggestions = true,
+  containerStyle,
+  ...searchBarProps
+}: SearchBarWithSuggestionsProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const cardColor = useColor('card');
+  const borderColor = useColor('border');
+
+  const filteredSuggestions = suggestions
+    .filter((suggestion) =>
+      suggestion
+        .toLowerCase()
+        .includes((searchBarProps.value || '').toLowerCase())
+    )
+    .slice(0, maxSuggestions);
+
+  const shouldShowSuggestions =
+    showSuggestions &&
+    isExpanded &&
+    filteredSuggestions.length > 0 &&
+    (searchBarProps.value || '').length > 0;
+
+  const handleSuggestionPress = (suggestion: string) => {
+    onSuggestionPress?.(suggestion);
+    setIsExpanded(false);
+  };
+
+  return (
+    <View style={[{ width: '100%' }, containerStyle]}>
+      <SearchBar
+        {...searchBarProps}
+        onFocus={(e) => {
+          setIsExpanded(true);
+          searchBarProps.onFocus?.(e);
+        }}
+        onBlur={(e) => {
+          // Delay hiding suggestions to allow for suggestion tap
+          setTimeout(() => setIsExpanded(false), 150);
+          searchBarProps.onBlur?.(e);
+        }}
+      />
+
+      {/* Suggestions Dropdown */}
+      {shouldShowSuggestions && (
+        <View
+          style={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            right: 0,
+            backgroundColor: cardColor,
+            marginTop: 8,
+            borderRadius: 12,
+            maxHeight: 200,
+            zIndex: 999,
+          }}
+        >
+          {filteredSuggestions.map((suggestion, index) => (
+            <TouchableOpacity
+              key={`${suggestion}-${index}`}
+              onPress={() => handleSuggestionPress(suggestion)}
+              style={{
+                paddingHorizontal: 16,
+                paddingVertical: 12,
+                borderBottomWidth:
+                  index < filteredSuggestions.length - 1 ? 0.6 : 0,
+                borderBottomColor: borderColor,
+              }}
+              activeOpacity={0.7}
+            >
+              <Text>{suggestion}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,31 @@
+/* eslint-disable */
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import React from 'react';
+import { ViewStyle } from 'react-native';
+
+interface SeparatorProps {
+  orientation?: 'horizontal' | 'vertical';
+  style?: ViewStyle;
+}
+
+export function Separator({
+  orientation = 'horizontal',
+  style,
+}: SeparatorProps) {
+  const borderColor = useColor('border');
+
+  return (
+    <View
+      style={[
+        {
+          backgroundColor: borderColor,
+          ...(orientation === 'horizontal'
+            ? { height: 1, width: '100%' }
+            : { width: 1, height: '100%' }),
+        },
+        style,
+      ]}
+    />
+  );
+}

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,0 +1,303 @@
+/* eslint-disable */
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS, FONT_SIZE } from '@/theme/globals';
+import { X } from 'lucide-react-native';
+import React, { useEffect } from 'react';
+import {
+  Dimensions,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  TouchableOpacity,
+  ViewStyle,
+} from 'react-native';
+import Animated, {
+  Easing,
+  interpolate,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+type SheetSide = 'left' | 'right';
+
+interface SheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  side?: SheetSide;
+  children: React.ReactNode;
+}
+
+interface SheetContentProps {
+  children: React.ReactNode;
+  style?: ViewStyle;
+}
+
+interface SheetHeaderProps {
+  children: React.ReactNode;
+  style?: ViewStyle;
+}
+
+interface SheetTitleProps {
+  children: React.ReactNode;
+}
+
+interface SheetDescriptionProps {
+  children: React.ReactNode;
+}
+
+interface SheetTriggerProps {
+  children: React.ReactNode;
+  asChild?: boolean;
+}
+
+interface SheetContextValue {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  side: SheetSide;
+}
+
+const SheetContext = React.createContext<SheetContextValue | null>(null);
+
+const useSheet = () => {
+  const context = React.useContext(SheetContext);
+  if (!context) {
+    throw new Error('Sheet components must be used within a Sheet');
+  }
+  return context;
+};
+
+export function Sheet({
+  open,
+  onOpenChange,
+  side = 'right',
+  children,
+}: SheetProps) {
+  return (
+    <SheetContext.Provider value={{ open, onOpenChange, side }}>
+      {children}
+    </SheetContext.Provider>
+  );
+}
+
+export function SheetTrigger({ children, asChild }: SheetTriggerProps) {
+  const context = React.useContext(SheetContext);
+
+  const handlePress = () => {
+    if (context) {
+      context.onOpenChange(true);
+    }
+  };
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children as React.ReactElement<any>, {
+      onPress: handlePress,
+    });
+  }
+
+  return <Button onPress={handlePress}>{children}</Button>;
+}
+
+export function SheetContent({ children, style }: SheetContentProps) {
+  const { open, onOpenChange, side } = useSheet();
+  const sheetWidth = Math.min(SCREEN_WIDTH * 0.8, 400);
+  const [isVisible, setIsVisible] = React.useState(open);
+
+  const backgroundColor = useColor('background');
+  const borderColor = useColor('border');
+  const iconColor = useColor('text');
+
+  // Animation values using Reanimated's useSharedValue
+  const initialPosition = side === 'left' ? -sheetWidth : sheetWidth;
+  const translateX = useSharedValue(initialPosition);
+  const overlayOpacity = useSharedValue(0);
+
+  // Effect to handle the animation based on the `open` prop
+  useEffect(() => {
+    // Reset position if side changes while closed
+    if (open && !isVisible) {
+      translateX.value = side === 'left' ? -sheetWidth : sheetWidth;
+    }
+
+    if (open) {
+      setIsVisible(true); // Mount the modal
+      // Animate in
+      translateX.value = withTiming(0, {
+        duration: 300,
+        easing: Easing.out(Easing.quad),
+      });
+      overlayOpacity.value = withTiming(1, { duration: 300 });
+    } else if (isVisible) {
+      // Animate out, then hide modal in the callback
+      translateX.value = withTiming(
+        initialPosition,
+        { duration: 250 },
+        (finished) => {
+          if (finished) {
+            // Use runOnJS to update React state from the UI thread
+            runOnJS(setIsVisible)(false);
+          }
+        }
+      );
+      overlayOpacity.value = withTiming(0, { duration: 250 });
+    }
+  }, [open, side, sheetWidth]); // Rerun if these change
+
+  // Animated style for the sheet content
+  const animatedSheetStyle = useAnimatedStyle(() => {
+    return {
+      transform: [{ translateX: translateX.value }],
+    };
+  });
+
+  // Animated style for the overlay
+  const animatedOverlayStyle = useAnimatedStyle(() => {
+    return {
+      opacity: interpolate(overlayOpacity.value, [0, 1], [0, 0.3]),
+    };
+  });
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <Modal
+      visible={isVisible}
+      transparent={true}
+      animationType='none'
+      onRequestClose={handleClose}
+      statusBarTranslucent={true}
+    >
+      <View style={styles.modalContainer}>
+        {/* Semi-transparent overlay */}
+        <Animated.View style={[styles.overlay, animatedOverlayStyle]}>
+          <Pressable style={styles.overlayPressable} onPress={handleClose} />
+        </Animated.View>
+
+        {/* Sheet */}
+        <Animated.View
+          style={[
+            styles.sheet,
+            {
+              borderRadius: BORDER_RADIUS,
+              backgroundColor,
+              borderColor,
+              width: sheetWidth,
+              [side]: 0,
+            },
+            animatedSheetStyle, // Apply the animated style
+            style,
+          ]}
+        >
+          {/* Close button */}
+          <TouchableOpacity
+            style={[
+              styles.closeButton,
+              {
+                backgroundColor: backgroundColor,
+                [side === 'left' ? 'right' : 'left']: 16,
+              },
+            ]}
+            onPress={handleClose}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
+            <X size={20} color={iconColor} />
+          </TouchableOpacity>
+
+          {/* Content */}
+          <View style={styles.contentContainer}>{children}</View>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}
+
+// Unchanged components below
+
+export function SheetHeader({ children, style }: SheetHeaderProps) {
+  return <View style={[styles.header, style]}>{children}</View>;
+}
+
+export function SheetTitle({ children }: SheetTitleProps) {
+  return (
+    <Text variant='title' style={styles.title}>
+      {children}
+    </Text>
+  );
+}
+
+export function SheetDescription({ children }: SheetDescriptionProps) {
+  const mutedColor = useColor('textMuted');
+
+  return (
+    <Text style={[styles.description, { color: mutedColor }]}>{children}</Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalContainer: {
+    flex: 1,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 1)', // Opacity is controlled by animation
+  },
+  overlayPressable: {
+    flex: 1,
+  },
+  sheet: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    borderLeftWidth: 1,
+    borderRightWidth: 1,
+    ...Platform.select({
+      ios: {
+        shadowColor: '#000',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.25,
+        shadowRadius: 8,
+      },
+      android: {
+        elevation: 10,
+      },
+    }),
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 50,
+    zIndex: 1,
+    borderRadius: 999, // Make it circular
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  contentContainer: {
+    flex: 1,
+  },
+  header: {
+    paddingTop: 90,
+    paddingHorizontal: 24,
+    paddingBottom: 16,
+  },
+  title: {
+    marginBottom: 8,
+  },
+  description: {
+    fontSize: FONT_SIZE,
+    lineHeight: 20,
+  },
+});

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,65 @@
+/* eslint-disable */
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS, CORNERS } from '@/theme/globals';
+import React, { useEffect } from 'react';
+import { ViewStyle } from 'react-native';
+import Animated, {
+  Easing,
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  withRepeat,
+} from 'react-native-reanimated';
+
+interface SkeletonProps {
+  width?: number | string;
+  height?: number;
+  style?: ViewStyle;
+  variant?: 'default' | 'rounded';
+}
+
+export function Skeleton({
+  width = '100%',
+  height = 100,
+  style,
+  variant = 'default',
+}: SkeletonProps) {
+  const mutedColor = useColor('muted');
+  // Start the opacity at its lowest point
+  const opacity = useSharedValue(0.5);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      opacity: opacity.value,
+    };
+  });
+
+  useEffect(() => {
+    // We only define the animation going from 0.5 -> 1.
+    // The `withRepeat` function will handle reversing it automatically.
+    opacity.value = withRepeat(
+      // Animate to an opacity of 1
+      withTiming(1, {
+        duration: 1000,
+        easing: Easing.inOut(Easing.quad),
+      }),
+      -1, // Loop infinitely
+      true // Set to true to automatically reverse the animation (yoyo effect)
+    );
+  }, []); // Use an empty dependency array as the shared value object is stable
+
+  return (
+    <Animated.View
+      style={[
+        {
+          width: width as any,
+          height,
+          backgroundColor: mutedColor,
+          borderRadius: variant === 'default' ? CORNERS : BORDER_RADIUS,
+        },
+        animatedStyle,
+        style,
+      ]}
+    />
+  );
+}

--- a/components/ui/spinner.tsx
+++ b/components/ui/spinner.tsx
@@ -1,0 +1,463 @@
+/* eslint-disable */
+import { Text } from '@/components/ui/text';
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS, CORNERS, FONT_SIZE } from '@/theme/globals';
+import { Loader2 } from 'lucide-react-native';
+import React, { useEffect, useMemo } from 'react';
+import { ActivityIndicator, StyleSheet, View, ViewStyle } from 'react-native';
+import Animated, {
+  Easing,
+  SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+// Types
+type SpinnerSize = 'default' | 'sm' | 'lg' | 'icon';
+export type SpinnerVariant = 'default' | 'circle' | 'dots' | 'pulse' | 'bars';
+
+interface SpinnerProps {
+  size?: SpinnerSize;
+  variant?: SpinnerVariant;
+  label?: string;
+  showLabel?: boolean;
+  style?: ViewStyle;
+  color?: string;
+  thickness?: number; // Note: thickness is not used in the original component logic
+  speed?: 'slow' | 'normal' | 'fast';
+}
+
+interface LoadingOverlayProps extends SpinnerProps {
+  visible: boolean;
+  backdrop?: boolean;
+  backdropColor?: string;
+  backdropOpacity?: number;
+  onRequestClose?: () => void;
+}
+
+interface SpinnerConfig {
+  size: number;
+  iconSize: number;
+  fontSize: number;
+  gap: number;
+  thickness: number;
+}
+
+// Configuration
+const sizeConfig: Record<SpinnerSize, SpinnerConfig> = {
+  sm: { size: 16, iconSize: 16, fontSize: 12, gap: 6, thickness: 2 },
+  default: {
+    size: 24,
+    iconSize: 24,
+    fontSize: FONT_SIZE,
+    gap: 8,
+    thickness: 2,
+  },
+  lg: { size: 32, iconSize: 32, fontSize: 16, gap: 10, thickness: 3 },
+  icon: { size: 24, iconSize: 24, fontSize: FONT_SIZE, gap: 8, thickness: 2 },
+};
+
+const speedConfig = {
+  slow: 1500,
+  normal: 1000,
+  fast: 500,
+};
+
+// --- Helper Animated Components for Dots and Bars ---
+
+interface AnimatedShapeProps {
+  anim: SharedValue<number>;
+  color: string;
+  size: number;
+  style: ViewStyle;
+}
+
+const AnimatedDot = React.memo(
+  ({ anim, color, size, style }: AnimatedShapeProps) => {
+    const animatedStyle = useAnimatedStyle(() => ({
+      opacity: anim.value,
+    }));
+    return (
+      <Animated.View
+        style={[
+          style,
+          { width: size, height: size, backgroundColor: color },
+          animatedStyle,
+        ]}
+      />
+    );
+  }
+);
+
+const AnimatedBar = React.memo(
+  ({ anim, color, size, style }: AnimatedShapeProps) => {
+    const animatedStyle = useAnimatedStyle(() => ({
+      opacity: anim.value,
+    }));
+    return (
+      <Animated.View
+        style={[
+          style,
+          { width: size / 6, height: size, backgroundColor: color },
+          animatedStyle,
+        ]}
+      />
+    );
+  }
+);
+
+// Main Spinner Component
+export function Spinner({
+  size = 'default',
+  variant = 'default',
+  label,
+  showLabel = false,
+  style,
+  color,
+  speed = 'normal',
+}: SpinnerProps) {
+  // Reanimated shared values
+  const rotate = useSharedValue(0);
+  const pulse = useSharedValue(1);
+
+  // --- FIX: Call hooks at the top level ---
+  // 1. Call useSharedValue at the top level for each dot/bar
+  const dotAnim1 = useSharedValue(0.3);
+  const dotAnim2 = useSharedValue(0.3);
+  const dotAnim3 = useSharedValue(0.3);
+
+  const barAnim1 = useSharedValue(0.3);
+  const barAnim2 = useSharedValue(0.3);
+  const barAnim3 = useSharedValue(0.3);
+  const barAnim4 = useSharedValue(0.3);
+
+  // 2. Use useMemo to create a stable array reference from the values
+  const dotsAnims = useMemo(
+    () => [dotAnim1, dotAnim2, dotAnim3],
+    [dotAnim1, dotAnim2, dotAnim3]
+  );
+  const barsAnims = useMemo(
+    () => [barAnim1, barAnim2, barAnim3, barAnim4],
+    [barAnim1, barAnim2, barAnim3, barAnim4]
+  );
+  // --- END FIX ---
+
+  // Theme colors
+  const primaryColor = useColor('text');
+  const textColor = useColor('text');
+
+  const config = sizeConfig[size];
+  const spinnerColor = color || primaryColor;
+  const animationDuration = speedConfig[speed];
+
+  // Rotation animation
+  useEffect(() => {
+    if (variant === 'circle') {
+      rotate.value = withRepeat(
+        withTiming(360, { duration: animationDuration, easing: Easing.linear }),
+        -1
+      );
+    } else {
+      rotate.value = 0; // Reset
+    }
+  }, [rotate, variant, animationDuration]);
+
+  // Pulse animation
+  useEffect(() => {
+    if (variant === 'pulse') {
+      pulse.value = withRepeat(
+        withSequence(
+          withTiming(1.3, { duration: animationDuration / 2 }),
+          withTiming(1, { duration: animationDuration / 2 })
+        ),
+        -1,
+        true
+      );
+    } else {
+      pulse.value = 1; // Reset
+    }
+  }, [pulse, variant, animationDuration]);
+
+  // Dots animation
+  useEffect(() => {
+    if (variant === 'dots') {
+      dotsAnims.forEach((anim, index) => {
+        anim.value = withRepeat(
+          withSequence(
+            withDelay(
+              index * (animationDuration / 6),
+              withTiming(1, { duration: animationDuration / 3 })
+            ),
+            withTiming(0.3, { duration: animationDuration / 3 })
+          ),
+          -1
+        );
+      });
+    } else {
+      dotsAnims.forEach((anim) => (anim.value = 0.3)); // Reset
+    }
+  }, [dotsAnims, variant, animationDuration]);
+
+  // Bars animation
+  useEffect(() => {
+    if (variant === 'bars') {
+      barsAnims.forEach((anim, index) => {
+        anim.value = withRepeat(
+          withSequence(
+            withDelay(
+              index * (animationDuration / 8),
+              withTiming(1, { duration: animationDuration / 4 })
+            ),
+            withTiming(0.3, { duration: animationDuration / 4 })
+          ),
+          -1
+        );
+      });
+    } else {
+      barsAnims.forEach((anim) => (anim.value = 0.3)); // Reset
+    }
+  }, [barsAnims, variant, animationDuration]);
+
+  // Animated styles
+  const animatedCircleStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${rotate.value}deg` }],
+  }));
+
+  const animatedPulseStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: pulse.value }],
+  }));
+
+  const renderSpinner = () => {
+    switch (variant) {
+      case 'default':
+        return (
+          <ActivityIndicator
+            size={config.size}
+            color={spinnerColor}
+            style={styles.spinner}
+          />
+        );
+
+      case 'circle':
+        return (
+          <Animated.View
+            style={[
+              styles.customSpinner,
+              { width: config.size, height: config.size },
+              animatedCircleStyle,
+            ]}
+          >
+            <Loader2 size={config.iconSize} color={spinnerColor} />
+          </Animated.View>
+        );
+
+      case 'pulse':
+        return (
+          <Animated.View
+            style={[
+              styles.pulseSpinner,
+              {
+                width: config.size,
+                height: config.size,
+                backgroundColor: spinnerColor,
+              },
+              animatedPulseStyle,
+            ]}
+          />
+        );
+
+      case 'dots':
+        return (
+          <View style={[styles.dotsContainer, { gap: config.size / 4 }]}>
+            {dotsAnims.map((anim, index) => (
+              <AnimatedDot
+                key={index}
+                anim={anim}
+                color={spinnerColor}
+                size={config.size / 3}
+                style={styles.dot}
+              />
+            ))}
+          </View>
+        );
+
+      case 'bars':
+        return (
+          <View style={[styles.barsContainer, { gap: config.size / 6 }]}>
+            {barsAnims.map((anim, index) => (
+              <AnimatedBar
+                key={index}
+                anim={anim}
+                color={spinnerColor}
+                size={config.size}
+                style={styles.bar}
+              />
+            ))}
+          </View>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  const containerStyle: ViewStyle = {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: config.gap,
+  };
+
+  return (
+    <View style={[containerStyle, style]}>
+      {renderSpinner()}
+      {(showLabel || label) && (
+        <Text
+          style={[
+            styles.label,
+            {
+              color: textColor,
+              fontSize: config.fontSize,
+            },
+          ]}
+        >
+          {label || 'Loading...'}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+// Loading Overlay Component
+export function LoadingOverlay({
+  visible,
+  backdrop = true,
+  backdropColor,
+  backdropOpacity = 0.5,
+  ...spinnerProps
+}: LoadingOverlayProps) {
+  const opacity = useSharedValue(0);
+  const backgroundColor = useColor('background');
+  const cardColor = useColor('card');
+
+  useEffect(() => {
+    opacity.value = withTiming(visible ? 1 : 0, {
+      duration: 200,
+    });
+  }, [visible, opacity]);
+
+  const animatedOverlayStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    // Conditionally render to avoid interaction issues
+    display: opacity.value === 0 ? 'none' : 'flex',
+  }));
+
+  const defaultBackdropColor =
+    backdropColor ||
+    `${backgroundColor}${Math.round(backdropOpacity * 255)
+      .toString(16)
+      .padStart(2, '0')}`;
+
+  return (
+    <Animated.View
+      style={[
+        styles.overlay,
+        { backgroundColor: backdrop ? defaultBackdropColor : 'transparent' },
+        animatedOverlayStyle,
+      ]}
+      pointerEvents={visible ? 'auto' : 'none'}
+    >
+      <View style={[styles.overlayContent, { backgroundColor: cardColor }]}>
+        <Spinner {...spinnerProps} />
+      </View>
+    </Animated.View>
+  );
+}
+
+// Inline Loader Component (for buttons, etc.)
+export function InlineLoader({
+  size = 'sm',
+  variant = 'default',
+  color,
+}: Omit<SpinnerProps, 'label' | 'showLabel'>) {
+  return (
+    <Spinner
+      size={size}
+      variant={variant}
+      color={color}
+      style={styles.inlineLoader}
+    />
+  );
+}
+
+// Button Spinner Component - optimized for button usage
+export function ButtonSpinner({
+  size = 'sm',
+  variant = 'default',
+  color,
+}: Omit<SpinnerProps, 'label' | 'showLabel'>) {
+  const primaryForegroundColor = useColor('primaryForeground');
+
+  return (
+    <Spinner
+      size={size}
+      variant={variant}
+      color={color || primaryForegroundColor}
+      style={styles.buttonSpinner}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  spinner: {
+    alignSelf: 'center',
+  },
+  customSpinner: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pulseSpinner: {
+    borderRadius: 999,
+  },
+  dotsContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dot: {
+    borderRadius: 999,
+  },
+  barsContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  bar: {
+    borderRadius: CORNERS,
+  },
+  label: {
+    textAlign: 'center',
+    fontWeight: '500',
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 9999,
+  },
+  overlayContent: {
+    padding: 60,
+    borderRadius: BORDER_RADIUS,
+  },
+  inlineLoader: {
+    minHeight: 0,
+    minWidth: 0,
+  },
+  buttonSpinner: {
+    minHeight: 0,
+    minWidth: 0,
+  },
+});

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,79 @@
+/* eslint-disable */
+import { useColor } from '@/hooks/useColor';
+import React from 'react';
+
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import {
+  Switch as RNSwitch,
+  SwitchProps as RNSwitchProps,
+  TextStyle,
+} from 'react-native';
+
+interface SwitchProps extends RNSwitchProps {
+  label?: string;
+  error?: string;
+  labelStyle?: TextStyle;
+}
+
+export function Switch({ label, error, labelStyle, ...props }: SwitchProps) {
+  const mutedColor = useColor('muted');
+  const primary = useColor('primary');
+  const danger = useColor('red');
+
+  return (
+    <View style={{ marginBottom: 8 }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          minHeight: 32, // Ensure consistent height
+        }}
+      >
+        {label && (
+          <Text
+            variant='caption'
+            numberOfLines={2} // Allow wrapping for longer labels
+            ellipsizeMode='tail'
+            style={[
+              {
+                color: error ? danger : primary,
+                flex: 1, // Take available space
+                marginRight: 12, // Add spacing between label and switch
+              },
+              labelStyle,
+            ]}
+            pointerEvents='none'
+          >
+            {label}
+          </Text>
+        )}
+
+        <RNSwitch
+          trackColor={{ false: mutedColor, true: '#7DD87D' }}
+          thumbColor={props.value ? '#ffffff' : '#f4f3f4'}
+          {...props}
+        />
+      </View>
+
+      {error && (
+        <Text
+          variant='caption'
+          numberOfLines={2}
+          ellipsizeMode='tail'
+          style={[
+            {
+              fontSize: 12, // Slightly smaller for error text
+              color: danger, // Always use danger color for errors
+              marginTop: 4, // Add spacing above error text
+            },
+          ]}
+          pointerEvents='none'
+        >
+          {error}
+        </Text>
+      )}
+    </View>
+  );
+}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,479 @@
+/* eslint-disable */
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS, FONT_SIZE, HEIGHT } from '@/theme/globals';
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  ChevronUp,
+  Search,
+} from 'lucide-react-native';
+import React, { useMemo, useState } from 'react';
+import {
+  ScrollView,
+  TextInput,
+  TextStyle,
+  TouchableOpacity,
+  ViewStyle,
+} from 'react-native';
+
+// Types
+export interface TableColumn<T = any> {
+  id: string;
+  header: string;
+  accessorKey: string;
+  sortable?: boolean;
+  filterable?: boolean;
+  width?: number | string;
+  minWidth?: number;
+  cell?: (value: any, row: T) => React.ReactNode;
+  headerCell?: () => React.ReactNode;
+  align?: 'left' | 'center' | 'right';
+}
+
+export interface TableProps<T = any> {
+  data: T[];
+  columns: TableColumn<T>[];
+  pagination?: boolean;
+  pageSize?: number;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  loading?: boolean;
+  emptyMessage?: string;
+  style?: ViewStyle;
+  headerStyle?: ViewStyle;
+  rowStyle?: ViewStyle;
+  cellStyle?: ViewStyle;
+  onRowPress?: (row: T, index: number) => void;
+  sortable?: boolean;
+  filterable?: boolean;
+}
+
+type SortDirection = 'asc' | 'desc' | null;
+
+interface SortState {
+  column: string | null;
+  direction: SortDirection;
+}
+
+export function Table<T = any>({
+  data,
+  columns,
+  pagination = true,
+  pageSize = 10,
+  searchable = true,
+  searchPlaceholder = 'Search...',
+  loading = false,
+  emptyMessage = 'No data available',
+  style,
+  headerStyle,
+  rowStyle,
+  cellStyle,
+  onRowPress,
+  sortable = true,
+  filterable = true,
+}: TableProps<T>) {
+  // Theme colors
+  const borderColor = useColor('border');
+  const textColor = useColor('text');
+  const mutedColor = useColor('textMuted');
+  const cardColor = useColor('card');
+  const primaryColor = useColor('primary');
+
+  // State
+  const [currentPage, setCurrentPage] = useState(1);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortState, setSortState] = useState<SortState>({
+    column: null,
+    direction: null,
+  });
+
+  // Filter and sort data
+  const filteredAndSortedData = useMemo(() => {
+    let processedData = [...data];
+
+    // Apply search filter
+    if (searchQuery && filterable) {
+      processedData = processedData.filter((row) =>
+        columns.some((column) => {
+          if (!column.filterable) return false;
+          const value = (row as any)[column.accessorKey];
+          return String(value || '')
+            .toLowerCase()
+            .includes(searchQuery.toLowerCase());
+        })
+      );
+    }
+
+    // Apply sorting
+    if (sortState.column && sortState.direction && sortable) {
+      processedData.sort((a, b) => {
+        const aValue = (a as any)[sortState.column!];
+        const bValue = (b as any)[sortState.column!];
+
+        if (aValue === null || aValue === undefined) return 1;
+        if (bValue === null || bValue === undefined) return -1;
+
+        if (typeof aValue === 'string' && typeof bValue === 'string') {
+          const comparison = aValue.localeCompare(bValue);
+          return sortState.direction === 'asc' ? comparison : -comparison;
+        }
+
+        if (aValue < bValue) return sortState.direction === 'asc' ? -1 : 1;
+        if (aValue > bValue) return sortState.direction === 'asc' ? 1 : -1;
+        return 0;
+      });
+    }
+
+    return processedData;
+  }, [data, searchQuery, sortState, columns, filterable, sortable]);
+
+  // Pagination
+  const totalPages = pagination
+    ? Math.ceil(filteredAndSortedData.length / pageSize)
+    : 1;
+  const startIndex = pagination ? (currentPage - 1) * pageSize : 0;
+  const endIndex = pagination
+    ? startIndex + pageSize
+    : filteredAndSortedData.length;
+  const paginatedData = filteredAndSortedData.slice(startIndex, endIndex);
+
+  // Handlers
+  const handleSort = (columnId: string) => {
+    if (!sortable) return;
+
+    const column = columns.find((col) => col.id === columnId);
+    if (!column?.sortable) return;
+
+    setSortState((prev) => {
+      if (prev.column === columnId) {
+        // Cycle through: asc -> desc -> null
+        const newDirection: SortDirection =
+          prev.direction === 'asc'
+            ? 'desc'
+            : prev.direction === 'desc'
+            ? null
+            : 'asc';
+
+        return {
+          column: newDirection ? columnId : null,
+          direction: newDirection,
+        };
+      } else {
+        return { column: columnId, direction: 'asc' };
+      }
+    });
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(Math.max(1, Math.min(page, totalPages)));
+  };
+
+  const renderSortIcon = (columnId: string) => {
+    if (!sortable) return null;
+
+    const column = columns.find((col) => col.id === columnId);
+    if (!column?.sortable) return null;
+
+    if (sortState.column !== columnId) {
+      return (
+        <ChevronUp size={16} color={mutedColor} style={{ opacity: 0.3 }} />
+      );
+    }
+
+    return sortState.direction === 'asc' ? (
+      <ChevronUp size={16} color={primaryColor} />
+    ) : (
+      <ChevronDown size={16} color={primaryColor} />
+    );
+  };
+
+  const renderCell = (column: TableColumn<T>, row: T, rowIndex: number) => {
+    const value = (row as any)[column.accessorKey];
+    const cellContent = column.cell
+      ? column.cell(value, row)
+      : String(value || '');
+
+    const alignStyle: TextStyle = {
+      textAlign: column.align || 'left',
+    };
+
+    return (
+      <View
+        key={column.id}
+        style={[
+          {
+            flex: column.width ? 0 : 1,
+            width: column.width as any,
+            minWidth: column.minWidth || 100,
+            paddingHorizontal: 18,
+            paddingVertical: 16,
+            justifyContent: 'center',
+          },
+          cellStyle,
+        ]}
+      >
+        {typeof cellContent === 'string' ? (
+          <Text style={[{ fontSize: FONT_SIZE }, alignStyle]}>
+            {cellContent}
+          </Text>
+        ) : (
+          cellContent
+        )}
+      </View>
+    );
+  };
+
+  const renderHeader = () => (
+    <View
+      style={[
+        {
+          flexDirection: 'row',
+          backgroundColor: cardColor,
+          borderBottomWidth: 1,
+          borderBottomColor: borderColor,
+        },
+        headerStyle,
+      ]}
+    >
+      {columns.map((column) => (
+        <TouchableOpacity
+          key={column.id}
+          style={{
+            flex: column.width ? 0 : 1,
+            width: column.width as any,
+            minWidth: column.minWidth || 100,
+            paddingHorizontal: 18,
+            paddingVertical: 16,
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent:
+              column.align === 'center'
+                ? 'center'
+                : column.align === 'right'
+                ? 'flex-end'
+                : 'flex-start',
+          }}
+          onPress={() => handleSort(column.id)}
+          disabled={!column.sortable || !sortable}
+        >
+          {column.headerCell ? (
+            column.headerCell()
+          ) : (
+            <>
+              <Text
+                variant='subtitle'
+                style={{
+                  marginRight: column.sortable && sortable ? 4 : 0,
+                  textAlign: column.align || 'left',
+                }}
+              >
+                {column.header}
+              </Text>
+              {renderSortIcon(column.id)}
+            </>
+          )}
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+
+  const renderRow = (row: T, index: number) => (
+    <TouchableOpacity
+      key={index}
+      style={[
+        {
+          flexDirection: 'row',
+          backgroundColor: cardColor,
+          borderBottomWidth: 1,
+          borderBottomColor: borderColor,
+        },
+        rowStyle,
+      ]}
+      onPress={() => onRowPress?.(row, index)}
+      disabled={!onRowPress}
+      activeOpacity={onRowPress ? 0.7 : 1}
+    >
+      {columns.map((column) => renderCell(column, row, index))}
+    </TouchableOpacity>
+  );
+
+  const renderPagination = () => {
+    if (!pagination || totalPages <= 1) return null;
+
+    return (
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          paddingHorizontal: 16,
+          paddingVertical: 18,
+          backgroundColor: cardColor,
+          borderTopWidth: 1,
+          borderTopColor: borderColor,
+        }}
+      >
+        <Text variant='caption'>
+          Page {currentPage} of {totalPages} ({filteredAndSortedData.length}{' '}
+          total)
+        </Text>
+
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+          <Button
+            variant='outline'
+            size='sm'
+            onPress={() => handlePageChange(1)}
+            disabled={currentPage === 1}
+          >
+            <ChevronsLeft
+              size={16}
+              color={currentPage === 1 ? mutedColor : textColor}
+            />
+          </Button>
+
+          <Button
+            variant='outline'
+            size='sm'
+            onPress={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+          >
+            <ChevronLeft
+              size={16}
+              color={currentPage === 1 ? mutedColor : textColor}
+            />
+          </Button>
+
+          <Button
+            variant='outline'
+            size='sm'
+            onPress={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+          >
+            <ChevronRight
+              size={16}
+              color={currentPage === totalPages ? mutedColor : textColor}
+            />
+          </Button>
+
+          <Button
+            variant='outline'
+            size='sm'
+            onPress={() => handlePageChange(totalPages)}
+            disabled={currentPage === totalPages}
+          >
+            <ChevronsRight
+              size={16}
+              color={currentPage === totalPages ? mutedColor : textColor}
+            />
+          </Button>
+        </View>
+      </View>
+    );
+  };
+
+  const renderSearchBar = () => {
+    if (!searchable || !filterable) return null;
+
+    return (
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          backgroundColor: cardColor,
+          borderBottomWidth: 1,
+          borderColor: borderColor,
+          paddingHorizontal: 18,
+          height: HEIGHT,
+          marginVertical: 2,
+        }}
+      >
+        <Search size={16} color={mutedColor} style={{ marginRight: 8 }} />
+
+        <TextInput
+          style={{
+            flex: 1,
+            fontSize: FONT_SIZE,
+            color: textColor,
+            paddingVertical: 8,
+          }}
+          placeholder={searchPlaceholder}
+          placeholderTextColor={mutedColor}
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+        />
+      </View>
+    );
+  };
+
+  const renderEmptyState = () => (
+    <View
+      style={{
+        padding: 32,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: cardColor,
+      }}
+    >
+      <Text variant='body' style={{ color: mutedColor }}>
+        {emptyMessage}
+      </Text>
+    </View>
+  );
+
+  const renderLoadingState = () => (
+    <View
+      style={{
+        padding: 32,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: cardColor,
+      }}
+    >
+      <Text variant='body' style={{ color: mutedColor }}>
+        Loading...
+      </Text>
+    </View>
+  );
+
+  return (
+    <View
+      style={[
+        {
+          width: '100%',
+          borderRadius: BORDER_RADIUS,
+          borderWidth: 1,
+          borderColor: borderColor,
+          backgroundColor: cardColor,
+          overflow: 'hidden',
+        },
+        style,
+      ]}
+    >
+      {renderSearchBar()}
+
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <View style={{ minWidth: '100%' }}>
+          {renderHeader()}
+
+          {loading ? (
+            renderLoadingState()
+          ) : paginatedData.length === 0 ? (
+            renderEmptyState()
+          ) : (
+            <ScrollView showsVerticalScrollIndicator={false}>
+              {paginatedData.map((row, index) => renderRow(row, index))}
+            </ScrollView>
+          )}
+        </View>
+      </ScrollView>
+
+      {renderPagination()}
+    </View>
+  );
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,501 @@
+/* eslint-disable */
+import { Text } from '@/components/ui/text';
+import { View } from '@/components/ui/view';
+import { useColor } from '@/hooks/useColor';
+import { BORDER_RADIUS, CORNERS, FONT_SIZE, HEIGHT } from '@/theme/globals';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import {
+  Dimensions,
+  ScrollView,
+  TextStyle,
+  TouchableOpacity,
+  ViewStyle,
+} from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  Extrapolate,
+  interpolate,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+const { width: screenWidth } = Dimensions.get('window');
+
+// Types
+interface TabsContextType {
+  activeTab: string;
+  setActiveTab: (value: string) => void;
+  orientation: 'horizontal' | 'vertical';
+  tabValues: string[];
+  registerTab: (value: string) => void;
+  unregisterTab: (value: string) => void;
+  enableSwipe?: boolean;
+  navigateToAdjacentTab?: (direction: 'next' | 'prev') => void;
+}
+
+interface TabsProps {
+  children: React.ReactNode;
+  defaultValue?: string;
+  value?: string;
+  onValueChange?: (value: string) => void;
+  orientation?: 'horizontal' | 'vertical';
+  style?: ViewStyle;
+  enableSwipe?: boolean;
+}
+
+interface TabsListProps {
+  children: React.ReactNode;
+  style?: ViewStyle;
+}
+
+interface TabsTriggerProps {
+  children: React.ReactNode;
+  value: string;
+  disabled?: boolean;
+  style?: ViewStyle;
+  textStyle?: TextStyle;
+}
+
+interface TabsContentProps {
+  children: React.ReactNode;
+  value: string;
+  style?: ViewStyle;
+}
+
+// Context
+const TabsContext = createContext<TabsContextType | undefined>(undefined);
+
+const useTabsContext = () => {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error('Tabs components must be used within a Tabs provider');
+  }
+  return context;
+};
+
+export function Tabs({
+  children,
+  defaultValue = '',
+  value,
+  onValueChange,
+  orientation = 'horizontal',
+  style,
+  enableSwipe = true,
+}: TabsProps) {
+  const [internalActiveTab, setInternalActiveTab] = useState(defaultValue);
+  const [tabValues, setTabValues] = useState<string[]>([]);
+
+  // Determine if we're in controlled or uncontrolled mode
+  const isControlled = value !== undefined;
+  const activeTab = isControlled ? value : internalActiveTab;
+
+  // Update internal state when value prop changes (controlled mode)
+  useEffect(() => {
+    if (isControlled && value !== internalActiveTab) {
+      setInternalActiveTab(value);
+    }
+  }, [value, isControlled, internalActiveTab]);
+
+  const setActiveTab = (newValue: string) => {
+    if (!isControlled) {
+      // Uncontrolled mode: update internal state
+      setInternalActiveTab(newValue);
+    }
+
+    // Call onValueChange callback if provided (works in both controlled and uncontrolled modes)
+    if (onValueChange) {
+      onValueChange(newValue);
+    }
+  };
+
+  const registerTab = useCallback((tabValue: string) => {
+    setTabValues((prev) => {
+      if (!prev.includes(tabValue)) {
+        return [...prev, tabValue];
+      }
+      return prev;
+    });
+  }, []);
+
+  const unregisterTab = useCallback((tabValue: string) => {
+    setTabValues((prev) => prev.filter((val) => val !== tabValue));
+  }, []);
+
+  const navigateToAdjacentTab = useCallback(
+    (direction: 'next' | 'prev') => {
+      const currentIndex = tabValues.indexOf(activeTab);
+      if (currentIndex === -1) return;
+
+      let nextIndex;
+      if (direction === 'next') {
+        nextIndex = currentIndex + 1;
+        if (nextIndex >= tabValues.length) nextIndex = 0; // Loop to first
+      } else {
+        nextIndex = currentIndex - 1;
+        if (nextIndex < 0) nextIndex = tabValues.length - 1; // Loop to last
+      }
+
+      const nextTab = tabValues[nextIndex];
+      if (nextTab) {
+        setActiveTab(nextTab);
+      }
+    },
+    [tabValues, activeTab, setActiveTab]
+  );
+
+  return (
+    <TabsContext.Provider
+      value={{
+        activeTab,
+        setActiveTab,
+        orientation,
+        tabValues,
+        registerTab,
+        unregisterTab,
+        enableSwipe,
+        navigateToAdjacentTab,
+      }}
+    >
+      <View
+        style={[
+          {
+            flexDirection: orientation === 'horizontal' ? 'column' : 'row',
+          },
+          style,
+        ]}
+      >
+        {children}
+      </View>
+    </TabsContext.Provider>
+  );
+}
+
+// Add this after the existing interfaces
+interface CarouselTabContentProps {
+  children: React.ReactNode;
+  value: string;
+  style?: ViewStyle;
+}
+
+// Add a ref to track all content components
+let allTabContents: { [key: string]: React.ReactNode } = {};
+
+function CarouselTabContent({
+  children,
+  value,
+  style,
+}: CarouselTabContentProps) {
+  const { activeTab, navigateToAdjacentTab, tabValues } = useTabsContext();
+
+  // Store this content
+  allTabContents[value] = children;
+
+  // Only render the carousel container for the active tab
+  if (activeTab !== value) {
+    return null;
+  }
+
+  return (
+    <CarouselContainer
+      activeTab={activeTab}
+      tabValues={tabValues}
+      onSwipe={navigateToAdjacentTab!}
+      style={style}
+    />
+  );
+}
+
+function CarouselContainer({
+  activeTab,
+  tabValues,
+  onSwipe,
+  style,
+}: {
+  activeTab: string;
+  tabValues: string[];
+  onSwipe: (direction: 'next' | 'prev') => void;
+  style?: ViewStyle;
+}) {
+  const translateX = useSharedValue(0);
+  const isGestureActive = useSharedValue(false);
+  const currentIndex = tabValues.indexOf(activeTab);
+
+  // Reset translation when active tab changes (only if not during gesture)
+  useEffect(() => {
+    if (!isGestureActive.value) {
+      translateX.value = withTiming(0, { duration: 300 });
+    }
+  }, [activeTab]);
+
+  const panGesture = Gesture.Pan()
+    .onBegin(() => {
+      isGestureActive.value = true;
+    })
+    .onUpdate((event) => {
+      translateX.value = event.translationX;
+    })
+    .onEnd((event) => {
+      isGestureActive.value = false;
+
+      const threshold = screenWidth * 0.15; // Lower threshold for easier swiping
+      const velocity = Math.abs(event.velocityX);
+      const translation = event.translationX;
+
+      // Determine if we should change tabs based on distance or velocity
+      const shouldChangeTab =
+        Math.abs(translation) > threshold || velocity > 500;
+
+      if (shouldChangeTab) {
+        if (translation > 0 && currentIndex > 0) {
+          // Swiped right - go to previous tab
+          runOnJS(onSwipe)('prev');
+        } else if (translation < 0 && currentIndex < tabValues.length - 1) {
+          // Swiped left - go to next tab
+          runOnJS(onSwipe)('next');
+        }
+      }
+
+      // No snapping back - let the tab change handle the reset
+    });
+
+  const getPreviousTab = () => {
+    const prevIndex = currentIndex - 1;
+    return prevIndex >= 0 ? tabValues[prevIndex] : null;
+  };
+
+  const getNextTab = () => {
+    const nextIndex = currentIndex + 1;
+    return nextIndex < tabValues.length ? tabValues[nextIndex] : null;
+  };
+
+  const previousTab = getPreviousTab();
+  const nextTab = getNextTab();
+
+  const containerStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
+
+  const previousStyle = useAnimatedStyle(() => {
+    const opacity = interpolate(
+      translateX.value,
+      [0, screenWidth * 0.5],
+      [0, 1],
+      Extrapolate.CLAMP
+    );
+
+    return {
+      transform: [{ translateX: translateX.value - screenWidth }],
+      opacity: previousTab ? opacity : 0,
+    };
+  });
+
+  const nextStyle = useAnimatedStyle(() => {
+    const opacity = interpolate(
+      translateX.value,
+      [-screenWidth * 0.5, 0],
+      [1, 0],
+      Extrapolate.CLAMP
+    );
+
+    return {
+      transform: [{ translateX: translateX.value + screenWidth }],
+      opacity: nextTab ? opacity : 0,
+    };
+  });
+
+  return (
+    <GestureDetector gesture={panGesture}>
+      <View style={{ overflow: 'hidden' }}>
+        {/* Previous content */}
+        {previousTab && (
+          <Animated.View
+            style={[
+              {
+                position: 'absolute',
+                width: screenWidth,
+                paddingTop: 16,
+              },
+              style,
+              previousStyle,
+            ]}
+            pointerEvents='none'
+          >
+            {allTabContents[previousTab]}
+          </Animated.View>
+        )}
+
+        {/* Current content */}
+        <Animated.View
+          style={[
+            {
+              paddingTop: 16,
+            },
+            style,
+            containerStyle,
+          ]}
+        >
+          {allTabContents[activeTab]}
+        </Animated.View>
+
+        {/* Next content */}
+        {nextTab && (
+          <Animated.View
+            style={[
+              {
+                position: 'absolute',
+                width: screenWidth,
+                paddingTop: 16,
+              },
+              style,
+              nextStyle,
+            ]}
+            pointerEvents='none'
+          >
+            {allTabContents[nextTab]}
+          </Animated.View>
+        )}
+      </View>
+    </GestureDetector>
+  );
+}
+
+export function TabsList({ children, style }: TabsListProps) {
+  const { orientation } = useTabsContext();
+  const backgroundColor = useColor('muted');
+
+  return (
+    <View
+      style={[
+        {
+          padding: 6,
+          backgroundColor,
+          borderRadius: orientation === 'horizontal' ? CORNERS : BORDER_RADIUS,
+        },
+        style,
+      ]}
+    >
+      <ScrollView
+        horizontal={orientation === 'horizontal'}
+        showsHorizontalScrollIndicator={false}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          flexDirection: orientation === 'horizontal' ? 'row' : 'column',
+          alignItems: 'center',
+        }}
+      >
+        {children}
+      </ScrollView>
+    </View>
+  );
+}
+
+export function TabsTrigger({
+  children,
+  value,
+  disabled = false,
+  style,
+  textStyle,
+}: TabsTriggerProps) {
+  const { activeTab, setActiveTab, orientation, registerTab, unregisterTab } =
+    useTabsContext();
+  const isActive = activeTab === value;
+
+  // Register/unregister tab for swipe navigation
+  useEffect(() => {
+    registerTab(value);
+    return () => unregisterTab(value);
+  }, [value, registerTab, unregisterTab]);
+
+  const primaryColor = useColor('primary');
+  const mutedForegroundColor = useColor('mutedForeground');
+  const backgroundColor = useColor('background');
+
+  const handlePress = () => {
+    if (!disabled) {
+      setActiveTab(value);
+    }
+  };
+
+  const triggerStyle: ViewStyle = {
+    paddingHorizontal: 12,
+    paddingVertical: orientation === 'vertical' ? 8 : undefined,
+    borderRadius: CORNERS,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: HEIGHT - 8,
+    backgroundColor: isActive ? backgroundColor : 'transparent',
+    opacity: disabled ? 0.5 : 1,
+    flex: orientation === 'horizontal' ? 1 : undefined,
+    marginBottom: orientation === 'vertical' ? 4 : 0,
+    ...style,
+  };
+
+  const triggerTextStyle: TextStyle = {
+    fontSize: FONT_SIZE,
+    fontWeight: '500',
+    color: isActive ? primaryColor : mutedForegroundColor,
+    textAlign: 'center',
+    ...textStyle,
+  };
+
+  return (
+    <TouchableOpacity
+      style={triggerStyle}
+      onPress={handlePress}
+      disabled={disabled}
+      activeOpacity={0.8}
+    >
+      {typeof children === 'string' ? (
+        <Text style={triggerTextStyle}>{children}</Text>
+      ) : (
+        children
+      )}
+    </TouchableOpacity>
+  );
+}
+
+export function TabsContent({ children, value, style }: TabsContentProps) {
+  const {
+    activeTab,
+    enableSwipe,
+    orientation,
+    navigateToAdjacentTab,
+    tabValues,
+  } = useTabsContext();
+  const isActive = activeTab === value;
+
+  // For carousel mode, we need to render all content but only show active one
+  if (enableSwipe && orientation === 'horizontal' && navigateToAdjacentTab) {
+    return (
+      <CarouselTabContent value={value} style={style}>
+        {children}
+      </CarouselTabContent>
+    );
+  }
+
+  // Regular mode - only render active content
+  if (!isActive) {
+    return null;
+  }
+
+  return (
+    <View
+      style={[
+        {
+          paddingTop: 16,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}

--- a/components/ui/text.tsx
+++ b/components/ui/text.tsx
@@ -1,0 +1,88 @@
+import { useColor } from '@/hooks/useColor';
+import { FONT_SIZE } from '@/theme/globals';
+import React, { forwardRef } from 'react';
+import {
+  Text as RNText,
+  TextProps as RNTextProps,
+  TextStyle,
+} from 'react-native';
+
+type TextVariant =
+  | 'body'
+  | 'title'
+  | 'subtitle'
+  | 'caption'
+  | 'heading'
+  | 'link';
+
+interface TextProps extends RNTextProps {
+  variant?: TextVariant;
+  lightColor?: string;
+  darkColor?: string;
+  children: React.ReactNode;
+}
+
+export const Text = forwardRef<RNText, TextProps>(
+  (
+    { variant = 'body', lightColor, darkColor, style, children, ...props },
+    ref
+  ) => {
+    const textColor = useColor('text', { light: lightColor, dark: darkColor });
+    const mutedColor = useColor('textMuted');
+
+    const getTextStyle = (): TextStyle => {
+      const baseStyle: TextStyle = {
+        color: textColor,
+      };
+
+      switch (variant) {
+        case 'heading':
+          return {
+            ...baseStyle,
+            fontSize: 28,
+            fontWeight: '800',
+          };
+        case 'title':
+          return {
+            ...baseStyle,
+            fontSize: 24,
+            fontWeight: '700',
+          };
+        case 'subtitle':
+          return {
+            ...baseStyle,
+            fontSize: 19,
+            fontWeight: '600',
+          };
+        case 'caption':
+          return {
+            ...baseStyle,
+            fontSize: FONT_SIZE,
+            fontWeight: '400',
+            color: mutedColor,
+          };
+        case 'link':
+          return {
+            ...baseStyle,
+            fontSize: FONT_SIZE,
+            fontWeight: '500',
+            textDecorationLine: 'underline',
+          };
+        default: // 'body'
+          return {
+            ...baseStyle,
+            fontSize: FONT_SIZE,
+            fontWeight: '400',
+          };
+      }
+    };
+
+    return (
+      <RNText ref={ref} style={[getTextStyle(), style]} {...props}>
+        {children}
+      </RNText>
+    );
+  }
+);
+
+Text.displayName = "Text";

--- a/components/ui/view.tsx
+++ b/components/ui/view.tsx
@@ -1,0 +1,16 @@
+import { forwardRef } from 'react';
+import { View as RNView, type ViewProps } from 'react-native';
+
+export const View = forwardRef<RNView, ViewProps>(
+  ({ style, ...otherProps }, ref) => {
+    return (
+      <RNView
+        ref={ref}
+        style={[{ backgroundColor: 'transparent' }, style]}
+        {...otherProps}
+      />
+    );
+  }
+);
+
+View.displayName = "View";

--- a/hooks/useColor.ts
+++ b/hooks/useColor.ts
@@ -1,0 +1,17 @@
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { Colors } from "@/theme/colors";
+
+export function useColor(
+  colorName: keyof typeof Colors.light & keyof typeof Colors.dark,
+  props?: { light?: string; dark?: string }
+) {
+  const scheme = useColorScheme() ?? "light";
+  const theme = scheme === "dark" ? "dark" : "light";
+  const colorFromProps = props?.[theme];
+
+  if (colorFromProps) {
+    return colorFromProps;
+  } else {
+    return Colors[theme][colorName];
+  }
+}

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,0 +1,1 @@
+export { useColorScheme } from "react-native";

--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+import { useColorScheme as useRNColorScheme } from "react-native";
+
+/**
+ * Re-calculate on the client side for web to support static rendering.
+ * The setState in the hydration effect is intentional — it triggers one
+ * rerender after mount so the server-rendered "light" is replaced by the
+ * actual system color scheme.
+ */
+let hydrated = false;
+
+export function useColorScheme() {
+  const [, rerender] = useState(0);
+
+  useEffect(() => {
+    if (!hydrated) {
+      hydrated = true;
+      rerender((n) => n + 1); // eslint-disable-line react-hooks/set-state-in-effect
+    }
+  }, []);
+
+  const colorScheme = useRNColorScheme();
+
+  return hydrated ? colorScheme : "light";
+}

--- a/hooks/useKeyboardHeight.ts
+++ b/hooks/useKeyboardHeight.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { Keyboard, Platform } from "react-native";
+
+export function useKeyboardHeight() {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    if (Platform.OS === "web") return;
+
+    const showSub = Keyboard.addListener(
+      Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow",
+      (e) => setKeyboardHeight(e.endCoordinates.height)
+    );
+    const hideSub = Keyboard.addListener(
+      Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide",
+      () => setKeyboardHeight(0)
+    );
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
+
+  return { keyboardHeight, isKeyboardVisible: keyboardHeight > 0 };
+}

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -1,0 +1,131 @@
+// FitForge "Electric Coral Energy" palette mapped to BNA UI semantic tokens.
+// Domain-specific colors (plates, muscles, semantic macros) remain in constants/theme.ts.
+
+const lightColors = {
+  // Base colors
+  background: "#FAFAFA",
+  foreground: "#1A2138",
+
+  // Card colors
+  card: "#F3F4F6",
+  cardForeground: "#1A2138",
+
+  // Popover colors
+  popover: "#F3F4F6",
+  popoverForeground: "#1A2138",
+
+  // Primary — Electric Coral
+  primary: "#FF6038",
+  primaryForeground: "#FFFFFF",
+
+  // Secondary — Navy
+  secondary: "#1A2138",
+  secondaryForeground: "#FFFFFF",
+
+  // Muted
+  muted: "#E5E7EB",
+  mutedForeground: "#6B7280",
+
+  // Accent
+  accent: "#FFE0D6",
+  accentForeground: "#6B1F0A",
+
+  // Destructive
+  destructive: "#EF4444",
+  destructiveForeground: "#FFFFFF",
+
+  // Border and input
+  border: "#D1D5DB",
+  input: "#E5E7EB",
+  ring: "#FF6038",
+
+  // Text colors
+  text: "#1A2138",
+  textMuted: "#6B7280",
+
+  // Legacy support
+  tint: "#FF6038",
+  icon: "#6B7280",
+  tabIconDefault: "#6B7280",
+  tabIconSelected: "#FF6038",
+
+  // iOS system colors
+  blue: "#007AFF",
+  green: "#10B981",
+  red: "#EF4444",
+  orange: "#F59E0B",
+  yellow: "#FFCC00",
+  pink: "#FF2D92",
+  purple: "#AF52DE",
+  teal: "#5AC8FA",
+  indigo: "#5856D6",
+};
+
+const darkColors = {
+  // Base colors
+  background: "#0D1117",
+  foreground: "#F0F2F5",
+
+  // Card colors
+  card: "#161B22",
+  cardForeground: "#F0F2F5",
+
+  // Popover colors
+  popover: "#161B22",
+  popoverForeground: "#F0F2F5",
+
+  // Primary — Lighter coral for dark mode
+  primary: "#FF7A55",
+  primaryForeground: "#FFFFFF",
+
+  // Secondary — Navy
+  secondary: "#2D3350",
+  secondaryForeground: "#FFFFFF",
+
+  // Muted
+  muted: "#21262D",
+  mutedForeground: "#8B949E",
+
+  // Accent
+  accent: "#6B1F0A",
+  accentForeground: "#FFE0D6",
+
+  // Destructive
+  destructive: "#F87171",
+  destructiveForeground: "#FFFFFF",
+
+  // Border and input
+  border: "#30363D",
+  input: "rgba(255, 255, 255, 0.15)",
+  ring: "#FF7A55",
+
+  // Text colors
+  text: "#F0F2F5",
+  textMuted: "#8B949E",
+
+  // Legacy support
+  tint: "#FF7A55",
+  icon: "#8B949E",
+  tabIconDefault: "#8B949E",
+  tabIconSelected: "#FF7A55",
+
+  // iOS system colors (dark-adapted)
+  blue: "#0A84FF",
+  green: "#30D158",
+  red: "#FF453A",
+  orange: "#FF9F0A",
+  yellow: "#FFD60A",
+  pink: "#FF375F",
+  purple: "#BF5AF2",
+  teal: "#64D2FF",
+  indigo: "#5E5CE6",
+};
+
+export const Colors = {
+  light: lightColors,
+  dark: darkColors,
+};
+
+export { darkColors, lightColors };
+
+export type ColorKeys = keyof typeof lightColors;

--- a/theme/globals.ts
+++ b/theme/globals.ts
@@ -1,0 +1,4 @@
+export const HEIGHT = 48;
+export const FONT_SIZE = 17;
+export const BORDER_RADIUS = 12;
+export const CORNERS = 9999;

--- a/theme/theme-provider.tsx
+++ b/theme/theme-provider.tsx
@@ -1,0 +1,51 @@
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider as RNThemeProvider,
+} from "@react-navigation/native";
+import "react-native-reanimated";
+
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { Colors } from "@/theme/colors";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const customLightTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    primary: Colors.light.primary,
+    background: Colors.light.background,
+    card: Colors.light.card,
+    text: Colors.light.text,
+    border: Colors.light.border,
+    notification: Colors.light.red,
+  },
+};
+
+const customDarkTheme = {
+  ...DarkTheme,
+  colors: {
+    ...DarkTheme.colors,
+    primary: Colors.dark.primary,
+    background: Colors.dark.background,
+    card: Colors.dark.card,
+    text: Colors.dark.text,
+    border: Colors.dark.border,
+    notification: Colors.dark.red,
+  },
+};
+
+export const BNAThemeProvider = ({ children }: Props) => {
+  const colorScheme = useColorScheme();
+
+  return (
+    <RNThemeProvider
+      value={colorScheme === "dark" ? customDarkTheme : customLightTheme}
+    >
+      {children}
+    </RNThemeProvider>
+  );
+};


### PR DESCRIPTION
## Summary
Phase 1 of the BNA UI migration (BLD-309 epic). Installs the BNA UI component library alongside react-native-paper for a gradual migration.

## Changes
- **26 BNA UI components** installed via `npx bna-ui add` into `components/ui/`
  - button, card, input, text, view, badge, tabs, toast, skeleton, spinner, switch, checkbox, progress, alert-dialog, bottom-sheet, separator, avatar, searchbar, accordion, radio, scroll-view, sheet, alert, table, icon, image
- **theme/colors.ts**: FitForge 'Electric Coral Energy' palette mapped to BNA semantic tokens
  - primary=#FF6038 (coral), secondary=#1A2138 (navy)
  - Light/dark mode with proper foreground colors for all tokens
- **theme/globals.ts**: BORDER_RADIUS=12 (FitForge standard, not BNA default 26)
- **theme/theme-provider.tsx**: BNAThemeProvider wrapping React Navigation ThemeProvider
- **hooks/**: useColor.ts, useColorScheme.ts, useColorScheme.web.ts, useKeyboardHeight.ts
- **components/ui/Chip.tsx**: Custom Chip component (BNA has no native Chip)
- BNA toast renamed to `bna-toast.tsx` to avoid casing conflict with existing Toast.tsx
- BNA vendored components have `eslint-disable` (standard shadcn/copy-paste pattern)
- **react-native-paper remains installed** — both systems coexist during migration

## Testing
- `npx tsc --noEmit` — no new errors (pre-existing errors in session/[id].tsx unchanged)
- `npx jest --no-coverage` — 1664/1665 pass (pre-existing failure unchanged)
- No existing screens broken — RNP still works alongside BNA

## Issue
Refs: BLD-310
Parent: BLD-309