### PR TITLE
fix: add missing lucide-react-native dependency (BLD-316)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fitforge",
-  "version": "0.8.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fitforge",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.9",
@@ -44,6 +44,7 @@
         "expo-status-bar": "~55.0.5",
         "expo-system-ui": "~55.0.15",
         "expo-web-browser": "~55.0.14",
+        "lucide-react-native": "^1.8.0",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-hook-form": "^7.72.1",
@@ -11604,6 +11605,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react-native": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react-native/-/lucide-react-native-1.8.0.tgz",
+      "integrity": "sha512-trgqSA2ghSHUE3yLUBTdhjF1EMbgcJuccI1VXe6zTI2u4tbeUXbtXeHGORRdeGUdC80XBn/XJa1YrG8uvKhpNg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-native": "*",
+        "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "expo-status-bar": "~55.0.5",
     "expo-system-ui": "~55.0.15",
     "expo-web-browser": "~55.0.14",
+    "lucide-react-native": "^1.8.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-hook-form": "^7.72.1",


### PR DESCRIPTION
## Summary

BNA UI components installed in PR #171 import from `lucide-react-native` for icons but the package was never added to `package.json`, causing 10 `tsc` errors on main.

## Changes

- Added `lucide-react-native` to dependencies in `package.json`

## Testing

- `npx tsc --noEmit` passes with 0 errors (was 10 errors before)
- `npm install --legacy-peer-deps` succeeds
- No test regressions (pre-existing test failures unchanged)

## Issue

Resolves BLD-316