### PR TITLE
fix: remove stale @ts-expect-error in FloatingTabBar (BLD-310)

### DIFF
--- a/components/FloatingTabBar.tsx
+++ b/components/FloatingTabBar.tsx
@@ -372,7 +372,6 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.25,
     shadowRadius: 12,
-    // @ts-expect-error -- web-only boxShadow for cross-platform shadow
     boxShadow: "0 4px 16px rgba(0,0,0,0.18)",
   },
   blurClip: {


### PR DESCRIPTION
## Summary
Remove stale `@ts-expect-error` directive for `boxShadow` in FloatingTabBar.tsx. The `boxShadow` property is now a recognized style property in the RN types, so the directive itself causes TS2578.

## Changes
- `components/FloatingTabBar.tsx`: Remove unnecessary `@ts-expect-error` comment (line 375)

## Testing
- `npx tsc --noEmit` — zero errors
- `npx jest --no-coverage` — no new failures (4 pre-existing)
- ESLint — zero warnings

## Issue
Refs: BLD-310