### PR TITLE
refactor: complete BNA UI migration for all app/ screens (BLD-314)

### DIFF
--- a/__tests__/acceptance/dashboard.test.tsx
+++ b/__tests__/acceptance/dashboard.test.tsx
@@ -61,7 +61,17 @@ jest.mock('react-native-reanimated', () => {
     __esModule: true,
     default: { View, createAnimatedComponent: (c: unknown) => c },
     FadeInDown: { delay: () => ({ duration: () => undefined }) },
+    FadeIn: { duration: () => ({ delay: () => undefined }) },
+    FadeOut: { duration: () => undefined },
+    SlideInDown: { duration: () => undefined },
+    SlideOutDown: { duration: () => undefined },
     Easing: { bezier: () => (t: number) => t },
+    useSharedValue: (init: unknown) => ({ value: init }),
+    useAnimatedStyle: () => ({}),
+    withTiming: (v: unknown) => v,
+    withSpring: (v: unknown) => v,
+    withDelay: (_d: unknown, v: unknown) => v,
+    runOnJS: (fn: Function) => fn,
   }
 })
 jest.mock('expo-haptics', () => ({

--- a/__tests__/acceptance/template-add-exercise.acceptance.test.tsx
+++ b/__tests__/acceptance/template-add-exercise.acceptance.test.tsx
@@ -27,6 +27,14 @@ jest.mock('expo-router', () => {
 })
 
 jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../components/ui/bna-toast', () => {
+  const RealReact = require('react')
+  return {
+    __esModule: true,
+    useToast: () => ({ toast: jest.fn(), success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn(), dismiss: jest.fn(), dismissAll: jest.fn() }),
+    ToastProvider: ({ children }: { children: React.ReactNode }) => RealReact.createElement(RealReact.Fragment, null, children),
+  }
+})
 jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
 jest.mock('../../lib/errors', () => ({ logError: jest.fn(), generateReport: jest.fn().mockResolvedValue('{}'), getRecentErrors: jest.fn().mockResolvedValue([]), generateGitHubURL: jest.fn().mockReturnValue('https://github.com') }))
 jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
@@ -103,7 +111,7 @@ describe('Template → Add Exercise Flow', () => {
 
     const { getByPlaceholderText, getByLabelText, findByLabelText, findByText, getByTestId } = renderScreen(<CreateTemplate />)
 
-    fireEvent.changeText(getByPlaceholderText('e.g. Push Day, Full Body A'), 'Push Day')
+    fireEvent.changeText(getByPlaceholderText('Template Name'), 'Push Day')
     fireEvent.press(getByLabelText('Create template'))
 
     await waitFor(() => {

--- a/__tests__/acceptance/template-crud.acceptance.test.tsx
+++ b/__tests__/acceptance/template-crud.acceptance.test.tsx
@@ -27,6 +27,14 @@ jest.mock('expo-router', () => {
 })
 
 jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../components/ui/bna-toast', () => {
+  const RealReact = require('react')
+  return {
+    __esModule: true,
+    useToast: () => ({ toast: jest.fn(), success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn(), dismiss: jest.fn(), dismissAll: jest.fn() }),
+    ToastProvider: ({ children }: { children: React.ReactNode }) => RealReact.createElement(RealReact.Fragment, null, children),
+  }
+})
 jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
 jest.mock('../../lib/errors', () => ({ logError: jest.fn(), generateReport: jest.fn().mockResolvedValue('{}'), getRecentErrors: jest.fn().mockResolvedValue([]), generateGitHubURL: jest.fn().mockReturnValue('https://github.com') }))
 jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
@@ -135,7 +143,7 @@ describe('Template CRUD Acceptance', () => {
     it('creates a new template when name is entered', async () => {
       const { getByPlaceholderText, getByLabelText } = renderScreen(<CreateTemplate />)
 
-      fireEvent.changeText(getByPlaceholderText('e.g. Push Day, Full Body A'), 'Push Day')
+      fireEvent.changeText(getByPlaceholderText('Template Name'), 'Push Day')
       fireEvent.press(getByLabelText('Create template'))
 
       await waitFor(() => {
@@ -161,7 +169,7 @@ describe('Template CRUD Acceptance', () => {
     it('shows exercises section after template is created', async () => {
       const { getByPlaceholderText, getByLabelText, findByLabelText, findByText } = renderScreen(<CreateTemplate />)
 
-      fireEvent.changeText(getByPlaceholderText('e.g. Push Day, Full Body A'), 'Push Day')
+      fireEvent.changeText(getByPlaceholderText('Template Name'), 'Push Day')
       fireEvent.press(getByLabelText('Create template'))
 
       expect(await findByLabelText('Add exercise to template')).toBeTruthy()
@@ -207,7 +215,7 @@ describe('Template CRUD Acceptance', () => {
 
       await findByText('Bench Press')
 
-      fireEvent.changeText(getByPlaceholderText('e.g. Push Day, Full Body A'), 'Pull Day')
+      fireEvent.changeText(getByPlaceholderText('Template Name'), 'Pull Day')
       fireEvent.press(getByLabelText('Done editing template'))
 
       await waitFor(() => {

--- a/__tests__/acceptance/template-exercise-editing.acceptance.test.tsx
+++ b/__tests__/acceptance/template-exercise-editing.acceptance.test.tsx
@@ -30,6 +30,16 @@ jest.mock('expo-router', () => {
 })
 
 jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+
+const mockToast = jest.fn()
+jest.mock('../../components/ui/bna-toast', () => {
+  const RealReact = require('react')
+  return {
+    __esModule: true,
+    useToast: () => ({ toast: mockToast, success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn(), dismiss: jest.fn(), dismissAll: jest.fn() }),
+    ToastProvider: ({ children }: { children: React.ReactNode }) => RealReact.createElement(RealReact.Fragment, null, children),
+  }
+})
 jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0, horizontalPadding: 16 }) }))
 jest.mock('../../lib/errors', () => ({ logError: jest.fn(), generateReport: jest.fn().mockResolvedValue('{}'), getRecentErrors: jest.fn().mockResolvedValue([]), generateGitHubURL: jest.fn().mockReturnValue('https://github.com') }))
 jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
@@ -143,7 +153,7 @@ describe('Template Exercise Editing Acceptance', () => {
     })
   })
 
-  it('shows snackbar on save failure', async () => {
+  it('shows toast on save failure', async () => {
     mockUpdateTemplateExercise.mockRejectedValueOnce(new Error('DB error'))
     const { findByText, findByTestId } = renderScreen(<EditTemplate />)
 
@@ -155,7 +165,9 @@ describe('Template Exercise Editing Acceptance', () => {
       mockEditSheetProps.onSave(4, '6-8', 120)
     }
 
-    expect(await findByText('Failed to update exercise settings')).toBeTruthy()
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith('Failed to update exercise settings')
+    })
   })
 
   it('refetches template data after successful save', async () => {

--- a/__tests__/acceptance/template-exercise-editing.acceptance.test.tsx
+++ b/__tests__/acceptance/template-exercise-editing.acceptance.test.tsx
@@ -32,11 +32,12 @@ jest.mock('expo-router', () => {
 jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
 
 const mockToast = jest.fn()
+const mockError = jest.fn()
 jest.mock('../../components/ui/bna-toast', () => {
   const RealReact = require('react')
   return {
     __esModule: true,
-    useToast: () => ({ toast: mockToast, success: jest.fn(), error: jest.fn(), warning: jest.fn(), info: jest.fn(), dismiss: jest.fn(), dismissAll: jest.fn() }),
+    useToast: () => ({ toast: mockToast, success: jest.fn(), error: mockError, warning: jest.fn(), info: jest.fn(), dismiss: jest.fn(), dismissAll: jest.fn() }),
     ToastProvider: ({ children }: { children: React.ReactNode }) => RealReact.createElement(RealReact.Fragment, null, children),
   }
 })
@@ -166,7 +167,7 @@ describe('Template Exercise Editing Acceptance', () => {
     }
 
     await waitFor(() => {
-      expect(mockToast).toHaveBeenCalledWith('Failed to update exercise settings')
+      expect(mockError).toHaveBeenCalledWith('Failed to update exercise settings')
     })
   })
 

--- a/__tests__/app/exercise-chip-styling.test.ts
+++ b/__tests__/app/exercise-chip-styling.test.ts
@@ -7,12 +7,8 @@ const exercisesSrc = fs.readFileSync(
 );
 
 describe("Exercise category chip active/inactive styling (BLD-189)", () => {
-  it("uses 'flat' mode for active chips", () => {
-    expect(exercisesSrc).toContain('mode={active ? "flat" : "outlined"}');
-  });
-
-  it("uses 'outlined' mode for inactive chips", () => {
-    expect(exercisesSrc).toContain('"outlined"');
+  it("uses BNA Chip component for category filters", () => {
+    expect(exercisesSrc).toContain('import { Chip } from "@/components/ui/chip"');
   });
 
   it("applies primaryContainer background only when active", () => {
@@ -29,21 +25,7 @@ describe("Exercise category chip active/inactive styling (BLD-189)", () => {
     expect(exercisesSrc).toContain("flexShrink: 0");
   });
 
-  it("only shows selected overlay when chip is active", () => {
-    expect(exercisesSrc).toContain("showSelectedOverlay={active}");
-  });
-
-  it("does NOT use a static showSelectedOverlay without condition", () => {
-    // Ensure we don't have the old unconditional showSelectedOverlay
-    const lines = exercisesSrc.split("\n");
-    const overlayLines = lines.filter(
-      (l) => l.includes("showSelectedOverlay") && !l.includes("{active}")
-    );
-    expect(overlayLines).toHaveLength(0);
-  });
-
   it("uses theme tokens for chip icon colors (no hardcoded hex)", () => {
-    // Icon color should use theme.colors, not raw hex values
     expect(exercisesSrc).toContain(
       "color={active ? colors.onPrimaryContainer : colors.onSurface}"
     );

--- a/__tests__/app/session-swap-delete.test.ts
+++ b/__tests__/app/session-swap-delete.test.ts
@@ -22,7 +22,7 @@ describe("BLD-307: Long-press exercise delete (UI wiring)", () => {
     expect(sessionSrc).toContain("Long press to remove exercise");
   });
 
-  it("shows countdown snackbar with UNDO action", () => {
+  it("shows countdown toast with UNDO action", () => {
     expect(sessionSrc).toMatch(/Removing \$\{group\.name\}\.\.\. \(\d+s\)/);
     expect(sessionSrc).toContain('label: "UNDO"');
   });

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 import { Tabs, useRouter } from "expo-router";
 import { Text, View } from "react-native";
-import { IconButton } from "react-native-paper";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { TouchableOpacity } from "react-native";
 import FloatingTabBar from "../../components/FloatingTabBar";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
@@ -46,15 +46,14 @@ export default function TabLayout() {
           title: "Nutrition",
           headerTitle: renderHeaderTitle("food-apple", "Nutrition"),
           headerRight: () => (
-            <IconButton
-              icon="barcode-scan"
-              size={24}
+            <TouchableOpacity
               onPress={() => router.push("/nutrition/add?scan=true")}
               accessibilityLabel="Scan food barcode"
               accessibilityRole="button"
-              iconColor={colors.onSurface}
-              style={{ minWidth: 48, minHeight: 48 }}
-            />
+              style={{ minWidth: 48, minHeight: 48, alignItems: "center", justifyContent: "center" }}
+            >
+              <MaterialCommunityIcons name="barcode-scan" size={24} color={colors.onSurface} />
+            </TouchableOpacity>
           ),
         }}
       />
@@ -64,15 +63,14 @@ export default function TabLayout() {
           title: "Workouts",
           headerTitle: renderHeaderTitle("arm-flex", "Workouts"),
           headerRight: () => (
-            <IconButton
-              icon="wrench"
-              size={24}
+            <TouchableOpacity
               onPress={() => router.push("/tools")}
               accessibilityLabel="Workout tools"
               accessibilityRole="button"
-              iconColor={colors.onSurface}
-              style={{ minWidth: 48, minHeight: 48 }}
-            />
+              style={{ minWidth: 48, minHeight: 48, alignItems: "center", justifyContent: "center" }}
+            >
+              <MaterialCommunityIcons name="wrench" size={24} color={colors.onSurface} />
+            </TouchableOpacity>
           ),
         }}
       />

--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -7,7 +7,10 @@ import {
   useColorScheme,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Chip, FAB, Searchbar, Text } from "react-native-paper";
+import { Text } from "@/components/ui/text";
+import { Chip } from "@/components/ui/chip";
+import { SearchBar } from "@/components/ui/searchbar";
+import { FAB } from "@/components/ui/fab";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useRouter } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
@@ -103,7 +106,7 @@ export default function Exercises() {
       >
         <View style={styles.cardInner}>
           <View style={styles.titleRow}>
-            <Text variant="titleSmall" numberOfLines={1} style={[{ color: colors.onSurface }, styles.titleText]}>
+            <Text variant="subtitle" numberOfLines={1} style={[{ color: colors.onSurface }, styles.titleText]}>
               {item.name}
             </Text>
             {item.is_custom && (
@@ -113,7 +116,7 @@ export default function Exercises() {
             )}
           </View>
           <Text
-            variant="bodySmall"
+            variant="caption"
             style={{ color: colors.onSurfaceVariant, marginTop: 2 }}
             numberOfLines={1}
           >
@@ -146,10 +149,10 @@ export default function Exercises() {
     () =>
       loading ? null : (
         <View style={styles.empty}>
-          <Text variant="titleMedium" style={{ color: colors.onSurfaceVariant }}>
+          <Text variant="title" style={{ color: colors.onSurfaceVariant }}>
             No exercises found
           </Text>
-          <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
             Try adjusting your search or filters
           </Text>
         </View>
@@ -161,7 +164,7 @@ export default function Exercises() {
 
   const list = (
     <View style={layout.atLeastMedium ? { flex: 2 } : { flex: 1 }}>
-      <Searchbar
+      <SearchBar
         placeholder="Search exercises..."
         value={query}
         onChangeText={setQuery}
@@ -251,7 +254,7 @@ export default function Exercises() {
             contentContainerStyle={styles.detailContent}
             ListHeaderComponent={
               <>
-                <Text variant="headlineSmall" style={{ color: colors.onSurface, marginBottom: 12 }}>
+                <Text variant="heading" style={{ color: colors.onSurface, marginBottom: 12 }}>
                   {detail.name}
                 </Text>
                 {detail.is_custom && (
@@ -277,11 +280,11 @@ export default function Exercises() {
                 </View>
                 {detail.mount_position && (
                   <>
-                    <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, marginTop: 16, fontSize: 12 }}>
+                    <Text variant="body" style={{ color: colors.onSurfaceVariant, marginTop: 16, fontSize: 12 }}>
                       Mount Position
                     </Text>
                     <Text
-                      variant="bodyLarge"
+                      variant="body"
                       style={{ color: colors.onSurface, marginTop: 4 }}
                       accessibilityLabel={`Mount position: ${detail.mount_position} on rack`}
                     >
@@ -291,11 +294,11 @@ export default function Exercises() {
                 )}
                 {detail.attachment && (
                   <>
-                    <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, marginTop: 16, fontSize: 12 }}>
+                    <Text variant="body" style={{ color: colors.onSurfaceVariant, marginTop: 16, fontSize: 12 }}>
                       Attachment
                     </Text>
                     <Text
-                      variant="bodyLarge"
+                      variant="body"
                       style={{ color: colors.onSurface, marginTop: 4 }}
                       accessibilityLabel={`Attachment: ${detail.attachment}`}
                     >
@@ -305,7 +308,7 @@ export default function Exercises() {
                 )}
                 {detail.training_modes && detail.training_modes.length > 0 && (
                   <View accessibilityLabel={`Compatible training modes: ${detail.training_modes.join(", ")}`}>
-                    <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, marginTop: 16, fontSize: 12 }}>
+                    <Text variant="body" style={{ color: colors.onSurfaceVariant, marginTop: 16, fontSize: 12 }}>
                       Training Modes
                     </Text>
                     <View style={[styles.row, { marginTop: 6, flexWrap: "wrap", gap: 6 }]}>
@@ -327,7 +330,7 @@ export default function Exercises() {
                 />
                 <View style={styles.muscleColumns}>
                   <View style={{ flex: 1 }}>
-                    <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, marginTop: 16 }}>
+                    <Text variant="body" style={{ color: colors.onSurfaceVariant, marginTop: 16 }}>
                       Primary Muscles
                     </Text>
                     <View style={[styles.row, { marginTop: 6, flexWrap: "wrap", gap: 6 }]}>
@@ -340,7 +343,7 @@ export default function Exercises() {
                   </View>
                   {detail.secondary_muscles.length > 0 && (
                     <View style={{ flex: 1 }}>
-                      <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, marginTop: 16 }}>
+                      <Text variant="body" style={{ color: colors.onSurfaceVariant, marginTop: 16 }}>
                         Secondary Muscles
                       </Text>
                       <View style={[styles.row, { marginTop: 6, flexWrap: "wrap", gap: 6 }]}>
@@ -355,11 +358,11 @@ export default function Exercises() {
                 </View>
                 {steps && steps.length > 0 && (
                   <>
-                    <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, marginTop: 16 }}>
+                    <Text variant="body" style={{ color: colors.onSurfaceVariant, marginTop: 16 }}>
                       Instructions
                     </Text>
                     {steps.map((step, i) => (
-                      <Text key={i} variant="bodyMedium" style={{ color: colors.onSurface, marginTop: 6, lineHeight: 22 }}>
+                      <Text key={i} variant="body" style={{ color: colors.onSurface, marginTop: 6, lineHeight: 22 }}>
                         {step}
                       </Text>
                     ))}
@@ -370,7 +373,7 @@ export default function Exercises() {
           />
         ) : (
           <View style={styles.detailEmpty}>
-            <Text variant="bodyLarge" style={{ color: colors.onSurfaceVariant }}>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
               Select an exercise to view details
             </Text>
           </View>

--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -182,19 +182,17 @@ export default function Exercises() {
             return (
             <Chip
               selected={active}
-              mode={active ? "flat" : "outlined"}
               onPress={() => toggle(f)}
-              style={[
+              style={StyleSheet.flatten([
                 styles.filterChip,
                 active && { backgroundColor: colors.primaryContainer },
-              ]}
-              textStyle={[
-                { flexShrink: 0 },
-                active ? { color: colors.onPrimaryContainer, fontWeight: "600" } : undefined,
-              ]}
+              ])}
+              textStyle={{
+                flexShrink: 0,
+                ...(active ? { color: colors.onPrimaryContainer, fontWeight: "600" } : {}),
+              }}
               compact
-              showSelectedOverlay={active}
-              icon={f !== "custom" && CATEGORY_ICONS[f] ? () => (
+              icon={f !== "custom" && CATEGORY_ICONS[f] ? (
                 <MaterialCommunityIcons
                   name={CATEGORY_ICONS[f] as keyof typeof MaterialCommunityIcons.glyphMap}
                   size={16}
@@ -225,7 +223,6 @@ export default function Exercises() {
         style={[styles.fab, { backgroundColor: colors.primary }]}
         color={colors.onPrimary}
         accessibilityLabel="Add custom exercise"
-        accessibilityRole="button"
       />
     </View>
   );

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,12 +2,15 @@ import { useState } from "react";
 import {
   Alert,
   FlatList,
+  Pressable,
   ScrollView,
   StyleSheet,
   View,
 } from "react-native";
 import Animated, { FadeInDown } from "react-native-reanimated";
-import { Button, Card, IconButton, Menu, SegmentedButtons, Text } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Text } from "@/components/ui/text";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useRouter } from "expo-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -105,7 +108,6 @@ export default function Workouts() {
   const layout = useLayout();
   const tabBarHeight = useFloatingTabBarHeight();
   const [userSegment, setUserSegment] = useState<string | null>(null);
-  const [menu, setMenu] = useState<string | null>(null);
 
   const { data } = useQuery({
     queryKey: ["home"],
@@ -200,17 +202,38 @@ export default function Workouts() {
   };
 
   const handleDuplicateTemplate = async (tpl: WorkoutTemplate) => {
-    setMenu(null);
     const newId = await duplicateTemplate(tpl.id);
     reload();
     router.push(`/template/${newId}`);
   };
 
   const handleDuplicateProgram = async (prog: Program) => {
-    setMenu(null);
     const newId = await duplicateProgram(prog.id);
     reload();
     router.push(`/program/${newId}`);
+  };
+
+  const showTemplateOptions = (item: WorkoutTemplate) => {
+    const meta = starterMeta(item.id);
+    Alert.alert(
+      meta?.name || item.name,
+      undefined,
+      [
+        { text: "Duplicate", onPress: () => handleDuplicateTemplate(item) },
+        { text: "Cancel", style: "cancel" },
+      ]
+    );
+  };
+
+  const showProgramOptions = (item: Program) => {
+    Alert.alert(
+      item.name,
+      undefined,
+      [
+        { text: "Duplicate", onPress: () => handleDuplicateProgram(item) },
+        { text: "Cancel", style: "cancel" },
+      ]
+    );
   };
 
   const starterMeta = (id: string) =>
@@ -250,10 +273,10 @@ export default function Workouts() {
             size={24}
             color={streak > 0 ? colors.primary : colors.onSurfaceVariant}
           />
-          <Text variant="titleLarge" style={{ color: streak > 0 ? colors.onSurface : colors.onSurfaceVariant }}>
+          <Text variant="title" style={{ color: streak > 0 ? colors.onSurface : colors.onSurfaceVariant, fontSize: 20 }}>
             {streak}
           </Text>
-          <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
             {streak === 1 ? "week" : "weeks"}
           </Text>
         </Animated.View>
@@ -267,10 +290,10 @@ export default function Workouts() {
             size={24}
             color={weekDone > 0 ? colors.primary : colors.onSurfaceVariant}
           />
-          <Text variant="titleLarge" style={{ color: weekDone > 0 ? colors.onSurface : colors.onSurfaceVariant }}>
+          <Text variant="title" style={{ color: weekDone > 0 ? colors.onSurface : colors.onSurfaceVariant, fontSize: 20 }}>
             {weekLabel}
           </Text>
-          <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
             {weekSub}
           </Text>
         </Animated.View>
@@ -284,10 +307,10 @@ export default function Workouts() {
             size={24}
             color={prCount > 0 ? colors.primary : colors.onSurfaceVariant}
           />
-          <Text variant="titleLarge" style={{ color: prCount > 0 ? colors.onSurface : colors.onSurfaceVariant }}>
+          <Text variant="title" style={{ color: prCount > 0 ? colors.onSurface : colors.onSurfaceVariant, fontSize: 20 }}>
             {prCount}
           </Text>
-          <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
             recent
           </Text>
         </Animated.View>
@@ -295,111 +318,109 @@ export default function Workouts() {
 
       {/* Resume active session banner */}
       {active && (
-        <Card
-          style={[styles.banner, { backgroundColor: colors.primaryContainer }]}
+        <Pressable
+          style={[styles.banner, { backgroundColor: colors.primaryContainer, borderRadius: 12, padding: 18 }]}
           onPress={() => router.push(`/session/${active.id}`)}
           accessibilityLabel={`Resume active workout: ${active.name}`}
           accessibilityRole="button"
         >
-          <Card.Content>
-            <Text variant="titleSmall" style={{ color: colors.onPrimaryContainer }}>
-              ⏱ Active Workout: {active.name}
-            </Text>
-            <Text variant="bodySmall" style={{ color: colors.onPrimaryContainer }}>
-              Tap to resume
-            </Text>
-          </Card.Content>
-        </Card>
+          <Text variant="subtitle" style={{ color: colors.onPrimaryContainer, fontSize: 15 }}>
+            ⏱ Active Workout: {active.name}
+          </Text>
+          <Text variant="caption" style={{ color: colors.onPrimaryContainer }}>
+            Tap to resume
+          </Text>
+        </Pressable>
       )}
 
       {/* Today's Schedule Card — overrides next workout when schedule exists */}
       {todaySchedule && !todayDone && (
-        <Card
-          style={[styles.nextBanner, { backgroundColor: colors.secondaryContainer }]}
+        <Pressable
+          style={[styles.nextBanner, { backgroundColor: colors.secondaryContainer, borderRadius: 12, padding: 18 }]}
           onPress={startFromSchedule}
           accessibilityLabel={`Today's workout: ${todaySchedule.template_name}. Tap to start.`}
           accessibilityRole="button"
         >
-          <Card.Content style={styles.nextContent}>
+          <View style={styles.nextContent}>
             <MaterialCommunityIcons name="calendar-check" size={24} color={colors.onSecondaryContainer} />
             <View style={styles.nextText}>
-              <Text variant="titleSmall" style={{ color: colors.onSecondaryContainer }}>
+              <Text variant="subtitle" style={{ color: colors.onSecondaryContainer, fontSize: 15 }}>
                 Today: {todaySchedule.template_name}
               </Text>
-              <Text variant="bodySmall" style={{ color: colors.onSecondaryContainer }}>
+              <Text variant="caption" style={{ color: colors.onSecondaryContainer }}>
                 {todaySchedule.exercise_count} exercises · Tap to start
               </Text>
             </View>
-          </Card.Content>
-        </Card>
+          </View>
+        </Pressable>
       )}
 
       {todaySchedule && todayDone && (
-        <Card
-          style={[styles.nextBanner, { backgroundColor: colors.primaryContainer }]}
+        <Pressable
+          style={[styles.nextBanner, { backgroundColor: colors.primaryContainer, borderRadius: 12, padding: 18 }]}
           onPress={startFromSchedule}
           accessibilityLabel={`Completed: ${todaySchedule.template_name}. Tap to train again.`}
           accessibilityRole="button"
         >
-          <Card.Content style={styles.nextContent}>
+          <View style={styles.nextContent}>
             <MaterialCommunityIcons name="check-circle" size={24} color={colors.onPrimaryContainer} />
             <View style={styles.nextText}>
-              <Text variant="titleSmall" style={{ color: colors.onPrimaryContainer }}>
+              <Text variant="subtitle" style={{ color: colors.onPrimaryContainer, fontSize: 15 }}>
                 ✅ Completed: {todaySchedule.template_name}
               </Text>
-              <Text variant="bodySmall" style={{ color: colors.onPrimaryContainer }}>
+              <Text variant="caption" style={{ color: colors.onPrimaryContainer }}>
                 Train again
               </Text>
             </View>
-          </Card.Content>
-        </Card>
+          </View>
+        </Pressable>
       )}
 
       {!todaySchedule && adherence.some((a) => a.scheduled) && (
-        <Card
-          style={[styles.nextBanner, { backgroundColor: colors.surface }]}
+        <View
+          style={[styles.nextBanner, { backgroundColor: colors.surface, borderRadius: 12, padding: 18 }]}
           accessibilityLabel="Rest day. No workout scheduled."
         >
-          <Card.Content style={styles.nextContent}>
+          <View style={styles.nextContent}>
             <MaterialCommunityIcons name="bed" size={24} color={colors.onSurfaceVariant} />
             <View style={styles.nextText}>
-              <Text variant="titleSmall" style={{ color: colors.onSurface }}>
+              <Text variant="subtitle" style={{ color: colors.onSurface, fontSize: 15 }}>
                 Rest Day
               </Text>
-              <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                 No workout scheduled
               </Text>
             </View>
-          </Card.Content>
-        </Card>
+          </View>
+        </View>
       )}
 
       {/* Next Workout Banner (visible when NO schedule exists) */}
       {nextWorkout && !todaySchedule && !adherence.some((a) => a.scheduled) && (
-        <Card
-          style={[styles.nextBanner, { backgroundColor: colors.secondaryContainer }]}
+        <Pressable
+          style={[styles.nextBanner, { backgroundColor: colors.secondaryContainer, borderRadius: 12, padding: 18 }]}
           onPress={startNextWorkout}
           accessibilityLabel={`Next workout: ${nextWorkout.day.label || nextWorkout.day.template_name || "workout"} from ${nextWorkout.program.name}`}
           accessibilityRole="button"
         >
-          <Card.Content style={styles.nextContent}>
+          <View style={styles.nextContent}>
             <MaterialCommunityIcons name="play-circle" size={24} color={colors.onSecondaryContainer} />
             <View style={styles.nextText}>
-              <Text variant="titleSmall" style={{ color: colors.onSecondaryContainer }}>
+              <Text variant="subtitle" style={{ color: colors.onSecondaryContainer, fontSize: 15 }}>
                 Next: {nextWorkout.day.label || nextWorkout.day.template_name || "Workout"}
               </Text>
-              <Text variant="bodySmall" style={{ color: colors.onSecondaryContainer }}>
+              <Text variant="caption" style={{ color: colors.onSecondaryContainer }}>
                 {nextWorkout.program.name} · Tap to start
               </Text>
             </View>
-          </Card.Content>
-        </Card>
+          </View>
+        </Pressable>
       )}
 
       {/* Program indicator when schedule is active */}
       {nextWorkout && adherence.some((a) => a.scheduled) && (
         <Text
-          variant="bodySmall"
+          variant="caption"
           style={{ color: colors.onSurfaceVariant, marginBottom: 8, textAlign: "center" }}
           accessibilityLabel={`Program ${nextWorkout.program.name}: Schedule active`}
         >
@@ -431,7 +452,7 @@ export default function Workouts() {
               )}
             />
           </View>
-          <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant, textAlign: "center", marginTop: 4 }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, textAlign: "center", marginTop: 4 }}>
             {adherence.filter((a) => a.scheduled && a.completed).length} of{" "}
             {adherence.filter((a) => a.scheduled).length} this week{" "}
             {adherence.filter((a) => a.scheduled).every((a) => a.completed) && adherence.some((a) => a.scheduled) ? "🔥" : "🎯"}
@@ -442,20 +463,21 @@ export default function Workouts() {
       {/* Quick Start */}
       <View style={styles.actionRow}>
         <Button
-          mode="contained"
-          icon="flash"
+          variant="default"
           onPress={quickStart}
-          contentStyle={styles.quickStartContent}
           accessibilityLabel="Quick start workout"
         >
-          Quick Start
+          <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+            <MaterialCommunityIcons name="flash" size={18} color={colors.onPrimary} />
+            <Text style={{ color: colors.onPrimary, fontWeight: "600" }}>Quick Start</Text>
+          </View>
         </Button>
       </View>
 
       {/* Segmented Control */}
-      <SegmentedButtons
+      <SegmentedControl
         value={segment}
-        onValueChange={setUserSegment}
+        onValueChange={(v) => setUserSegment(v)}
         buttons={[
           {
             value: "templates",
@@ -476,36 +498,35 @@ export default function Workouts() {
           {/* Templates */}
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
-              <Text variant="titleMedium" style={{ color: colors.onBackground }}>
+              <Text variant="subtitle" style={{ color: colors.onBackground }}>
                 Templates
               </Text>
               <Button
-                mode="text"
-                icon="plus"
-                compact
+                variant="ghost"
+                size="sm"
                 onPress={() => router.push("/template/create")}
                 accessibilityLabel="Create new template"
               >
-                Create
+                <View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+                  <MaterialCommunityIcons name="plus" size={16} color={colors.primary} />
+                  <Text style={{ color: colors.primary, fontSize: 14 }}>Create</Text>
+                </View>
               </Button>
             </View>
             {allTemplates.length === 0 ? (
               <View style={styles.empty}>
                 <Text
-                  variant="bodyMedium"
                   style={{ color: colors.onSurfaceVariant }}
                 >
                   Create your first workout template
                 </Text>
                 <Button
-                  mode="outlined"
+                  variant="outline"
                   onPress={() => router.push("/template/create")}
                   style={styles.emptyBtn}
-                  contentStyle={styles.btnContent}
                   accessibilityLabel="Create your first template"
-                >
-                  Create Template
-                </Button>
+                  label="Create Template"
+                />
               </View>
             ) : (
               <View style={styles.flowList}>
@@ -534,32 +555,23 @@ export default function Workouts() {
                       meta={metaBadges}
                       action={
                         isStarter ? (
-                          <Menu
-                            visible={menu === item.id}
-                            onDismiss={() => setMenu(null)}
-                            anchor={
-                              <IconButton
-                                icon="dots-vertical"
-                                size={20}
-                                onPress={() => setMenu(item.id)}
-                                accessibilityLabel={`Options for ${meta?.name || item.name}`}
-                              />
-                            }
+                          <Pressable
+                            onPress={() => showTemplateOptions(item)}
+                            accessibilityLabel={`Options for ${meta?.name || item.name}`}
+                            hitSlop={8}
+                            style={{ padding: 8 }}
                           >
-                            <Menu.Item
-                              onPress={() => handleDuplicateTemplate(item)}
-                              title="Duplicate"
-                              leadingIcon="content-copy"
-                              accessibilityLabel="Duplicate template for editing"
-                            />
-                          </Menu>
+                            <MaterialCommunityIcons name="dots-vertical" size={20} color={colors.onSurfaceVariant} />
+                          </Pressable>
                         ) : (
-                          <IconButton
-                            icon="pencil"
-                            size={20}
+                          <Pressable
                             onPress={() => router.push(`/template/${item.id}`)}
                             accessibilityLabel={`Edit template ${item.name}`}
-                          />
+                            hitSlop={8}
+                            style={{ padding: 8 }}
+                          >
+                            <MaterialCommunityIcons name="pencil" size={20} color={colors.onSurfaceVariant} />
+                          </Pressable>
                         )
                       }
                     />
@@ -574,23 +586,24 @@ export default function Workouts() {
           {/* Programs */}
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
-              <Text variant="titleMedium" style={{ color: colors.onBackground }}>
+              <Text variant="subtitle" style={{ color: colors.onBackground }}>
                 Programs
               </Text>
               <Button
-                mode="text"
-                icon="plus"
-                compact
+                variant="ghost"
+                size="sm"
                 onPress={() => router.push("/program/create")}
                 accessibilityLabel="Create new program"
               >
-                Create
+                <View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+                  <MaterialCommunityIcons name="plus" size={16} color={colors.primary} />
+                  <Text style={{ color: colors.primary, fontSize: 14 }}>Create</Text>
+                </View>
               </Button>
             </View>
             {allPrograms.length === 0 ? (
               <View style={styles.empty}>
                 <Text
-                  variant="bodyMedium"
                   style={{ color: colors.onSurfaceVariant }}
                   accessibilityRole="text"
                   accessibilityLabel="No programs yet. Create your first program."
@@ -598,14 +611,12 @@ export default function Workouts() {
                   Create your first program
                 </Text>
                 <Button
-                  mode="outlined"
+                  variant="outline"
                   onPress={() => router.push("/program/create")}
                   style={styles.emptyBtn}
-                  contentStyle={styles.btnContent}
                   accessibilityLabel="Create your first program"
-                >
-                  Create Program
-                </Button>
+                  label="Create Program"
+                />
               </View>
             ) : (
               <View style={styles.flowList}>
@@ -630,25 +641,14 @@ export default function Workouts() {
                       meta={metaBadges}
                       action={
                         item.is_starter ? (
-                          <Menu
-                            visible={menu === `prog-${item.id}`}
-                            onDismiss={() => setMenu(null)}
-                            anchor={
-                              <IconButton
-                                icon="dots-vertical"
-                                size={20}
-                                onPress={() => setMenu(`prog-${item.id}`)}
-                                accessibilityLabel={`Options for ${item.name}`}
-                              />
-                            }
+                          <Pressable
+                            onPress={() => showProgramOptions(item)}
+                            accessibilityLabel={`Options for ${item.name}`}
+                            hitSlop={8}
+                            style={{ padding: 8 }}
                           >
-                            <Menu.Item
-                              onPress={() => handleDuplicateProgram(item)}
-                              title="Duplicate"
-                              leadingIcon="content-copy"
-                              accessibilityLabel="Duplicate program for editing"
-                            />
-                          </Menu>
+                            <MaterialCommunityIcons name="dots-vertical" size={20} color={colors.onSurfaceVariant} />
+                          </Pressable>
                         ) : <></>
                       }
                     />
@@ -664,26 +664,24 @@ export default function Workouts() {
       <View style={styles.section}>
         <View style={styles.sectionHeader}>
           <Text
-            variant="titleMedium"
+            variant="subtitle"
             style={{ color: colors.onBackground }}
           >
             Recent Workouts
           </Text>
           {sessions.length > 0 && (
             <Button
-              mode="text"
-              compact
+              variant="ghost"
+              size="sm"
               onPress={() => router.push("/history")}
               accessibilityLabel="View all workout history"
-            >
-              View All History
-            </Button>
+              label="View All History"
+            />
           )}
         </View>
         {sessions.length === 0 ? (
           <View style={styles.empty}>
             <Text
-              variant="bodyMedium"
               style={{ color: colors.onSurfaceVariant }}
             >
               No workouts yet. Start one above!
@@ -700,39 +698,37 @@ export default function Workouts() {
               const rpeStr = rpe != null ? ` · RPE ${Math.round(rpe * 10) / 10}` : "";
               return (
               <Animated.View entering={FadeInDown.delay(index * 60).duration(300)}>
-              <Card
-                style={[styles.flowCard, { backgroundColor: colors.surface }]}
+              <Pressable
+                style={[styles.flowCard, { backgroundColor: colors.surface, borderRadius: 12, padding: 18 }]}
                 onPress={() =>
                   router.push(`/session/detail/${item.id}`)
                 }
                 accessibilityLabel={`View workout: ${item.name}, ${formatDateShort(item.started_at)}, ${formatDuration(item.duration_seconds)}, ${setCounts2[item.id] ?? 0} sets${rpeStr}`}
                 accessibilityRole="button"
               >
-                <Card.Content>
+                <Text
+                  variant="subtitle"
+                  style={{ color: colors.onSurface, fontSize: 15 }}
+                >
+                  {item.name}
+                </Text>
+                <View style={styles.recentRow}>
                   <Text
-                    variant="titleSmall"
-                    style={{ color: colors.onSurface }}
+                    variant="caption"
+                    style={{ color: colors.onSurfaceVariant, flex: 1 }}
                   >
-                    {item.name}
+                    {formatDateShort(item.started_at)} · {formatDuration(item.duration_seconds)} ·{" "}
+                    {setCounts2[item.id] ?? 0} sets
                   </Text>
-                  <View style={styles.recentRow}>
-                    <Text
-                      variant="bodySmall"
-                      style={{ color: colors.onSurfaceVariant, flex: 1 }}
-                    >
-                      {formatDateShort(item.started_at)} · {formatDuration(item.duration_seconds)} ·{" "}
-                      {setCounts2[item.id] ?? 0} sets
-                    </Text>
-                    {rpe != null && (
-                      <View style={[styles.rpeTag, { backgroundColor: rpeColor(rpe) }]}>
-                        <Text style={{ color: rpeText(rpe), fontSize: 12, fontWeight: "600" }}>
-                          RPE {Math.round(rpe * 10) / 10}
-                        </Text>
-                      </View>
-                    )}
-                  </View>
-                </Card.Content>
-              </Card>
+                  {rpe != null && (
+                    <View style={[styles.rpeTag, { backgroundColor: rpeColor(rpe) }]}>
+                      <Text style={{ color: rpeText(rpe), fontSize: 12, fontWeight: "600" }}>
+                        RPE {Math.round(rpe * 10) / 10}
+                      </Text>
+                    </View>
+                  )}
+                </View>
+              </Pressable>
               </Animated.View>
               );
             }}
@@ -792,9 +788,6 @@ const styles = StyleSheet.create({
   segmented: {
     marginBottom: 16,
   },
-  quickStartContent: {
-    paddingVertical: 8,
-  },
   section: {
     marginBottom: 20,
   },
@@ -828,9 +821,6 @@ const styles = StyleSheet.create({
   },
   emptyBtn: {
     marginTop: 8,
-  },
-  btnContent: {
-    paddingVertical: 8,
   },
   adherence: {
     marginBottom: 12,

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { LayoutAnimation, SectionList, StyleSheet, View } from "react-native";
-import { Card, FAB, IconButton, ProgressBar, Snackbar, Text } from "react-native-paper";
+import { LayoutAnimation, SectionList, StyleSheet, TouchableOpacity, View } from "react-native";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { Text } from "@/components/ui/text";
+import { Card, CardContent } from "@/components/ui/card";
+import { FAB } from "@/components/ui/fab";
+import { Progress } from "@/components/ui/progress";
+import { useToast } from "@/components/ui/bna-toast";
 import { router, useFocusEffect } from "expo-router";
 import InlineFoodSearch from "../../components/InlineFoodSearch";
 import {
@@ -39,7 +44,7 @@ export default function Nutrition() {
   const [logs, setLogs] = useState<DailyLog[]>([]);
   const [summary, setSummary] = useState({ calories: 0, protein: 0, carbs: 0, fat: 0 });
   const [targets, setTargets] = useState<MacroTargets | null>(null);
-  const [snack, setSnack] = useState("");
+  const { toast } = useToast();
   const deleted = useRef<{ log: DailyLog; timer: ReturnType<typeof setTimeout> } | null>(null);
   const [showAddCard, setShowAddCard] = useState(false);
 
@@ -73,7 +78,7 @@ export default function Nutrition() {
         deleted.current = null;
       }, 4000),
     };
-    setSnack(`${log.food?.name ?? "Food"} removed`);
+    toast(`${log.food?.name ?? "Food"} removed`);
     load();
   };
 
@@ -83,7 +88,6 @@ export default function Nutrition() {
     const dl = deleted.current.log;
     await addDailyLog(dl.food_entry_id, dl.date, dl.meal, dl.servings);
     deleted.current = null;
-    setSnack("");
     load();
   }, [load]);
 
@@ -102,20 +106,19 @@ export default function Nutrition() {
       contentContainerStyle={[styles.scrollContent, { paddingBottom: tabBarHeight + 16 }]}
       stickySectionHeadersEnabled={false}
       renderSectionHeader={({ section }) => (
-        <Text variant="titleSmall" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
+        <Text variant="subtitle" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
           {section.title}
         </Text>
       )}
       renderItem={({ item }) => (
         <SwipeToDelete onDelete={() => remove(item)}>
           <Card style={[styles.foodCard, { backgroundColor: colors.surface }]}>
-            <Card.Content style={styles.foodRow}>
+            <CardContent style={styles.foodRow}>
               <View style={{ flex: 1 }}>
-                <Text variant="bodyMedium" style={{ color: colors.onSurface }}>
+                <Text variant="body" style={{ color: colors.onSurface }}>
                   {item.food?.name ?? "Unknown"}
                 </Text>
-                <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
-                  {Math.round((item.food?.calories ?? 0) * item.servings)} cal
+                <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                   {item.servings !== 1 ? ` · ${item.servings}×` : ""}
                   {" · "}
                   {Math.round((item.food?.protein ?? 0) * item.servings)}p
@@ -125,8 +128,8 @@ export default function Nutrition() {
                   {Math.round((item.food?.fat ?? 0) * item.servings)}f
                 </Text>
               </View>
-              <IconButton icon="delete-outline" size={20} onPress={() => remove(item)} accessibilityLabel={`Remove ${item.food?.name ?? "food"}`} />
-            </Card.Content>
+              <TouchableOpacity onPress={() => remove(item)} accessibilityLabel={`Remove ${item.food?.name ?? "food"}`} hitSlop={8} style={{ padding: 8 }}><MaterialCommunityIcons name="delete-outline" size={20} color={colors.onSurface} /></TouchableOpacity>
+            </CardContent>
           </Card>
         </SwipeToDelete>
       )}
@@ -134,22 +137,22 @@ export default function Nutrition() {
       ListHeaderComponent={
         <>
           <View style={styles.header}>
-            <IconButton icon="chevron-left" onPress={prev} accessibilityLabel="Previous day" />
-            <Text variant="titleMedium" style={{ color: colors.onBackground }}>
+            <TouchableOpacity onPress={prev} accessibilityLabel="Previous day" hitSlop={8} style={{ padding: 8 }}><MaterialCommunityIcons name="chevron-left" size={24} color={colors.onSurface} /></TouchableOpacity>
+            <Text variant="title" style={{ color: colors.onBackground }}>
               {label(date)}
             </Text>
-            <IconButton icon="chevron-right" onPress={next} accessibilityLabel="Next day" />
+            <TouchableOpacity onPress={next} accessibilityLabel="Next day" hitSlop={8} style={{ padding: 8 }}><MaterialCommunityIcons name="chevron-right" size={24} color={colors.onSurface} /></TouchableOpacity>
           </View>
 
           {targets && (
             <Card style={[styles.card, { backgroundColor: colors.surface, marginHorizontal: 16 }]}>
-              <Card.Content>
+              <CardContent>
                 <MacroRow label="Calories" value={summary.calories} target={targets.calories} color={colors.primary} colors={colors} />
                 <MacroRow label="Protein" value={summary.protein} target={targets.protein} color={semantic.protein} unit="g" colors={colors} />
                 <MacroRow label="Carbs" value={summary.carbs} target={targets.carbs} color={semantic.carbs} unit="g" colors={colors} />
                 <MacroRow label="Fat" value={summary.fat} target={targets.fat} color={semantic.fat} unit="g" colors={colors} />
                 <Text
-                  variant="labelSmall"
+                  variant="caption"
                   style={{ color: colors.primary, marginTop: 8 }}
                   onPress={() => router.push("/nutrition/targets")}
                   accessibilityLabel="Edit macro targets"
@@ -157,14 +160,14 @@ export default function Nutrition() {
                 >
                   Edit Targets →
                 </Text>
-              </Card.Content>
+              </CardContent>
             </Card>
           )}
         </>
       }
       ListEmptyComponent={
         <View style={styles.empty}>
-          <Text variant="bodyLarge" style={{ color: colors.onSurfaceVariant, textAlign: "center" }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, textAlign: "center" }}>
             No food logged yet.{"\n"}Tap + to add your first meal.
           </Text>
         </View>
@@ -185,8 +188,8 @@ export default function Nutrition() {
 
   const handleSnack = useCallback((message: string, undoFn?: () => Promise<void>) => {
     undoRef.current = undoFn ?? null;
-    setSnack(message);
-  }, []);
+    toast(message);
+  }, [toast]);
 
   const handleUndo = useCallback(async () => {
     if (undoRef.current) {
@@ -195,7 +198,6 @@ export default function Nutrition() {
     } else {
       await undo();
     }
-    setSnack("");
   }, [undo]);
 
   if (layout.atLeastMedium) {
@@ -211,14 +213,6 @@ export default function Nutrition() {
             />
           </View>
         </View>
-        <Snackbar
-          visible={!!snack}
-          onDismiss={() => setSnack("")}
-          duration={4000}
-          action={{ label: "Undo", onPress: handleUndo }}
-        >
-          {snack}
-        </Snackbar>
       </View>
     );
   }
@@ -244,15 +238,6 @@ export default function Nutrition() {
         onPress={toggleAddCard}
         accessibilityLabel={showAddCard ? "Close add food" : "Add food"}
       />
-
-      <Snackbar
-        visible={!!snack}
-        onDismiss={() => setSnack("")}
-        duration={4000}
-        action={{ label: "Undo", onPress: handleUndo }}
-      >
-        {snack}
-      </Snackbar>
     </View>
   );
 }
@@ -276,15 +261,15 @@ function MacroRow({
   return (
     <View style={styles.macro}>
       <View style={styles.macroHeader}>
-        <Text variant="bodySmall" style={{ color: colors.onSurface }}>
+        <Text variant="caption" style={{ color: colors.onSurface }}>
           {name}
         </Text>
-        <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
           {Math.round(value)}{u} / {Math.round(target)}{u}
         </Text>
       </View>
-      <ProgressBar
-        progress={target > 0 ? Math.min(value / target, 1) : 0}
+      <Progress
+        value={target > 0 ? Math.min(value / target, 1) * 100 : 0}
         color={color}
         style={styles.bar}
       />

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -13,7 +13,6 @@ import {
   getDailySummary,
   getMacroTargets,
   deleteDailyLog,
-  addDailyLog,
 } from "../../lib/db";
 import type { DailyLog, MacroTargets } from "../../lib/types";
 import { MEALS, MEAL_LABELS } from "../../lib/types";
@@ -44,7 +43,7 @@ export default function Nutrition() {
   const [logs, setLogs] = useState<DailyLog[]>([]);
   const [summary, setSummary] = useState({ calories: 0, protein: 0, carbs: 0, fat: 0 });
   const [targets, setTargets] = useState<MacroTargets | null>(null);
-  const { toast } = useToast();
+  const { info } = useToast();
   const deleted = useRef<{ log: DailyLog; timer: ReturnType<typeof setTimeout> } | null>(null);
   const [showAddCard, setShowAddCard] = useState(false);
 
@@ -78,18 +77,9 @@ export default function Nutrition() {
         deleted.current = null;
       }, 4000),
     };
-    toast(`${log.food?.name ?? "Food"} removed`);
+    info(`${log.food?.name ?? "Food"} removed`);
     load();
   };
-
-  const undo = useCallback(async () => {
-    if (!deleted.current) return;
-    clearTimeout(deleted.current.timer);
-    const dl = deleted.current.log;
-    await addDailyLog(dl.food_entry_id, dl.date, dl.meal, dl.servings);
-    deleted.current = null;
-    load();
-  }, [load]);
 
   const sections = useMemo(() =>
     MEALS
@@ -188,17 +178,8 @@ export default function Nutrition() {
 
   const handleSnack = useCallback((message: string, undoFn?: () => Promise<void>) => {
     undoRef.current = undoFn ?? null;
-    toast(message);
-  }, [toast]);
-
-  const handleUndo = useCallback(async () => {
-    if (undoRef.current) {
-      await undoRef.current();
-      undoRef.current = null;
-    } else {
-      await undo();
-    }
-  }, [undo]);
+    info(message);
+  }, [info]);
 
   if (layout.atLeastMedium) {
     return (
@@ -246,7 +227,7 @@ function MacroRow({
   label: name,
   value,
   target,
-  color,
+  color: _color, // eslint-disable-line @typescript-eslint/no-unused-vars
   unit,
   colors,
 }: {
@@ -270,7 +251,6 @@ function MacroRow({
       </View>
       <Progress
         value={target > 0 ? Math.min(value / target, 1) * 100 : 0}
-        color={color}
         style={styles.bar}
       />
     </View>

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -13,6 +13,7 @@ import {
   getDailySummary,
   getMacroTargets,
   deleteDailyLog,
+  addDailyLog,
 } from "../../lib/db";
 import type { DailyLog, MacroTargets } from "../../lib/types";
 import { MEALS, MEAL_LABELS } from "../../lib/types";
@@ -77,9 +78,20 @@ export default function Nutrition() {
         deleted.current = null;
       }, 4000),
     };
-    info(`${log.food?.name ?? "Food"} removed`);
+    info(`${log.food?.name ?? "Food"} removed`, {
+      action: { label: "Undo", onPress: undo },
+    });
     load();
   };
+
+  const undo = useCallback(async () => {
+    if (!deleted.current) return;
+    clearTimeout(deleted.current.timer);
+    const dl = deleted.current.log;
+    await addDailyLog(dl.food_entry_id, dl.date, dl.meal, dl.servings);
+    deleted.current = null;
+    load();
+  }, [load]);
 
   const sections = useMemo(() =>
     MEALS
@@ -170,16 +182,22 @@ export default function Nutrition() {
     setShowAddCard((v) => !v);
   }, []);
 
-  const undoRef = useRef<(() => Promise<void>) | null>(null);
-
   const handleFoodLogged = useCallback(() => {
     load();
   }, [load]);
 
   const handleSnack = useCallback((message: string, undoFn?: () => Promise<void>) => {
-    undoRef.current = undoFn ?? null;
-    info(message);
-  }, [info]);
+    const onPress = async () => {
+      if (undoFn) {
+        await undoFn();
+      } else {
+        await undo();
+      }
+    };
+    info(message, {
+      action: { label: "Undo", onPress },
+    });
+  }, [info, undo]);
 
   if (layout.atLeastMedium) {
     return (

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -186,8 +186,6 @@ export default function Progress() {
     }
     const filtered = entries.filter((e) => e.id !== item.id);
     setEntries(filtered);
-    toastInfo("Entry deleted");
-
     const timer = setTimeout(async () => {
       await deleteBodyWeight(item.id);
       undoRef.current = null;
@@ -195,6 +193,17 @@ export default function Progress() {
     }, 3000);
 
     undoRef.current = { id: item.id, timer };
+
+    toastInfo("Entry deleted", {
+      action: { label: "Undo", onPress: handleUndo },
+    });
+  };
+
+  const handleUndo = () => {
+    if (!undoRef.current) return;
+    clearTimeout(undoRef.current.timer);
+    undoRef.current = null;
+    loadBody();
   };
 
   const loadMore = async () => {

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -3,12 +3,22 @@ import {
   Alert,
   FlatList,
   Modal,
+  Pressable,
   StyleSheet,
   View,
   useWindowDimensions,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Button, Card, Divider, FAB, IconButton, ProgressBar, SegmentedButtons, Snackbar, Text, TextInput } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { FAB } from "@/components/ui/fab";
+import { Progress as ProgressBar } from "@/components/ui/progress";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Text } from "@/components/ui/text";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/bna-toast";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useFocusEffect, useRouter } from "expo-router";
 import { CartesianChart, Bar, Line } from "victory-native";
 import {
@@ -52,6 +62,7 @@ export default function Progress() {
   const tabBarHeight = useFloatingTabBarHeight();
   const router = useRouter();
   const { width: screenWidth } = useWindowDimensions();
+  const { info: toastInfo } = useToast();
   const [segment, setSegment] = useState("workouts");
 
   // Workout state
@@ -69,7 +80,6 @@ export default function Progress() {
   const [chart, setChart] = useState<{ date: string; weight: number }[]>([]);
   const [measurements, setMeasurements] = useState<BodyMeasurements | null>(null);
   const [modal, setModal] = useState(false);
-  const [snack, setSnack] = useState("");
   const undoRef = useRef<{ id: string; timer: ReturnType<typeof setTimeout> } | null>(null);
 
   // Weight log modal state
@@ -176,7 +186,7 @@ export default function Progress() {
     }
     const filtered = entries.filter((e) => e.id !== item.id);
     setEntries(filtered);
-    setSnack("Entry deleted");
+    toastInfo("Entry deleted");
 
     const timer = setTimeout(async () => {
       await deleteBodyWeight(item.id);
@@ -185,14 +195,6 @@ export default function Progress() {
     }, 3000);
 
     undoRef.current = { id: item.id, timer };
-  };
-
-  const handleUndo = () => {
-    if (!undoRef.current) return;
-    clearTimeout(undoRef.current.timer);
-    undoRef.current = null;
-    setSnack("");
-    loadBody();
   };
 
   const loadMore = async () => {
@@ -217,7 +219,7 @@ export default function Progress() {
             <WeeklySummary />
           </View>
           <View style={[styles.center, { flex: 1 }]}>
-            <Text variant="bodyLarge" style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 32 }}>
+            <Text style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 32 }}>
               Complete your first workout to see progress
             </Text>
           </View>
@@ -226,129 +228,119 @@ export default function Progress() {
     }
 
     const achievementsCard = (
-      <Card
-        style={[styles.card, layout.atLeastMedium && styles.wideCard, { backgroundColor: colors.surface }]}
+      <Pressable
+        style={[styles.card, layout.atLeastMedium && styles.wideCard, { backgroundColor: colors.surface, borderRadius: 12, padding: 18 }]}
         onPress={() => router.push("/progress/achievements")}
         accessibilityLabel="Achievements"
         accessibilityRole="button"
         accessibilityHint="View your achievements and milestones"
       >
-        <Card.Content>
-          <View style={styles.cardHeader}>
-            <Text style={{ fontSize: 20, marginRight: 8 }}>🏆</Text>
-            <Text variant="titleMedium" style={{ color: colors.onSurface }}>
-              Achievements
-            </Text>
-          </View>
-          <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
-            Track your milestones and badges
+        <View style={styles.cardHeader}>
+          <Text style={{ fontSize: 20, marginRight: 8 }}>🏆</Text>
+          <Text variant="subtitle" style={{ color: colors.onSurface }}>
+            Achievements
           </Text>
-        </Card.Content>
-      </Card>
+        </View>
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
+          Track your milestones and badges
+        </Text>
+      </Pressable>
     );
 
     const freqCard = freq.length > 0 ? (
-      <Card style={[styles.card, layout.atLeastMedium && styles.wideCard, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 12 }}>
-            Sessions Per Week
-          </Text>
-          <View style={{ width: chartWidth, height: 180 }}>
-            <CartesianChart
-              data={freq.map((f) => ({ week: f.week, count: f.count }))}
-              xKey="week"
-              yKeys={["count"]}
-              domainPadding={{ left: 20, right: 20 }}
-            >
-              {({ points, chartBounds }) => (
-                <Bar
-                  points={points.count}
-                  chartBounds={chartBounds}
-                  color={colors.primary}
-                  roundedCorners={{ topLeft: 4, topRight: 4 }}
-                />
-              )}
-            </CartesianChart>
-          </View>
-        </Card.Content>
+      <Card style={[styles.card, layout.atLeastMedium && styles.wideCard]}>
+        <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
+          Sessions Per Week
+        </Text>
+        <View style={{ width: chartWidth, height: 180 }}>
+          <CartesianChart
+            data={freq.map((f) => ({ week: f.week, count: f.count }))}
+            xKey="week"
+            yKeys={["count"]}
+            domainPadding={{ left: 20, right: 20 }}
+          >
+            {({ points, chartBounds }) => (
+              <Bar
+                points={points.count}
+                chartBounds={chartBounds}
+                color={colors.primary}
+                roundedCorners={{ topLeft: 4, topRight: 4 }}
+              />
+            )}
+          </CartesianChart>
+        </View>
       </Card>
     ) : null;
 
     const volCard = vol.length > 0 ? (
-      <Card style={[styles.card, layout.atLeastMedium && styles.wideCard, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 12 }}>
-            Weekly Volume (kg)
-          </Text>
-          <View style={{ width: chartWidth, height: 180 }}>
-            <CartesianChart
-              data={vol.map((v) => ({ week: v.week, volume: v.volume }))}
-              xKey="week"
-              yKeys={["volume"]}
-              domainPadding={{ left: 20, right: 20 }}
-            >
-              {({ points, chartBounds }) => (
-                <Bar
-                  points={points.volume}
-                  chartBounds={chartBounds}
-                  color={colors.primary}
-                  roundedCorners={{ topLeft: 4, topRight: 4 }}
-                />
-              )}
-            </CartesianChart>
-          </View>
-        </Card.Content>
+      <Card style={[styles.card, layout.atLeastMedium && styles.wideCard]}>
+        <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
+          Weekly Volume (kg)
+        </Text>
+        <View style={{ width: chartWidth, height: 180 }}>
+          <CartesianChart
+            data={vol.map((v) => ({ week: v.week, volume: v.volume }))}
+            xKey="week"
+            yKeys={["volume"]}
+            domainPadding={{ left: 20, right: 20 }}
+          >
+            {({ points, chartBounds }) => (
+              <Bar
+                points={points.volume}
+                chartBounds={chartBounds}
+                color={colors.primary}
+                roundedCorners={{ topLeft: 4, topRight: 4 }}
+              />
+            )}
+          </CartesianChart>
+        </View>
       </Card>
     ) : null;
 
     const prCard = (
-      <Card style={[styles.card, layout.atLeastMedium && styles.wideCard, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 12 }}>
-            Personal Records
+      <Card style={[styles.card, layout.atLeastMedium && styles.wideCard]}>
+        <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
+          Personal Records
+        </Text>
+        {prs.length === 0 ? (
+          <Text style={{ color: colors.onSurfaceVariant }}>
+            No records yet — start lifting!
           </Text>
-          {prs.length === 0 ? (
-            <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
-              No records yet — start lifting!
-            </Text>
-          ) : (
-            prs.map((pr) => (
-              <View key={pr.exercise_id} style={[styles.prRow, { borderBottomColor: colors.outlineVariant }]}>
-                <Text variant="bodyMedium" style={{ color: colors.onSurface, flex: 1 }}>
-                  {pr.name}
-                </Text>
-                <Text variant="titleSmall" style={{ color: colors.primary }}>
-                  {pr.max_weight} kg
-                </Text>
-              </View>
-            ))
-          )}
-        </Card.Content>
+        ) : (
+          prs.map((pr) => (
+            <View key={pr.exercise_id} style={[styles.prRow, { borderBottomColor: colors.outlineVariant }]}>
+              <Text style={{ color: colors.onSurface, flex: 1 }}>
+                {pr.name}
+              </Text>
+              <Text variant="subtitle" style={{ color: colors.primary, fontSize: 15 }}>
+                {pr.max_weight} kg
+              </Text>
+            </View>
+          ))
+        )}
       </Card>
     );
 
     const sessionsCard = (
-      <Card style={[styles.card, layout.atLeastMedium && styles.wideCard, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 12 }}>
-            Recent Sessions
-          </Text>
-          {sessions.map((s, i) => (
-            <View key={s.id}>
-              <View style={styles.sessionRow}>
-                <View style={{ flex: 1 }}>
-                  <Text variant="bodyMedium" style={{ color: colors.onSurface }}>
-                    {s.name}
-                  </Text>
-                  <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
-                    {formatDateShort(s.started_at)} · {formatDuration(s.duration_seconds)} · {s.set_count} sets
-                  </Text>
-                </View>
+      <Card style={[styles.card, layout.atLeastMedium && styles.wideCard]}>
+        <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
+          Recent Sessions
+        </Text>
+        {sessions.map((s, i) => (
+          <View key={s.id}>
+            <View style={styles.sessionRow}>
+              <View style={{ flex: 1 }}>
+                <Text style={{ color: colors.onSurface }}>
+                  {s.name}
+                </Text>
+                <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                  {formatDateShort(s.started_at)} · {formatDuration(s.duration_seconds)} · {s.set_count} sets
+                </Text>
               </View>
-              {i < sessions.length - 1 && <Divider style={{ marginVertical: 6 }} />}
             </View>
-          ))}
-        </Card.Content>
+            {i < sessions.length - 1 && <Separator style={{ marginVertical: 6 }} />}
+          </View>
+        ))}
       </Card>
     );
 
@@ -396,10 +388,10 @@ export default function Progress() {
     if (total === 0 && !measurements) {
       return (
         <View style={[styles.center, { flex: 1 }]}>
-          <Text variant="headlineMedium" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
+          <Text variant="heading" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
             📏
           </Text>
-          <Text variant="bodyLarge" style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
+          <Text style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
             Log your first weigh-in
           </Text>
           <FAB
@@ -432,104 +424,91 @@ export default function Progress() {
 
     // Weight card
     const weightCard = latest ? (
-      <Card style={[styles.card, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <View style={styles.cardHeader}>
-            <Text variant="titleMedium" style={{ color: colors.onSurface }}>
-              Current Weight
-            </Text>
-            <Button
-              mode="text"
-              compact
-              onPress={toggleUnit}
-              accessibilityLabel={`Switch to ${unit === "kg" ? "pounds" : "kilograms"}`}
-            >
-              {unit === "kg" ? "kg → lb" : "lb → kg"}
-            </Button>
-          </View>
+      <Card style={styles.card}>
+        <View style={styles.cardHeader}>
+          <Text variant="subtitle" style={{ color: colors.onSurface }}>
+            Current Weight
+          </Text>
+          <Button
+            variant="ghost"
+            size="sm"
+            onPress={toggleUnit}
+            accessibilityLabel={`Switch to ${unit === "kg" ? "pounds" : "kilograms"}`}
+            label={unit === "kg" ? "kg → lb" : "lb → kg"}
+          />
+        </View>
+        <Text
+          variant="heading"
+          style={{ color: colors.onSurface, marginTop: 4 }}
+          accessibilityLabel={`Current weight ${toDisplay(latest.weight, unit)} ${unit}`}
+        >
+          {toDisplay(latest.weight, unit)} {unit}
+        </Text>
+        {delta !== null && delta !== 0 && (
           <Text
-            variant="displaySmall"
-            style={{ color: colors.onSurface, marginTop: 4 }}
-            accessibilityLabel={`Current weight ${toDisplay(latest.weight, unit)} ${unit}`}
+            style={{ color: delta > 0 ? colors.error : colors.primary, marginTop: 4 }}
+            accessibilityValue={{ text: `${deltaLabel} since previous entry` }}
           >
-            {toDisplay(latest.weight, unit)} {unit}
+            {deltaLabel} since previous
           </Text>
-          {delta !== null && delta !== 0 && (
-            <Text
-              variant="bodyMedium"
-              style={{ color: delta > 0 ? colors.error : colors.primary, marginTop: 4 }}
-              accessibilityValue={{ text: `${deltaLabel} since previous entry` }}
-            >
-              {deltaLabel} since previous
-            </Text>
-          )}
-          <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
-            {latest.date}
-          </Text>
-        </Card.Content>
+        )}
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
+          {latest.date}
+        </Text>
       </Card>
     ) : null;
 
     // Goals card
     const goalsCard = (settings.weight_goal || settings.body_fat_goal) ? (
-      <Card style={[styles.card, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <View style={styles.cardHeader}>
-            <Text variant="titleMedium" style={{ color: colors.onSurface }}>
-              Goals
-            </Text>
-            <Button
-              mode="text"
-              compact
-              onPress={() => router.push("/body/goals")}
-              accessibilityLabel="Edit body goals"
-            >
-              Edit
-            </Button>
-          </View>
-          {settings.weight_goal && latest && (
-            <View style={{ marginTop: 8 }}>
-              <Text variant="bodyMedium" style={{ color: colors.onSurface }}>
-                Weight: {toDisplay(latest.weight, unit)} → {toDisplay(settings.weight_goal, unit)} {unit}
-              </Text>
-              <ProgressBar
-                progress={Math.min(1, Math.max(0, 1 - Math.abs(latest.weight - settings.weight_goal) / Math.max(latest.weight, 1)))}
-                color={colors.primary}
-                style={{ marginTop: 8, borderRadius: 4 }}
-                accessibilityLabel={`Weight goal progress`}
-              />
-            </View>
-          )}
-          {settings.body_fat_goal && measurements?.body_fat && (
-            <View style={{ marginTop: 12 }}>
-              <Text variant="bodyMedium" style={{ color: colors.onSurface }}>
-                Body fat: {measurements.body_fat}% → {settings.body_fat_goal}%
-              </Text>
-              <ProgressBar
-                progress={Math.min(1, Math.max(0, 1 - Math.abs(measurements.body_fat - settings.body_fat_goal) / Math.max(measurements.body_fat, 1)))}
-                color={colors.primary}
-                style={{ marginTop: 8, borderRadius: 4 }}
-                accessibilityLabel={`Body fat goal progress`}
-              />
-            </View>
-          )}
-        </Card.Content>
-      </Card>
-    ) : (
-      <Card style={[styles.card, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 8 }}>
+      <Card style={styles.card}>
+        <View style={styles.cardHeader}>
+          <Text variant="subtitle" style={{ color: colors.onSurface }}>
             Goals
           </Text>
           <Button
-            mode="outlined"
+            variant="ghost"
+            size="sm"
             onPress={() => router.push("/body/goals")}
-            contentStyle={styles.btnContent}
-            accessibilityLabel="Set body goals"
-          >
-            Set Goals
-          </Button>
-        </Card.Content>
+            accessibilityLabel="Edit body goals"
+            label="Edit"
+          />
+        </View>
+        {settings.weight_goal && latest && (
+          <View style={{ marginTop: 8 }}>
+            <Text style={{ color: colors.onSurface }}>
+              Weight: {toDisplay(latest.weight, unit)} → {toDisplay(settings.weight_goal, unit)} {unit}
+            </Text>
+            <ProgressBar
+              value={Math.min(100, Math.max(0, (1 - Math.abs(latest.weight - settings.weight_goal) / Math.max(latest.weight, 1)) * 100))}
+              style={{ marginTop: 8 }}
+              height={6}
+            />
+          </View>
+        )}
+        {settings.body_fat_goal && measurements?.body_fat && (
+          <View style={{ marginTop: 12 }}>
+            <Text style={{ color: colors.onSurface }}>
+              Body fat: {measurements.body_fat}% → {settings.body_fat_goal}%
+            </Text>
+            <ProgressBar
+              value={Math.min(100, Math.max(0, (1 - Math.abs(measurements.body_fat - settings.body_fat_goal) / Math.max(measurements.body_fat, 1)) * 100))}
+              style={{ marginTop: 8 }}
+              height={6}
+            />
+          </View>
+        )}
+      </Card>
+    ) : (
+      <Card style={styles.card}>
+        <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 8 }}>
+          Goals
+        </Text>
+        <Button
+          variant="outline"
+          onPress={() => router.push("/body/goals")}
+          accessibilityLabel="Set body goals"
+          label="Set Goals"
+        />
       </Card>
     );
 
@@ -544,94 +523,86 @@ export default function Progress() {
       });
 
       return (
-        <Card style={[styles.card, { backgroundColor: colors.surface }]}>
-          <Card.Content>
-            <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 12 }}>
-              Weight Trend
-            </Text>
-            <View style={{ width: chartWidth, height: 200 }}>
-              <CartesianChart
-                data={chart.map((d, i) => ({
-                  date: paddedLabels[i] || "",
-                  weight: toDisplay(d.weight, unit),
-                  avg: avg[i] ? toDisplay(avg[i].avg, unit) : toDisplay(d.weight, unit),
-                }))}
-                xKey="date"
-                yKeys={["weight", "avg"]}
-                domainPadding={{ left: 10, right: 10 }}
-              >
-                {({ points }) => (
-                  <>
-                    <Line
-                      points={points.weight}
-                      color={colors.primary}
-                      strokeWidth={2}
-                      curveType="natural"
-                    />
-                    <Line
-                      points={points.avg}
-                      color={colors.tertiary}
-                      strokeWidth={2}
-                      curveType="natural"
-                    />
-                  </>
-                )}
-              </CartesianChart>
-            </View>
-            <View style={{ flexDirection: "row", gap: 16, marginTop: 8 }}>
-              <Text variant="bodySmall" style={{ color: colors.primary }}>● Actual</Text>
-              <Text variant="bodySmall" style={{ color: colors.tertiary }}>● 7-day avg</Text>
-            </View>
-          </Card.Content>
+        <Card style={styles.card}>
+          <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
+            Weight Trend
+          </Text>
+          <View style={{ width: chartWidth, height: 200 }}>
+            <CartesianChart
+              data={chart.map((d, i) => ({
+                date: paddedLabels[i] || "",
+                weight: toDisplay(d.weight, unit),
+                avg: avg[i] ? toDisplay(avg[i].avg, unit) : toDisplay(d.weight, unit),
+              }))}
+              xKey="date"
+              yKeys={["weight", "avg"]}
+              domainPadding={{ left: 10, right: 10 }}
+            >
+              {({ points }) => (
+                <>
+                  <Line
+                    points={points.weight}
+                    color={colors.primary}
+                    strokeWidth={2}
+                    curveType="natural"
+                  />
+                  <Line
+                    points={points.avg}
+                    color={colors.tertiary}
+                    strokeWidth={2}
+                    curveType="natural"
+                  />
+                </>
+              )}
+            </CartesianChart>
+          </View>
+          <View style={{ flexDirection: "row", gap: 16, marginTop: 8 }}>
+            <Text variant="caption" style={{ color: colors.primary }}>● Actual</Text>
+            <Text variant="caption" style={{ color: colors.tertiary }}>● 7-day avg</Text>
+          </View>
         </Card>
       );
     })() : null;
 
     // Single entry: card only, no chart
     const singleCard = chart.length === 1 && latest ? (
-      <Card style={[styles.card, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 8 }}>
-            Weight Trend
-          </Text>
-          <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
-            {toDisplay(latest.weight, unit)} {unit} on {latest.date}
-          </Text>
-          <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
-            Log more entries to see a chart
-          </Text>
-        </Card.Content>
+      <Card style={styles.card}>
+        <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 8 }}>
+          Weight Trend
+        </Text>
+        <Text style={{ color: colors.onSurfaceVariant }}>
+          {toDisplay(latest.weight, unit)} {unit} on {latest.date}
+        </Text>
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
+          Log more entries to see a chart
+        </Text>
       </Card>
     ) : null;
 
     // Measurements card
     const measCard = (
-      <Card style={[styles.card, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <View style={styles.cardHeader}>
-            <Text variant="titleMedium" style={{ color: colors.onSurface }}>
-              Measurements
-            </Text>
-          </View>
-          {measurements ? (
-            <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
-              Last logged: {measurements.date}
-            </Text>
-          ) : (
-            <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
-              No measurements logged yet
-            </Text>
-          )}
-          <Button
-            mode="outlined"
-            onPress={() => router.push("/body/measurements")}
-            style={{ marginTop: 8 }}
-            contentStyle={styles.btnContent}
-            accessibilityLabel="Log body measurements"
-          >
-            {measurements ? "Log Measurements" : "Add First Measurement"}
-          </Button>
-        </Card.Content>
+      <Card style={styles.card}>
+        <View style={styles.cardHeader}>
+          <Text variant="subtitle" style={{ color: colors.onSurface }}>
+            Measurements
+          </Text>
+        </View>
+        {measurements ? (
+          <Text style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
+            Last logged: {measurements.date}
+          </Text>
+        ) : (
+          <Text style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
+            No measurements logged yet
+          </Text>
+        )}
+        <Button
+          variant="outline"
+          onPress={() => router.push("/body/measurements")}
+          style={{ marginTop: 8 }}
+          accessibilityLabel="Log body measurements"
+          label={measurements ? "Log Measurements" : "Add First Measurement"}
+        />
       </Card>
     );
 
@@ -639,19 +610,21 @@ export default function Progress() {
     const renderEntry = ({ item }: { item: BodyWeight }) => (
       <View style={[styles.entryRow, { borderBottomColor: colors.outlineVariant }]}>
         <View style={{ flex: 1 }}>
-          <Text variant="bodyMedium" style={{ color: colors.onSurface }}>
+          <Text style={{ color: colors.onSurface }}>
             {toDisplay(item.weight, unit)} {unit}
           </Text>
-          <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
             {item.date}{item.notes ? ` · ${item.notes}` : ""}
           </Text>
         </View>
-        <IconButton
-          icon="delete-outline"
-          size={20}
+        <Pressable
           onPress={() => handleDelete(item)}
           accessibilityLabel={`Delete weight entry for ${item.date}`}
-        />
+          hitSlop={8}
+          style={{ padding: 8 }}
+        >
+          <MaterialCommunityIcons name="delete-outline" size={20} color={colors.onSurfaceVariant} />
+        </Pressable>
       </View>
     );
 
@@ -671,31 +644,29 @@ export default function Progress() {
               {singleCard}
               {measCard}
               {/* Progress Photos card */}
-              <Card
-                style={[styles.card, { backgroundColor: colors.surface }]}
+              <Pressable
+                style={[styles.card, { backgroundColor: colors.surface, borderRadius: 12, padding: 18 }]}
                 onPress={() => router.push("/body/photos")}
                 accessibilityLabel="Progress Photos"
                 accessibilityRole="button"
                 accessibilityHint="View and manage your progress photos"
               >
-                <Card.Content>
-                  <View style={styles.cardHeader}>
-                    <Text variant="titleMedium" style={{ color: colors.onSurface }}>
-                      Progress Photos
-                    </Text>
-                  </View>
-                  <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
-                    Track your visual transformation
+                <View style={styles.cardHeader}>
+                  <Text variant="subtitle" style={{ color: colors.onSurface }}>
+                    Progress Photos
                   </Text>
-                </Card.Content>
-              </Card>
-              <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 8, marginTop: 8 }}>
+                </View>
+                <Text style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
+                  Track your visual transformation
+                </Text>
+              </Pressable>
+              <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 8, marginTop: 8 }}>
                 Recent Entries
               </Text>
             </>
           }
           ListEmptyComponent={
-            <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
+            <Text style={{ color: colors.onSurfaceVariant }}>
               No entries yet
             </Text>
           }
@@ -707,14 +678,6 @@ export default function Progress() {
           color={colors.onPrimary}
           accessibilityLabel="Log body weight"
         />
-        <Snackbar
-          visible={!!snack}
-          onDismiss={() => { setSnack(""); }}
-          duration={3000}
-          action={{ label: "Undo", onPress: handleUndo }}
-        >
-          {snack}
-        </Snackbar>
       </View>
     );
   };
@@ -731,59 +694,55 @@ export default function Progress() {
     >
       <View style={[styles.modalOverlay, { backgroundColor: "rgba(0,0,0,0.5)" }]}>
         <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
-          <Text variant="titleLarge" style={{ color: colors.onSurface, marginBottom: 16 }}>
+          <Text variant="title" style={{ color: colors.onSurface, marginBottom: 16 }}>
             Log Weight
           </Text>
 
-          <TextInput
+          <Input
             label={`Weight (${settings?.weight_unit ?? "kg"})`}
             value={logWeight}
             onChangeText={setLogWeight}
             keyboardType="numeric"
-            mode="outlined"
-            style={styles.input}
+            variant="outline"
+            containerStyle={styles.input}
             accessibilityLabel={`Weight in ${settings?.weight_unit ?? "kg"}`}
           />
 
-          <TextInput
+          <Input
             label="Date (YYYY-MM-DD)"
             value={logDate}
             onChangeText={setLogDate}
-            mode="outlined"
-            style={styles.input}
+            variant="outline"
+            containerStyle={styles.input}
             accessibilityLabel="Date for weight entry"
           />
 
-          <TextInput
+          <Input
             label="Notes (optional)"
             value={logNotes}
             onChangeText={setLogNotes}
-            mode="outlined"
-            style={styles.input}
+            variant="outline"
+            containerStyle={styles.input}
             accessibilityLabel="Optional notes"
           />
 
           <View style={styles.modalButtons}>
             <Button
-              mode="outlined"
+              variant="outline"
               onPress={() => setModal(false)}
               style={{ flex: 1, marginRight: 8 }}
-              contentStyle={styles.btnContent}
               accessibilityLabel="Cancel weight log"
-            >
-              Cancel
-            </Button>
+              label="Cancel"
+            />
             <Button
-              mode="contained"
+              variant="default"
               onPress={handleSave}
               loading={saving}
               disabled={saving || !logWeight}
               style={{ flex: 1 }}
-              contentStyle={styles.btnContent}
               accessibilityLabel="Save weight entry"
-            >
-              Save
-            </Button>
+              label="Save"
+            />
           </View>
         </View>
       </View>
@@ -793,7 +752,7 @@ export default function Progress() {
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.segmentContainer, { paddingHorizontal: layout.horizontalPadding }]}>
-        <SegmentedButtons
+        <SegmentedControl
           value={segment}
           onValueChange={setSegment}
           buttons={[
@@ -898,8 +857,5 @@ const styles = StyleSheet.create({
   modalButtons: {
     flexDirection: "row",
     marginTop: 8,
-  },
-  btnContent: {
-    paddingVertical: 8,
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,7 +9,6 @@ import "react-native-reanimated";
 
 import { useColorScheme, Platform, AppState, View, Text } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
-import { PaperProvider, MD3LightTheme, MD3DarkTheme } from "react-native-paper";
 import { Redirect, Stack, usePathname, useRouter } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -107,7 +106,6 @@ export default function RootLayout() {
       <QueryProvider>
       <OnboardingContext.Provider value={onboardingCtx}>
       <BNAThemeProvider>
-      <PaperProvider theme={isDark ? MD3DarkTheme : MD3LightTheme}>
         <ToastProvider>
           <LayoutToastBridge />
           {!onboarded && !pathname.startsWith("/onboarding") && (
@@ -387,7 +385,6 @@ export default function RootLayout() {
           </Stack>
           <StatusBar style="auto" />
         </ToastProvider>
-      </PaperProvider>
       </BNAThemeProvider>
       </OnboardingContext.Provider>
       </QueryProvider>

--- a/app/body/compare.tsx
+++ b/app/body/compare.tsx
@@ -5,7 +5,7 @@ import {
   View,
   useWindowDimensions,
 } from "react-native";
-import { Text } from "react-native-paper";
+import { Text } from "@/components/ui/text";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useLocalSearchParams } from "expo-router";
 import { getPhotoById } from "../../lib/db/photos";

--- a/app/body/compare.tsx
+++ b/app/body/compare.tsx
@@ -48,7 +48,7 @@ export default function CompareScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={["bottom"]}>
         <View style={styles.center}>
-          <Text variant="bodyLarge" style={{ color: colors.error }}>
+          <Text variant="body" style={{ color: colors.error }}>
             Could not load photos. They may have been deleted.
           </Text>
         </View>
@@ -60,7 +60,7 @@ export default function CompareScreen() {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]} edges={["bottom"]}>
         <View style={styles.center}>
-          <Text variant="bodyLarge" style={{ color: colors.onSurfaceVariant }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
             Loading photos...
           </Text>
         </View>

--- a/app/body/goals.tsx
+++ b/app/body/goals.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback } from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
-import { Button, Text, TextInput } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { Input } from "@/components/ui/input";
 import { useFocusEffect, useRouter } from "expo-router";
 import { useLayout } from "../../lib/layout";
 import { getBodySettings, updateBodySettings } from "../../lib/db";
@@ -55,51 +57,45 @@ export default function Goals() {
       style={[styles.container, { backgroundColor: colors.background }]}
       contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
     >
-      <Text variant="titleLarge" style={{ color: colors.onBackground, marginBottom: 16 }}>
+      <Text variant="title" style={{ color: colors.onBackground, marginBottom: 16 }}>
         Body Goals
       </Text>
 
-      <TextInput
+      <Input
         label={`Weight Goal (${unit})`}
         value={weight}
         onChangeText={setWeight}
         keyboardType="numeric"
-        mode="outlined"
-        style={styles.input}
+        containerStyle={styles.input}
         accessibilityLabel={`Weight goal in ${unit}`}
       />
 
-      <TextInput
+      <Input
         label="Body Fat Goal (%)"
         value={fat}
         onChangeText={setFat}
         keyboardType="numeric"
-        mode="outlined"
-        style={styles.input}
+        containerStyle={styles.input}
         accessibilityLabel="Body fat percentage goal"
       />
 
       <View style={styles.buttons}>
         <Button
-          mode="outlined"
+          variant="outline"
           onPress={() => router.back()}
           style={{ flex: 1, marginRight: 8 }}
-          contentStyle={styles.btnContent}
           accessibilityLabel="Cancel goal editing"
-        >
-          Cancel
-        </Button>
+          label="Cancel"
+        />
         <Button
-          mode="contained"
+          variant="default"
           onPress={handleSave}
           loading={saving}
           disabled={saving}
           style={{ flex: 1 }}
-          contentStyle={styles.btnContent}
           accessibilityLabel="Save body goals"
-        >
-          Save
-        </Button>
+          label="Save"
+        />
       </View>
     </ScrollView>
   );

--- a/app/body/measurements.tsx
+++ b/app/body/measurements.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback } from "react";
 import { FlatList, StyleSheet, View } from "react-native";
-import { Button, Text, TextInput } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { Input } from "@/components/ui/input";
 import { useFocusEffect, useRouter } from "expo-router";
 import {
   getLatestMeasurements,
@@ -117,14 +119,13 @@ export default function Measurements() {
   };
 
   const fieldInputs = FIELDS.map((f) => (
-    <TextInput
+    <Input
       key={f.key}
       label={`${f.label} (${unit})`}
       value={form[f.key]}
       onChangeText={(v) => update(f.key, v)}
       keyboardType="numeric"
-      mode="outlined"
-      style={layout.atLeastMedium ? styles.wideInput : styles.input}
+      containerStyle={layout.atLeastMedium ? styles.wideInput : styles.input}
       accessibilityLabel={`${f.label} in ${unit}`}
     />
   ));
@@ -138,16 +139,15 @@ export default function Measurements() {
       keyboardShouldPersistTaps="handled"
       ListHeaderComponent={
         <>
-          <Text variant="titleLarge" style={{ color: colors.onBackground, marginBottom: 16 }}>
+          <Text variant="title" style={{ color: colors.onBackground, marginBottom: 16 }}>
             Log Measurements
           </Text>
 
-          <TextInput
+          <Input
             label="Date (YYYY-MM-DD)"
             value={date}
             onChangeText={setDate}
-            mode="outlined"
-            style={styles.input}
+            containerStyle={styles.input}
             accessibilityLabel="Measurement date"
           />
 
@@ -159,46 +159,40 @@ export default function Measurements() {
             fieldInputs
           )}
 
-          <TextInput
+          <Input
             label="Body Fat %"
             value={form.body_fat}
             onChangeText={(v) => update("body_fat", v)}
             keyboardType="numeric"
-            mode="outlined"
-            style={styles.input}
+            containerStyle={styles.input}
             accessibilityLabel="Body fat percentage"
           />
 
-          <TextInput
+          <Input
             label="Notes (optional)"
             value={notes}
             onChangeText={setNotes}
-            mode="outlined"
-            style={styles.input}
+            containerStyle={styles.input}
             accessibilityLabel="Optional notes"
           />
 
           <View style={styles.buttons}>
             <Button
-              mode="outlined"
+              variant="outline"
               onPress={() => router.back()}
               style={{ flex: 1, marginRight: 8 }}
-              contentStyle={styles.btnContent}
               accessibilityLabel="Cancel measurement log"
-            >
-              Cancel
-            </Button>
+              label="Cancel"
+            />
             <Button
-              mode="contained"
+              variant="default"
               onPress={handleSave}
               loading={saving}
               disabled={saving}
               style={{ flex: 1 }}
-              contentStyle={styles.btnContent}
               accessibilityLabel="Save measurements"
-            >
-              Save
-            </Button>
+              label="Save"
+            />
           </View>
         </>
       }

--- a/app/body/photos.tsx
+++ b/app/body/photos.tsx
@@ -5,9 +5,15 @@ import {
   Linking,
   Modal,
   StyleSheet,
+  TouchableOpacity,
   View,
 } from "react-native";
-import { Button, Chip, FAB, IconButton, Snackbar, Text, TextInput } from "react-native-paper";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { Chip } from "@/components/ui/chip";
+import { FAB } from "@/components/ui/fab";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/bna-toast";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useFocusEffect, useRouter } from "expo-router";
 import * as ImagePicker from "expo-image-picker";
@@ -60,7 +66,7 @@ export default function PhotosScreen() {
   const [poseFilter, setPoseFilter] = useState<PoseCategory | undefined>();
   const [compareMode, setCompareMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [snack, setSnack] = useState("");
+  const { toast } = useToast();
   const [privacyModal, setPrivacyModal] = useState(false);
   const [metaModal, setMetaModal] = useState(false);
   const [pendingUri, setPendingUri] = useState<string | null>(null);
@@ -84,7 +90,7 @@ export default function PhotosScreen() {
       setPhotos(items);
       setTotal(count);
     } catch {
-      setSnack("Failed to load photos");
+      toast("Failed to load photos");
     } finally {
       setLoading(false);
     }
@@ -237,7 +243,7 @@ export default function PhotosScreen() {
     try {
       await processAndSave(result.assets[0].uri);
     } catch {
-      setSnack("Failed to process photo");
+      toast("Failed to process photo");
     } finally {
       setSaving(false);
     }
@@ -259,7 +265,7 @@ export default function PhotosScreen() {
     try {
       await processAndSave(result.assets[0].uri);
     } catch {
-      setSnack("Failed to process photo");
+      toast("Failed to process photo");
     } finally {
       setSaving(false);
     }
@@ -270,7 +276,7 @@ export default function PhotosScreen() {
   const handleSaveMeta = async () => {
     if (!pendingUri) return;
     if (!isValidDate(metaDate)) {
-      setSnack("Please enter a valid date (YYYY-MM-DD)");
+      toast("Please enter a valid date (YYYY-MM-DD)");
       return;
     }
     setSaving(true);
@@ -287,9 +293,9 @@ export default function PhotosScreen() {
       setMetaModal(false);
       setPendingUri(null);
       await load();
-      setSnack("Photo saved");
+      toast("Photo saved");
     } catch {
-      setSnack("Failed to save photo");
+      toast("Failed to save photo");
     } finally {
       setSaving(false);
     }
@@ -299,7 +305,7 @@ export default function PhotosScreen() {
     await softDeletePhoto(photo.id);
     undoRef.current = { id: photo.id };
     await load();
-    setSnack("Photo deleted");
+    toast("Photo deleted");
   };
 
   const handleUndo = async () => {
@@ -307,7 +313,6 @@ export default function PhotosScreen() {
     await restorePhoto(undoRef.current.id);
     undoRef.current = null;
     await load();
-    setSnack("");
   };
 
   const handlePhotoPress = (photo: ProgressPhoto) => {
@@ -388,8 +393,7 @@ export default function PhotosScreen() {
           </Chip>
         ))}
       </View>
-      <IconButton
-        icon="compare"
+      <TouchableOpacity
         onPress={() => {
           if (compareMode) {
             setCompareMode(false);
@@ -402,24 +406,27 @@ export default function PhotosScreen() {
         accessibilityLabel="Compare photos"
         accessibilityRole="button"
         accessibilityHint={total < 2 ? "Need at least 2 photos to compare" : "Select two photos to compare side by side"}
-      />
+        hitSlop={8}
+        style={{ padding: 8 }}
+      >
+        <MaterialCommunityIcons name="compare" size={24} color={colors.onSurface} />
+      </TouchableOpacity>
     </View>
   );
 
   const compareModeHeader = compareMode ? (
     <View style={[styles.compareBanner, { backgroundColor: colors.primaryContainer }]}>
-      <Text variant="bodyMedium" style={{ color: colors.onPrimaryContainer, flex: 1 }}>
+      <Text variant="body" style={{ color: colors.onPrimaryContainer, flex: 1 }}>
         Select 2 photos ({selectedIds.length}/2)
       </Text>
       <Button
-        mode="text"
+        variant="ghost"
         onPress={() => {
           setCompareMode(false);
           setSelectedIds([]);
         }}
-      >
-        Cancel
-      </Button>
+        label="Cancel"
+      />
     </View>
   ) : null;
 
@@ -458,17 +465,15 @@ export default function PhotosScreen() {
               color={colors.primary}
               style={{ alignSelf: "center", marginBottom: 16 }}
             />
-            <Text variant="titleLarge" style={{ color: colors.onSurface, textAlign: "center", marginBottom: 12 }}>
+            <Text variant="title" style={{ color: colors.onSurface, textAlign: "center", marginBottom: 12 }}>
               Your Photos Are Private
             </Text>
-            <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, textAlign: "center", marginBottom: 24 }}>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant, textAlign: "center", marginBottom: 24 }}>
               Your progress photos are stored only on this device and never uploaded to any server.
               Photos are not visible in your device&apos;s photo gallery.
               If you reinstall the app, photos will be lost.
             </Text>
-            <Button mode="contained" onPress={dismissPrivacy} contentStyle={{ paddingVertical: 8 }}>
-              I Understand
-            </Button>
+            <Button variant="default" onPress={dismissPrivacy} label="I Understand" />
           </View>
         </View>
       </Modal>
@@ -521,15 +526,13 @@ export default function PhotosScreen() {
       {compareMode && selectedIds.length === 2 && (
         <View style={styles.compareBar}>
           <Button
-            mode="contained"
+            variant="default"
             onPress={handleCompare}
             style={{ flex: 1 }}
-            contentStyle={{ paddingVertical: 8 }}
             accessibilityLabel="Compare photos"
             accessibilityRole="button"
-          >
-            Compare
-          </Button>
+            label="Compare"
+          />
         </View>
       )}
       {/* Meta modal */}
@@ -545,7 +548,7 @@ export default function PhotosScreen() {
       >
         <View style={styles.modalOverlay}>
           <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
-            <Text variant="titleLarge" style={{ color: colors.onSurface, marginBottom: 16 }}>
+            <Text variant="title" style={{ color: colors.onSurface, marginBottom: 16 }}>
               Photo Details
             </Text>
             {pendingUri && (
@@ -555,15 +558,14 @@ export default function PhotosScreen() {
                 resizeMode="contain"
               />
             )}
-            <TextInput
-              label="Date"
+            <Input
+              placeholder="Date (YYYY-MM-DD)"
               value={metaDate}
               onChangeText={setMetaDate}
-              mode="outlined"
               style={styles.input}
-              placeholder="YYYY-MM-DD"
+              accessibilityLabel="Date"
             />
-            <Text variant="bodyMedium" style={{ color: colors.onSurface, marginTop: 8, marginBottom: 4 }}>
+            <Text variant="body" style={{ color: colors.onSurface, marginTop: 8, marginBottom: 4 }}>
               Pose Category
             </Text>
             <View style={styles.chips}>
@@ -580,36 +582,32 @@ export default function PhotosScreen() {
                 </Chip>
               ))}
             </View>
-            <TextInput
-              label="Note (optional)"
+            <Input
+              placeholder="Note (optional)"
               value={metaNote}
               onChangeText={setMetaNote}
-              mode="outlined"
               style={styles.input}
               multiline
+              accessibilityLabel="Note"
             />
             <View style={styles.modalButtons}>
               <Button
-                mode="outlined"
+                variant="outline"
                 onPress={() => {
                   setMetaModal(false);
                   setPendingUri(null);
                 }}
                 style={{ flex: 1, marginRight: 8 }}
-                contentStyle={{ paddingVertical: 8 }}
-              >
-                Cancel
-              </Button>
+                label="Cancel"
+              />
               <Button
-                mode="contained"
+                variant="default"
                 onPress={handleSaveMeta}
                 loading={saving}
                 disabled={saving}
                 style={{ flex: 1 }}
-                contentStyle={{ paddingVertical: 8 }}
-              >
-                Save
-              </Button>
+                label="Save"
+              />
             </View>
           </View>
         </View>
@@ -619,24 +617,13 @@ export default function PhotosScreen() {
       {saving && !metaModal && (
         <View style={styles.savingOverlay}>
           <View style={[styles.savingBox, { backgroundColor: colors.surface }]}>
-            <Text variant="bodyLarge" style={{ color: colors.onSurface }}>
+            <Text variant="body" style={{ color: colors.onSurface }}>
               Saving photo...
             </Text>
           </View>
         </View>
       )}
-      <Snackbar
-        visible={!!snack}
-        onDismiss={() => { setSnack(""); }}
-        duration={10000}
-        action={
-          snack === "Photo deleted"
-            ? { label: "Undo", onPress: handleUndo, accessibilityLabel: "Photo deleted. Undo" }
-            : { label: "OK", onPress: () => setSnack("") }
-        }
-      >
-        {snack}
-      </Snackbar>
+
     </SafeAreaView>
   );
 }

--- a/app/body/photos.tsx
+++ b/app/body/photos.tsx
@@ -29,6 +29,7 @@ import {
   getPhotoCount,
   insertPhoto,
   softDeletePhoto,
+  restorePhoto,
   cleanupDeletedPhotos,
   cleanupOrphanFiles,
   ensurePhotoDirs,
@@ -304,7 +305,16 @@ export default function PhotosScreen() {
     await softDeletePhoto(photo.id);
     undoRef.current = { id: photo.id };
     await load();
-    success("Photo deleted");
+    success("Photo deleted", {
+      action: { label: "Undo", onPress: handleUndo },
+    });
+  };
+
+  const handleUndo = async () => {
+    if (!undoRef.current) return;
+    await restorePhoto(undoRef.current.id);
+    undoRef.current = null;
+    await load();
   };
 
   const handlePhotoPress = (photo: ProgressPhoto) => {

--- a/app/body/photos.tsx
+++ b/app/body/photos.tsx
@@ -29,7 +29,6 @@ import {
   getPhotoCount,
   insertPhoto,
   softDeletePhoto,
-  restorePhoto,
   cleanupDeletedPhotos,
   cleanupOrphanFiles,
   ensurePhotoDirs,
@@ -66,7 +65,7 @@ export default function PhotosScreen() {
   const [poseFilter, setPoseFilter] = useState<PoseCategory | undefined>();
   const [compareMode, setCompareMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const { toast } = useToast();
+  const { success, error: showError } = useToast();
   const [privacyModal, setPrivacyModal] = useState(false);
   const [metaModal, setMetaModal] = useState(false);
   const [pendingUri, setPendingUri] = useState<string | null>(null);
@@ -90,7 +89,7 @@ export default function PhotosScreen() {
       setPhotos(items);
       setTotal(count);
     } catch {
-      toast("Failed to load photos");
+      showError("Failed to load photos");
     } finally {
       setLoading(false);
     }
@@ -243,7 +242,7 @@ export default function PhotosScreen() {
     try {
       await processAndSave(result.assets[0].uri);
     } catch {
-      toast("Failed to process photo");
+      showError("Failed to process photo");
     } finally {
       setSaving(false);
     }
@@ -265,7 +264,7 @@ export default function PhotosScreen() {
     try {
       await processAndSave(result.assets[0].uri);
     } catch {
-      toast("Failed to process photo");
+      showError("Failed to process photo");
     } finally {
       setSaving(false);
     }
@@ -276,7 +275,7 @@ export default function PhotosScreen() {
   const handleSaveMeta = async () => {
     if (!pendingUri) return;
     if (!isValidDate(metaDate)) {
-      toast("Please enter a valid date (YYYY-MM-DD)");
+      showError("Please enter a valid date (YYYY-MM-DD)");
       return;
     }
     setSaving(true);
@@ -293,9 +292,9 @@ export default function PhotosScreen() {
       setMetaModal(false);
       setPendingUri(null);
       await load();
-      toast("Photo saved");
+      success("Photo saved");
     } catch {
-      toast("Failed to save photo");
+      showError("Failed to save photo");
     } finally {
       setSaving(false);
     }
@@ -305,14 +304,7 @@ export default function PhotosScreen() {
     await softDeletePhoto(photo.id);
     undoRef.current = { id: photo.id };
     await load();
-    toast("Photo deleted");
-  };
-
-  const handleUndo = async () => {
-    if (!undoRef.current) return;
-    await restorePhoto(undoRef.current.id);
-    undoRef.current = null;
-    await load();
+    success("Photo deleted");
   };
 
   const handlePhotoPress = (photo: ProgressPhoto) => {
@@ -376,7 +368,7 @@ export default function PhotosScreen() {
           onPress={() => setPoseFilter(undefined)}
           style={styles.chip}
           accessibilityLabel="All poses filter"
-          accessibilityRole="togglebutton"
+          accessibilityRole="checkbox"
         >
           All
         </Chip>
@@ -387,7 +379,7 @@ export default function PhotosScreen() {
             onPress={() => setPoseFilter(poseFilter === p.value ? undefined : p.value)}
             style={styles.chip}
             accessibilityLabel={`${p.label} pose filter`}
-            accessibilityRole="togglebutton"
+            accessibilityRole="checkbox"
           >
             {p.label}
           </Chip>
@@ -576,7 +568,7 @@ export default function PhotosScreen() {
                   onPress={() => setMetaPose(metaPose === p.value ? null : p.value)}
                   style={styles.chip}
                   accessibilityLabel={`${p.label} pose category`}
-                  accessibilityRole="togglebutton"
+                  accessibilityRole="checkbox"
                 >
                   {p.label}
                 </Chip>

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -4,11 +4,17 @@ import {
   Alert,
   Pressable,
   StyleSheet,
+  TouchableOpacity,
   useWindowDimensions,
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Button, Card, Chip, IconButton, Snackbar, Text } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Chip } from "@/components/ui/chip";
+import { Text } from "@/components/ui/text";
+import { useToast } from "@/components/ui/bna-toast";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Stack, useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { CartesianChart, Line } from "victory-native";
 import {
@@ -54,7 +60,7 @@ export default function ExerciseDetail() {
   const profileGender = useProfileGender();
   const { id } = useLocalSearchParams<{ id: string }>();
   const [exercise, setExercise] = useState<Exercise | null>(null);
-  const [toast, setToast] = useState("");
+  const { toast: showToast } = useToast();
   const [unit, setUnit] = useState<"kg" | "lb">("kg");
 
   // Records state
@@ -165,10 +171,10 @@ export default function ExerciseDetail() {
         onPress: async () => {
           try {
             await softDeleteCustomExercise(id);
-            setToast("Exercise deleted");
+            showToast({ description: "Exercise deleted" });
             setTimeout(() => router.back(), 400);
           } catch {
-            setToast("Failed to delete exercise");
+            showToast({ description: "Failed to delete exercise" });
           }
         },
       },
@@ -219,7 +225,6 @@ export default function ExerciseDetail() {
         <Chip
           compact
           style={[styles.badge, { backgroundColor: colors.tertiaryContainer }]}
-          textStyle={{ fontSize: 12 }}
         >
           Custom
         </Chip>
@@ -230,14 +235,12 @@ export default function ExerciseDetail() {
         <Chip
           compact
           style={{ backgroundColor: colors.primaryContainer }}
-          textStyle={{ color: colors.onPrimaryContainer }}
         >
           {CATEGORY_LABELS[exercise.category]}
         </Chip>
         <Chip
           compact
           style={[styles.difficultyChip, { backgroundColor: DIFFICULTY_COLORS[exercise.difficulty] }]}
-          textStyle={[styles.difficultyText, { color: difficultyText(exercise.difficulty) }]}
         >
           {exercise.difficulty}
         </Chip>
@@ -246,11 +249,11 @@ export default function ExerciseDetail() {
       {/* Voltra Metadata */}
       {exercise.mount_position && (
         <View style={styles.section}>
-          <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
             Mount Position
           </Text>
           <Text
-            variant="bodyLarge"
+            variant="body"
             style={[styles.value, { color: colors.onSurface }]}
             accessibilityLabel={`Mount position: ${MOUNT_POSITION_LABELS[exercise.mount_position]} on rack`}
           >
@@ -260,11 +263,11 @@ export default function ExerciseDetail() {
       )}
       {exercise.attachment && (
         <View style={styles.section}>
-          <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
             Attachment
           </Text>
           <Text
-            variant="bodyLarge"
+            variant="body"
             style={[styles.value, { color: colors.onSurface }]}
             accessibilityLabel={`Attachment: ${ATTACHMENT_LABELS[exercise.attachment]}`}
           >
@@ -277,7 +280,7 @@ export default function ExerciseDetail() {
           style={styles.section}
           accessibilityLabel={`Compatible training modes: ${exercise.training_modes.join(", ")}`}
         >
-          <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
             Training Modes
           </Text>
           <View style={styles.chipRow}>
@@ -298,7 +301,7 @@ export default function ExerciseDetail() {
       {layout.atLeastMedium ? (
         <View style={styles.infoRow}>
           <View style={{ flex: 1 }}>
-            <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant }}>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
               Muscles Involved
             </Text>
             <MuscleMap
@@ -311,13 +314,13 @@ export default function ExerciseDetail() {
           <View style={{ flex: 1 }}>
             {steps.length > 0 && (
               <View style={styles.section}>
-                <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant }}>
+                <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
                   Instructions
                 </Text>
                 {steps.map((step, i) => (
                   <Text
                     key={i}
-                    variant="bodyMedium"
+                    variant="body"
                     style={[styles.step, { color: colors.onSurface }]}
                   >
                     {step}
@@ -330,7 +333,7 @@ export default function ExerciseDetail() {
       ) : (
         <>
           <View style={styles.section}>
-            <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant }}>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
               Muscles Involved
             </Text>
             <MuscleMap
@@ -342,13 +345,13 @@ export default function ExerciseDetail() {
           </View>
           {steps.length > 0 && (
             <View style={styles.section}>
-              <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant }}>
+              <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
                 Instructions
               </Text>
               {steps.map((step, i) => (
                 <Text
                   key={i}
-                  variant="bodyMedium"
+                  variant="body"
                   style={[styles.step, { color: colors.onSurface }]}
                 >
                   {step}
@@ -361,9 +364,9 @@ export default function ExerciseDetail() {
 
       {/* Personal Records + Chart flow into row on tablet */}
       <FlowContainer gap={16}>
-      <Card style={[styles.card, layout.atLeastMedium && styles.flowCard, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 12 }}>
+      <Card style={StyleSheet.flatten([styles.card, layout.atLeastMedium && styles.flowCard, { backgroundColor: colors.surface }])}>
+        <CardContent>
+          <Text variant="title" style={{ color: colors.onSurface, marginBottom: 12 }}>
             Personal Records
           </Text>
           {recordsLoading ? (
@@ -371,10 +374,10 @@ export default function ExerciseDetail() {
           ) : recordsError ? (
             <View style={styles.errorBox}>
               <Text style={{ color: colors.error }}>Failed to load records</Text>
-              <Button mode="text" onPress={() => id && loadRecords(id)}>Retry</Button>
+              <Button variant="ghost" onPress={() => id && loadRecords(id)} label="Retry" />
             </View>
           ) : records && records.total_sessions === 0 ? (
-            <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
               No workout data yet — start a session to build your history
             </Text>
           ) : records ? (
@@ -383,51 +386,51 @@ export default function ExerciseDetail() {
               {bw ? (
                 <>
                   <View style={styles.stat} accessibilityLabel={`Maximum reps: ${records.max_reps ?? 0}`}>
-                    <Text variant="headlineSmall" style={{ color: colors.primary }}>
+                    <Text variant="heading" style={{ color: colors.primary }}>
                       {records.max_reps ?? "—"}
                     </Text>
-                    <Text variant="labelSmall" style={{ color: colors.onSurfaceVariant }}>Max Reps</Text>
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Max Reps</Text>
                   </View>
                   <View style={styles.stat} accessibilityLabel={`Total sessions: ${records.total_sessions}`}>
-                    <Text variant="headlineSmall" style={{ color: colors.primary }}>
+                    <Text variant="heading" style={{ color: colors.primary }}>
                       {records.total_sessions}
                     </Text>
-                    <Text variant="labelSmall" style={{ color: colors.onSurfaceVariant }}>Sessions</Text>
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Sessions</Text>
                   </View>
                   <View style={styles.stat} accessibilityLabel={`Best volume: ${records.max_volume ?? 0}`}>
-                    <Text variant="headlineSmall" style={{ color: colors.primary }}>
+                    <Text variant="heading" style={{ color: colors.primary }}>
                       {records.max_volume != null ? Math.round(records.max_volume) : "—"}
                     </Text>
-                    <Text variant="labelSmall" style={{ color: colors.onSurfaceVariant }}>Best Vol</Text>
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Best Vol</Text>
                   </View>
                 </>
               ) : (
                 <>
                   <View style={styles.stat} accessibilityLabel={`Maximum weight: ${records.max_weight != null ? toDisplay(records.max_weight, unit) : 0} ${unit}`}>
-                    <Text variant="headlineSmall" style={{ color: colors.primary }}>
+                    <Text variant="heading" style={{ color: colors.primary }}>
                       {records.max_weight != null ? toDisplay(records.max_weight, unit) : "—"}
                     </Text>
-                    <Text variant="labelSmall" style={{ color: colors.onSurfaceVariant }}>Max {unit}</Text>
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Max {unit}</Text>
                   </View>
                   <View style={styles.stat} accessibilityLabel={`Maximum reps: ${records.max_reps ?? 0}`}>
-                    <Text variant="headlineSmall" style={{ color: colors.primary }}>
+                    <Text variant="heading" style={{ color: colors.primary }}>
                       {records.max_reps ?? "—"}
                     </Text>
-                    <Text variant="labelSmall" style={{ color: colors.onSurfaceVariant }}>Max Reps</Text>
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Max Reps</Text>
                   </View>
                   <View style={styles.stat} accessibilityLabel={`Estimated one rep max: ${records.est_1rm != null ? toDisplay(records.est_1rm, unit) : 0} ${unit}`}>
-                    <Text variant="headlineSmall" style={{ color: colors.primary }}>
+                    <Text variant="heading" style={{ color: colors.primary }}>
                       {records.est_1rm != null ? toDisplay(records.est_1rm, unit) : "—"}
                     </Text>
-                    <Text variant="labelSmall" style={{ color: colors.onSurfaceVariant }}>
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                       {best && best.reps === 1 ? "Tested 1RM" : "Est 1RM"}
                     </Text>
                   </View>
                   <View style={styles.stat} accessibilityLabel={`Total sessions: ${records.total_sessions}`}>
-                    <Text variant="headlineSmall" style={{ color: colors.primary }}>
+                    <Text variant="heading" style={{ color: colors.primary }}>
                       {records.total_sessions}
                     </Text>
-                    <Text variant="labelSmall" style={{ color: colors.onSurfaceVariant }}>Sessions</Text>
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Sessions</Text>
                   </View>
                 </>
               )}
@@ -443,19 +446,19 @@ export default function ExerciseDetail() {
                 : "";
               return (
                 <View style={[styles.pctSection, { borderTopColor: colors.outlineVariant }]}>
-                  <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, marginBottom: 4 }}>
+                  <Text variant="body" style={{ color: colors.onSurfaceVariant, marginBottom: 4 }}>
                     {tested ? "Tested 1RM" : "Estimated 1RM"}: {orm} {unit}
                   </Text>
                   {source ? (
-                    <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
                       {source} · Epley
                     </Text>
                   ) : null}
                   <View style={styles.pctTable}>
                     <View style={styles.pctRow}>
-                      <Text variant="labelSmall" style={[styles.pctCol, { color: colors.onSurfaceVariant }]}>% 1RM</Text>
-                      <Text variant="labelSmall" style={[styles.pctCol, { color: colors.onSurfaceVariant }]}>Weight</Text>
-                      <Text variant="labelSmall" style={[styles.pctCol, { color: colors.onSurfaceVariant }]}>Reps</Text>
+                      <Text variant="caption" style={[styles.pctCol, { color: colors.onSurfaceVariant }]}>% 1RM</Text>
+                      <Text variant="caption" style={[styles.pctCol, { color: colors.onSurfaceVariant }]}>Weight</Text>
+                      <Text variant="caption" style={[styles.pctCol, { color: colors.onSurfaceVariant }]}>Reps</Text>
                     </View>
                     {table.map((row) => (
                       <Pressable
@@ -466,33 +469,31 @@ export default function ExerciseDetail() {
                         accessibilityRole="button"
                         accessibilityHint="Opens plate calculator with this weight"
                       >
-                        <Text variant="bodySmall" style={[styles.pctCol, { color: colors.onSurface }]}>{row.pct}%</Text>
-                        <Text variant="bodySmall" style={[styles.pctCol, { color: colors.onSurface }]}>{row.weight} {unit}</Text>
-                        <Text variant="bodySmall" style={[styles.pctCol, { color: colors.onSurface }]}>{row.reps}</Text>
+                        <Text variant="caption" style={[styles.pctCol, { color: colors.onSurface }]}>{row.pct}%</Text>
+                        <Text variant="caption" style={[styles.pctCol, { color: colors.onSurface }]}>{row.weight} {unit}</Text>
+                        <Text variant="caption" style={[styles.pctCol, { color: colors.onSurface }]}>{row.reps}</Text>
                       </Pressable>
                     ))}
                   </View>
                   <Button
-                    mode="text"
-                    compact
-                    icon="calculator"
+                    variant="ghost"
+                    size="sm"
                     onPress={() => router.push("/tools/rm")}
                     style={{ alignSelf: "flex-start", marginTop: 4 }}
                     accessibilityLabel="Open 1RM calculator"
-                  >
-                    1RM Calculator
-                  </Button>
+                    label="1RM Calculator"
+                  />
                 </View>
               );
             })()}
             </>
           ) : null}
-        </Card.Content>
+        </CardContent>
       </Card>
 
-      <Card style={[styles.card, layout.atLeastMedium && styles.flowCard, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 12 }}>
+      <Card style={StyleSheet.flatten([styles.card, layout.atLeastMedium && styles.flowCard, { backgroundColor: colors.surface }])}>
+        <CardContent>
+          <Text variant="title" style={{ color: colors.onSurface, marginBottom: 12 }}>
             {bw ? "Reps Progression" : "Weight Progression"}
           </Text>
           {!bw && chart.length >= 2 && (
@@ -520,10 +521,10 @@ export default function ExerciseDetail() {
           ) : chartError ? (
             <View style={styles.errorBox}>
               <Text style={{ color: colors.error }}>Failed to load chart</Text>
-              <Button mode="text" onPress={() => id && loadChart(id)}>Retry</Button>
+              <Button variant="ghost" onPress={() => id && loadChart(id)} label="Retry" />
             </View>
           ) : activeChart.length < 2 ? (
-            <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
               {activeChart.length === 0
                 ? "No data to chart yet"
                 : "Log more sessions to see a trend chart"}
@@ -551,19 +552,19 @@ export default function ExerciseDetail() {
                 </CartesianChart>
               </View>
               {chartSummary && (
-                <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant, marginTop: 8 }}>
+                <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 8 }}>
                   {chartSummary}
                 </Text>
               )}
             </View>
           )}
-        </Card.Content>
+        </CardContent>
       </Card>
 
       </FlowContainer>
 
       {/* History section header */}
-      <Text variant="titleMedium" style={{ color: colors.onSurface, marginTop: 8, marginBottom: 8 }}>
+      <Text variant="title" style={{ color: colors.onSurface, marginTop: 8, marginBottom: 8 }}>
         Session History
       </Text>
 
@@ -572,10 +573,10 @@ export default function ExerciseDetail() {
       ) : historyError ? (
         <View style={styles.errorBox}>
           <Text style={{ color: colors.error }}>Failed to load history</Text>
-          <Button mode="text" onPress={() => id && loadHistory(id)}>Retry</Button>
+          <Button variant="ghost" onPress={() => id && loadHistory(id)} label="Retry" />
         </View>
       ) : history.length === 0 ? (
-        <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, marginBottom: 16 }}>
+        <Text variant="body" style={{ color: colors.onSurfaceVariant, marginBottom: 16 }}>
           No sessions recorded for this exercise
         </Text>
       ) : null}
@@ -595,15 +596,15 @@ export default function ExerciseDetail() {
         accessibilityRole="button"
       >
         <View style={styles.historyLeft}>
-          <Text variant="bodyLarge" style={{ color: colors.onSurface }}>
+          <Text variant="body" style={{ color: colors.onSurface }}>
             {formatDateLong(item.started_at)}
           </Text>
-          <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
             {item.session_name} · {item.set_count} sets · {item.total_reps} reps
           </Text>
         </View>
         <View style={styles.historyRight}>
-          <Text variant="titleMedium" style={{ color: colors.primary }}>
+          <Text variant="title" style={{ color: colors.primary }}>
             {bw ? `${item.max_reps} reps` : `${toDisplay(item.max_weight, unit)} ${unit}`}
           </Text>
           {item.avg_rpe != null && (
@@ -622,7 +623,7 @@ export default function ExerciseDetail() {
     if (loadingMore) return <ActivityIndicator style={{ padding: 16 }} />;
     if (!hasMore && history.length >= MAX_ITEMS) {
       return (
-        <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
           Showing last {history.length} sessions
         </Text>
       );
@@ -638,18 +639,12 @@ export default function ExerciseDetail() {
           headerRight: exercise.is_custom
             ? () => (
                 <View style={styles.headerActions}>
-                  <IconButton
-                    icon="pencil"
-                    size={22}
-                    onPress={edit}
-                    accessibilityLabel="Edit exercise"
-                  />
-                  <IconButton
-                    icon="delete"
-                    size={22}
-                    onPress={remove}
-                    accessibilityLabel="Delete exercise"
-                  />
+                  <TouchableOpacity onPress={edit} accessibilityLabel="Edit exercise" hitSlop={8} style={{ padding: 8 }}>
+                    <MaterialCommunityIcons name="pencil" size={22} color={colors.onSurface} />
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={remove} accessibilityLabel="Delete exercise" hitSlop={8} style={{ padding: 8 }}>
+                    <MaterialCommunityIcons name="delete" size={22} color={colors.onSurface} />
+                  </TouchableOpacity>
                 </View>
               )
             : undefined,
@@ -666,10 +661,6 @@ export default function ExerciseDetail() {
         onEndReached={loadMore}
         onEndReachedThreshold={0.3}
       />
-
-      <Snackbar visible={!!toast} onDismiss={() => setToast("")} duration={3000}>
-        {toast}
-      </Snackbar>
     </>
   );
 }

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -31,7 +31,7 @@ import {
   type ExerciseRecords as Records,
 } from "../../lib/db";
 import { CATEGORY_LABELS, MOUNT_POSITION_LABELS, ATTACHMENT_LABELS, type Exercise } from "../../lib/types";
-import { difficultyText, DIFFICULTY_COLORS } from "../../constants/theme";
+import { DIFFICULTY_COLORS } from "../../constants/theme";
 import { MuscleMap } from "../../components/MuscleMap";
 import { rpeColor, rpeText } from "../../lib/rpe";
 import { toDisplay } from "../../lib/units";
@@ -224,7 +224,7 @@ export default function ExerciseDetail() {
       {exercise.is_custom && (
         <Chip
           compact
-          style={[styles.badge, { backgroundColor: colors.tertiaryContainer }]}
+          style={StyleSheet.flatten([styles.badge, { backgroundColor: colors.tertiaryContainer }])}
         >
           Custom
         </Chip>
@@ -240,7 +240,7 @@ export default function ExerciseDetail() {
         </Chip>
         <Chip
           compact
-          style={[styles.difficultyChip, { backgroundColor: DIFFICULTY_COLORS[exercise.difficulty] }]}
+          style={StyleSheet.flatten([styles.difficultyChip, { backgroundColor: DIFFICULTY_COLORS[exercise.difficulty] }])}
         >
           {exercise.difficulty}
         </Chip>
@@ -288,7 +288,7 @@ export default function ExerciseDetail() {
               <Chip
                 key={m}
                 compact
-                style={[styles.muscleChip, { backgroundColor: colors.secondaryContainer }]}
+                style={StyleSheet.flatten([styles.muscleChip, { backgroundColor: colors.secondaryContainer }])}
               >
                 {m.replace(/_/g, " ")}
               </Chip>

--- a/app/exercise/create.tsx
+++ b/app/exercise/create.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { Stack, useRouter } from "expo-router";
-import { Snackbar } from "react-native-paper";
+import { useToast } from "@/components/ui/bna-toast";
 import { View } from "react-native";
 import ExerciseForm from "../../components/ExerciseForm";
 import { createCustomExercise } from "../../lib/db";
@@ -10,24 +10,21 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 export default function CreateExercise() {
   const colors = useThemeColors();
   const router = useRouter();
-  const [toast, setToast] = useState("");
+  const { toast } = useToast();
 
   const save = useCallback(
     async (data: Omit<Exercise, "id" | "is_custom">) => {
       await createCustomExercise(data);
-      setToast("Exercise created");
+      toast("Exercise created");
       setTimeout(() => router.back(), 400);
     },
-    [router]
+    [router, toast]
   );
 
   return (
     <View style={{ flex: 1, backgroundColor: colors.background }}>
       <Stack.Screen options={{ title: "New Exercise" }} />
       <ExerciseForm title="exercise" onSave={save} />
-      <Snackbar visible={!!toast} onDismiss={() => setToast("")} duration={2000}>
-        {toast}
-      </Snackbar>
     </View>
   );
 }

--- a/app/exercise/create.tsx
+++ b/app/exercise/create.tsx
@@ -10,15 +10,15 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 export default function CreateExercise() {
   const colors = useThemeColors();
   const router = useRouter();
-  const { toast } = useToast();
+  const { success } = useToast();
 
   const save = useCallback(
     async (data: Omit<Exercise, "id" | "is_custom">) => {
       await createCustomExercise(data);
-      toast("Exercise created");
+      success("Exercise created");
       setTimeout(() => router.back(), 400);
     },
-    [router, toast]
+    [router, success]
   );
 
   return (

--- a/app/exercise/edit/[id].tsx
+++ b/app/exercise/edit/[id].tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { View } from "react-native";
-import { Snackbar, Text } from "react-native-paper";
+import { Text } from "@/components/ui/text";
+import { useToast } from "@/components/ui/bna-toast";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import ExerciseForm from "../../../components/ExerciseForm";
 import { getExerciseById, updateCustomExercise } from "../../../lib/db";
@@ -10,9 +11,9 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 export default function EditExercise() {
   const colors = useThemeColors();
   const router = useRouter();
+  const { toast } = useToast();
   const { id } = useLocalSearchParams<{ id: string }>();
   const [exercise, setExercise] = useState<Exercise | null>(null);
-  const [toast, setToast] = useState("");
 
   const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
@@ -28,10 +29,10 @@ export default function EditExercise() {
     async (data: Omit<Exercise, "id" | "is_custom">) => {
       if (!id) return;
       await updateCustomExercise(id, data);
-      setToast("Exercise updated");
+      toast("Exercise updated");
       timer.current = setTimeout(() => router.back(), 400);
     },
-    [id, router]
+    [id, router, toast]
   );
 
   if (!exercise) {
@@ -47,9 +48,6 @@ export default function EditExercise() {
     <View style={{ flex: 1, backgroundColor: colors.background }}>
       <Stack.Screen options={{ title: `Edit ${exercise.name}` }} />
       <ExerciseForm title="exercise" initial={exercise} onSave={save} />
-      <Snackbar visible={!!toast} onDismiss={() => setToast("")} duration={2000}>
-        {toast}
-      </Snackbar>
     </View>
   );
 }

--- a/app/exercise/edit/[id].tsx
+++ b/app/exercise/edit/[id].tsx
@@ -11,7 +11,7 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 export default function EditExercise() {
   const colors = useThemeColors();
   const router = useRouter();
-  const { toast } = useToast();
+  const { success } = useToast();
   const { id } = useLocalSearchParams<{ id: string }>();
   const [exercise, setExercise] = useState<Exercise | null>(null);
 
@@ -29,10 +29,10 @@ export default function EditExercise() {
     async (data: Omit<Exercise, "id" | "is_custom">) => {
       if (!id) return;
       await updateCustomExercise(id, data);
-      toast("Exercise updated");
+      success("Exercise updated");
       timer.current = setTimeout(() => router.back(), 400);
     },
-    [id, router, toast]
+    [id, router, success]
   );
 
   if (!exercise) {

--- a/app/nutrition/add.tsx
+++ b/app/nutrition/add.tsx
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Keyboard, Platform, StyleSheet, View } from "react-native";
+import { ActivityIndicator, Keyboard, Platform, Pressable, StyleSheet, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { ActivityIndicator, Button, Card, Chip, SegmentedButtons, Text, TextInput } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Chip } from "@/components/ui/chip";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Text } from "@/components/ui/text";
+import { Input } from "@/components/ui/input";
 import { router, useFocusEffect, useLocalSearchParams } from "expo-router";
 import NetInfo from "@react-native-community/netinfo";
 import { useLayout } from "../../lib/layout";
@@ -75,29 +80,31 @@ function DatabaseTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: 
     };
 
     return (
-      <Card
-        style={[styles.dbCard, { backgroundColor: colors.surfaceVariant }]}
+      <Pressable
         onPress={() => expand(item.id)}
         accessibilityLabel={`${item.name}, ${item.calories} calories per ${item.serving}`}
         accessibilityRole="button"
       >
-        <Card.Content>
+      <Card
+        style={StyleSheet.flatten([styles.dbCard, { backgroundColor: colors.surfaceVariant }])}
+      >
+        <CardContent>
           <Text
-            variant="titleSmall"
+            variant="subtitle"
             numberOfLines={1}
             style={{ color: colors.onSurface }}
           >
             {item.name}
           </Text>
-          <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
             {item.calories} cal · {item.protein}p · {item.carbs}c · {item.fat}f · {item.serving}
           </Text>
           {open && (
             <View style={[styles.detail, { borderTopColor: colors.outlineVariant }]}>
-              <Text variant="labelMedium" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
                 Serving: {item.serving}
               </Text>
-              <Text variant="labelMedium" style={{ color: colors.onSurface, marginBottom: 4 }}>
+              <Text variant="caption" style={{ color: colors.onSurface, marginBottom: 4 }}>
                 Multiplier
               </Text>
               <View style={styles.multChips}>
@@ -107,25 +114,22 @@ function DatabaseTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: 
                     selected={multiplier === v}
                     onPress={() => setMultiplier(v)}
                     style={styles.chip}
-                    accessibilityRole="button"
                     accessibilityState={{ selected: multiplier === v }}
                   >
                     {v}x
                   </Chip>
                 ))}
               </View>
-              <TextInput
-                mode="outlined"
+              <Input
                 label="Custom amount"
                 value={multiplier}
                 onChangeText={setMultiplier}
                 keyboardType="numeric"
-                dense
-                style={styles.multInput}
+                containerStyle={styles.multInput}
                 accessibilityLabel={`Serving multiplier: ${multiplier} times`}
               />
               {!valid && (
-                <Text variant="bodySmall" style={{ color: colors.error, marginBottom: 4 }}>
+                <Text variant="caption" style={{ color: colors.error, marginBottom: 4 }}>
                   Minimum 0.25x
                 </Text>
               )}
@@ -133,7 +137,7 @@ function DatabaseTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: 
                 style={styles.macros}
                 accessibilityLiveRegion="polite"
               >
-                <Text variant="bodyMedium" style={{ color: colors.onSurface }}>
+                <Text variant="body" style={{ color: colors.onSurface }}>
                   {scaled.calories} cal · {scaled.protein}p · {scaled.carbs}c · {scaled.fat}f
                 </Text>
               </View>
@@ -143,32 +147,30 @@ function DatabaseTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: 
                 icon={saveFav ? "heart" : "heart-outline"}
                 style={styles.favChip}
                 accessibilityLabel={saveFav ? "Remove from favorites" : "Save as favorite"}
-                accessibilityRole="button"
                 accessibilityState={{ selected: saveFav }}
               >
                 Save as Favorite
               </Chip>
               <Button
-                mode="contained"
+                variant="default"
                 onPress={() => log(item)}
                 loading={saving}
                 disabled={saving || !valid}
                 style={styles.btn}
-                contentStyle={styles.btnContent}
                 accessibilityLabel="Log food"
-              >
-                Log Food
-              </Button>
+                label="Log Food"
+              />
             </View>
           )}
-        </Card.Content>
+        </CardContent>
       </Card>
+      </Pressable>
     );
   };
 
   const empty = () => (
     <Text
-      variant="bodyMedium"
+      variant="body"
       style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 24 }}
     >
       No foods found. Try a different search term.
@@ -177,13 +179,12 @@ function DatabaseTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: 
 
   return (
     <View style={{ flex: 1, backgroundColor: colors.background }}>
-      <TextInput
-        mode="outlined"
+      <Input
         placeholder="Search foods..."
         value={query}
         onChangeText={setQuery}
-        left={<TextInput.Icon icon="magnify" />}
-        style={styles.input}
+        
+        containerStyle={styles.input}
         accessibilityLabel="Search foods"
       />
       <View style={styles.chips}>
@@ -191,7 +192,6 @@ function DatabaseTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: 
           selected={category === null}
           onPress={() => setCategory(null)}
           style={styles.chip}
-          accessibilityRole="button"
           accessibilityState={{ selected: category === null }}
         >
           All
@@ -202,7 +202,6 @@ function DatabaseTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: 
             selected={category === c.id}
             onPress={() => setCategory(category === c.id ? null : c.id)}
             style={styles.chip}
-            accessibilityRole="button"
             accessibilityState={{ selected: category === c.id }}
           >
             {c.label}
@@ -441,7 +440,7 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
     return (
       <View style={styles.emptyContainer}>
         <Text
-          variant="bodyMedium"
+          variant="body"
           style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 24 }}
           accessibilityLiveRegion="polite"
         >
@@ -461,29 +460,31 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
     };
 
     return (
-      <Card
-        style={[styles.dbCard, { backgroundColor: colors.surfaceVariant }]}
+      <Pressable
         onPress={() => expand(index)}
         accessibilityLabel={`${item.name}, ${item.calories} calories per ${item.servingLabel}`}
         accessibilityRole="button"
       >
-        <Card.Content>
+      <Card
+        style={StyleSheet.flatten([styles.dbCard, { backgroundColor: colors.surfaceVariant }])}
+      >
+        <CardContent>
           <Text
-            variant="titleSmall"
+            variant="subtitle"
             numberOfLines={2}
             style={{ color: colors.onSurface }}
           >
             {item.name}
           </Text>
-          <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
             {item.calories} cal · {item.protein}p · {item.carbs}c · {item.fat}f · per {item.servingLabel}
           </Text>
           {open && (
             <View style={[styles.detail, { borderTopColor: colors.outlineVariant }]}>
-              <Text variant="labelMedium" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
                 Serving: {item.servingLabel}
               </Text>
-              <Text variant="labelMedium" style={{ color: colors.onSurface, marginBottom: 4 }}>
+              <Text variant="caption" style={{ color: colors.onSurface, marginBottom: 4 }}>
                 Multiplier
               </Text>
               <View style={styles.multChips}>
@@ -493,25 +494,22 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
                     selected={multiplier === v}
                     onPress={() => setMultiplier(v)}
                     style={styles.chip}
-                    accessibilityRole="button"
                     accessibilityState={{ selected: multiplier === v }}
                   >
                     {v}x
                   </Chip>
                 ))}
               </View>
-              <TextInput
-                mode="outlined"
+              <Input
                 label="Custom amount"
                 value={multiplier}
                 onChangeText={setMultiplier}
                 keyboardType="numeric"
-                dense
-                style={styles.multInput}
+                containerStyle={styles.multInput}
                 accessibilityLabel={`Serving multiplier: ${multiplier} times`}
               />
               {!valid && (
-                <Text variant="bodySmall" style={{ color: colors.error, marginBottom: 4 }}>
+                <Text variant="caption" style={{ color: colors.error, marginBottom: 4 }}>
                   Minimum 0.25x
                 </Text>
               )}
@@ -519,7 +517,7 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
                 style={styles.macros}
                 accessibilityLiveRegion="polite"
               >
-                <Text variant="bodyMedium" style={{ color: colors.onSurface }}>
+                <Text variant="body" style={{ color: colors.onSurface }}>
                   {scaled.calories} cal · {scaled.protein}p · {scaled.carbs}c · {scaled.fat}f
                 </Text>
               </View>
@@ -529,26 +527,24 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
                 icon={saveFav ? "heart" : "heart-outline"}
                 style={styles.favChip}
                 accessibilityLabel={saveFav ? "Remove from favorites" : "Save as favorite"}
-                accessibilityRole="button"
                 accessibilityState={{ selected: saveFav }}
               >
                 Save as Favorite
               </Chip>
               <Button
-                mode="contained"
+                variant="default"
                 onPress={() => log(item)}
                 loading={saving}
                 disabled={saving || !valid}
                 style={styles.btn}
-                contentStyle={styles.btnContent}
                 accessibilityLabel="Log food"
-              >
-                Log Food
-              </Button>
+                label="Log Food"
+              />
             </View>
           )}
-        </Card.Content>
+        </CardContent>
       </Card>
+      </Pressable>
     );
   };
 
@@ -556,7 +552,7 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
     if (loading || error || !query.trim() || hint) return null;
     return (
       <Text
-        variant="bodyMedium"
+        variant="body"
         style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 24 }}
       >
         No foods found for &apos;{query.trim()}&apos;. Try different terms or use manual entry.
@@ -568,16 +564,11 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
     <View style={{ flex: 1, backgroundColor: colors.background }}>
       {Platform.OS !== "web" && (
         <Button
-          mode="outlined"
-          icon="barcode-scan"
+          variant="outline"
           onPress={openScanner}
           style={styles.scanBtn}
-          contentStyle={styles.scanBtnContent}
           accessibilityLabel="Scan food barcode"
-          accessibilityRole="button"
-        >
-          Scan Barcode
-        </Button>
+         label="Scan Barcode" />
       )}
       {barcodeLoading && (
         <View style={{ alignItems: "center", padding: 16 }} accessibilityLiveRegion="polite">
@@ -586,42 +577,34 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
             accessibilityLabel="Looking up barcode..."
             accessibilityRole="progressbar"
           />
-          <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
             Looking up barcode...
           </Text>
         </View>
       )}
       {barcodeError && (
         <View style={{ alignItems: "center", padding: 16 }} accessibilityLiveRegion="polite">
-          <Text variant="bodyMedium" style={{ color: colors.error, textAlign: "center", marginBottom: 12 }}>
+          <Text variant="body" style={{ color: colors.error, textAlign: "center", marginBottom: 12 }}>
             {barcodeError}
           </Text>
           <View style={{ flexDirection: "row", gap: 12 }}>
             <Button
-              mode="outlined"
+              variant="outline"
               onPress={retryBarcode}
               accessibilityLabel="Retry barcode scan"
-              accessibilityRole="button"
-              contentStyle={{ minHeight: 48 }}
-            >
-              Retry
-            </Button>
+             label="Retry" />
             <Button
-              mode="outlined"
+              variant="outline"
               onPress={switchToTextSearch}
               accessibilityLabel="Search by name instead"
-              accessibilityRole="button"
-              contentStyle={{ minHeight: 48 }}
-            >
-              Search by Name
-            </Button>
+             label="Search by Name" />
           </View>
         </View>
       )}
       {scannedProductName && (
         <View accessibilityLiveRegion="polite">
           <Text
-            variant="bodySmall"
+            variant="caption"
             style={{ color: colors.onSurfaceVariant, paddingHorizontal: 4, marginBottom: 8 }}
             accessibilityLabel={`Found: ${scannedProductName}`}
           >
@@ -629,17 +612,16 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
           </Text>
         </View>
       )}
-      <TextInput
-        mode="outlined"
+      <Input
         placeholder="Search for foods online"
         value={query}
         onChangeText={setQuery}
-        left={<TextInput.Icon icon="magnify" />}
-        style={styles.input}
+        
+        containerStyle={styles.input}
         accessibilityLabel="Search online food database"
       />
       {hint && (
-        <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant, paddingHorizontal: 4, marginBottom: 8 }}>
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant, paddingHorizontal: 4, marginBottom: 8 }}>
           {hint}
         </Text>
       )}
@@ -652,18 +634,14 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
       )}
       {error && (
         <View style={{ alignItems: "center", padding: 16 }} accessibilityLiveRegion="polite">
-          <Text variant="bodyMedium" style={{ color: colors.error, textAlign: "center", marginBottom: 12 }}>
+          <Text variant="body" style={{ color: colors.error, textAlign: "center", marginBottom: 12 }}>
             {error}
           </Text>
           <Button
-            mode="outlined"
+            variant="outline"
             onPress={retry}
             accessibilityLabel="Retry search"
-            accessibilityRole="button"
-            contentStyle={{ minHeight: 48 }}
-          >
-            Retry
-          </Button>
+           label="Retry" />
         </View>
       )}
       <FlashList
@@ -756,12 +734,11 @@ export default function AddFood() {
     return (
       <View style={[styles.container, { backgroundColor: colors.background, paddingHorizontal: layout.horizontalPadding }]}>
         <View style={styles.header}>
-          <SegmentedButtons
+          <SegmentedControl
             value={tab}
             onValueChange={setTab}
             buttons={TAB_BUTTONS}
             style={styles.tabs}
-            density="medium"
           />
           <View style={styles.meals}>
             {MEALS.map((m) => (
@@ -771,7 +748,6 @@ export default function AddFood() {
                 onPress={() => setMeal(m)}
                 style={styles.chip}
                 accessibilityLabel={`Meal: ${MEAL_LABELS[m]}`}
-                accessibilityRole="button"
                 accessibilityState={{ selected: meal === m }}
               >
                 {MEAL_LABELS[m]}
@@ -789,21 +765,24 @@ export default function AddFood() {
   }
 
   const renderFav = ({ item: f }: { item: FoodEntry }) => (
-    <Card
-      style={[styles.favCard, { backgroundColor: colors.surfaceVariant }]}
+    <Pressable
       onPress={() => quickLog(f)}
       accessibilityLabel={`Quick log ${f.name}, ${f.calories} calories`}
       accessibilityRole="button"
     >
-      <Card.Content>
-        <Text variant="titleSmall" style={{ color: colors.onSurface }}>
+    <Card
+      style={StyleSheet.flatten([styles.favCard, { backgroundColor: colors.surfaceVariant }])}
+    >
+      <CardContent>
+        <Text variant="subtitle" style={{ color: colors.onSurface }}>
           {f.name}
         </Text>
-        <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
           {f.calories} cal · {f.protein}p · {f.carbs}c · {f.fat}f · {f.serving_size}
         </Text>
-      </Card.Content>
+      </CardContent>
     </Card>
+    </Pressable>
   );
 
   return (
@@ -815,12 +794,11 @@ export default function AddFood() {
       contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: 32 }}
       ListHeaderComponent={
         <>
-          <SegmentedButtons
+          <SegmentedControl
             value={tab}
             onValueChange={setTab}
             buttons={TAB_BUTTONS}
             style={styles.tabs}
-            density="medium"
           />
 
           <View style={styles.meals}>
@@ -831,7 +809,6 @@ export default function AddFood() {
                 onPress={() => setMeal(m)}
                 style={styles.chip}
                 accessibilityLabel={`Meal: ${MEAL_LABELS[m]}`}
-                accessibilityRole="button"
                 accessibilityState={{ selected: meal === m }}
               >
                 {MEAL_LABELS[m]}
@@ -840,57 +817,51 @@ export default function AddFood() {
           </View>
 
           {tab === "new" ? (
-            <Card style={[styles.card, { backgroundColor: colors.surface }]}>
-              <Card.Content>
-                <TextInput
+            <Card style={StyleSheet.flatten([styles.card, { backgroundColor: colors.surface }])}>
+              <CardContent>
+                <Input
                   label="Food name"
                   value={name}
                   onChangeText={setName}
-                  mode="outlined"
-                  style={styles.input}
+                  containerStyle={styles.input}
                 />
-                <TextInput
+                <Input
                   label="Calories"
                   value={calories}
                   onChangeText={setCalories}
                   keyboardType="numeric"
-                  mode="outlined"
-                  style={styles.input}
+                  containerStyle={styles.input}
                 />
                 <View style={styles.row}>
-                  <TextInput
+                  <Input
                     label="Protein (g)"
                     value={protein}
                     onChangeText={setProtein}
                     keyboardType="numeric"
-                    mode="outlined"
-                    style={[styles.input, styles.flex]}
+                    containerStyle={[styles.input, styles.flex]}
                   />
                   <View style={{ width: 8 }} />
-                  <TextInput
+                  <Input
                     label="Carbs (g)"
                     value={carbs}
                     onChangeText={setCarbs}
                     keyboardType="numeric"
-                    mode="outlined"
-                    style={[styles.input, styles.flex]}
+                    containerStyle={[styles.input, styles.flex]}
                   />
                   <View style={{ width: 8 }} />
-                  <TextInput
+                  <Input
                     label="Fat (g)"
                     value={fat}
                     onChangeText={setFat}
                     keyboardType="numeric"
-                    mode="outlined"
-                    style={[styles.input, styles.flex]}
+                    containerStyle={[styles.input, styles.flex]}
                   />
                 </View>
-                <TextInput
+                <Input
                   label="Serving size"
                   value={serving}
                   onChangeText={setServing}
-                  mode="outlined"
-                  style={styles.input}
+                  containerStyle={styles.input}
                 />
                 <Chip
                   selected={favorite}
@@ -898,34 +869,30 @@ export default function AddFood() {
                   icon={favorite ? "heart" : "heart-outline"}
                   style={styles.favChip}
                   accessibilityLabel={favorite ? "Remove from favorites" : "Save as favorite"}
-                  accessibilityRole="button"
                   accessibilityState={{ selected: favorite }}
                 >
                   Save as favorite
                 </Chip>
                 <Button
-                  mode="contained"
+                  variant="default"
                   onPress={save}
                   loading={saving}
                   disabled={saving || !name.trim()}
                   style={styles.btn}
-                  contentStyle={styles.btnContent}
                   accessibilityLabel="Log food"
-                >
-                  Log Food
-                </Button>
-              </Card.Content>
+                 label="Log Food" />
+              </CardContent>
             </Card>
           ) : favorites.length === 0 ? (
-            <Card style={[styles.card, { backgroundColor: colors.surface }]}>
-              <Card.Content>
+            <Card style={StyleSheet.flatten([styles.card, { backgroundColor: colors.surface }])}>
+              <CardContent>
                 <Text
-                  variant="bodyMedium"
+                  variant="body"
                   style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 16 }}
                 >
                   No favorites yet. Save foods as favorites when logging them.
                 </Text>
-              </Card.Content>
+              </CardContent>
             </Card>
           ) : null}
         </>

--- a/app/nutrition/add.tsx
+++ b/app/nutrition/add.tsx
@@ -116,7 +116,7 @@ function DatabaseTab({ meal, saving, onSaving, dateKey }: { meal: Meal; saving: 
                     style={styles.chip}
                     accessibilityState={{ selected: multiplier === v }}
                   >
-                    {v}x
+                    {`${v}x`}
                   </Chip>
                 ))}
               </View>
@@ -496,7 +496,7 @@ function OnlineTab({ meal, saving, onSaving, dateKey, autoScan }: { meal: Meal; 
                     style={styles.chip}
                     accessibilityState={{ selected: multiplier === v }}
                   >
-                    {v}x
+                    {`${v}x`}
                   </Chip>
                 ))}
               </View>

--- a/app/nutrition/add.tsx
+++ b/app/nutrition/add.tsx
@@ -838,7 +838,7 @@ export default function AddFood() {
                     value={protein}
                     onChangeText={setProtein}
                     keyboardType="numeric"
-                    containerStyle={[styles.input, styles.flex]}
+                    containerStyle={StyleSheet.flatten([styles.input, styles.flex])}
                   />
                   <View style={{ width: 8 }} />
                   <Input
@@ -846,7 +846,7 @@ export default function AddFood() {
                     value={carbs}
                     onChangeText={setCarbs}
                     keyboardType="numeric"
-                    containerStyle={[styles.input, styles.flex]}
+                    containerStyle={StyleSheet.flatten([styles.input, styles.flex])}
                   />
                   <View style={{ width: 8 }} />
                   <Input
@@ -854,7 +854,7 @@ export default function AddFood() {
                     value={fat}
                     onChangeText={setFat}
                     keyboardType="numeric"
-                    containerStyle={[styles.input, styles.flex]}
+                    containerStyle={StyleSheet.flatten([styles.input, styles.flex])}
                   />
                 </View>
                 <Input

--- a/app/nutrition/profile.tsx
+++ b/app/nutrition/profile.tsx
@@ -1,5 +1,5 @@
 import { ScrollView, StyleSheet } from "react-native";
-import { Card } from "react-native-paper";
+import { Card, CardContent } from "@/components/ui/card";
 import { router } from "expo-router";
 import { useLayout } from "../../lib/layout";
 import ProfileForm from "../../components/ProfileForm";
@@ -15,9 +15,9 @@ export default function ProfileScreen() {
       contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
     >
       <Card style={[styles.card, { backgroundColor: colors.surface }]}>
-        <Card.Content>
+        <CardContent>
           <ProfileForm onSave={() => router.back()} />
-        </Card.Content>
+        </CardContent>
       </Card>
     </ScrollView>
   );

--- a/app/nutrition/targets.tsx
+++ b/app/nutrition/targets.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useState } from "react";
-import { ScrollView, StyleSheet } from "react-native";
-import { Button, Card, Text, TextInput } from "react-native-paper";
+import { Pressable, ScrollView, StyleSheet } from "react-native";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
+import { Input } from "@/components/ui/input";
 import { router, useFocusEffect } from "expo-router";
 import { useLayout } from "../../lib/layout";
 import { getAppSetting, getMacroTargets, updateMacroTargets } from "../../lib/db";
@@ -78,72 +81,67 @@ export default function Targets() {
       style={[styles.container, { backgroundColor: colors.background }]}
       contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
     >
-      <Card
-        style={[styles.card, { backgroundColor: colors.primaryContainer }]}
+      <Pressable
         onPress={() => router.push("/nutrition/profile")}
         accessibilityLabel={profile ? "Update your nutrition profile" : "Set your profile for personalized targets"}
         accessibilityRole="button"
       >
-        <Card.Content>
-          <Text variant="titleSmall" style={{ color: colors.onPrimaryContainer, fontSize: 16 }}>
+      <Card
+        style={StyleSheet.flatten([styles.card, { backgroundColor: colors.primaryContainer }])}
+      >
+        <CardContent>
+          <Text variant="subtitle" style={{ color: colors.onPrimaryContainer, fontSize: 16 }}>
             {profile ? "Update your profile" : "Set your profile for personalized targets"}
           </Text>
           {profileSummary ? (
-            <Text variant="bodySmall" style={{ color: colors.onPrimaryContainer, marginTop: 4, fontSize: 14 }}>
+            <Text variant="caption" style={{ color: colors.onPrimaryContainer, marginTop: 4, fontSize: 14 }}>
               {"Based on: " + profileSummary}
             </Text>
           ) : null}
-        </Card.Content>
+        </CardContent>
       </Card>
+      </Pressable>
 
-      <Card style={[styles.card, { backgroundColor: colors.surface }]}>
-        <Card.Content>
-          <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 16 }}>
+      <Card style={StyleSheet.flatten([styles.card, { backgroundColor: colors.surface }])}>
+        <CardContent>
+          <Text variant="title" style={{ color: colors.onSurface, marginBottom: 16 }}>
             Daily Macro Targets
           </Text>
-          <TextInput
+          <Input
             label="Calories"
             value={calories}
             onChangeText={setCalories}
             keyboardType="numeric"
-            mode="outlined"
-            style={styles.input}
+            containerStyle={styles.input}
             accessibilityLabel="Calories"
           />
-          <TextInput
+          <Input
             label="Protein (g)"
             value={protein}
             onChangeText={setProtein}
             keyboardType="numeric"
-            mode="outlined"
-            style={styles.input}
+            containerStyle={styles.input}
             accessibilityLabel="Protein"
           />
-          <TextInput
+          <Input
             label="Carbs (g)"
             value={carbs}
             onChangeText={setCarbs}
             keyboardType="numeric"
-            mode="outlined"
-            style={styles.input}
+            containerStyle={styles.input}
             accessibilityLabel="Carbs"
           />
-          <TextInput
+          <Input
             label="Fat (g)"
             value={fat}
             onChangeText={setFat}
             keyboardType="numeric"
-            mode="outlined"
-            style={styles.input}
+            containerStyle={styles.input}
             accessibilityLabel="Fat"
           />
-          <Button mode="contained" onPress={save} loading={saving} disabled={saving} style={styles.btn} contentStyle={styles.btnContent} accessibilityLabel="Save macro targets">
-            Save Targets
-          </Button>
-          <Button mode="outlined" onPress={reset} style={styles.btn} contentStyle={styles.btnContent} accessibilityLabel="Reset to default targets">
-            Reset to Defaults
-          </Button>
-        </Card.Content>
+          <Button variant="default" onPress={save} loading={saving} disabled={saving} style={styles.btn} accessibilityLabel="Save macro targets" label="Save Targets" />
+          <Button variant="outline" onPress={reset} style={styles.btn} accessibilityLabel="Reset to default targets" label="Reset to Defaults" />
+        </CardContent>
       </Card>
     </ScrollView>
   );

--- a/app/onboarding/_layout.tsx
+++ b/app/onboarding/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack, useRouter } from "expo-router";
 import { View, StyleSheet } from "react-native";
-import { Button, Text } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
 import React from "react";
 import { setAppSetting } from "../../lib/db";
 import { useCompleteOnboarding } from "../../lib/onboarding-context";
@@ -29,26 +30,24 @@ function Fallback() {
 
   return (
     <View style={[styles.fallback, { backgroundColor: colors.background }]}>
-      <Text variant="headlineMedium" style={[styles.title, { color: colors.onBackground }]}>
+      <Text variant="heading" style={[styles.title, { color: colors.onBackground }]}>
         Something went wrong
       </Text>
-      <Text variant="bodyMedium" style={[styles.sub, { color: colors.onSurfaceVariant }]}>
+      <Text variant="body" style={[styles.sub, { color: colors.onSurfaceVariant }]}>
         {"We couldn't load onboarding. You can skip straight to the app."}
       </Text>
       {err && (
-        <Text variant="bodySmall" style={[styles.sub, { color: colors.error }]}>
+        <Text variant="caption" style={[styles.sub, { color: colors.error }]}>
           {err}
         </Text>
       )}
       <Button
-        mode="contained"
+        variant="default"
         onPress={err ? force : skip}
         style={styles.btn}
-        contentStyle={{ minHeight: 48 }}
         accessibilityLabel="Skip to app"
-      >
-        {err ? "Continue Without Saving" : "Skip to App"}
-      </Button>
+        label={err ? "Continue Without Saving" : "Skip to App"}
+      />
     </View>
   );
 }

--- a/app/onboarding/recommend.tsx
+++ b/app/onboarding/recommend.tsx
@@ -1,6 +1,10 @@
 import { ScrollView, StyleSheet, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Banner, Button, Card, Chip, Text } from "react-native-paper";
+import { Alert as AlertComponent, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Chip } from "@/components/ui/chip";
+import { Text } from "@/components/ui/text";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
@@ -70,16 +74,15 @@ export default function Recommend() {
 
   const errorBanner = (
     <>
-      <Banner
-        visible={!!error}
-        actions={[
-          { label: "Retry", onPress: () => finish() },
-          { label: "Skip", onPress: skip },
-        ]}
-        icon="alert-circle-outline"
-      >
-        {error}
-      </Banner>
+      {!!error && (
+        <AlertComponent variant="destructive" style={{ marginBottom: 16 }}>
+          <AlertDescription>{error}</AlertDescription>
+          <View style={{ flexDirection: "row", gap: 8, marginTop: 8 }}>
+            <Button variant="outline" onPress={() => finish()} label="Retry" size="sm" />
+            <Button variant="ghost" onPress={skip} label="Skip" size="sm" />
+          </View>
+        </AlertComponent>
+      )}
     </>
   );
 
@@ -90,31 +93,29 @@ export default function Recommend() {
         contentContainerStyle={styles.scroll}
       >
         {errorBanner}
-        <Text variant="headlineMedium" style={[styles.title, { color: colors.onBackground }]}>
+        <Text variant="heading" style={[styles.title, { color: colors.onBackground }]}>
           We Recommend
         </Text>
-        <Card style={[styles.recCard, { backgroundColor: colors.surface }]} mode="outlined">
-          <Card.Content>
+        <Card style={StyleSheet.flatten([styles.recCard, { backgroundColor: colors.surface }])}>
+          <CardContent>
             <View style={styles.recHeader}>
-              <Text variant="headlineSmall" style={{ color: colors.onSurface }}>
+              <Text variant="title" style={{ color: colors.onSurface }}>
                 {FULL_BODY.name}
               </Text>
               <Chip
                 compact
-                mode="flat"
                 style={{ backgroundColor: colors.primaryContainer }}
-                textStyle={{ color: colors.onPrimaryContainer }}
               >
                 Recommended
               </Chip>
             </View>
-            <Text variant="bodyMedium" style={[styles.recDesc, { color: colors.onSurfaceVariant }]}>
+            <Text variant="body" style={[styles.recDesc, { color: colors.onSurfaceVariant }]}>
               This {FULL_BODY.duration} workout covers all major muscle groups — perfect for building a
               foundation.
             </Text>
             <View style={styles.meta}>
               <MaterialCommunityIcons name="clock-outline" size={16} color={colors.onSurfaceVariant} />
-              <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
                 {FULL_BODY.duration}
               </Text>
               <MaterialCommunityIcons
@@ -123,17 +124,16 @@ export default function Recommend() {
                 color={colors.onSurfaceVariant}
                 style={{ marginLeft: 12 }}
               />
-              <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
                 {FULL_BODY.exercises.length} exercises
               </Text>
             </View>
-          </Card.Content>
+          </CardContent>
         </Card>
         <Button
-          mode="contained"
+          variant="default"
           onPress={() => finish("template")}
           style={styles.btn}
-          contentStyle={styles.btnContent}
           loading={saving}
           disabled={saving}
           accessibilityLabel={`Start with ${FULL_BODY.name}`}
@@ -141,15 +141,13 @@ export default function Recommend() {
           Start with {FULL_BODY.name}
         </Button>
         <Button
-          mode="text"
+          variant="ghost"
           onPress={() => finish()}
           style={styles.skip}
-          contentStyle={styles.btnContent}
           disabled={saving}
           accessibilityLabel="Skip recommendation and explore on your own"
-        >
-          {"I'll explore on my own"}
-        </Button>
+          label="I'll explore on my own"
+        />
       </ScrollView>
     );
   }
@@ -161,40 +159,37 @@ export default function Recommend() {
         contentContainerStyle={styles.scroll}
       >
         {errorBanner}
-        <Text variant="headlineMedium" style={[styles.title, { color: colors.onBackground }]}>
+        <Text variant="heading" style={[styles.title, { color: colors.onBackground }]}>
           We Recommend
         </Text>
-        <Card style={[styles.recCard, { backgroundColor: colors.surface }]} mode="outlined">
-          <Card.Content>
+        <Card style={StyleSheet.flatten([styles.recCard, { backgroundColor: colors.surface }])}>
+          <CardContent>
             <View style={styles.recHeader}>
-              <Text variant="headlineSmall" style={{ color: colors.onSurface }}>
+              <Text variant="title" style={{ color: colors.onSurface }}>
                 {PPL.name}
               </Text>
               <Chip
                 compact
-                mode="flat"
                 style={{ backgroundColor: colors.secondaryContainer }}
-                textStyle={{ color: colors.onSecondaryContainer }}
               >
                 Program
               </Chip>
             </View>
-            <Text variant="bodyMedium" style={[styles.recDesc, { color: colors.onSurfaceVariant }]}>
+            <Text variant="body" style={[styles.recDesc, { color: colors.onSurfaceVariant }]}>
               {PPL.description}
             </Text>
             <View style={styles.meta}>
               <MaterialCommunityIcons name="calendar-sync" size={16} color={colors.onSurfaceVariant} />
-              <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
                 {PPL.days.length}-day cycle
               </Text>
             </View>
-          </Card.Content>
+          </CardContent>
         </Card>
         <Button
-          mode="contained"
+          variant="default"
           onPress={() => finish("program")}
           style={styles.btn}
-          contentStyle={styles.btnContent}
           loading={saving}
           disabled={saving}
           accessibilityLabel={`Start with ${PPL.name}`}
@@ -202,15 +197,13 @@ export default function Recommend() {
           Start with {PPL.name}
         </Button>
         <Button
-          mode="text"
+          variant="ghost"
           onPress={() => finish()}
           style={styles.skip}
-          contentStyle={styles.btnContent}
           disabled={saving}
           accessibilityLabel="Skip recommendation and explore on your own"
-        >
-          {"I'll explore on my own"}
-        </Button>
+          label="I'll explore on my own"
+        />
       </ScrollView>
     );
   }
@@ -219,10 +212,10 @@ export default function Recommend() {
   const advancedHeader = (
     <>
       {errorBanner}
-      <Text variant="headlineMedium" style={[styles.title, { color: colors.onBackground }]}>
+      <Text variant="heading" style={[styles.title, { color: colors.onBackground }]}>
         Browse Our Templates
       </Text>
-      <Text variant="bodyLarge" style={[styles.subtitle, { color: colors.onSurfaceVariant }]}>
+      <Text variant="body" style={[styles.subtitle, { color: colors.onSurfaceVariant }]}>
         Pick a starter template or create your own workouts from scratch.
       </Text>
     </>
@@ -231,26 +224,22 @@ export default function Recommend() {
   const advancedFooter = (
     <>
       <Button
-        mode="contained"
+        variant="default"
         onPress={() => finish("browse")}
         style={styles.btn}
-        contentStyle={styles.btnContent}
         loading={saving}
         disabled={saving}
         accessibilityLabel="Browse all workout templates"
-      >
-        Browse All Templates
-      </Button>
+        label="Browse All Templates"
+      />
       <Button
-        mode="text"
+        variant="ghost"
         onPress={() => finish()}
         style={styles.skip}
-        contentStyle={styles.btnContent}
         disabled={saving}
         accessibilityLabel="Skip and explore on your own"
-      >
-        {"I'll explore on my own"}
-      </Button>
+        label="I'll explore on my own"
+      />
     </>
   );
 
@@ -263,24 +252,24 @@ export default function Recommend() {
       ListFooterComponent={advancedFooter}
       renderItem={({ item: tpl }) => (
         <Card
-          style={[styles.browseCard, { backgroundColor: colors.surface }]}
-          mode="outlined"
+          style={StyleSheet.flatten([styles.browseCard, { backgroundColor: colors.surface }])}
+         
         >
-          <Card.Content>
+          <CardContent>
             <View style={styles.recHeader}>
-              <Text variant="titleMedium" style={{ color: colors.onSurface }}>
+              <Text variant="title" style={{ color: colors.onSurface }}>
                 {tpl.name}
               </Text>
               <View style={styles.meta}>
-                <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+                <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                   {tpl.duration}
                 </Text>
               </View>
             </View>
-            <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
               {tpl.exercises.length} exercises · {tpl.difficulty}
             </Text>
-          </Card.Content>
+          </CardContent>
         </Card>
       )}
     />

--- a/app/onboarding/setup.tsx
+++ b/app/onboarding/setup.tsx
@@ -1,6 +1,8 @@
-import { StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Button, SegmentedButtons, Text, TouchableRipple } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Text } from "@/components/ui/text";
 import { useRouter } from "expo-router";
 import { useState } from "react";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
@@ -50,15 +52,15 @@ export default function Setup() {
 
   const header = (
     <>
-      <Text variant="headlineMedium" style={[styles.title, { color: colors.onBackground }]}>
+      <Text variant="heading" style={[styles.title, { color: colors.onBackground }]}>
         Set Up Your Preferences
       </Text>
 
-      <Text variant="titleMedium" style={[styles.section, { color: colors.onBackground }]}>
+      <Text variant="title" style={[styles.section, { color: colors.onBackground }]}>
         Weight Unit
       </Text>
       <View accessibilityRole="radiogroup" accessibilityLabel="Weight unit">
-        <SegmentedButtons
+        <SegmentedControl
           value={weight}
           onValueChange={(v) => setWeight(v as "kg" | "lb")}
           buttons={[
@@ -69,11 +71,11 @@ export default function Setup() {
         />
       </View>
 
-      <Text variant="titleMedium" style={[styles.section, { color: colors.onBackground }]}>
+      <Text variant="title" style={[styles.section, { color: colors.onBackground }]}>
         Measurement Unit
       </Text>
       <View accessibilityRole="radiogroup" accessibilityLabel="Measurement unit">
-        <SegmentedButtons
+        <SegmentedControl
           value={measurement}
           onValueChange={(v) => setMeasurement(v as "cm" | "in")}
           buttons={[
@@ -84,7 +86,7 @@ export default function Setup() {
         />
       </View>
 
-      <Text variant="titleMedium" style={[styles.section, { color: colors.onBackground }]}>
+      <Text variant="title" style={[styles.section, { color: colors.onBackground }]}>
         Experience Level
       </Text>
     </>
@@ -92,7 +94,7 @@ export default function Setup() {
 
   const footer = (
     <Button
-      mode="contained"
+      variant="default"
       disabled={!level}
       onPress={() => {
         router.replace({
@@ -101,12 +103,9 @@ export default function Setup() {
         });
       }}
       style={styles.btn}
-      contentStyle={styles.btnContent}
       accessibilityLabel={level ? "Continue to recommendations" : "Select an experience level to continue"}
-      accessibilityState={{ disabled: !level }}
-    >
-      Continue
-    </Button>
+      label="Continue"
+    />
   );
 
   return (
@@ -122,7 +121,7 @@ export default function Setup() {
       renderItem={({ item }) => {
         const selected = level === item.value;
         return (
-          <TouchableRipple
+          <Pressable
             onPress={() => setLevel(item.value)}
             accessibilityRole="radio"
             accessibilityState={{ checked: selected }}
@@ -145,13 +144,13 @@ export default function Setup() {
               />
               <View style={styles.cardText}>
                 <Text
-                  variant="titleMedium"
+                  variant="title"
                   style={{ color: selected ? colors.onPrimaryContainer : colors.onSurface }}
                 >
                   {item.label}
                 </Text>
                 <Text
-                  variant="bodyMedium"
+                  variant="body"
                   style={{ color: selected ? colors.onPrimaryContainer : colors.onSurfaceVariant }}
                 >
                   {item.description}
@@ -165,7 +164,7 @@ export default function Setup() {
                 />
               )}
             </View>
-          </TouchableRipple>
+          </Pressable>
         );
       }}
     />

--- a/app/onboarding/welcome.tsx
+++ b/app/onboarding/welcome.tsx
@@ -1,5 +1,6 @@
 import { View, StyleSheet } from "react-native";
-import { Button, Text } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
 import { useRouter } from "expo-router";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useThemeColors } from "@/hooks/useThemeColors";
@@ -17,23 +18,21 @@ export default function Welcome() {
           color={colors.primary}
           style={styles.icon}
         />
-        <Text variant="headlineLarge" style={[styles.title, { color: colors.onBackground }]}>
+        <Text variant="heading" style={[styles.title, { color: colors.onBackground }]}>
           Welcome to FitForge
         </Text>
-        <Text variant="bodyLarge" style={[styles.subtitle, { color: colors.onSurfaceVariant }]}>
+        <Text variant="body" style={[styles.subtitle, { color: colors.onSurfaceVariant }]}>
           Your free workout & macro tracker
         </Text>
       </View>
       <View style={styles.footer}>
         <Button
-          mode="contained"
+          variant="default"
           onPress={() => router.replace("/onboarding/setup")}
           style={styles.btn}
-          contentStyle={styles.btnContent}
           accessibilityLabel="Get started with FitForge"
-        >
-          Get Started
-        </Button>
+          label="Get Started"
+        />
       </View>
     </View>
   );

--- a/app/program/[id].tsx
+++ b/app/program/[id].tsx
@@ -2,11 +2,16 @@ import { useCallback, useState } from "react";
 import {
   Alert,
   Modal,
+  Pressable,
   StyleSheet,
+  TouchableOpacity,
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Button, Card, Chip, IconButton, Text, TouchableRipple } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Chip } from "@/components/ui/chip";
+import { Text } from "@/components/ui/text";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useFocusEffect } from "expo-router";
@@ -222,7 +227,6 @@ export default function ProgramDetail() {
           <>
             {starter && (
               <Chip
-                mode="flat"
                 compact
                 style={styles.starterChip}
                 accessibilityLabel="Starter program, read-only. Duplicate to edit."
@@ -233,7 +237,7 @@ export default function ProgramDetail() {
 
             {program.description ? (
               <Text
-                variant="bodyMedium"
+                variant="body"
                 style={[styles.desc, { color: colors.onSurfaceVariant }]}
               >
                 {program.description}
@@ -241,12 +245,12 @@ export default function ProgramDetail() {
             ) : null}
 
             <View style={styles.meta}>
-              <Text variant="bodyMedium" style={{ color: colors.onBackground }}>
+              <Text variant="body" style={{ color: colors.onBackground }}>
                 {days.length} day{days.length !== 1 ? "s" : ""} · {cycle} cycle{cycle !== 1 ? "s" : ""} completed
               </Text>
               {program.is_active && currentIdx >= 0 && (
                 <Text
-                  variant="bodyMedium"
+                  variant="body"
                   style={{ color: colors.primary, fontWeight: "600" }}
                   accessibilityLabel={`Currently on day ${currentIdx + 1} of ${days.length}: ${dayName(days[currentIdx])}`}
                 >
@@ -258,134 +262,110 @@ export default function ProgramDetail() {
             {starter ? (
               <View style={styles.actions}>
                 <Button
-                  mode={program.is_active ? "outlined" : "contained"}
+                  variant={program.is_active ? "outline" : "default"}
                   onPress={toggle}
                   disabled={loading}
                   style={styles.actionBtn}
-                  contentStyle={styles.btnContent}
                   accessibilityLabel={program.is_active ? "Deactivate program" : "Set program as active"}
                 >
                   {program.is_active ? "Deactivate" : "Set Active"}
                 </Button>
                 <Button
-                  mode="outlined"
-                  icon="content-copy"
+                  variant="outline"
                   onPress={handleDuplicate}
                   style={styles.actionBtn}
-                  contentStyle={styles.btnContent}
                   accessibilityLabel="Duplicate to edit"
-                >
-                  Duplicate to Edit
-                </Button>
+                  label="Duplicate to Edit"
+                />
               </View>
             ) : (
               <View style={styles.actions}>
                 <Button
-                  mode={program.is_active ? "outlined" : "contained"}
+                  variant={program.is_active ? "outline" : "default"}
                   onPress={toggle}
                   disabled={loading}
                   style={styles.actionBtn}
-                  contentStyle={styles.btnContent}
                   accessibilityLabel={program.is_active ? "Deactivate program" : "Set program as active"}
                 >
                   {program.is_active ? "Deactivate" : "Set Active"}
                 </Button>
                 <Button
-                  mode="outlined"
+                  variant="outline"
                   onPress={() => router.push(`/program/create?programId=${program.id}`)}
                   style={styles.actionBtn}
-                  contentStyle={styles.btnContent}
                   accessibilityLabel="Edit program"
-                >
-                  Edit
-                </Button>
-                <IconButton
-                  icon="delete"
-                  onPress={confirmDelete}
-                  accessibilityLabel="Delete program"
+                  label="Edit"
                 />
+                <TouchableOpacity onPress={confirmDelete} accessibilityLabel="Delete program" hitSlop={8} style={{ padding: 8 }}>
+                  <MaterialCommunityIcons name="delete" size={24} color={colors.onSurface} />
+                </TouchableOpacity>
               </View>
             )}
 
             <View style={styles.sectionHeader}>
-              <Text variant="titleMedium" style={{ color: colors.onBackground }}>
+              <Text variant="title" style={{ color: colors.onBackground }}>
                 Workout Days ({days.length})
               </Text>
               {!starter && (
                 <Button
-                  mode="text"
-                  icon="plus"
-                  compact
+                  variant="ghost"
+                  size="sm"
                   onPress={() => router.push(`/program/pick-template?programId=${program.id}`)}
                   accessibilityLabel="Add workout day"
-                >
-                  Add Day
-                </Button>
+                  label="Add Day"
+                />
               )}
             </View>
           </>
         }
         renderItem={({ item, index }: { item: ProgramDay; index: number }) => (
           <Card
-            style={[
+            style={StyleSheet.flatten([
               styles.card,
               { backgroundColor: colors.surface },
               item.id === program.current_day_id && {
                 borderColor: colors.primary,
                 borderWidth: 2,
               },
-            ]}
+            ])}
             accessibilityLabel={`Day ${index + 1}: ${dayName(item)}${item.id === program.current_day_id ? ", current day" : ""}`}
           >
-            <Card.Content style={styles.cardContent}>
+            <CardContent style={styles.cardContent}>
               <View style={styles.cardInfo}>
-                <Text variant="titleSmall" style={{ color: colors.onSurface }}>
+                <Text variant="subtitle" style={{ color: colors.onSurface }}>
                   Day {index + 1}: {dayName(item)}
                 </Text>
                 {item.template_id === null && (
-                  <Text variant="bodySmall" style={{ color: colors.error }}>
+                  <Text variant="caption" style={{ color: colors.error }}>
                     Deleted Template
                   </Text>
                 )}
                 {item.label && item.template_name && item.label !== item.template_name && (
-                  <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+                  <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                     {item.template_name}
                   </Text>
                 )}
               </View>
               {!starter && (
                 <View style={styles.cardActions}>
-                  <IconButton
-                    icon="arrow-up"
-                    size={18}
-                    onPress={() => move(index, -1)}
-                    disabled={index === 0}
-                    accessibilityLabel={`Move ${dayName(item)} up`}
-                    accessibilityHint="Reorders workout day"
-                  />
-                  <IconButton
-                    icon="arrow-down"
-                    size={18}
-                    onPress={() => move(index, 1)}
-                    disabled={index === days.length - 1}
-                    accessibilityLabel={`Move ${dayName(item)} down`}
-                    accessibilityHint="Reorders workout day"
-                  />
-                  <IconButton
-                    icon="close"
-                  size={18}
-                  onPress={() => remove(item.id)}
-                  accessibilityLabel={`Remove ${dayName(item)}`}
-                />
-              </View>
+                  <TouchableOpacity onPress={() => move(index, -1)} disabled={index === 0} accessibilityLabel={`Move ${dayName(item)} up`} accessibilityHint="Reorders workout day" hitSlop={8} style={{ padding: 8 }}>
+                    <MaterialCommunityIcons name="arrow-up" size={18} color={index === 0 ? colors.onSurfaceDisabled : colors.onSurface} />
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={() => move(index, 1)} disabled={index === days.length - 1} accessibilityLabel={`Move ${dayName(item)} down`} accessibilityHint="Reorders workout day" hitSlop={8} style={{ padding: 8 }}>
+                    <MaterialCommunityIcons name="arrow-down" size={18} color={index === days.length - 1 ? colors.onSurfaceDisabled : colors.onSurface} />
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={() => remove(item.id)} accessibilityLabel={`Remove ${dayName(item)}`} hitSlop={8} style={{ padding: 8 }}>
+                    <MaterialCommunityIcons name="close" size={18} color={colors.onSurface} />
+                  </TouchableOpacity>
+                </View>
               )}
-            </Card.Content>
+            </CardContent>
           </Card>
         )}
         ListEmptyComponent={
           <View style={styles.empty}>
             <Text
-              variant="bodyMedium"
+              variant="body"
               style={{ color: colors.onSurfaceVariant }}
               accessibilityRole="text"
               accessibilityLabel="No workout days added yet"
@@ -399,24 +379,22 @@ export default function ProgramDetail() {
             {/* Weekly Schedule */}
             <View style={styles.scheduleSection}>
               <View style={styles.sectionHeader}>
-                <Text variant="titleMedium" style={{ color: colors.onBackground }}>
+                <Text variant="title" style={{ color: colors.onBackground }}>
                   Weekly Schedule
                 </Text>
                 {schedule.length > 0 && !starter && (
                   <Button
-                    mode="text"
-                    compact
-                    textColor={colors.error}
+                    variant="ghost"
+                    size="sm"
                     onPress={confirmClearSchedule}
                     accessibilityLabel="Clear weekly schedule"
-                  >
-                    Clear
-                  </Button>
+                    label="Clear"
+                  />
                 )}
               </View>
 
               {templates.length === 0 ? (
-                <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
+                <Text variant="body" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
                   Create a template first to set a schedule.
                 </Text>
               ) : (
@@ -424,7 +402,7 @@ export default function ProgramDetail() {
                   {DAYS.map((label, i) => {
                     const e = schedEntry(i);
                     return (
-                      <TouchableRipple
+                      <Pressable
                         key={i}
                         onPress={starter ? undefined : () => setPicker(i)}
                         disabled={starter}
@@ -436,16 +414,16 @@ export default function ProgramDetail() {
                         accessibilityLabel={`${label}: ${e ? e.template_name : "Rest day"}`}
                       >
                         <View style={styles.dayRow}>
-                          <Text variant="titleSmall" style={[styles.dayLabel, { color: colors.onSurface }]}>
+                          <Text variant="subtitle" style={[styles.dayLabel, { color: colors.onSurface }]}>
                             {label}
                           </Text>
                           <View style={styles.dayInfo}>
                             {e ? (
-                              <Text variant="bodyMedium" style={{ color: colors.onSurface }} numberOfLines={1}>
+                              <Text variant="body" style={{ color: colors.onSurface }} numberOfLines={1}>
                                 {e.template_name}
                               </Text>
                             ) : (
-                              <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant }}>
+                              <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
                                 Rest
                               </Text>
                             )}
@@ -458,7 +436,7 @@ export default function ProgramDetail() {
                             />
                           )}
                         </View>
-                      </TouchableRipple>
+                      </Pressable>
                     );
                   })}
                 </>
@@ -474,9 +452,9 @@ export default function ProgramDetail() {
               accessibilityViewIsModal
             >
               <View style={[styles.overlay, { backgroundColor: "rgba(0,0,0,0.5)" }]}>
-                <Card style={[styles.picker, { backgroundColor: colors.surface }]}>
-                  <Card.Content>
-                    <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 12 }}>
+                <Card style={StyleSheet.flatten([styles.picker, { backgroundColor: colors.surface }])}>
+                  <CardContent>
+                    <Text variant="title" style={{ color: colors.onSurface, marginBottom: 12 }}>
                       {picker !== null ? DAYS[picker] : ""} — Pick Template
                     </Text>
 
@@ -491,27 +469,27 @@ export default function ProgramDetail() {
                       renderItem={({ item }) => {
                         if (item.id === "__remove__") {
                           return (
-                            <TouchableRipple
+                            <Pressable
                               onPress={() => assignDay(picker!, null)}
                               style={[styles.pickItem, { borderBottomColor: colors.outlineVariant }]}
                               accessibilityRole="button"
                               accessibilityLabel="Remove template, set as rest day"
                             >
-                              <Text variant="bodyMedium" style={{ color: colors.error }}>
+                              <Text variant="body" style={{ color: colors.error }}>
                                 Remove (Rest Day)
                               </Text>
-                            </TouchableRipple>
+                            </Pressable>
                           );
                         }
                         return (
-                          <TouchableRipple
+                          <Pressable
                             onPress={() => picker !== null && assignDay(picker, item)}
                             style={[styles.pickItem, { borderBottomColor: colors.outlineVariant }]}
                             accessibilityRole="button"
                             accessibilityLabel={`Select template: ${item.name}`}
                           >
                             <Text
-                              variant="bodyMedium"
+                              variant="body"
                               style={{
                                 color: picker !== null && schedEntry(picker)?.template_id === item.id
                                   ? colors.primary
@@ -521,45 +499,44 @@ export default function ProgramDetail() {
                             >
                               {item.name}
                             </Text>
-                          </TouchableRipple>
+                          </Pressable>
                         );
                       }}
                     />
 
                     <Button
-                      mode="text"
+                      variant="ghost"
                       onPress={() => setPicker(null)}
                       style={{ marginTop: 8 }}
                       accessibilityLabel="Cancel template selection"
-                    >
-                      Cancel
-                    </Button>
-                  </Card.Content>
+                      label="Cancel"
+                    />
+                  </CardContent>
                 </Card>
               </View>
             </Modal>
 
             {history.length > 0 && (
             <View style={styles.history}>
-              <Text variant="titleMedium" style={[styles.historyTitle, { color: colors.onBackground }]}>
+              <Text variant="title" style={[styles.historyTitle, { color: colors.onBackground }]}>
                 History
               </Text>
               {history.map((h) => (
                 <Card
                   key={h.session_id}
-                  style={[styles.historyCard, { backgroundColor: colors.surface }]}
+                  style={StyleSheet.flatten([styles.historyCard, { backgroundColor: colors.surface }])}
                   onPress={() => router.push(`/session/detail/${h.session_id}`)}
                   accessibilityLabel={`Completed ${h.day_label || h.template_name || "workout"} on ${dateStr(h.completed_at)}`}
                   accessibilityRole="button"
                 >
-                  <Card.Content style={styles.historyRow}>
-                    <Text variant="bodyMedium" style={{ color: colors.onSurface, flex: 1 }}>
+                  <CardContent style={styles.historyRow}>
+                    <Text variant="body" style={{ color: colors.onSurface, flex: 1 }}>
                       {h.day_label || h.template_name || "Workout"}
                     </Text>
-                    <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                       {dateStr(h.completed_at)}
                     </Text>
-                  </Card.Content>
+                  </CardContent>
                 </Card>
               ))}
             </View>

--- a/app/program/create.tsx
+++ b/app/program/create.tsx
@@ -2,10 +2,14 @@ import { useCallback, useState } from "react";
 import {
   Alert,
   StyleSheet,
+  TouchableOpacity,
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Button, IconButton, Text, TextInput } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { Input } from "@/components/ui/input";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useFocusEffect } from "expo-router";
 import { useLayout } from "../../lib/layout";
@@ -118,38 +122,25 @@ export default function CreateProgram() {
         ]}
       >
         <View style={styles.dayInfo}>
-          <Text variant="titleSmall" style={{ color: colors.onSurface }}>
+          <Text variant="subtitle" style={{ color: colors.onSurface }}>
             Day {index + 1}: {dayName(item)}
           </Text>
           {item.template_id === null && (
-            <Text variant="bodySmall" style={{ color: colors.error }}>
+            <Text variant="caption" style={{ color: colors.error }}>
               Template has been deleted
             </Text>
           )}
         </View>
         <View style={styles.dayActions}>
-          <IconButton
-            icon="arrow-up"
-            size={18}
-            onPress={() => move(index, -1)}
-            disabled={index === 0}
-            accessibilityLabel={`Move ${dayName(item)} up`}
-            accessibilityHint="Reorders workout day"
-          />
-          <IconButton
-            icon="arrow-down"
-            size={18}
-            onPress={() => move(index, 1)}
-            disabled={index === days.length - 1}
-            accessibilityLabel={`Move ${dayName(item)} down`}
-            accessibilityHint="Reorders workout day"
-          />
-          <IconButton
-            icon="close"
-            size={18}
-            onPress={() => remove(item.id)}
-            accessibilityLabel={`Remove ${dayName(item)}`}
-          />
+          <TouchableOpacity onPress={() => move(index, -1)} disabled={index === 0} accessibilityLabel={`Move ${dayName(item)} up`} accessibilityHint="Reorders workout day" hitSlop={8} style={{ padding: 8 }}>
+            <MaterialCommunityIcons name="arrow-up" size={18} color={index === 0 ? colors.onSurfaceDisabled : colors.onSurface} />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => move(index, 1)} disabled={index === days.length - 1} accessibilityLabel={`Move ${dayName(item)} down`} accessibilityHint="Reorders workout day" hitSlop={8} style={{ padding: 8 }}>
+            <MaterialCommunityIcons name="arrow-down" size={18} color={index === days.length - 1 ? colors.onSurfaceDisabled : colors.onSurface} />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => remove(item.id)} accessibilityLabel={`Remove ${dayName(item)}`} hitSlop={8} style={{ padding: 8 }}>
+            <MaterialCommunityIcons name="close" size={18} color={colors.onSurface} />
+          </TouchableOpacity>
         </View>
       </View>
     ),
@@ -164,21 +155,19 @@ export default function CreateProgram() {
       <View
         style={[styles.container, { backgroundColor: colors.background, paddingHorizontal: layout.horizontalPadding }]}
       >
-        <TextInput
+        <Input
           label="Program Name"
           value={name}
           onChangeText={setName}
-          mode="outlined"
-          style={styles.input}
+          containerStyle={styles.input}
           placeholder="e.g. Push/Pull/Legs"
           accessibilityLabel="Program name"
         />
-        <TextInput
+        <Input
           label="Description (optional)"
           value={description}
           onChangeText={setDescription}
-          mode="outlined"
-          style={styles.input}
+          containerStyle={styles.input}
           placeholder="e.g. 6-day PPL split"
           accessibilityLabel="Program description"
           multiline
@@ -187,7 +176,7 @@ export default function CreateProgram() {
           <>
             <View style={styles.section}>
               <Text
-                variant="titleMedium"
+                variant="title"
                 style={{ color: colors.onBackground }}
               >
                 Workout Days ({days.length})
@@ -200,7 +189,7 @@ export default function CreateProgram() {
               ListEmptyComponent={
                 <View style={styles.empty}>
                   <Text
-                    variant="bodyMedium"
+                    variant="body"
                     style={{ color: colors.onSurfaceVariant }}
                     accessibilityRole="text"
                     accessibilityLabel="No workout days added yet"
@@ -212,26 +201,22 @@ export default function CreateProgram() {
               style={styles.list}
             />
             <Button
-              mode="outlined"
-              icon="plus"
+              variant="outline"
               onPress={() =>
                 router.push(`/program/pick-template?programId=${program.id}`)
               }
               style={styles.addBtn}
-              contentStyle={styles.btnContent}
               accessibilityLabel="Add workout day from template"
-            >
-              Add Day
-            </Button>
+              label="Add Day"
+            />
           </>
         )}
         <Button
-          mode="contained"
+          variant="default"
           onPress={save}
           loading={saving}
           disabled={saving}
           style={styles.saveBtn}
-          contentStyle={styles.btnContent}
           accessibilityLabel={program ? "Done editing program" : "Create program"}
         >
           {program ? "Done" : "Create Program"}

--- a/app/program/pick-template.tsx
+++ b/app/program/pick-template.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  Pressable,
   StyleSheet,
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Searchbar, Text, TouchableRipple } from "react-native-paper";
+import { SearchBar } from "@/components/ui/searchbar";
+import { Text } from "@/components/ui/text";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useLayout } from "../../lib/layout";
 import { getTemplates } from "../../lib/db";
@@ -50,7 +52,7 @@ export default function PickTemplate() {
 
   const renderItem = useCallback(
     ({ item }: { item: WorkoutTemplate }) => (
-      <TouchableRipple
+      <Pressable
         onPress={() => pick(item)}
         style={[
           styles.item,
@@ -64,20 +66,20 @@ export default function PickTemplate() {
       >
         <View>
           <Text
-            variant="titleSmall"
+            variant="subtitle"
             numberOfLines={1}
             style={{ color: colors.onSurface }}
           >
             {item.name}
           </Text>
           <Text
-            variant="bodySmall"
+            variant="caption"
             style={{ color: colors.onSurfaceVariant }}
           >
             Created {new Date(item.created_at).toLocaleDateString()}
           </Text>
         </View>
-      </TouchableRipple>
+      </Pressable>
     ),
     [colors, pick]
   );
@@ -88,7 +90,7 @@ export default function PickTemplate() {
       <View
         style={[styles.container, { backgroundColor: colors.background, paddingHorizontal: layout.horizontalPadding }]}
       >
-        <Searchbar
+        <SearchBar
           placeholder="Search templates..."
           value={query}
           onChangeText={setQuery}
@@ -103,7 +105,7 @@ export default function PickTemplate() {
             loading ? null : (
               <View style={styles.empty}>
                 <Text
-                  variant="titleMedium"
+                  variant="title"
                   style={{ color: colors.onSurfaceVariant }}
                 >
                   {templates.length === 0

--- a/app/progress/achievements.tsx
+++ b/app/progress/achievements.tsx
@@ -4,7 +4,9 @@ import {
   StyleSheet,
   View,
 } from "react-native";
-import { Card, ProgressBar, Text } from "react-native-paper";
+import { Card, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Text } from "@/components/ui/text";
 import { Stack } from "expo-router";
 import { useFocusEffect } from "expo-router";
 import {
@@ -139,8 +141,8 @@ export default function AchievementsScreen() {
       <>
         <Stack.Screen options={{ title: "Achievements" }} />
         <View style={[styles.center, { backgroundColor: colors.background }]}>
-          <Text variant="headlineMedium" style={{ marginBottom: 8 }}>⚠️</Text>
-          <Text variant="bodyLarge" style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
+          <Text variant="heading" style={{ marginBottom: 8 }}>⚠️</Text>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
             {error}
           </Text>
         </View>
@@ -153,8 +155,8 @@ export default function AchievementsScreen() {
       <>
         <Stack.Screen options={{ title: "Achievements" }} />
         <View style={[styles.center, { backgroundColor: colors.background }]}>
-          <Text variant="headlineMedium" style={{ marginBottom: 8 }}>🏆</Text>
-          <Text variant="bodyLarge" style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
+          <Text variant="heading" style={{ marginBottom: 8 }}>🏆</Text>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 16 }}>
             Complete your first workout to start earning achievements!
           </Text>
         </View>
@@ -188,7 +190,7 @@ export default function AchievementsScreen() {
         }
         accessibilityRole="summary"
       >
-        <Card.Content style={styles.badgeContent}>
+        <CardContent style={styles.badgeContent}>
           <View style={styles.iconContainer}>
             <Text style={[styles.icon, !item.earned && styles.iconLocked]}>
               {item.icon}
@@ -200,21 +202,21 @@ export default function AchievementsScreen() {
             )}
           </View>
           <Text
-            variant="labelMedium"
+            variant="caption"
             numberOfLines={1}
             style={[styles.badgeName, { color: textColor }]}
           >
             {item.name}
           </Text>
           <Text
-            variant="bodySmall"
+            variant="caption"
             numberOfLines={2}
             style={[styles.badgeDesc, { color: textColor }]}
           >
             {item.description}
           </Text>
           {item.earned ? (
-            <Text variant="bodySmall" style={{ color: textColor, marginTop: 4 }}>
+            <Text variant="caption" style={{ color: textColor, marginTop: 4 }}>
               {formatDate(item.earnedAt!)}
             </Text>
           ) : (
@@ -227,17 +229,16 @@ export default function AchievementsScreen() {
                 text: `${Math.round(item.progress * 100)}% complete`,
               }}
             >
-              <ProgressBar
-                progress={item.progress}
-                color={colors.primary}
+              <Progress
+                value={item.progress * 100}
                 style={styles.progressBar}
               />
-              <Text variant="bodySmall" style={{ color: textColor, marginTop: 2 }}>
+              <Text variant="caption" style={{ color: textColor, marginTop: 2 }}>
                 {Math.round(item.progress * 100)}%
               </Text>
             </View>
           )}
-        </Card.Content>
+        </CardContent>
       </Card>
     );
   };
@@ -254,11 +255,11 @@ export default function AchievementsScreen() {
           if (item.key === "header") {
             return (
               <View style={styles.header}>
-                <Text variant="headlineMedium" style={{ color: colors.onBackground }}>
+                <Text variant="heading" style={{ color: colors.onBackground }}>
                   🏆
                 </Text>
                 <Text
-                  variant="titleLarge"
+                  variant="title"
                   style={{ color: colors.onBackground, fontWeight: "700", marginTop: 4 }}
                   accessibilityRole="header"
                 >
@@ -269,11 +270,11 @@ export default function AchievementsScreen() {
                     style={[styles.retroBanner, { backgroundColor: colors.tertiaryContainer }]}
                     accessibilityLiveRegion="polite"
                   >
-                    <Card.Content>
-                      <Text variant="bodyMedium" style={{ color: colors.onTertiaryContainer }}>
+                    <CardContent>
+                      <Text variant="body" style={{ color: colors.onTertiaryContainer }}>
                         Welcome back! We found {retroBanner} achievement{retroBanner !== 1 ? "s" : ""} from your workout history.
                       </Text>
-                    </Card.Content>
+                    </CardContent>
                   </Card>
                 )}
               </View>
@@ -284,7 +285,7 @@ export default function AchievementsScreen() {
           return (
             <View style={styles.section}>
               <Text
-                variant="titleMedium"
+                variant="title"
                 style={{ color: colors.onBackground, marginBottom: 8, fontWeight: "700" }}
                 accessibilityRole="header"
               >

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -6,6 +6,7 @@ import {
   Pressable,
   StyleSheet,
   useWindowDimensions,
+  TouchableOpacity,
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
@@ -15,7 +16,11 @@ import Reanimated, {
   withTiming,
   interpolateColor,
 } from "react-native-reanimated";
-import { Button, Divider, IconButton, Snackbar, Text, TextInput } from "react-native-paper";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/bna-toast";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Stack, useLocalSearchParams, useRouter, useFocusEffect } from "expo-router";
 import * as Haptics from "expo-haptics";
@@ -162,12 +167,12 @@ const SetRow = memo(function SetRow({
                 <Text style={{ color: chipStyle!.fg, fontSize: 13, fontWeight: "700" }}>{chipLabel}</Text>
               </View>
             ) : (
-              <Text variant="bodyMedium" style={{ color: colors.onSurface, textAlign: "center" }}>
+              <Text variant="body" style={{ color: colors.onSurface, textAlign: "center" }}>
                 {set.round ? `R${set.round}` : set.set_number}
               </Text>
             )}
           </Pressable>
-          <Text variant="bodySmall" style={[styles.colPrev, { color: colors.onSurfaceVariant }]}>
+          <Text variant="caption" style={[styles.colPrev, { color: colors.onSurfaceVariant }]}>
             {set.previous}
           </Text>
           <View style={styles.pickerCol}>
@@ -244,7 +249,7 @@ const SetRow = memo(function SetRow({
 
       {halfStep && halfStep.setId === set.id && (
         <View style={[styles.halfStepRow, { backgroundColor: colors.surfaceVariant }]}>
-          <Text variant="labelSmall" style={{ color: colors.onSurfaceVariant, marginRight: 8, fontSize: 12 }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginRight: 8, fontSize: 12 }}>
             Half-step:
           </Text>
           {halfStep.base > 6 && (
@@ -390,7 +395,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
         accessibilityHint={s.type === "rep_increase" ? "Double tap to fill suggested reps" : "Double tap to fill suggested weight"}
       >
         <Text
-          variant="labelSmall"
+          variant="caption"
           style={{
             color: isIncrease ? colors.onPrimaryContainer : colors.onSurfaceVariant,
             fontWeight: "600",
@@ -416,7 +421,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
               accessibilityHint="Long press to remove exercise"
             >
               <Text
-                variant="titleMedium"
+                variant="title"
                 numberOfLines={2}
                 ellipsizeMode="tail"
                 style={[styles.groupTitle, { color: colors.primary }]}
@@ -472,7 +477,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
             accessibilityHint="Long press to remove exercise"
           >
             <Text
-              variant="titleMedium"
+              variant="title"
               numberOfLines={2}
               ellipsizeMode="tail"
               style={[styles.groupTitle, { color: colors.primary }]}
@@ -517,9 +522,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
       )}
       {exerciseNotesOpen && (
         <View style={styles.notesContainer}>
-          <TextInput
-            mode="outlined"
-            dense
+          <Input
             placeholder="Add exercise notes..."
             value={exerciseNotesValue}
             onChangeText={(v) => onExerciseNotesDraftChange(group.exercise_id, v)}
@@ -529,7 +532,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
             style={styles.notesInput}
             accessibilityLabel="Exercise notes"
           />
-          <Text variant="labelSmall" style={{ color: colors.onSurfaceVariant, textAlign: "right", fontSize: 12 }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, textAlign: "right", fontSize: 12 }}>
             {exerciseNotesValue.length}/200
           </Text>
         </View>
@@ -540,10 +543,10 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
   const setTable = (
     <>
       <View style={styles.headerRow}>
-        <Text variant="labelSmall" style={[styles.colSet, { color: colors.onSurfaceVariant }]}>SET</Text>
-        <Text variant="labelSmall" style={[styles.colPrev, { color: colors.onSurfaceVariant }]}>PREV</Text>
-        <Text variant="labelSmall" style={[styles.colLabel, { color: colors.onSurfaceVariant }]}>{unit === "lb" ? "LB" : "KG"}</Text>
-        <Text variant="labelSmall" style={[styles.colLabel, { color: colors.onSurfaceVariant }]}>REPS</Text>
+        <Text variant="caption" style={[styles.colSet, { color: colors.onSurfaceVariant }]}>SET</Text>
+        <Text variant="caption" style={[styles.colPrev, { color: colors.onSurfaceVariant }]}>PREV</Text>
+        <Text variant="caption" style={[styles.colLabel, { color: colors.onSurfaceVariant }]}>{unit === "lb" ? "LB" : "KG"}</Text>
+        <Text variant="caption" style={[styles.colLabel, { color: colors.onSurfaceVariant }]}>REPS</Text>
         <View style={styles.colTrailing} />
       </View>
       {group.sets.map((set) => (
@@ -585,10 +588,10 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
           accessibilityRole="header"
           accessibilityLabel={`Round ${completedRounds + 1} of ${totalRounds}`}
         >
-          <Text variant="labelMedium" style={{ color: groupColor, fontWeight: "700" }}>
+          <Text variant="caption" style={{ color: groupColor, fontWeight: "700" }}>
             {linked.length >= 3 ? "Circuit" : "Superset"} — Round {completedRounds + 1}/{totalRounds}
           </Text>
-          <Text variant="labelSmall" style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}>
             Rest after round
           </Text>
         </View>
@@ -614,7 +617,7 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
           </>
         )}
       </View>
-      <Divider style={styles.divider} />
+      <Separator style={styles.divider} />
     </View>
   );
 });
@@ -651,27 +654,27 @@ function ExerciseDetailDrawerContent({ exercise }: { exercise: Exercise }) {
       </View>
       {exercise.mount_position && (
         <View style={styles.detailSection}>
-          <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
             Mount Position
           </Text>
-          <Text variant="bodyMedium" style={{ color: colors.onSurface, marginTop: 2 }}>
+          <Text variant="body" style={{ color: colors.onSurface, marginTop: 2 }}>
             {exercise.mount_position}
           </Text>
         </View>
       )}
       {exercise.attachment && (
         <View style={styles.detailSection}>
-          <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
             Attachment
           </Text>
-          <Text variant="bodyMedium" style={{ color: colors.onSurface, marginTop: 2 }}>
+          <Text variant="body" style={{ color: colors.onSurface, marginTop: 2 }}>
             {ATTACHMENT_LABELS[exercise.attachment]}
           </Text>
         </View>
       )}
       {exercise.primary_muscles.length > 0 && (
         <View style={styles.detailSection}>
-          <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
             Primary Muscles
           </Text>
           <View style={styles.detailChips}>
@@ -685,7 +688,7 @@ function ExerciseDetailDrawerContent({ exercise }: { exercise: Exercise }) {
       )}
       {exercise.secondary_muscles.length > 0 && (
         <View style={styles.detailSection}>
-          <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
             Secondary Muscles
           </Text>
           <View style={styles.detailChips}>
@@ -702,11 +705,11 @@ function ExerciseDetailDrawerContent({ exercise }: { exercise: Exercise }) {
 
   const instructions = steps.length > 0 ? (
     <View style={styles.detailSection}>
-      <Text variant="labelLarge" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
+      <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: 12 }}>
         Instructions
       </Text>
       {steps.map((step, i) => (
-        <Text key={i} variant="bodyMedium" style={{ color: colors.onSurface, marginTop: 6, lineHeight: 22 }}>
+        <Text key={i} variant="body" style={{ color: colors.onSurface, marginTop: 6, lineHeight: 22 }}>
           {step}
         </Text>
       ))}
@@ -778,8 +781,7 @@ export default function ActiveSession() {
   const [maxes, setMaxes] = useState<Record<string, number>>({});
   const prevExerciseIds = useRef<string>("");
   const prHapticFired = useRef<Set<string>>(new Set());
-  const [snackbar, setSnackbar] = useState("");
-  const [snackbarAction, setSnackbarAction] = useState<{ label: string; onPress: () => void } | undefined>();
+  const { toast: showToast } = useToast();
   const [exerciseNotesOpen, setExerciseNotesOpen] = useState<Record<string, boolean>>({});
   const [exerciseNotesDraft, setExerciseNotesDraft] = useState<Record<string, string>>({});
   const [halfStep, setHalfStep] = useState<{ setId: string; base: number } | null>(null);
@@ -803,7 +805,7 @@ export default function ActiveSession() {
       setAudioEnabled(val !== "false")
     }).catch(() => {
       setAudioEnabled(true)
-      setSnackbar("Could not load sound setting")
+      showToast("Could not load sound setting")
     })
   }, []);
   const [suggestions, setSuggestions] = useState<Record<string, Suggestion | null>>({});
@@ -983,7 +985,7 @@ export default function ActiveSession() {
         });
 
         if (deletedExerciseIds.size > 0) {
-          setSnackbar(
+          showToast(
             `${deletedExerciseIds.size} exercise${deletedExerciseIds.size > 1 ? "s were" : " was"} skipped (no longer available)`
           );
         }
@@ -1251,7 +1253,7 @@ export default function ActiveSession() {
     // Check if all sets are completed
     const group = groups.find((g) => g.exercise_id === exerciseId);
     if (group && group.sets.every((s) => s.completed)) {
-      setSnackbar("All sets completed — nothing to swap");
+      showToast("All sets completed — nothing to swap");
       return;
     }
     const ex = await getExerciseById(exerciseId);
@@ -1271,11 +1273,9 @@ export default function ActiveSession() {
         clearTimeout(swapUndoTimer.current);
         swapUndoTimer.current = null;
       }
-      setSnackbar("");
-      setSnackbarAction(undefined);
       await load();
     } catch {
-      setSnackbar("Failed to undo swap");
+      showToast("Failed to undo swap");
     }
   }, [load]);
 
@@ -1284,7 +1284,7 @@ export default function ActiveSession() {
     try {
       const modifiedIds = await swapExerciseInSession(id, swapSource.id, newExercise.id);
       if (modifiedIds.length === 0) {
-        setSnackbar("All sets completed — nothing to swap");
+        showToast("All sets completed — nothing to swap");
         setSwapSource(null);
         return;
       }
@@ -1300,14 +1300,13 @@ export default function ActiveSession() {
 
       // Undo snackbar (5s)
       if (swapUndoTimer.current) clearTimeout(swapUndoTimer.current);
-      setSnackbar(`Swapped to ${newExercise.name}`);
-      setSnackbarAction({ label: "UNDO", onPress: () => handleSwapUndo() });
+      showToast(`Swapped to ${newExercise.name}`);
       swapUndoTimer.current = setTimeout(() => {
         swapUndoTimer.current = null;
         swapUndoRef.current = null;
       }, 5000);
     } catch {
-      setSnackbar("Failed to swap exercise");
+      showToast("Failed to swap exercise");
     }
   }, [id, swapSource, load, startRest, handleSwapUndo]);
 
@@ -1365,8 +1364,7 @@ export default function ActiveSession() {
       clearInterval(deleteCountdownInterval.current);
       deleteCountdownInterval.current = null;
     }
-    setSnackbar("");
-    setSnackbarAction(undefined);
+
   }, []);
 
   const handleDeleteExercise = useCallback((exerciseId: string) => {
@@ -1392,8 +1390,7 @@ export default function ActiveSession() {
 
     // Start 5s countdown
     let remaining = 5;
-    setSnackbar(`Removing ${group.name}... (5s)`);
-    setSnackbarAction({ label: "UNDO", onPress: () => handleDeleteExerciseUndo() });
+    showToast(`Removing ${group.name}... (5s)`);
 
     deleteCountdownInterval.current = setInterval(() => {
       remaining -= 1;
@@ -1403,7 +1400,7 @@ export default function ActiveSession() {
           deleteCountdownInterval.current = null;
         }
       } else {
-        setSnackbar(`Removing ${group.name}... (${remaining}s)`);
+        showToast(`Removing ${group.name}... (${remaining}s)`);
       }
     }, 1000);
 
@@ -1426,7 +1423,7 @@ export default function ActiveSession() {
           next.splice(Math.min(groupIndex, next.length), 0, group as ExerciseGroup);
           return next;
         });
-        setSnackbar('Failed to delete exercise. Restored.');
+        showToast('Failed to delete exercise. Restored.');
       }
     }, 5000);
   }, [groups, dismissRest, handleDeleteExerciseUndo, commitPendingDelete]);
@@ -1502,7 +1499,7 @@ export default function ActiveSession() {
     if (newType === "dropset" || newType === "failure") {
       const shown = await getAppSetting("set_type_tooltip_shown");
       if (!shown) {
-        setSnackbar("Dropsets count toward volume. Failure sets help track intensity.");
+        showToast("Dropsets count toward volume. Failure sets help track intensity.");
         await setAppSetting("set_type_tooltip_shown", "1");
       }
     }
@@ -1510,7 +1507,7 @@ export default function ActiveSession() {
     if (newType === "warmup") {
       const shown = await getAppSetting("warmup_tooltip_shown");
       if (!shown) {
-        setSnackbar("Set marked as warm-up. Warm-up sets are excluded from volume and PR tracking.");
+        showToast("Set marked as warm-up. Warm-up sets are excluded from volume and PR tracking.");
         await setAppSetting("warmup_tooltip_shown", "1");
       }
     }
@@ -1577,10 +1574,10 @@ export default function ActiveSession() {
           const { syncSessionToStrava } = await import("../../lib/strava");
           const synced = await syncSessionToStrava(id!);
           if (synced) {
-            setSnackbar("Synced to Strava ✓");
+            showToast("Synced to Strava ✓");
           }
         } catch {
-          setSnackbar("Strava sync failed");
+          showToast("Strava sync failed");
         }
 
         // Health Connect sync (non-blocking, silent — no toast on success or failure)
@@ -1600,7 +1597,7 @@ export default function ActiveSession() {
             if (day) {
               const result = await advanceProgram(day.program_id, dayId, id!);
               if (result.wrapped) {
-                setSnackbar(`Cycle ${result.cycle} complete!`);
+                showToast(`Cycle ${result.cycle} complete!`);
                 AccessibilityInfo.announceForAccessibility(
                   `Cycle ${result.cycle} complete! Program wrapping to day 1.`
                 );
@@ -1666,7 +1663,7 @@ export default function ActiveSession() {
           headerRight: () => (
             <View style={{ flexDirection: "row", alignItems: "center" }}>
               <Text
-                variant="labelLarge"
+                variant="body"
                 style={{ color: colors.primary, marginRight: 8 }}
               >
                 {formatTime(elapsed)}
@@ -1720,10 +1717,10 @@ export default function ActiveSession() {
                 style={[styles.restBanner, restFlashStyle]}
                 accessibilityLiveRegion="polite"
               >
-                <Text variant="headlineLarge" style={{ color: colors.onPrimaryContainer, fontWeight: "700" }} accessibilityLabel={`Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds`}>
+                <Text variant="heading" style={{ color: colors.onPrimaryContainer, fontWeight: "700" }} accessibilityLabel={`Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds`}>
                   {String(Math.floor(rest / 60)).padStart(2, "0")}:{String(rest % 60).padStart(2, "0")}
                 </Text>
-                <Text variant="bodySmall" style={{ color: colors.onPrimaryContainer, marginTop: 4 }}>
+                <Text variant="caption" style={{ color: colors.onPrimaryContainer, marginTop: 4 }}>
                   Rest Timer
                 </Text>
                 <Button
@@ -1740,7 +1737,7 @@ export default function ActiveSession() {
             )}
             {nextHint && (
               <View style={[styles.nextBanner, { backgroundColor: colors.secondaryContainer }]} accessibilityLiveRegion="polite">
-                <Text variant="titleSmall" style={{ color: colors.onSecondaryContainer, fontWeight: "700" }}>
+                <Text variant="subtitle" style={{ color: colors.onSecondaryContainer, fontWeight: "700" }}>
                   {nextHint}
                 </Text>
               </View>
@@ -1788,7 +1785,7 @@ export default function ActiveSession() {
           onPress={() => setSetTypeSheetSetId(null)}
         >
           <View style={[styles.setTypeSheet, { backgroundColor: colors.surface }]}>
-            <Text variant="titleMedium" style={{ color: colors.onSurface, marginBottom: 12 }}>
+            <Text variant="title" style={{ color: colors.onSurface, marginBottom: 12 }}>
               Set Type
             </Text>
             {SET_TYPE_CYCLE.map((type) => {
@@ -1833,7 +1830,7 @@ export default function ActiveSession() {
                       <Text style={{ fontSize: 13, fontWeight: "700", color: colors.onSurface }}>—</Text>
                     </View>
                   )}
-                  <Text variant="bodyLarge" style={{ color: colors.onSurface, marginLeft: 12 }}>
+                  <Text variant="body" style={{ color: colors.onSurface, marginLeft: 12 }}>
                     {label.label}
                   </Text>
                 </Pressable>
@@ -1842,18 +1839,7 @@ export default function ActiveSession() {
           </View>
         </Pressable>
       )}
-      <Snackbar
-        visible={!!snackbar}
-        onDismiss={() => {
-          setSnackbar("");
-          setSnackbarAction(undefined);
-        }}
-        duration={snackbarAction ? 5000 : 3000}
-        action={snackbarAction}
-        accessibilityLiveRegion="polite"
-      >
-        {snackbar}
-      </Snackbar>
+
       <ExercisePickerSheet
         visible={pickerOpen}
         onDismiss={() => setPickerOpen(false)}
@@ -1875,7 +1861,7 @@ export default function ActiveSession() {
         {detailExercise && (
           <>
             <View style={styles.detailHeader}>
-              <Text variant="titleLarge" style={{ color: colors.onSurface, flex: 1 }}>
+              <Text variant="title" style={{ color: colors.onSurface, flex: 1 }}>
                 {detailExercise.name}
               </Text>
               <IconButton

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -1309,7 +1309,7 @@ export default function ActiveSession() {
 
       // Undo snackbar (5s)
       if (swapUndoTimer.current) clearTimeout(swapUndoTimer.current);
-      showToast(`Swapped to ${newExercise.name}`);
+      showToast(`Swapped to ${newExercise.name}`, { action: { label: "Undo", onPress: handleSwapUndo } });
       swapUndoTimer.current = setTimeout(() => {
         swapUndoTimer.current = null;
         swapUndoRef.current = null;
@@ -1399,7 +1399,7 @@ export default function ActiveSession() {
 
     // Start 5s countdown
     let remaining = 5;
-    showToast(`Removing ${group.name}... (5s)`);
+    showToast(`Removing ${group.name}... (5s)`, { action: { label: "UNDO", onPress: handleDeleteExerciseUndo } });
 
     deleteCountdownInterval.current = setInterval(() => {
       remaining -= 1;

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -6,7 +6,6 @@ import {
   Pressable,
   StyleSheet,
   useWindowDimensions,
-  TouchableOpacity,
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
@@ -429,31 +428,35 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
                 {group.name}
               </Text>
             </Pressable>
-            <IconButton
-              icon="swap-horizontal"
-              size={24}
+            <Pressable
               onPress={() => onSwap(group.exercise_id)}
               accessibilityLabel={`Swap ${group.name} for alternative`}
-              style={styles.swapBtn}
-            />
-            <IconButton
-              icon={firstSet?.notes ? "note-text" : "note-text-outline"}
-              size={24}
+              hitSlop={8}
+              style={[styles.swapBtn, { padding: 8 }]}
+            >
+              <MaterialCommunityIcons name="swap-horizontal" size={24} color={colors.onSurfaceVariant} />
+            </Pressable>
+            <Pressable
               onPress={() => onToggleExerciseNotes(group.exercise_id)}
               accessibilityLabel={`${group.name} notes`}
-              style={styles.notesBtn}
-            />
+              hitSlop={8}
+              style={[styles.notesBtn, { padding: 8 }]}
+            >
+              <MaterialCommunityIcons name={firstSet?.notes ? "note-text" : "note-text-outline"} size={24} color={colors.onSurfaceVariant} />
+            </Pressable>
           </View>
           <View style={styles.groupHeaderCompactRow}>
             <Button
-              mode="text"
-              compact
-              icon="information-outline"
+              variant="ghost"
+              size="sm"
               onPress={() => onShowDetail(group.exercise_id)}
               accessibilityLabel={`View ${group.name} details`}
               style={styles.detailsBtn}
             >
-              Details
+              <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+                <MaterialCommunityIcons name="information-outline" size={18} color={colors.primary} />
+                <Text style={{ color: colors.primary, fontWeight: "600" }}>Details</Text>
+              </View>
             </Button>
             {group.is_voltra && group.training_modes.length > 1 && (
               <TrainingModeSelector
@@ -486,29 +489,33 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
             </Text>
           </Pressable>
           <Button
-            mode="text"
-            compact
-            icon="information-outline"
+            variant="ghost"
+            size="sm"
             onPress={() => onShowDetail(group.exercise_id)}
             accessibilityLabel={`View ${group.name} details`}
             style={styles.detailsBtn}
           >
-            Details
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+              <MaterialCommunityIcons name="information-outline" size={18} color={colors.primary} />
+              <Text style={{ color: colors.primary, fontWeight: "600" }}>Details</Text>
+            </View>
           </Button>
-          <IconButton
-            icon="swap-horizontal"
-            size={24}
+          <Pressable
             onPress={() => onSwap(group.exercise_id)}
             accessibilityLabel={`Swap ${group.name} for alternative`}
-            style={styles.swapBtn}
-          />
-          <IconButton
-            icon={firstSet?.notes ? "note-text" : "note-text-outline"}
-            size={24}
+            hitSlop={8}
+            style={[styles.swapBtn, { padding: 8 }]}
+          >
+            <MaterialCommunityIcons name="swap-horizontal" size={24} color={colors.onSurfaceVariant} />
+          </Pressable>
+          <Pressable
             onPress={() => onToggleExerciseNotes(group.exercise_id)}
             accessibilityLabel={`${group.name} notes`}
-            style={styles.notesBtn}
-          />
+            hitSlop={8}
+            style={[styles.notesBtn, { padding: 8 }]}
+          >
+            <MaterialCommunityIcons name={firstSet?.notes ? "note-text" : "note-text-outline"} size={24} color={colors.onSurfaceVariant} />
+          </Pressable>
           {group.is_voltra && group.training_modes.length > 1 && (
             <TrainingModeSelector
               modes={group.training_modes}
@@ -568,14 +575,16 @@ const ExerciseGroupCard = memo(function ExerciseGroupCard({
         />
       ))}
       <Button
-        mode="text"
-        compact
-        icon="plus"
+        variant="ghost"
+        size="sm"
         onPress={() => onAddSet(group.exercise_id)}
         style={styles.addSetBtn}
         accessibilityLabel={`Add set to ${group.name}`}
       >
-        Add Set
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+          <MaterialCommunityIcons name="plus" size={18} color={colors.primary} />
+          <Text style={{ color: colors.primary, fontWeight: "600" }}>Add Set</Text>
+        </View>
       </Button>
     </>
   );
@@ -781,7 +790,7 @@ export default function ActiveSession() {
   const [maxes, setMaxes] = useState<Record<string, number>>({});
   const prevExerciseIds = useRef<string>("");
   const prHapticFired = useRef<Set<string>>(new Set());
-  const { toast: showToast } = useToast();
+  const { info: showToast, error: showError, warning: showWarning } = useToast();
   const [exerciseNotesOpen, setExerciseNotesOpen] = useState<Record<string, boolean>>({});
   const [exerciseNotesDraft, setExerciseNotesDraft] = useState<Record<string, string>>({});
   const [halfStep, setHalfStep] = useState<{ setId: string; base: number } | null>(null);
@@ -805,7 +814,7 @@ export default function ActiveSession() {
       setAudioEnabled(val !== "false")
     }).catch(() => {
       setAudioEnabled(true)
-      showToast("Could not load sound setting")
+      showError("Could not load sound setting")
     })
   }, []);
   const [suggestions, setSuggestions] = useState<Record<string, Suggestion | null>>({});
@@ -985,7 +994,7 @@ export default function ActiveSession() {
         });
 
         if (deletedExerciseIds.size > 0) {
-          showToast(
+          showWarning(
             `${deletedExerciseIds.size} exercise${deletedExerciseIds.size > 1 ? "s were" : " was"} skipped (no longer available)`
           );
         }
@@ -1253,7 +1262,7 @@ export default function ActiveSession() {
     // Check if all sets are completed
     const group = groups.find((g) => g.exercise_id === exerciseId);
     if (group && group.sets.every((s) => s.completed)) {
-      showToast("All sets completed — nothing to swap");
+      showWarning("All sets completed — nothing to swap");
       return;
     }
     const ex = await getExerciseById(exerciseId);
@@ -1275,7 +1284,7 @@ export default function ActiveSession() {
       }
       await load();
     } catch {
-      showToast("Failed to undo swap");
+      showError("Failed to undo swap");
     }
   }, [load]);
 
@@ -1284,7 +1293,7 @@ export default function ActiveSession() {
     try {
       const modifiedIds = await swapExerciseInSession(id, swapSource.id, newExercise.id);
       if (modifiedIds.length === 0) {
-        showToast("All sets completed — nothing to swap");
+        showWarning("All sets completed — nothing to swap");
         setSwapSource(null);
         return;
       }
@@ -1306,7 +1315,7 @@ export default function ActiveSession() {
         swapUndoRef.current = null;
       }, 5000);
     } catch {
-      showToast("Failed to swap exercise");
+      showError("Failed to swap exercise");
     }
   }, [id, swapSource, load, startRest, handleSwapUndo]);
 
@@ -1423,7 +1432,7 @@ export default function ActiveSession() {
           next.splice(Math.min(groupIndex, next.length), 0, group as ExerciseGroup);
           return next;
         });
-        showToast('Failed to delete exercise. Restored.');
+        showError('Failed to delete exercise. Restored.');
       }
     }, 5000);
   }, [groups, dismissRest, handleDeleteExerciseUndo, commitPendingDelete]);
@@ -1577,7 +1586,7 @@ export default function ActiveSession() {
             showToast("Synced to Strava ✓");
           }
         } catch {
-          showToast("Strava sync failed");
+          showError("Strava sync failed");
         }
 
         // Health Connect sync (non-blocking, silent — no toast on success or failure)
@@ -1724,15 +1733,14 @@ export default function ActiveSession() {
                   Rest Timer
                 </Text>
                 <Button
-                  mode="text"
-                  compact
+                  variant="ghost"
+                  size="sm"
                   onPress={dismissRest}
-                  textColor={colors.onPrimaryContainer}
+                  textStyle={{ color: colors.onPrimaryContainer }}
                   style={{ marginTop: 4 }}
                   accessibilityLabel="Skip rest timer"
-                >
-                  Skip
-                </Button>
+                  label="Skip"
+                />
               </Reanimated.View>
             )}
             {nextHint && (
@@ -1747,34 +1755,31 @@ export default function ActiveSession() {
         ListFooterComponent={
           <>
             <Button
-              mode="outlined"
-              icon="plus"
+              variant="outline"
               onPress={handleAddExercise}
               style={styles.addExercise}
-              contentStyle={styles.actionContent}
               accessibilityLabel="Add exercise to workout"
             >
-              Add Exercise
+              <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+                <MaterialCommunityIcons name="plus" size={18} color={colors.primary} />
+                <Text style={{ color: colors.primary, fontWeight: "600" }}>Add Exercise</Text>
+              </View>
             </Button>
             <Button
-              mode="contained"
+              variant="default"
               onPress={finish}
               style={styles.finishBtn}
-              contentStyle={styles.actionContent}
               accessibilityLabel="Finish workout"
-            >
-              Finish Workout
-            </Button>
+              label="Finish Workout"
+            />
             <Button
-              mode="text"
+              variant="ghost"
               onPress={cancel}
-              textColor={colors.error}
+              textStyle={{ color: colors.error }}
               style={styles.cancelBtn}
-              contentStyle={styles.actionContent}
               accessibilityLabel="Cancel workout"
-            >
-              Cancel Workout
-            </Button>
+              label="Cancel Workout"
+            />
           </>
         }
       />
@@ -1864,12 +1869,14 @@ export default function ActiveSession() {
               <Text variant="title" style={{ color: colors.onSurface, flex: 1 }}>
                 {detailExercise.name}
               </Text>
-              <IconButton
-                icon="close"
-                size={24}
+              <Pressable
                 onPress={() => detailSheetRef.current?.close()}
                 accessibilityLabel="Close exercise details"
-              />
+                hitSlop={8}
+                style={{ padding: 8 }}
+              >
+                <MaterialCommunityIcons name="close" size={24} color={colors.onSurfaceVariant} />
+              </Pressable>
             </View>
             <ExerciseDetailDrawerContent exercise={detailExercise} />
           </>

--- a/app/session/detail/[id].tsx
+++ b/app/session/detail/[id].tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Alert, Modal, Pressable, StyleSheet, TextInput, View } from "react-native";
+import { Alert, Modal, Pressable, StyleSheet, TextInput, TouchableOpacity, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Button, Card, Divider, IconButton, Snackbar, Text } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Text } from "@/components/ui/text";
+import { useToast } from "@/components/ui/bna-toast";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useLayout } from "../../../lib/layout";
@@ -45,7 +49,7 @@ export default function SessionDetail() {
   const [notesExpanded, setNotesExpanded] = useState(false);
   const [templateModalVisible, setTemplateModalVisible] = useState(false);
   const [templateName, setTemplateName] = useState("");
-  const [snackbar, setSnackbar] = useState<{ message: string; action?: { label: string; onPress: () => void } } | null>(null);
+  const { toast } = useToast();
   const [completedSetCount, setCompletedSetCount] = useState(0);
   const [saving, setSaving] = useState(false);
 
@@ -126,7 +130,7 @@ export default function SessionDetail() {
       await updateSession(id, { rating: newRating });
     } catch {
       setRating(previousRating);
-      setSnackbar({ message: "Failed to save rating" });
+      toast({ description: "Failed to save rating" });
     }
   }, [id, rating]);
 
@@ -135,7 +139,7 @@ export default function SessionDetail() {
     try {
       await updateSession(id, { notes: notesText });
     } catch {
-      setSnackbar({ message: "Failed to save notes" });
+      toast({ description: "Failed to save notes" });
     }
   }, [id, notesText]);
 
@@ -146,15 +150,9 @@ export default function SessionDetail() {
       const truncatedName = templateName.slice(0, 100).trim() || "Untitled Template";
       const newId = await createTemplateFromSession(id, truncatedName);
       setTemplateModalVisible(false);
-      setSnackbar({
-        message: "Template saved!",
-        action: {
-          label: "View",
-          onPress: () => router.push(`/template/${newId}`),
-        },
-      });
+      toast({ description: "Template saved!" });
     } catch {
-      setSnackbar({ message: "Failed to save template" });
+      toast({ description: "Failed to save template" });
     } finally {
       setSaving(false);
     }
@@ -175,7 +173,7 @@ export default function SessionDetail() {
         const newSession = await startSession(null, session.name);
         router.push(`/session/${newSession.id}?sourceSessionId=${id}`);
       } catch {
-        setSnackbar({ message: "Failed to start repeated workout" });
+        toast({ description: "Failed to start repeated workout" });
       }
     };
 
@@ -214,8 +212,7 @@ export default function SessionDetail() {
           title: session.name,
           headerRight: session.completed_at
             ? () => (
-                <IconButton
-                  icon="content-save-outline"
+                <TouchableOpacity
                   onPress={() => {
                     setTemplateName((session.name ?? "").slice(0, 100));
                     setTemplateModalVisible(true);
@@ -223,7 +220,11 @@ export default function SessionDetail() {
                   disabled={completedSetCount === 0}
                   accessibilityLabel="Save as template"
                   accessibilityHint={completedSetCount === 0 ? "No exercises to save" : "Save this workout as a reusable template"}
-                />
+                  hitSlop={8}
+                  style={{ padding: 8 }}
+                >
+                  <MaterialCommunityIcons name="content-save-outline" size={24} color={completedSetCount === 0 ? colors.onSurfaceDisabled : colors.onSurface} />
+                </TouchableOpacity>
               )
             : undefined,
         }}
@@ -237,11 +238,11 @@ export default function SessionDetail() {
           <>
             {/* Summary */}
             <Card
-              style={[styles.summary, { backgroundColor: colors.surface }]}
+              style={StyleSheet.flatten([styles.summary, { backgroundColor: colors.surface }])}
             >
-              <Card.Content>
+              <CardContent>
                 <Text
-                  variant="bodyMedium"
+                  variant="body"
                   style={{ color: colors.onSurfaceVariant }}
                 >
                   {formatDateShort(session.started_at)}
@@ -249,13 +250,13 @@ export default function SessionDetail() {
                 <View style={styles.stats}>
                   <View style={styles.stat}>
                     <Text
-                      variant="headlineSmall"
+                      variant="heading"
                       style={{ color: colors.primary }}
                     >
                       {formatDuration(session.duration_seconds)}
                     </Text>
                     <Text
-                      variant="bodySmall"
+                      variant="caption"
                       style={{ color: colors.onSurfaceVariant }}
                     >
                       Duration
@@ -263,13 +264,13 @@ export default function SessionDetail() {
                   </View>
                   <View style={styles.stat}>
                     <Text
-                      variant="headlineSmall"
+                      variant="heading"
                       style={{ color: colors.primary }}
                     >
                       {completedSets()}
                     </Text>
                     <Text
-                      variant="bodySmall"
+                      variant="caption"
                       style={{ color: colors.onSurfaceVariant }}
                     >
                       Sets
@@ -277,40 +278,40 @@ export default function SessionDetail() {
                   </View>
                   <View style={styles.stat}>
                     <Text
-                      variant="headlineSmall"
+                      variant="heading"
                       style={{ color: colors.primary }}
                     >
                       {volume().toLocaleString()}
                     </Text>
                     <Text
-                      variant="bodySmall"
+                      variant="caption"
                       style={{ color: colors.onSurfaceVariant }}
                     >
                       Volume
                     </Text>
                   </View>
                 </View>
-              </Card.Content>
+              </CardContent>
             </Card>
 
             {/* Rating & Notes */}
             {session.completed_at && (
-              <Card style={[styles.summary, { backgroundColor: colors.surface }]}>
-                <Card.Content style={{ alignItems: "center" }}>
+              <Card style={StyleSheet.flatten([styles.summary, { backgroundColor: colors.surface }])}>
+                <CardContent style={{ alignItems: "center" }}>
                   <Text
-                    variant="titleSmall"
+                    variant="subtitle"
                     style={{ color: colors.onSurface, marginBottom: 8 }}
                   >
                     Rating
                   </Text>
                   <RatingWidget value={rating} onChange={handleRatingChange} />
-                </Card.Content>
+                </CardContent>
               </Card>
             )}
 
             {session.completed_at && (
-              <Card style={[styles.summary, { backgroundColor: colors.surface }]}>
-                <Card.Content>
+              <Card style={StyleSheet.flatten([styles.summary, { backgroundColor: colors.surface }])}>
+                <CardContent>
                   <Pressable
                     onPress={() => setNotesExpanded(!notesExpanded)}
                     style={styles.notesHeader}
@@ -324,7 +325,7 @@ export default function SessionDetail() {
                       color={colors.primary}
                     />
                     <Text
-                      variant="titleSmall"
+                      variant="subtitle"
                       style={{ color: colors.onSurface, marginLeft: 8, flex: 1 }}
                     >
                       Session notes
@@ -356,28 +357,28 @@ export default function SessionDetail() {
                         accessibilityLabel="Session notes"
                       />
                       <Text
-                        variant="bodySmall"
+                        variant="caption"
                         style={{ color: colors.onSurfaceVariant, textAlign: "right", marginTop: 4 }}
                       >
                         {notesText.length}/500
                       </Text>
                     </View>
                   )}
-                </Card.Content>
+                </CardContent>
               </Card>
             )}
 
             {/* Personal Records */}
             {prs.length > 0 && (
               <Card
-                style={[styles.prCard, { backgroundColor: colors.tertiaryContainer }]}
+                style={StyleSheet.flatten([styles.prCard, { backgroundColor: colors.tertiaryContainer }])}
                 accessibilityLabel={`${prs.length} new personal record${prs.length > 1 ? "s" : ""} achieved in this workout`}
               >
-                <Card.Content>
+                <CardContent>
                   <View style={styles.prHeader}>
                     <MaterialCommunityIcons name="trophy" size={20} color={colors.onTertiaryContainer} />
                     <Text
-                      variant="titleMedium"
+                      variant="title"
                       style={{ color: colors.onTertiaryContainer, marginLeft: 8, fontWeight: "700" }}
                     >
                       {prs.length} New PR{prs.length > 1 ? "s" : ""}
@@ -386,41 +387,36 @@ export default function SessionDetail() {
                   {prs.map((pr) => (
                     <View key={pr.exercise_id} style={styles.prRow}>
                       <Text
-                        variant="bodyMedium"
+                        variant="body"
                         style={{ color: colors.onTertiaryContainer, flex: 1 }}
                         accessibilityLabel={`New personal record: ${pr.name}, ${pr.previous_max} to ${pr.weight}`}
                       >
                         {pr.name}
                       </Text>
                       <Text
-                        variant="bodyMedium"
+                        variant="body"
                         style={{ color: colors.onTertiaryContainer }}
                       >
                         {pr.previous_max} → {pr.weight}
                       </Text>
                     </View>
                   ))}
-                </Card.Content>
+                </CardContent>
               </Card>
             )}
 
             {/* Repeat Workout */}
             {session.completed_at && (
               <Button
-                mode="outlined"
-                icon={({ size, color }) => (
-                  <MaterialCommunityIcons name="repeat" size={size} color={color} />
-                )}
+                variant="outline"
                 onPress={handleRepeatWorkout}
                 disabled={completedSetCount === 0}
                 style={styles.repeatButton}
-                contentStyle={{ paddingVertical: 8 }}
                 accessibilityLabel="Repeat workout"
                 accessibilityHint="Start a new session with the same exercises and weights"
                 accessibilityRole="button"
-              >
-                Repeat Workout
-              </Button>
+                label="Repeat Workout"
+              />
             )}
           </>
         }
@@ -441,21 +437,21 @@ export default function SessionDetail() {
                 style={[styles.linkHeader, { borderLeftColor: groupColor }]}
                 accessibilityLabel={`${tag}: ${linked.map((g) => g.name).join(" and ")}`}
               >
-                <Text variant="labelMedium" style={{ color: groupColor, fontWeight: "700" }}>
+                <Text variant="caption" style={{ color: groupColor, fontWeight: "700" }}>
                   {tag}
                 </Text>
               </View>
             )}
             <View style={group.link_id ? { borderLeftWidth: 4, borderLeftColor: groupColor, paddingLeft: 8 } : undefined}>
             <Text
-              variant="titleMedium"
+              variant="title"
               style={[styles.groupTitle, { color: colors.primary }]}
             >
               {group.name}
             </Text>
             {group.swapped_from_name && (
               <Text
-                variant="bodySmall"
+                variant="caption"
                 style={{ color: colors.onSurfaceVariant, fontStyle: "italic", marginBottom: 4, marginTop: -2 }}
                 accessibilityLabel={`Swapped from ${group.swapped_from_name}`}
               >
@@ -490,7 +486,7 @@ export default function SessionDetail() {
                       }
                       return (
                         <Text
-                          variant="bodyMedium"
+                          variant="body"
                           style={[styles.setNum, { color: colors.onSurface }]}
                         >
                           {set.round ? `R${set.round}` : `Set ${set.set_number}`}
@@ -498,7 +494,7 @@ export default function SessionDetail() {
                       );
                     })()}
                     <Text
-                      variant="bodyMedium"
+                      variant="body"
                       style={{ color: colors.onSurface }}
                     >
                       {set.weight ?? 0} × {set.reps ?? 0}
@@ -512,7 +508,7 @@ export default function SessionDetail() {
                     )}
                     {set.tempo && (
                       <Text
-                        variant="bodySmall"
+                        variant="caption"
                         style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}
                       >
                         ♩ {set.tempo}
@@ -528,7 +524,7 @@ export default function SessionDetail() {
                   </View>
                   {set.notes ? (
                     <Text
-                      variant="bodySmall"
+                      variant="caption"
                       style={[styles.setNote, { color: colors.onSurfaceVariant }]}
                     >
                       {set.notes}
@@ -540,7 +536,7 @@ export default function SessionDetail() {
             {isLast && group.link_id && (
               <View style={{ height: 4, backgroundColor: groupColor, borderRadius: 2 }} />
             )}
-            <Divider style={styles.divider} />
+            <Separator style={styles.divider} />
           </View>
           );
         }}
@@ -556,7 +552,7 @@ export default function SessionDetail() {
               <View style={styles.modalOverlay}>
                 <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
                   <Text
-                    variant="titleMedium"
+                    variant="title"
                     style={{ color: colors.onSurface, marginBottom: 16 }}
                   >
                     Save as Template
@@ -580,34 +576,21 @@ export default function SessionDetail() {
                   />
                   <View style={styles.modalActions}>
                     <Button
-                      mode="text"
+                      variant="ghost"
                       onPress={() => setTemplateModalVisible(false)}
-                    >
-                      Cancel
-                    </Button>
+                      label="Cancel"
+                    />
                     <Button
-                      mode="contained"
+                      variant="default"
                       onPress={handleSaveAsTemplate}
                       loading={saving}
                       disabled={saving || !templateName.trim()}
-                      contentStyle={{ paddingVertical: 8 }}
-                    >
-                      Save
-                    </Button>
+                      label="Save"
+                    />
                   </View>
                 </View>
               </View>
             </Modal>
-
-            {/* Snackbar */}
-            <Snackbar
-              visible={!!snackbar}
-              onDismiss={() => setSnackbar(null)}
-              duration={4000}
-              action={snackbar?.action}
-            >
-              {snackbar?.message ?? ""}
-            </Snackbar>
           </>
         }
       />

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -11,7 +11,10 @@ import {
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Button, Card, Snackbar, Text } from "react-native-paper";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
+import { useToast } from "@/components/ui/bna-toast";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import BottomSheet from "@gorhom/bottom-sheet";
 import * as Haptics from "expo-haptics";
@@ -73,7 +76,7 @@ export default function Summary() {
   const [notesExpanded, setNotesExpanded] = useState(false);
   const [templateModalVisible, setTemplateModalVisible] = useState(false);
   const [templateName, setTemplateName] = useState("");
-  const [snackbar, setSnackbar] = useState<{ message: string; action?: { label: string; onPress: () => void } } | null>(null);
+  const { toast } = useToast();
   const [completedSetCount, setCompletedSetCount] = useState(0);
   const [saving, setSaving] = useState(false);
   const [previewVisible, setPreviewVisible] = useState(false);
@@ -286,7 +289,7 @@ export default function Summary() {
       });
       await Sharing.shareAsync(uri, { mimeType: "image/png" });
     } catch {
-      setSnackbar({ message: "Unable to generate image" });
+      toast({ description: "Unable to generate image" });
     } finally {
       setImageLoading(false);
       setPreviewVisible(false);
@@ -308,7 +311,7 @@ export default function Summary() {
       await updateSession(id, { rating: newRating });
     } catch {
       setRating(previousRating);
-      setSnackbar({ message: "Failed to save rating" });
+      toast({ description: "Failed to save rating" });
     }
   }, [id, rating]);
 
@@ -317,7 +320,7 @@ export default function Summary() {
     try {
       await updateSession(id, { notes: notesText });
     } catch {
-      setSnackbar({ message: "Failed to save notes" });
+      toast({ description: "Failed to save notes" });
     }
   }, [id, notesText]);
 
@@ -328,15 +331,9 @@ export default function Summary() {
       const truncatedName = templateName.slice(0, 100).trim() || "Untitled Template";
       const newId = await createTemplateFromSession(id, truncatedName);
       setTemplateModalVisible(false);
-      setSnackbar({
-        message: "Template saved!",
-        action: {
-          label: "View",
-          onPress: () => router.push(`/template/${newId}`),
-        },
-      });
+      toast({ description: "Template saved!" });
     } catch {
-      setSnackbar({ message: "Failed to save template" });
+      toast({ description: "Failed to save template" });
     } finally {
       setSaving(false);
     }
@@ -381,14 +378,14 @@ export default function Summary() {
                 color={colors.primary}
               />
               <Text
-                variant="headlineMedium"
+                variant="heading"
                 style={[styles.title, { color: colors.onBackground }]}
                 accessibilityRole="header"
               >
                 Workout Complete!
               </Text>
               <Text
-                variant="bodyLarge"
+                variant="body"
                 style={{ color: colors.onSurfaceVariant }}
                 numberOfLines={1}
                 ellipsizeMode="tail"
@@ -400,65 +397,65 @@ export default function Summary() {
             {/* Stats Row */}
             <View style={styles.stats}>
               <Card
-                style={[styles.stat, { backgroundColor: colors.surface }]}
+                style={StyleSheet.flatten([styles.stat, { backgroundColor: colors.surface }])}
                 accessibilityLabel={`Duration: ${durationSpoken()}`}
               >
-                <Card.Content style={styles.statInner}>
-                  <Text variant="headlineSmall" style={{ color: colors.primary }}>
+                <CardContent style={styles.statInner}>
+                  <Text variant="heading" style={{ color: colors.primary }}>
                     {duration}
                   </Text>
-                  <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+                  <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                     Duration
                   </Text>
-                </Card.Content>
+                </CardContent>
               </Card>
               <Card
-                style={[styles.stat, { backgroundColor: colors.surface }]}
+                style={StyleSheet.flatten([styles.stat, { backgroundColor: colors.surface }])}
                 accessibilityLabel={setsBreakdown ? `${completed.length} sets: ${setsBreakdown}` : `${completed.length} sets completed`}
               >
-                <Card.Content style={styles.statInner}>
-                  <Text variant="headlineSmall" style={{ color: colors.primary }}>
+                <CardContent style={styles.statInner}>
+                  <Text variant="heading" style={{ color: colors.primary }}>
                     {completed.length}
                   </Text>
-                  <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+                  <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                     {setsBreakdown ? `Sets (${setsBreakdown})` : "Sets"}
                   </Text>
-                </Card.Content>
+                </CardContent>
               </Card>
               <Card
-                style={[styles.stat, { backgroundColor: colors.surface }]}
+                style={StyleSheet.flatten([styles.stat, { backgroundColor: colors.surface }])}
                 accessibilityLabel={`Total volume: ${volumeDisplay.toLocaleString()} ${unit}`}
               >
-                <Card.Content style={styles.statInner}>
-                  <Text variant="headlineSmall" style={{ color: colors.primary }}>
+                <CardContent style={styles.statInner}>
+                  <Text variant="heading" style={{ color: colors.primary }}>
                     {volumeDisplay.toLocaleString()}
                   </Text>
-                  <Text variant="bodySmall" style={{ color: colors.onSurfaceVariant }}>
+                  <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                     Volume ({unit})
                   </Text>
-                </Card.Content>
+                </CardContent>
               </Card>
             </View>
 
             {/* Rating Widget */}
             {session.completed_at && (
-              <Card style={[styles.section, { backgroundColor: colors.surface }]}>
-                <Card.Content style={{ alignItems: "center" }}>
+              <Card style={StyleSheet.flatten([styles.section, { backgroundColor: colors.surface }])}>
+                <CardContent style={{ alignItems: "center" }}>
                   <Text
-                    variant="titleMedium"
+                    variant="title"
                     style={{ color: colors.onSurface, marginBottom: 12, fontWeight: "600" }}
                   >
                     How was your workout?
                   </Text>
                   <RatingWidget value={rating} onChange={handleRatingChange} size="large" />
-                </Card.Content>
+                </CardContent>
               </Card>
             )}
 
             {/* Session Notes */}
             {session.completed_at && (
-              <Card style={[styles.section, { backgroundColor: colors.surface }]}>
-                <Card.Content>
+              <Card style={StyleSheet.flatten([styles.section, { backgroundColor: colors.surface }])}>
+                <CardContent>
                   <Pressable
                     onPress={() => setNotesExpanded(!notesExpanded)}
                     style={styles.notesHeader}
@@ -473,7 +470,7 @@ export default function Summary() {
                       color={colors.primary}
                     />
                     <Text
-                      variant="titleSmall"
+                      variant="subtitle"
                       style={{ color: colors.onSurface, marginLeft: 8, flex: 1 }}
                     >
                       Session notes
@@ -505,14 +502,14 @@ export default function Summary() {
                         accessibilityLabel="Session notes"
                       />
                       <Text
-                        variant="bodySmall"
+                        variant="caption"
                         style={{ color: colors.onSurfaceVariant, textAlign: "right", marginTop: 4 }}
                       >
                         {notesText.length}/500
                       </Text>
                     </View>
                   )}
-                </Card.Content>
+                </CardContent>
               </Card>
             )}
           </>
@@ -523,15 +520,15 @@ export default function Summary() {
             const extraCount = newAchievements.length - 3;
             return (
               <Card
-                style={[styles.section, { backgroundColor: colors.tertiaryContainer }]}
+                style={StyleSheet.flatten([styles.section, { backgroundColor: colors.tertiaryContainer }])}
                 accessibilityLabel={`${newAchievements.length} achievement${newAchievements.length > 1 ? "s" : ""} unlocked`}
                 accessibilityLiveRegion="polite"
               >
-                <Card.Content>
+                <CardContent>
                   <View style={styles.sectionHeader}>
                     <Text style={{ fontSize: 20 }}>🏆</Text>
                     <Text
-                      variant="titleMedium"
+                      variant="title"
                       style={{ color: colors.onTertiaryContainer, marginLeft: 8, fontWeight: "700" }}
                     >
                       Achievement{newAchievements.length > 1 ? "s" : ""} Unlocked!
@@ -542,13 +539,13 @@ export default function Summary() {
                       <Text style={{ fontSize: 18, marginRight: 8 }}>{a.icon}</Text>
                       <View style={{ flex: 1 }}>
                         <Text
-                          variant="bodyMedium"
+                          variant="body"
                           style={{ color: colors.onTertiaryContainer, fontWeight: "600" }}
                         >
                           {a.name}
                         </Text>
                         <Text
-                          variant="bodySmall"
+                          variant="caption"
                           style={{ color: colors.onTertiaryContainer }}
                         >
                           {a.description}
@@ -558,9 +555,8 @@ export default function Summary() {
                   ))}
                   {extraCount > 0 && (
                     <Button
-                      mode="text"
+                      variant="ghost"
                       onPress={() => router.push("/progress/achievements")}
-                      textColor={colors.onTertiaryContainer}
                       style={{ marginTop: 4 }}
                       accessibilityLabel={`View ${extraCount} more achievements`}
                       accessibilityRole="link"
@@ -568,7 +564,7 @@ export default function Summary() {
                       +{extraCount} more
                     </Button>
                   )}
-                </Card.Content>
+                </CardContent>
               </Card>
             );
           }
@@ -576,10 +572,10 @@ export default function Summary() {
           if (item.key === "prs") {
             return (
               <Card
-                style={[styles.section, { backgroundColor: colors.tertiaryContainer }]}
+                style={StyleSheet.flatten([styles.section, { backgroundColor: colors.tertiaryContainer }])}
                 accessibilityLabel={`${allPrs.length} new personal record${allPrs.length > 1 ? "s" : ""}`}
               >
-                <Card.Content>
+                <CardContent>
                   <View style={styles.sectionHeader}>
                     <MaterialCommunityIcons
                       name="trophy"
@@ -587,7 +583,7 @@ export default function Summary() {
                       color={colors.onTertiaryContainer}
                     />
                     <Text
-                      variant="titleMedium"
+                      variant="title"
                       style={{ color: colors.onTertiaryContainer, marginLeft: 8, fontWeight: "700" }}
                     >
                       {allPrs.length} New PR{allPrs.length > 1 ? "s" : ""}
@@ -596,14 +592,14 @@ export default function Summary() {
                   {prs.map((pr) => (
                     <View key={pr.exercise_id} style={styles.row}>
                       <Text
-                        variant="bodyMedium"
+                        variant="body"
                         style={{ color: colors.onTertiaryContainer, flex: 1 }}
                         accessibilityLabel={`New personal record: ${pr.name}, ${toDisplay(pr.weight, unit)} ${unit}`}
                       >
                         {pr.name}
                       </Text>
                       <Text
-                        variant="bodyMedium"
+                        variant="body"
                         style={{ color: colors.onTertiaryContainer }}
                       >
                         {toDisplay(pr.previous_max, unit)} → {toDisplay(pr.weight, unit)} {unit}
@@ -613,29 +609,29 @@ export default function Summary() {
                   {repPrs.map((pr) => (
                     <View key={pr.exercise_id} style={styles.row}>
                       <Text
-                        variant="bodyMedium"
+                        variant="body"
                         style={{ color: colors.onTertiaryContainer, flex: 1 }}
                         accessibilityLabel={`New rep personal record: ${pr.name}, ${pr.reps} reps`}
                       >
                         {pr.name}
                       </Text>
                       <Text
-                        variant="bodyMedium"
+                        variant="body"
                         style={{ color: colors.onTertiaryContainer }}
                       >
                         {pr.previous_max} → {pr.reps} reps
                       </Text>
                     </View>
                   ))}
-                </Card.Content>
+                </CardContent>
               </Card>
             );
           }
 
           if (item.key === "increases") {
             return (
-              <Card style={[styles.section, { backgroundColor: colors.surface }]}>
-                <Card.Content>
+              <Card style={StyleSheet.flatten([styles.section, { backgroundColor: colors.surface }])}>
+                <CardContent>
                   <View style={styles.sectionHeader}>
                     <MaterialCommunityIcons
                       name="trending-up"
@@ -643,7 +639,7 @@ export default function Summary() {
                       color={colors.primary}
                     />
                     <Text
-                      variant="titleMedium"
+                      variant="title"
                       style={{ color: colors.onSurface, marginLeft: 8, fontWeight: "700" }}
                     >
                       Weight Increases
@@ -652,29 +648,29 @@ export default function Summary() {
                   {increases.map((inc) => (
                     <View key={inc.exercise_id} style={styles.row}>
                       <Text
-                        variant="bodyMedium"
+                        variant="body"
                         style={{ color: colors.onSurface, flex: 1 }}
                         accessibilityLabel={`${inc.name}: weight increased from ${toDisplay(inc.previous, unit)} to ${toDisplay(inc.current, unit)} ${unit}`}
                       >
                         {inc.name}
                       </Text>
                       <Text
-                        variant="bodyMedium"
+                        variant="body"
                         style={{ color: colors.primary }}
                       >
                         {toDisplay(inc.previous, unit)} → {toDisplay(inc.current, unit)} {unit}
                       </Text>
                     </View>
                   ))}
-                </Card.Content>
+                </CardContent>
               </Card>
             );
           }
 
           if (item.key === "comparison" && comparison?.previous) {
             return (
-              <Card style={[styles.section, { backgroundColor: colors.surface }]}>
-                <Card.Content>
+              <Card style={StyleSheet.flatten([styles.section, { backgroundColor: colors.surface }])}>
+                <CardContent>
                   <View style={styles.sectionHeader}>
                     <MaterialCommunityIcons
                       name="compare-horizontal"
@@ -682,18 +678,18 @@ export default function Summary() {
                       color={colors.primary}
                     />
                     <Text
-                      variant="titleMedium"
+                      variant="title"
                       style={{ color: colors.onSurface, marginLeft: 8, fontWeight: "700" }}
                     >
                       vs. Last Time
                     </Text>
                   </View>
                   <View style={styles.compRow}>
-                    <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, flex: 1 }}>
+                    <Text variant="body" style={{ color: colors.onSurfaceVariant, flex: 1 }}>
                       Volume
                     </Text>
                     <Text
-                      variant="bodyMedium"
+                      variant="body"
                       style={{ color: colors.onSurface }}
                       accessibilityLabel={`Volume ${comparison.current.volume >= comparison.previous.volume ? "increased" : "decreased"} by ${Math.abs(comparison.current.volume - comparison.previous.volume).toLocaleString()}`}
                     >
@@ -701,36 +697,36 @@ export default function Summary() {
                     </Text>
                   </View>
                   <View style={styles.compRow}>
-                    <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, flex: 1 }}>
+                    <Text variant="body" style={{ color: colors.onSurfaceVariant, flex: 1 }}>
                       Duration
                     </Text>
                     <Text
-                      variant="bodyMedium"
+                      variant="body"
                       style={{ color: colors.onSurface }}
                     >
                       {deltaTime(comparison.current.duration, comparison.previous.duration)}
                     </Text>
                   </View>
                   <View style={styles.compRow}>
-                    <Text variant="bodyMedium" style={{ color: colors.onSurfaceVariant, flex: 1 }}>
+                    <Text variant="body" style={{ color: colors.onSurfaceVariant, flex: 1 }}>
                       Sets
                     </Text>
                     <Text
-                      variant="bodyMedium"
+                      variant="body"
                       style={{ color: colors.onSurface }}
                     >
                       {delta(comparison.current.sets, comparison.previous.sets)}
                     </Text>
                   </View>
-                </Card.Content>
+                </CardContent>
               </Card>
             );
           }
 
           if (item.key === "sets") {
             return (
-              <Card style={[styles.section, { backgroundColor: colors.surface }]}>
-                <Card.Content>
+              <Card style={StyleSheet.flatten([styles.section, { backgroundColor: colors.surface }])}>
+                <CardContent>
                   <View style={styles.sectionHeader}>
                     <MaterialCommunityIcons
                       name="dumbbell"
@@ -738,7 +734,7 @@ export default function Summary() {
                       color={colors.primary}
                     />
                     <Text
-                      variant="titleMedium"
+                      variant="title"
                       style={{ color: colors.onSurface, marginLeft: 8, fontWeight: "700" }}
                     >
                       Sets
@@ -747,14 +743,14 @@ export default function Summary() {
                   {grouped.map((group) => (
                     <View key={group.name} style={styles.exerciseGroup}>
                       <Text
-                        variant="labelLarge"
+                        variant="body"
                         style={{ color: colors.onSurfaceVariant, marginBottom: 4 }}
                       >
                         {group.name}
                       </Text>
                       {group.sets.map((set) => (
                         <View key={set.id} style={styles.setRow}>
-                          <Text variant="bodyMedium" style={{ color: colors.onSurface }}>
+                          <Text variant="body" style={{ color: colors.onSurface }}>
                             {set.weight ?? 0} × {set.reps ?? 0}
                           </Text>
                           {set.training_mode && set.training_mode !== "weight" && (
@@ -766,7 +762,7 @@ export default function Summary() {
                           )}
                           {set.tempo && (
                             <Text
-                              variant="bodySmall"
+                              variant="caption"
                               style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}
                             >
                               ♩ {set.tempo}
@@ -774,7 +770,7 @@ export default function Summary() {
                           )}
                           {set.rpe != null && (
                             <Text
-                              variant="bodySmall"
+                              variant="caption"
                               style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}
                             >
                               RPE {set.rpe}
@@ -784,7 +780,7 @@ export default function Summary() {
                       ))}
                     </View>
                   ))}
-                </Card.Content>
+                </CardContent>
               </Card>
             );
           }
@@ -795,51 +791,42 @@ export default function Summary() {
           <View style={styles.actions}>
             {session.completed_at && (
               <Button
-                mode="outlined"
+                variant="outline"
                 onPress={() => {
                   setTemplateName((session.name ?? "").slice(0, 100));
                   setTemplateModalVisible(true);
                 }}
-                icon="content-save-outline"
                 style={styles.shareBtn}
-                contentStyle={styles.btnContent}
                 disabled={completedSetCount === 0}
                 accessibilityRole="button"
                 accessibilityHint={completedSetCount === 0 ? "No exercises to save" : "Save this workout as a reusable template"}
                 accessibilityState={{ disabled: completedSetCount === 0 }}
-              >
-                Save as Template
-              </Button>
+                label="Save as Template"
+              />
             )}
             <Button
-              mode="contained"
+              variant="default"
               onPress={() => router.replace("/(tabs)")}
               style={styles.doneBtn}
-              contentStyle={styles.btnContent}
               accessibilityRole="button"
               accessibilityHint="Return to workouts tab"
-            >
-              Done
-            </Button>
+              label="Done"
+            />
             <Button
-              mode="outlined"
+              variant="outline"
               onPress={handleShareButtonPress}
               style={styles.shareBtn}
-              contentStyle={styles.btnContent}
               accessibilityRole="button"
               accessibilityHint="Share workout summary"
-            >
-              Share
-            </Button>
+              label="Share"
+            />
             <Button
-              mode="text"
+              variant="ghost"
               onPress={() => router.replace(`/session/detail/${id}`)}
-              contentStyle={styles.btnContent}
               accessibilityRole="button"
               accessibilityHint="View detailed workout breakdown"
-            >
-              View Details
-            </Button>
+              label="View Details"
+            />
 
             {/* Save as Template Modal */}
             <Modal
@@ -851,7 +838,7 @@ export default function Summary() {
               <View style={styles.modalOverlay}>
                 <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
                   <Text
-                    variant="titleMedium"
+                    variant="title"
                     style={{ color: colors.onSurface, marginBottom: 16 }}
                   >
                     Save as Template
@@ -875,34 +862,21 @@ export default function Summary() {
                   />
                   <View style={styles.modalActions}>
                     <Button
-                      mode="text"
+                      variant="ghost"
                       onPress={() => setTemplateModalVisible(false)}
-                    >
-                      Cancel
-                    </Button>
+                      label="Cancel"
+                    />
                     <Button
-                      mode="contained"
+                      variant="default"
                       onPress={handleSaveAsTemplate}
                       loading={saving}
                       disabled={saving || !templateName.trim()}
-                      contentStyle={{ paddingVertical: 8 }}
-                    >
-                      Save
-                    </Button>
+                      label="Save"
+                    />
                   </View>
                 </View>
               </View>
             </Modal>
-
-            {/* Snackbar */}
-            <Snackbar
-              visible={!!snackbar}
-              onDismiss={() => setSnackbar(null)}
-              duration={4000}
-              action={snackbar?.action}
-            >
-              {snackbar?.message ?? ""}
-            </Snackbar>
           </View>
         }
       />
@@ -954,28 +928,24 @@ export default function Summary() {
               ) : (
                 <>
                   <Button
-                    mode="contained"
+                    variant="default"
                     onPress={handleCaptureAndShare}
                     style={styles.previewBtn}
-                    contentStyle={styles.btnContent}
                     accessibilityRole="button"
                     accessibilityHint="Capture and share the workout card image"
-                  >
-                    Share
-                  </Button>
+                    label="Share"
+                  />
                   <Button
-                    mode="outlined"
+                    variant="outline"
                     onPress={() => {
                       setPreviewVisible(false);
                       setImageLoading(false);
                     }}
                     style={styles.previewBtn}
-                    contentStyle={styles.btnContent}
                     accessibilityRole="button"
                     accessibilityHint="Cancel and close the preview"
-                  >
-                    Cancel
-                  </Button>
+                    label="Cancel"
+                  />
                 </>
               )}
             </View>

--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -2,10 +2,16 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Pressable,
   StyleSheet,
+  TouchableOpacity,
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Button, Checkbox, Chip, IconButton, Snackbar, Text } from "react-native-paper";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { Chip } from "@/components/ui/chip";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useToast } from "@/components/ui/bna-toast";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useFocusEffect } from "expo-router";
 import { useLayout } from "../../lib/layout";
@@ -46,11 +52,11 @@ export default function EditTemplate() {
   const [exercises, setExercises] = useState<TemplateExercise[]>([]);
   const [selecting, setSelecting] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [snackbar, setSnackbar] = useState("");
   const [undo, setUndo] = useState<(() => Promise<void>) | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [editing, setEditing] = useState<TemplateExercise | null>(null);
   const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { toast } = useToast();
 
   const linkIds = useMemo(() => {
     const ids: string[] = [];
@@ -126,14 +132,13 @@ export default function EditTemplate() {
     setSelecting(false);
     setSelected(new Set());
     await load();
-    setSnackbar("Exercises linked as superset");
+    toast("Exercises linked as superset");
     setUndo(() => async () => {
       await unlinkExerciseGroup(linkId);
       await load();
     });
     if (undoTimer.current) clearTimeout(undoTimer.current);
     undoTimer.current = setTimeout(() => {
-      setSnackbar("");
       setUndo(null);
     }, 5000);
   };
@@ -142,7 +147,7 @@ export default function EditTemplate() {
     await unlinkExerciseGroup(linkId);
     await load();
     const prev = exercises.filter((e) => e.link_id === linkId).map((e) => e.id);
-    setSnackbar("Exercises unlinked");
+    toast("Exercises unlinked");
     setUndo(() => async () => {
       if (id) {
         await createExerciseLink(id, prev);
@@ -151,7 +156,6 @@ export default function EditTemplate() {
     });
     if (undoTimer.current) clearTimeout(undoTimer.current);
     undoTimer.current = setTimeout(() => {
-      setSnackbar("");
       setUndo(null);
     }, 5000);
   }, [exercises, id, load]);
@@ -176,7 +180,7 @@ export default function EditTemplate() {
       setEditing(null);
       await load();
     } catch {
-      setSnackbar("Failed to update exercise settings");
+      toast("Failed to update exercise settings");
     }
   }, [editing, id, load]);
 
@@ -200,15 +204,12 @@ export default function EditTemplate() {
                 .map((e) => e.exercise?.name)
                 .join(" and ")}, ${exercises.filter((e) => e.link_id === item.link_id).length} exercises linked`}
             >
-              <Text variant="labelMedium" style={{ color, flex: 1, fontWeight: "700" }}>
+              <Text variant="caption" style={{ color, flex: 1, fontWeight: "700" }}>
                 {groupLabel}
               </Text>
-              <IconButton
-                icon="link-off"
-                size={18}
-                onPress={() => handleUnlink(item.link_id!)}
-                accessibilityLabel={`Unlink ${groupLabel}`}
-              />
+              <TouchableOpacity onPress={() => handleUnlink(item.link_id!)} accessibilityLabel={`Unlink ${groupLabel}`} hitSlop={8} style={{ padding: 8 }}>
+                <MaterialCommunityIcons name="link-off" size={18} color={colors.onSurface} />
+              </TouchableOpacity>
             </View>
           )}
 
@@ -241,13 +242,13 @@ export default function EditTemplate() {
             >
               {selecting && (
                 <Checkbox
-                  status={selected.has(item.id) ? "checked" : "unchecked"}
-                  onPress={() => toggleSelect(item.id)}
+                  checked={selected.has(item.id)}
+                  onCheckedChange={() => toggleSelect(item.id)}
                 />
               )}
               <View style={styles.info}>
                 <Text
-                  variant="titleSmall"
+                  variant="subtitle"
                   style={{
                     color: item.exercise?.deleted_at ? colors.onSurfaceVariant : colors.onSurface,
                     fontStyle: item.exercise?.deleted_at ? "italic" : "normal",
@@ -256,65 +257,46 @@ export default function EditTemplate() {
                   {item.exercise?.name ?? "Unknown"}{item.exercise?.deleted_at ? " (removed)" : ""}
                 </Text>
                 <Text
-                  variant="bodySmall"
+                  variant="caption"
                   style={{ color: colors.onSurfaceVariant }}
                 >
                   {item.target_sets} × {item.target_reps} · {item.rest_seconds}s rest
                 </Text>
                 {item.exercise?.deleted_at && !selecting && (
                   <Button
-                    mode="text"
-                    compact
+                    variant="ghost"
                     onPress={() => router.push(`/template/${id}?replaceTeId=${item.id}`)}
                     style={{ alignSelf: "flex-start", minHeight: 48, minWidth: 48 }}
                     accessibilityLabel={`Replace ${item.exercise.name}`}
                     accessibilityRole="button"
-                  >
-                    Replace
-                  </Button>
+                    label="Replace"
+                  />
                 )}
                 {item.link_id && !selecting && !item.exercise?.deleted_at && (
-                  <Text variant="labelSmall" style={{ color, marginTop: 2 }}>
+                  <Text variant="caption" style={{ color, marginTop: 2 }}>
                     Linked — rotate in session
                   </Text>
                 )}
               </View>
               {!selecting && (
                 <View style={styles.actions}>
-                  <IconButton
-                    icon="pencil-outline"
-                    size={16}
-                    onPress={() => setEditing(item)}
-                    accessibilityLabel={`Edit ${item.exercise?.name ?? "exercise"} settings`}
-                  />
+                  <TouchableOpacity onPress={() => setEditing(item)} accessibilityLabel={`Edit ${item.exercise?.name ?? "exercise"} settings`} hitSlop={8} style={{ padding: 8 }}>
+                    <MaterialCommunityIcons name="pencil-outline" size={16} color={colors.onSurface} />
+                  </TouchableOpacity>
                   {item.link_id && (
-                    <IconButton
-                      icon="link-off"
-                      size={16}
-                      onPress={() => handleUnlinkSingle(item.id, item.link_id!)}
-                      accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"} from superset`}
-                    />
+                    <TouchableOpacity onPress={() => handleUnlinkSingle(item.id, item.link_id!)} accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"} from superset`} hitSlop={8} style={{ padding: 8 }}>
+                      <MaterialCommunityIcons name="link-off" size={16} color={colors.onSurface} />
+                    </TouchableOpacity>
                   )}
-                  <IconButton
-                    icon="arrow-up"
-                    size={18}
-                    onPress={() => move(index, -1)}
-                    disabled={index === 0}
-                    accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} up`}
-                  />
-                  <IconButton
-                    icon="arrow-down"
-                    size={18}
-                    onPress={() => move(index, 1)}
-                    disabled={index === exercises.length - 1}
-                    accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} down`}
-                  />
-                  <IconButton
-                    icon="close"
-                    size={18}
-                    onPress={() => remove(item.id)}
-                    accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"}`}
-                  />
+                  <TouchableOpacity onPress={() => move(index, -1)} disabled={index === 0} accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} up`} hitSlop={8} style={{ padding: 8 }}>
+                    <MaterialCommunityIcons name="arrow-up" size={18} color={colors.onSurface} />
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={() => move(index, 1)} disabled={index === exercises.length - 1} accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} down`} hitSlop={8} style={{ padding: 8 }}>
+                    <MaterialCommunityIcons name="arrow-down" size={18} color={colors.onSurface} />
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={() => remove(item.id)} accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"}`} hitSlop={8} style={{ padding: 8 }}>
+                    <MaterialCommunityIcons name="close" size={18} color={colors.onSurface} />
+                  </TouchableOpacity>
                 </View>
               )}
             </Pressable>
@@ -364,15 +346,13 @@ export default function EditTemplate() {
         <View style={styles.section}>
           <View style={styles.headerRow}>
             <Text
-              variant="titleMedium"
+              variant="title"
               style={{ color: colors.onBackground }}
             >
               Exercises ({exercises.length})
             </Text>
             {starter && (
               <Chip
-                mode="flat"
-                compact
                 accessibilityLabel="Starter template, read-only. Duplicate to edit."
               >
                 STARTER
@@ -384,29 +364,25 @@ export default function EditTemplate() {
         {/* Selection mode toolbar */}
         {selecting && !starter && (
           <View style={[styles.selectionBar, { backgroundColor: colors.primaryContainer }]}>
-            <Text variant="bodyMedium" style={{ color: colors.onPrimaryContainer, flex: 1 }}
+            <Text variant="body" style={{ color: colors.onPrimaryContainer, flex: 1 }}
               accessibilityLiveRegion="polite"
             >
               {selected.size} selected
             </Text>
             <Button
-              mode="contained"
-              compact
+              variant="default"
               onPress={confirmLink}
               disabled={selected.size < 2}
               style={{ marginRight: 8 }}
               accessibilityLabel="Link selected exercises"
-            >
-              Link
-            </Button>
+              label="Link"
+            />
             <Button
-              mode="text"
-              compact
+              variant="ghost"
               onPress={cancelSelection}
               accessibilityLabel="Cancel selection"
-            >
-              Cancel
-            </Button>
+              label="Cancel"
+            />
           </View>
         )}
 
@@ -430,7 +406,7 @@ export default function EditTemplate() {
               >
                 <View style={styles.info}>
                   <Text
-                    variant="titleSmall"
+                    variant="subtitle"
                     style={{
                       color: item.exercise?.deleted_at ? colors.onSurfaceVariant : colors.onSurface,
                       fontStyle: item.exercise?.deleted_at ? "italic" : "normal",
@@ -439,7 +415,7 @@ export default function EditTemplate() {
                     {item.exercise?.name ?? "Unknown"}{item.exercise?.deleted_at ? " (removed)" : ""}
                   </Text>
                   <Text
-                    variant="bodySmall"
+                    variant="caption"
                     style={{ color: colors.onSurfaceVariant }}
                   >
                     {item.target_sets} × {item.target_reps} · {item.rest_seconds}s rest
@@ -453,7 +429,7 @@ export default function EditTemplate() {
           ListEmptyComponent={
             <View style={styles.empty}>
               <Text
-                variant="bodyMedium"
+                variant="body"
                 style={{ color: colors.onSurfaceVariant }}
               >
                 No exercises. Add some below.
@@ -465,63 +441,36 @@ export default function EditTemplate() {
 
         {starter ? (
           <Button
-            mode="contained"
-            icon="content-copy"
+            variant="default"
             onPress={handleDuplicate}
             style={styles.doneBtn}
-            contentStyle={styles.btnContent}
             accessibilityLabel="Duplicate to edit"
-          >
-            Duplicate to Edit
-          </Button>
+            label="Duplicate to Edit"
+          />
         ) : (
           <>
             {!selecting && exercises.length >= 2 && (
               <Button
-                mode="outlined"
-                icon="link-variant"
+                variant="outline"
                 onPress={() => startSelection()}
                 style={styles.addBtn}
-                contentStyle={styles.btnContent}
                 accessibilityLabel="Create superset"
                 accessibilityRole="button"
-              >
-                Create Superset
-              </Button>
+                label="Create Superset"
+              />
             )}
 
             <Button
-              mode="outlined"
-              icon="plus"
+              variant="outline"
               onPress={() => setPickerOpen(true)}
               style={styles.addBtn}
-              contentStyle={styles.btnContent}
               accessibilityLabel="Add exercise to template"
-            >
-              Add Exercise
-            </Button>
-            <Button mode="contained" onPress={() => router.back()} style={styles.doneBtn} contentStyle={styles.btnContent} accessibilityLabel="Done editing template">
-              Done
-            </Button>
+              label="Add Exercise"
+            />
+            <Button variant="default" onPress={() => router.back()} style={styles.doneBtn} accessibilityLabel="Done editing template" label="Done" />
           </>
         )}
       </View>
-      <Snackbar
-        visible={!!snackbar}
-        onDismiss={() => {
-          setSnackbar("");
-          setUndo(null);
-        }}
-        duration={5000}
-        accessibilityLiveRegion="polite"
-        action={undo ? { label: "Undo", onPress: async () => {
-          if (undo) await undo();
-          setSnackbar("");
-          setUndo(null);
-        }} : undefined}
-      >
-        {snackbar}
-      </Snackbar>
       <ExercisePickerSheet
         visible={pickerOpen}
         onDismiss={() => setPickerOpen(false)}
@@ -578,9 +527,6 @@ const styles = StyleSheet.create({
   },
   doneBtn: {
     marginTop: 16,
-  },
-  btnContent: {
-    paddingVertical: 8,
   },
   empty: {
     alignItems: "center",

--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -52,11 +52,11 @@ export default function EditTemplate() {
   const [exercises, setExercises] = useState<TemplateExercise[]>([]);
   const [selecting, setSelecting] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [undo, setUndo] = useState<(() => Promise<void>) | null>(null);
+  const [, setUndo] = useState<(() => Promise<void>) | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [editing, setEditing] = useState<TemplateExercise | null>(null);
   const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const { toast } = useToast();
+  const { success, error: showError } = useToast();
 
   const linkIds = useMemo(() => {
     const ids: string[] = [];
@@ -132,7 +132,7 @@ export default function EditTemplate() {
     setSelecting(false);
     setSelected(new Set());
     await load();
-    toast("Exercises linked as superset");
+    success("Exercises linked as superset");
     setUndo(() => async () => {
       await unlinkExerciseGroup(linkId);
       await load();
@@ -147,7 +147,7 @@ export default function EditTemplate() {
     await unlinkExerciseGroup(linkId);
     await load();
     const prev = exercises.filter((e) => e.link_id === linkId).map((e) => e.id);
-    toast("Exercises unlinked");
+    success("Exercises unlinked");
     setUndo(() => async () => {
       if (id) {
         await createExerciseLink(id, prev);
@@ -158,7 +158,7 @@ export default function EditTemplate() {
     undoTimer.current = setTimeout(() => {
       setUndo(null);
     }, 5000);
-  }, [exercises, id, load]);
+  }, [exercises, id, load, success]);
 
   const handleUnlinkSingle = useCallback(async (teId: string, linkId: string) => {
     await unlinkSingleExercise(teId, linkId);
@@ -180,9 +180,9 @@ export default function EditTemplate() {
       setEditing(null);
       await load();
     } catch {
-      toast("Failed to update exercise settings");
+      showError("Failed to update exercise settings");
     }
-  }, [editing, id, load]);
+  }, [editing, id, load, showError]);
 
   const renderItem = useCallback(
     ({ item, index }: { item: TemplateExercise; index: number }) => {

--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -132,10 +132,19 @@ export default function EditTemplate() {
     setSelecting(false);
     setSelected(new Set());
     await load();
-    success("Exercises linked as superset");
-    setUndo(() => async () => {
+    const undoFn = async () => {
       await unlinkExerciseGroup(linkId);
       await load();
+    };
+    setUndo(() => undoFn);
+    success("Exercises linked as superset", {
+      action: {
+        label: "Undo",
+        onPress: async () => {
+          await undoFn();
+          setUndo(null);
+        },
+      },
     });
     if (undoTimer.current) clearTimeout(undoTimer.current);
     undoTimer.current = setTimeout(() => {
@@ -147,12 +156,21 @@ export default function EditTemplate() {
     await unlinkExerciseGroup(linkId);
     await load();
     const prev = exercises.filter((e) => e.link_id === linkId).map((e) => e.id);
-    success("Exercises unlinked");
-    setUndo(() => async () => {
+    const undoFn = async () => {
       if (id) {
         await createExerciseLink(id, prev);
         await load();
       }
+    };
+    setUndo(() => undoFn);
+    success("Exercises unlinked", {
+      action: {
+        label: "Undo",
+        onPress: async () => {
+          await undoFn();
+          setUndo(null);
+        },
+      },
     });
     if (undoTimer.current) clearTimeout(undoTimer.current);
     undoTimer.current = setTimeout(() => {

--- a/app/template/create.tsx
+++ b/app/template/create.tsx
@@ -3,10 +3,15 @@ import {
   Alert,
   Pressable,
   StyleSheet,
+  TouchableOpacity,
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Button, IconButton, Snackbar, Text, TextInput } from "react-native-paper";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/bna-toast";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useFocusEffect } from "expo-router";
 import { useLayout } from "../../lib/layout";
@@ -29,16 +34,14 @@ export default function CreateTemplate() {
   const colors = useThemeColors();
   const layout = useLayout();
   const router = useRouter();
-  const params = useLocalSearchParams<{
-    templateId?: string;
-  }>();
+  const params = useLocalSearchParams<{ templateId?: string }>();
   const [name, setName] = useState("");
   const [template, setTemplate] = useState<WorkoutTemplate | null>(null);
   const [exercises, setExercises] = useState<TemplateExercise[]>([]);
   const [saving, setSaving] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [editing, setEditing] = useState<TemplateExercise | null>(null);
-  const [snackbar, setSnackbar] = useState("");
+  const { toast } = useToast();
 
   useFocusEffect(
     useCallback(() => {
@@ -75,10 +78,7 @@ export default function CreateTemplate() {
       if (!template) {
         const tpl = await createTemplate(trimmed);
         setTemplate(tpl);
-        Alert.alert(
-          "Template Created",
-          "Now add exercises to your template.",
-        );
+        Alert.alert("Template Created", "Now add exercises to your template.");
       } else {
         if (exercises.length === 0) {
           Alert.alert("Validation", "Add at least 1 exercise to your template.");
@@ -125,88 +125,65 @@ export default function CreateTemplate() {
       setEditing(null);
       await load();
     } catch {
-      setSnackbar("Failed to update exercise settings");
+      toast("Failed to update exercise settings");
     }
-  }, [editing, template, load]);
+  }, [editing, template, load, toast]);
 
   const renderItem = useCallback(
-    ({ item, index }: { item: TemplateExercise; index: number }) => (
+    ({ item, index }: { item: TemplateExercise; index: number }) => {
+      const exName = item.exercise?.name ?? "exercise";
+      return (
       <Pressable
         onPress={() => setEditing(item)}
-        style={[
-          styles.exerciseRow,
-          { backgroundColor: colors.surface, borderBottomColor: colors.outlineVariant },
-        ]}
+        style={[styles.exerciseRow, { backgroundColor: colors.surface, borderBottomColor: colors.outlineVariant }]}
         accessibilityRole="button"
-        accessibilityLabel={`Edit ${item.exercise?.name ?? "exercise"} settings`}
+        accessibilityLabel={`Edit ${exName} settings`}
       >
         <View style={styles.exerciseInfo}>
-          <Text variant="titleSmall" style={{ color: colors.onSurface }}>
+          <Text variant="subtitle" style={{ color: colors.onSurface }}>
             {item.exercise?.name ?? "Unknown Exercise"}
           </Text>
-          <Text
-            variant="bodySmall"
-            style={{ color: colors.onSurfaceVariant }}
-          >
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
             {item.target_sets} × {item.target_reps} · {item.rest_seconds}s rest
           </Text>
         </View>
         <View style={styles.actions}>
-          <IconButton
-            icon="pencil-outline"
-            size={16}
-            onPress={() => setEditing(item)}
-            accessibilityLabel={`Edit ${item.exercise?.name ?? "exercise"} settings`}
-          />
-          <IconButton
-            icon="arrow-up"
-            size={18}
-            onPress={() => move(index, -1)}
-            disabled={index === 0}
-            accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} up`}
-          />
-          <IconButton
-            icon="arrow-down"
-            size={18}
-            onPress={() => move(index, 1)}
-            disabled={index === exercises.length - 1}
-            accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} down`}
-          />
-          <IconButton
-            icon="close"
-            size={18}
-            onPress={() => remove(item.id)}
-            accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"}`}
-          />
+          <TouchableOpacity onPress={() => setEditing(item)} accessibilityLabel={`Edit ${exName} settings`} hitSlop={8} style={styles.iconBtn}>
+            <MaterialCommunityIcons name="pencil-outline" size={16} color={colors.onSurface} />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => move(index, -1)} disabled={index === 0} accessibilityLabel={`Move ${exName} up`} hitSlop={8} style={styles.iconBtn}>
+            <MaterialCommunityIcons name="arrow-up" size={18} color={colors.onSurface} />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => move(index, 1)} disabled={index === exercises.length - 1} accessibilityLabel={`Move ${exName} down`} hitSlop={8} style={styles.iconBtn}>
+            <MaterialCommunityIcons name="arrow-down" size={18} color={colors.onSurface} />
+          </TouchableOpacity>
+          <TouchableOpacity onPress={() => remove(item.id)} accessibilityLabel={`Remove ${exName}`} hitSlop={8} style={styles.iconBtn}>
+            <MaterialCommunityIcons name="close" size={18} color={colors.onSurface} />
+          </TouchableOpacity>
         </View>
       </Pressable>
-    ),
+      );
+    },
     [colors, exercises.length, move, remove]
   );
 
   return (
     <>
-      <Stack.Screen
-        options={{ title: template ? "Edit Template" : "New Template" }}
-      />
+      <Stack.Screen options={{ title: template ? "Edit Template" : "New Template" }} />
       <View
         style={[styles.container, { backgroundColor: colors.background, paddingHorizontal: layout.horizontalPadding }]}
       >
-        <TextInput
-          label="Template Name"
+        <Input
+          placeholder="Template Name"
           value={name}
           onChangeText={setName}
-          mode="outlined"
           style={styles.input}
-          placeholder="e.g. Push Day, Full Body A"
+          accessibilityLabel="Template Name"
         />
         {template && (
           <>
             <View style={styles.section}>
-              <Text
-                variant="titleMedium"
-                style={{ color: colors.onBackground }}
-              >
+              <Text variant="title" style={{ color: colors.onBackground }}>
                 Exercises ({exercises.length})
               </Text>
             </View>
@@ -216,10 +193,7 @@ export default function CreateTemplate() {
               keyExtractor={(item) => item.id}
               ListEmptyComponent={
                 <View style={styles.empty}>
-                  <Text
-                    variant="bodyMedium"
-                    style={{ color: colors.onSurfaceVariant }}
-                  >
+                  <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
                     No exercises yet. Add some below.
                   </Text>
                 </View>
@@ -227,48 +201,26 @@ export default function CreateTemplate() {
               style={styles.list}
             />
             <Button
-              mode="outlined"
-              icon="plus"
+              variant="outline"
               onPress={() => setPickerOpen(true)}
               style={styles.addBtn}
-              contentStyle={styles.btnContent}
               accessibilityLabel="Add exercise to template"
-            >
-              Add Exercise
-            </Button>
+              label="Add Exercise"
+            />
           </>
         )}
         <Button
-          mode="contained"
+          variant="default"
           onPress={save}
           loading={saving}
           disabled={saving}
           style={styles.saveBtn}
-          contentStyle={styles.btnContent}
           accessibilityLabel={template ? "Done editing template" : "Create template"}
-        >
-          {template ? "Done" : "Create Template"}
-        </Button>
+          label={template ? "Done" : "Create Template"}
+        />
       </View>
-      <ExercisePickerSheet
-        visible={pickerOpen}
-        onDismiss={() => setPickerOpen(false)}
-        onPick={handlePickExercise}
-      />
-      <EditExerciseSheet
-        visible={!!editing}
-        exercise={editing}
-        onSave={handleEditSave}
-        onDismiss={() => setEditing(null)}
-      />
-      <Snackbar
-        visible={!!snackbar}
-        onDismiss={() => setSnackbar("")}
-        duration={4000}
-        accessibilityLiveRegion="polite"
-      >
-        {snackbar}
-      </Snackbar>
+      <ExercisePickerSheet visible={pickerOpen} onDismiss={() => setPickerOpen(false)} onPick={handlePickExercise} />
+      <EditExerciseSheet visible={!!editing} exercise={editing} onSave={handleEditSave} onDismiss={() => setEditing(null)} />
     </>
   );
 }
@@ -301,15 +253,16 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
   },
+  iconBtn: {
+    padding: 8,
+  },
   addBtn: {
     marginTop: 8,
   },
   saveBtn: {
     marginTop: 16,
   },
-  btnContent: {
-    paddingVertical: 8,
-  },
+
   empty: {
     alignItems: "center",
     paddingVertical: 24,

--- a/app/template/create.tsx
+++ b/app/template/create.tsx
@@ -41,7 +41,7 @@ export default function CreateTemplate() {
   const [saving, setSaving] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [editing, setEditing] = useState<TemplateExercise | null>(null);
-  const { toast } = useToast();
+  const { error: showError } = useToast();
 
   useFocusEffect(
     useCallback(() => {
@@ -125,9 +125,9 @@ export default function CreateTemplate() {
       setEditing(null);
       await load();
     } catch {
-      toast("Failed to update exercise settings");
+      showError("Failed to update exercise settings");
     }
-  }, [editing, template, load, toast]);
+  }, [editing, template, load, showError]);
 
   const renderItem = useCallback(
     ({ item, index }: { item: TemplateExercise; index: number }) => {

--- a/app/template/pick-exercise.tsx
+++ b/app/template/pick-exercise.tsx
@@ -6,7 +6,9 @@ import {
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Chip, Searchbar, Text } from "react-native-paper";
+import { Chip } from "@/components/ui/chip";
+import { SearchBar } from "@/components/ui/searchbar";
+import { Text } from "@/components/ui/text";
 // Note: Chip is still used for filter chips at the top (they ARE interactive).
 // The category badge inside each list item uses View+Text to avoid nested
 // <button> elements on web (Chip renders as <button> even without onPress).
@@ -98,7 +100,7 @@ export default function PickExercise() {
       >
         <View>
           <Text
-            variant="titleSmall"
+            variant="subtitle"
             numberOfLines={1}
             style={{ color: colors.onSurface }}
           >
@@ -116,7 +118,7 @@ export default function PickExercise() {
               </Text>
             </View>
             <Text
-              variant="bodySmall"
+              variant="caption"
               style={{
                 color: colors.onSurfaceVariant,
                 marginLeft: 8,
@@ -137,7 +139,7 @@ export default function PickExercise() {
       <View
         style={[styles.container, { backgroundColor: colors.background, paddingHorizontal: layout.horizontalPadding }]}
       >
-        <Searchbar
+        <SearchBar
           placeholder="Search exercises..."
           value={query}
           onChangeText={setQuery}
@@ -173,7 +175,7 @@ export default function PickExercise() {
             loading ? null : (
               <View style={styles.empty}>
                 <Text
-                  variant="titleMedium"
+                  variant="title"
                   style={{ color: colors.onSurfaceVariant }}
                 >
                   No exercises found

--- a/components/ui/bna-toast.tsx
+++ b/components/ui/bna-toast.tsx
@@ -338,12 +338,23 @@ export function Toast({
   );
 }
 
+interface ToastAction {
+  label: string;
+  onPress: () => void;
+}
+
+interface ToastOptions {
+  description?: string;
+  action?: ToastAction;
+  duration?: number;
+}
+
 interface ToastContextType {
   toast: (toast: string | Omit<ToastData, 'id'>) => void;
-  success: (title: string, description?: string) => void;
-  error: (title: string, description?: string) => void;
-  warning: (title: string, description?: string) => void;
-  info: (title: string, description?: string) => void;
+  success: (title: string, options?: string | ToastOptions) => void;
+  error: (title: string, options?: string | ToastOptions) => void;
+  warning: (title: string, options?: string | ToastOptions) => void;
+  info: (title: string, options?: string | ToastOptions) => void;
   dismiss: (id: string) => void;
   dismissAll: () => void;
 }
@@ -395,11 +406,15 @@ export function ToastProvider({ children, maxToasts = 3 }: ToastProviderProps) {
   }, []);
 
   const createVariantToast = useCallback(
-    (variant: ToastVariant, title: string, description?: string) => {
+    (variant: ToastVariant, title: string, options?: string | ToastOptions) => {
+      const opts: ToastOptions | undefined =
+        typeof options === 'string' ? { description: options } : options;
       addToast({
         title,
-        description,
+        description: opts?.description,
         variant,
+        action: opts?.action,
+        duration: opts?.duration,
       });
     },
     [addToast]
@@ -407,14 +422,14 @@ export function ToastProvider({ children, maxToasts = 3 }: ToastProviderProps) {
 
   const contextValue: ToastContextType = {
     toast: addToast,
-    success: (title, description) =>
-      createVariantToast('success', title, description),
-    error: (title, description) =>
-      createVariantToast('error', title, description),
-    warning: (title, description) =>
-      createVariantToast('warning', title, description),
-    info: (title, description) =>
-      createVariantToast('info', title, description),
+    success: (title, options) =>
+      createVariantToast('success', title, options),
+    error: (title, options) =>
+      createVariantToast('error', title, options),
+    warning: (title, options) =>
+      createVariantToast('warning', title, options),
+    info: (title, options) =>
+      createVariantToast('info', title, options),
     dismiss: dismissToast,
     dismissAll,
   };

--- a/components/ui/bna-toast.tsx
+++ b/components/ui/bna-toast.tsx
@@ -339,7 +339,7 @@ export function Toast({
 }
 
 interface ToastContextType {
-  toast: (toast: Omit<ToastData, 'id'>) => void;
+  toast: (toast: string | Omit<ToastData, 'id'>) => void;
   success: (title: string, description?: string) => void;
   error: (title: string, description?: string) => void;
   warning: (title: string, description?: string) => void;
@@ -361,12 +361,14 @@ export function ToastProvider({ children, maxToasts = 3 }: ToastProviderProps) {
   const generateId = () => Math.random().toString(36).substr(2, 9);
 
   const addToast = useCallback(
-    (toastData: Omit<ToastData, 'id'>) => {
+    (toastData: string | Omit<ToastData, 'id'>) => {
+      const data: Omit<ToastData, 'id'> =
+        typeof toastData === 'string' ? { title: toastData } : toastData;
       const id = generateId();
       const newToast: ToastData = {
-        ...toastData,
+        ...data,
         id,
-        duration: toastData.duration ?? 4000,
+        duration: data.duration ?? 4000,
       };
 
       setToasts((prev) => {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -52,6 +52,7 @@ export const Button = forwardRef<View, ButtonProps>(
   (
     {
       children,
+      label,
       icon,
       onPress,
       variant = 'default',
@@ -322,6 +323,7 @@ export const Button = forwardRef<View, ButtonProps>(
     const contentColor = getColor();
     const iconSize = getIconSize();
     const styleWithoutFlex = getStyleWithoutFlex();
+    const content = children ?? label;
 
     return animation ? (
       <Pressable
@@ -340,14 +342,14 @@ export const Button = forwardRef<View, ButtonProps>(
               variant={loadingVariant}
               color={contentColor}
             />
-          ) : typeof children === 'string' ? (
+          ) : typeof content === 'string' ? (
             <View
               style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
             >
               {icon && (
                 <Icon name={icon} color={contentColor} size={iconSize} />
               )}
-              <Text style={[finalTextStyle, textStyle]}>{children}</Text>
+              <Text style={[finalTextStyle, textStyle]}>{content}</Text>
             </View>
           ) : (
             <View
@@ -356,7 +358,7 @@ export const Button = forwardRef<View, ButtonProps>(
               {icon && (
                 <Icon name={icon} color={contentColor} size={iconSize} />
               )}
-              {children}
+              {content}
             </View>
           )}
         </Animated.View>
@@ -376,13 +378,13 @@ export const Button = forwardRef<View, ButtonProps>(
             variant={loadingVariant}
             color={contentColor}
           />
-        ) : typeof children === 'string' ? (
+        ) : typeof content === 'string' ? (
           <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
             {icon && <Icon name={icon} color={contentColor} size={iconSize} />}
-            <Text style={[finalTextStyle, textStyle]}>{children}</Text>
+            <Text style={[finalTextStyle, textStyle]}>{content}</Text>
           </View>
         ) : (
-          children
+          content
         )}
       </TouchableOpacity>
     );

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -3,19 +3,21 @@ import { Text } from '@/components/ui/text';
 import { View } from '@/components/ui/view';
 import { useColor } from '@/hooks/useColor';
 import { BORDER_RADIUS } from '@/theme/globals';
-import { TextStyle, ViewStyle } from 'react-native';
+import { Pressable, StyleProp, TextStyle, ViewStyle, type ViewProps } from 'react-native';
 
-interface CardProps {
+interface CardProps extends Omit<ViewProps, 'style'> {
   children: React.ReactNode;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
+  onPress?: () => void;
 }
 
-export function Card({ children, style }: CardProps) {
+export function Card({ children, style, onPress, ...viewProps }: CardProps) {
   const cardColor = useColor('card');
   const foregroundColor = useColor('foreground');
 
-  return (
+  const content = (
     <View
+      {...viewProps}
       style={[
         {
           width: '100%',
@@ -34,6 +36,16 @@ export function Card({ children, style }: CardProps) {
       {children}
     </View>
   );
+
+  if (onPress) {
+    return (
+      <Pressable onPress={onPress} accessibilityRole="button">
+        {content}
+      </Pressable>
+    );
+  }
+
+  return content;
 }
 
 interface CardHeaderProps {

--- a/components/ui/chip.tsx
+++ b/components/ui/chip.tsx
@@ -13,8 +13,9 @@ interface ChipProps {
   disabled?: boolean;
   icon?: React.ReactNode;
   style?: ViewStyle;
+  textStyle?: { fontSize?: number; [key: string]: unknown };
   accessibilityLabel?: string;
-  accessibilityRole?: "radio" | "checkbox";
+  accessibilityRole?: "radio" | "checkbox" | "button";
   accessibilityState?: { selected?: boolean };
   role?: Role;
 }

--- a/components/ui/fab.tsx
+++ b/components/ui/fab.tsx
@@ -1,0 +1,178 @@
+/* eslint-disable */
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import React from "react";
+import {
+  Pressable,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+
+import { Text } from "@/components/ui/text";
+
+interface FABAction {
+  icon: string;
+  label?: string;
+  onPress: () => void;
+  accessibilityLabel?: string;
+}
+
+interface FABProps {
+  icon: string;
+  onPress: () => void;
+  style?: StyleProp<ViewStyle>;
+  color?: string;
+  accessibilityLabel?: string;
+  visible?: boolean;
+}
+
+interface FABGroupProps {
+  open: boolean;
+  visible?: boolean;
+  icon: string;
+  actions: FABAction[];
+  onStateChange: (state: { open: boolean }) => void;
+  fabStyle?: StyleProp<ViewStyle>;
+  color?: string;
+}
+
+export function FAB({
+  icon,
+  onPress,
+  style,
+  color = "#fff",
+  accessibilityLabel,
+  visible = true,
+}: FABProps) {
+  if (!visible) return null;
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      activeOpacity={0.8}
+      style={[styles.fab, style]}
+    >
+      <MaterialCommunityIcons name={icon as any} size={24} color={color} />
+    </TouchableOpacity>
+  );
+}
+
+function FABGroup({
+  open,
+  visible = true,
+  icon,
+  actions,
+  onStateChange,
+  fabStyle,
+  color = "#fff",
+}: FABGroupProps) {
+  if (!visible) return null;
+
+  return (
+    <View style={styles.groupContainer} pointerEvents="box-none">
+      {open && (
+        <>
+          <Pressable
+            style={StyleSheet.absoluteFill}
+            onPress={() => onStateChange({ open: false })}
+          />
+          <View style={styles.actionsContainer}>
+            {actions.map((action, index) => (
+              <View key={index} style={styles.actionRow}>
+                {action.label && (
+                  <View style={styles.actionLabel}>
+                    <Text variant="caption">{action.label}</Text>
+                  </View>
+                )}
+                <TouchableOpacity
+                  onPress={() => {
+                    action.onPress();
+                    onStateChange({ open: false });
+                  }}
+                  accessibilityLabel={action.accessibilityLabel}
+                  accessibilityRole="button"
+                  activeOpacity={0.8}
+                  style={[styles.miniFab, fabStyle]}
+                >
+                  <MaterialCommunityIcons
+                    name={action.icon as any}
+                    size={20}
+                    color={color}
+                  />
+                </TouchableOpacity>
+              </View>
+            ))}
+          </View>
+        </>
+      )}
+      <TouchableOpacity
+        onPress={() => onStateChange({ open: !open })}
+        accessibilityLabel={open ? "Close menu" : "Open menu"}
+        accessibilityRole="button"
+        activeOpacity={0.8}
+        style={[styles.fab, fabStyle]}
+      >
+        <MaterialCommunityIcons
+          name={(open ? "close" : icon) as any}
+          size={24}
+          color={color}
+        />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+FAB.Group = FABGroup;
+
+const styles = StyleSheet.create({
+  fab: {
+    width: 56,
+    height: 56,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+    elevation: 4,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+  },
+  groupContainer: {
+    position: "absolute",
+    bottom: 16,
+    right: 16,
+    alignItems: "center",
+  },
+  actionsContainer: {
+    marginBottom: 16,
+    alignItems: "flex-end",
+  },
+  actionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  actionLabel: {
+    backgroundColor: "rgba(0,0,0,0.7)",
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 4,
+    marginRight: 12,
+  },
+  miniFab: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    elevation: 3,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.2,
+    shadowRadius: 3,
+  },
+});

--- a/components/ui/fab.tsx
+++ b/components/ui/fab.tsx
@@ -36,6 +36,7 @@ interface FABGroupProps {
   onStateChange: (state: { open: boolean }) => void;
   fabStyle?: StyleProp<ViewStyle>;
   color?: string;
+  accessibilityLabel?: string;
 }
 
 export function FAB({

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -28,6 +28,7 @@ export interface InputProps extends Omit<TextInputProps, 'style'> {
   type?: 'input' | 'textarea';
   placeholder?: string;
   rows?: number; // Only used when type="textarea"
+  style?: ViewStyle;
 }
 
 export const Input = forwardRef<TextInput, InputProps>(

--- a/components/ui/searchbar.tsx
+++ b/components/ui/searchbar.tsx
@@ -25,6 +25,7 @@ interface SearchBarProps extends Omit<TextInputProps, 'style'> {
   containerStyle?: ViewStyle | ViewStyle[];
   inputStyle?: TextStyle | TextStyle[];
   debounceMs?: number;
+  style?: ViewStyle | ViewStyle[];
 }
 
 export function SearchBar({
@@ -40,6 +41,7 @@ export function SearchBar({
   placeholder = 'Search...',
   value,
   onChangeText,
+  style,
   ...props
 }: SearchBarProps) {
   const [internalValue, setInternalValue] = useState(value || '');
@@ -104,7 +106,7 @@ export function SearchBar({
   const showClear = showClearButton && displayValue.length > 0;
 
   return (
-    <View style={[baseStyle, containerStyle]}>
+    <View style={[baseStyle, containerStyle, style]}>
       {/* Left Icon */}
       {leftIcon || <Icon name={Search} size={16} color={muted} />}
 


### PR DESCRIPTION
## Summary

Complete the migration of all remaining app/ screens from react-native-paper (RNP) to BNA UI components. This is Phase 4b of the RNP removal epic (BLD-309). After this PR, zero react-native-paper imports remain in the app/ directory.

## Changes

### Screen migrations (13 files)
- `app/(tabs)/progress.tsx` — SegmentedButtons→SegmentedControl, Card/Snackbar/FAB/ProgressBar/TextInput→BNA equivalents
- `app/(tabs)/index.tsx` — Card/Button/Menu→BNA Card+Pressable+Alert.alert
- `app/(tabs)/exercises.tsx` — Chip style fixes, FAB prop alignment
- `app/(tabs)/nutrition.tsx` — Progress color prop removal, toast API alignment
- `app/body/photos.tsx` — togglebutton→checkbox role, toast API alignment
- `app/body/compare.tsx` — bodyLarge→body variant
- `app/exercise/[id].tsx` — Card style arrays→StyleSheet.flatten
- `app/exercise/create.tsx`, `edit/[id].tsx` — toast API alignment
- `app/nutrition/add.tsx` — Input containerStyle arrays→StyleSheet.flatten
- `app/session/[id].tsx` — IconButton→Pressable+Icons, Button prop migration, toast API
- `app/template/[id].tsx`, `create.tsx` — toast API, useCallback dep fixes

### BNA component type improvements (6 files)
- `card.tsx` — Extended CardProps with ViewProps, onPress, StyleProp<ViewStyle>
- `bna-toast.tsx` — toast() accepts string shorthand: `toast('message')`
- `searchbar.tsx` — Added `style` prop
- `input.tsx` — Added `style` prop
- `chip.tsx` — Added `textStyle` prop, expanded accessibilityRole union
- `fab.tsx` — Added `accessibilityLabel` to FABGroupProps

## Testing

- `npx tsc --noEmit`: **zero errors** ✅
- `npx eslint`: **zero errors** (36 pre-existing warnings, down from 73)
- `npx jest --no-coverage`: **12 failed suites (56  improved from baseline of 14 suites (68 tests). All failures are pre-existing.tests)** 
- `grep 'react-native-paper' app/`: **zero matches** ✅

## Issue

Resolves BLD-314