### PR TITLE
feat: consolidate food-add into InlineFoodSearch with expand-on-tap (BLD-318)

### DIFF
--- a/__tests__/acceptance/barcode-scanner.acceptance.test.tsx
+++ b/__tests__/acceptance/barcode-scanner.acceptance.test.tsx
@@ -1,0 +1,227 @@
+jest.setTimeout(10000)
+
+/**
+ * BLD-318: Barcode Scanner acceptance tests.
+ * Tests barcode scanning flow (found, not found, incomplete, offline, timeout)
+ * via InlineFoodSearch component.
+ */
+
+import React from 'react'
+import { Platform } from 'react-native'
+import { waitFor, act } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+import { resetIds } from '../helpers/factories'
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    router: { back: jest.fn(), push: jest.fn(), setParams: jest.fn() },
+    useRouter: () => ({ back: jest.fn(), push: jest.fn() }),
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/nutrition',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
+jest.mock('../../lib/errors', () => ({ logError: jest.fn() }))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn() }))
+
+const mockAddFoodEntry = jest.fn().mockResolvedValue({ id: 'fe-1', name: 'Test', calories: 100, protein: 10, carbs: 5, fat: 3, serving_size: '1 cup', is_favorite: false })
+const mockAddDailyLog = jest.fn().mockResolvedValue({ id: 'dl-1' })
+const mockGetFavoriteFoods = jest.fn().mockResolvedValue([])
+const mockDeleteDailyLog = jest.fn().mockResolvedValue(undefined)
+const mockFindDuplicate = jest.fn().mockResolvedValue(null)
+const mockToggleFavorite = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('../../lib/db', () => ({
+  addFoodEntry: (...args: unknown[]) => mockAddFoodEntry(...args),
+  addDailyLog: (...args: unknown[]) => mockAddDailyLog(...args),
+  getFavoriteFoods: (...args: unknown[]) => mockGetFavoriteFoods(...args),
+  deleteDailyLog: (...args: unknown[]) => mockDeleteDailyLog(...args),
+  findDuplicateFoodEntry: (...args: unknown[]) => mockFindDuplicate(...args),
+  toggleFavorite: (...args: unknown[]) => mockToggleFavorite(...args),
+}))
+
+const mockLookupBarcodeWithTimeout = jest.fn()
+jest.mock('../../lib/openfoodfacts', () => ({
+  fetchWithTimeout: jest.fn().mockResolvedValue({ ok: true, foods: [] }),
+  lookupBarcodeWithTimeout: (...args: unknown[]) => mockLookupBarcodeWithTimeout(...args),
+}))
+
+// Mock BarcodeScanner to expose onBarcodeScanned via captured ref
+let capturedOnBarcodeScanned: ((barcode: string) => void) | null = null
+jest.mock('../../components/BarcodeScanner', () => {
+  const RealReact = require('react')
+  const { View, Text, Pressable } = require('react-native')
+  return {
+    __esModule: true,
+    default: ({ visible, onBarcodeScanned }: { visible: boolean; onBarcodeScanned: (b: string) => void; onClose: () => void }) => {
+      capturedOnBarcodeScanned = onBarcodeScanned
+      if (!visible) return null
+      return RealReact.createElement(View, { testID: 'barcode-scanner' },
+        RealReact.createElement(Text, null, 'Camera Preview'),
+        RealReact.createElement(Pressable, {
+          testID: 'mock-scan-trigger',
+          onPress: () => onBarcodeScanned('1234567890123')
+        }, RealReact.createElement(Text, null, 'Trigger Scan'))
+      )
+    }
+  }
+})
+
+import InlineFoodSearch from '../../components/InlineFoodSearch'
+
+const mockOnFoodLogged = jest.fn()
+const mockOnSnack = jest.fn()
+
+function renderSearch() {
+  return renderScreen(
+    <InlineFoodSearch dateKey="2026-01-15" onFoodLogged={mockOnFoodLogged} onSnack={mockOnSnack} />
+  )
+}
+
+async function openScanner(screen: ReturnType<typeof renderSearch>) {
+  const scanBtn = await screen.findByLabelText('Scan barcode')
+  await act(async () => {
+    const { fireEvent } = require('@testing-library/react-native')
+    fireEvent.press(scanBtn)
+  })
+}
+
+async function triggerBarcode(screen: ReturnType<typeof renderSearch>, barcode: string) {
+  await openScanner(screen)
+  await waitFor(() => {
+    expect(screen.getByTestId('barcode-scanner')).toBeTruthy()
+  })
+  await act(async () => {
+    if (capturedOnBarcodeScanned) capturedOnBarcodeScanned(barcode)
+  })
+}
+
+describe('Barcode Scanner Acceptance (BLD-318)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+    capturedOnBarcodeScanned = null
+    Platform.OS = 'ios'
+  })
+
+  afterEach(() => {
+    Platform.OS = 'ios'
+  })
+
+  it('hides scan button on web platform', () => {
+    Platform.OS = 'web' as typeof Platform.OS
+    const screen = renderSearch()
+    expect(screen.queryByLabelText('Scan barcode')).toBeNull()
+  })
+
+  it('shows scan button on native platforms', () => {
+    const screen = renderSearch()
+    expect(screen.getByLabelText('Scan barcode')).toBeTruthy()
+  })
+
+  it('displays found product as result card after barcode scan', async () => {
+    mockLookupBarcodeWithTimeout.mockResolvedValue({
+      ok: true,
+      status: 'found',
+      food: {
+        name: 'Oatly Oat Milk',
+        calories: 115, protein: 2.5, carbs: 16.8, fat: 3.8,
+        servingLabel: '250ml', isPerServing: true,
+      },
+    })
+
+    const screen = renderSearch()
+    await triggerBarcode(screen, '7394376616037')
+
+    await waitFor(() => {
+      expect(screen.getByText('Oatly Oat Milk')).toBeTruthy()
+    })
+    expect(screen.getByText(/115 cal/)).toBeTruthy()
+    expect(mockLookupBarcodeWithTimeout).toHaveBeenCalledWith('7394376616037', expect.anything())
+  })
+
+  it('shows product not found message', async () => {
+    mockLookupBarcodeWithTimeout.mockResolvedValue({ ok: true, status: 'not_found' })
+
+    const screen = renderSearch()
+    await triggerBarcode(screen, '0000000000000')
+
+    await waitFor(() => {
+      expect(screen.getByText('Product not found. Try searching by name.')).toBeTruthy()
+    })
+  })
+
+  it('shows incomplete data message for invalid product', async () => {
+    mockLookupBarcodeWithTimeout.mockResolvedValue({ ok: true, status: 'incomplete' })
+
+    const screen = renderSearch()
+    await triggerBarcode(screen, '1234567890123')
+
+    await waitFor(() => {
+      expect(screen.getByText('Product found but nutrition data is incomplete.')).toBeTruthy()
+    })
+  })
+
+  it('shows network error when offline', async () => {
+    mockLookupBarcodeWithTimeout.mockResolvedValue({ ok: false, error: 'offline' })
+
+    const screen = renderSearch()
+    await triggerBarcode(screen, '1234567890123')
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not look up barcode. Check your connection.')).toBeTruthy()
+    })
+  })
+
+  it('shows timeout error when barcode lookup times out', async () => {
+    mockLookupBarcodeWithTimeout.mockResolvedValue({ ok: false, error: 'timeout' })
+
+    const screen = renderSearch()
+    await triggerBarcode(screen, '1234567890123')
+
+    await waitFor(() => {
+      expect(screen.getByText('Lookup timed out. Please try again.')).toBeTruthy()
+    })
+  })
+
+  it('shows retry button on error', async () => {
+    mockLookupBarcodeWithTimeout.mockResolvedValue({ ok: false, error: 'offline' })
+
+    const screen = renderSearch()
+    await triggerBarcode(screen, '1234567890123')
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Retry barcode scan')).toBeTruthy()
+    })
+  })
+
+  it('announces found product name for screen readers', async () => {
+    mockLookupBarcodeWithTimeout.mockResolvedValue({
+      ok: true,
+      status: 'found',
+      food: {
+        name: 'Chobani Greek Yogurt',
+        calories: 130, protein: 15, carbs: 12, fat: 4,
+        servingLabel: '1 cup', isPerServing: true,
+      },
+    })
+
+    const screen = renderSearch()
+    await triggerBarcode(screen, '0075240001001')
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Found: Chobani Greek Yogurt')).toBeTruthy()
+    })
+  })
+})

--- a/__tests__/acceptance/food-database.acceptance.test.tsx
+++ b/__tests__/acceptance/food-database.acceptance.test.tsx
@@ -1,0 +1,244 @@
+jest.setTimeout(10000)
+
+/**
+ * BLD-57 / BLD-318: Built-in Food Database acceptance tests.
+ * Tests search, macro display, serving multipliers, favorites toggle,
+ * and logging flow via InlineFoodSearch component.
+ */
+
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+import { resetIds } from '../helpers/factories'
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    router: { back: jest.fn(), push: jest.fn(), setParams: jest.fn() },
+    useRouter: () => ({ back: jest.fn(), push: jest.fn() }),
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/nutrition',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
+jest.mock('../../lib/errors', () => ({ logError: jest.fn() }))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn() }))
+
+const mockAddFoodEntry = jest.fn().mockResolvedValue({ id: 'fe-1', name: 'Chicken Breast (grilled)', calories: 165, protein: 31, carbs: 0, fat: 3.6, serving: '100g', is_favorite: false })
+const mockAddDailyLog = jest.fn().mockResolvedValue({ id: 'dl-1' })
+const mockGetFavoriteFoods = jest.fn().mockResolvedValue([])
+const mockDeleteDailyLog = jest.fn().mockResolvedValue(undefined)
+const mockFindDuplicateFoodEntry = jest.fn().mockResolvedValue(null)
+const mockToggleFavorite = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('../../lib/db', () => ({
+  addFoodEntry: (...args: unknown[]) => mockAddFoodEntry(...args),
+  addDailyLog: (...args: unknown[]) => mockAddDailyLog(...args),
+  getFavoriteFoods: (...args: unknown[]) => mockGetFavoriteFoods(...args),
+  deleteDailyLog: (...args: unknown[]) => mockDeleteDailyLog(...args),
+  findDuplicateFoodEntry: (...args: unknown[]) => mockFindDuplicateFoodEntry(...args),
+  toggleFavorite: (...args: unknown[]) => mockToggleFavorite(...args),
+}))
+
+jest.mock('../../lib/openfoodfacts', () => ({
+  fetchWithTimeout: jest.fn().mockResolvedValue({ ok: true, foods: [] }),
+  lookupBarcodeWithTimeout: jest.fn().mockResolvedValue({ ok: false, error: 'timeout' }),
+}))
+
+import InlineFoodSearch from '../../components/InlineFoodSearch'
+
+const mockOnFoodLogged = jest.fn()
+const mockOnSnack = jest.fn()
+
+function renderSearch() {
+  return renderScreen(
+    <InlineFoodSearch dateKey="2026-01-15" onFoodLogged={mockOnFoodLogged} onSnack={mockOnSnack} />
+  )
+}
+
+describe('Built-in Food Database (BLD-57)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+    mockGetFavoriteFoods.mockResolvedValue([])
+  })
+
+  describe('search rendering', () => {
+    it('shows search input', async () => {
+      const screen = renderSearch()
+      await waitFor(() => {
+        expect(screen.getByLabelText('Search foods')).toBeTruthy()
+      })
+    })
+
+    it('shows meal selector chips', async () => {
+      const screen = renderSearch()
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Meal: Breakfast/)).toBeTruthy()
+        expect(screen.getByLabelText(/Meal: Lunch/)).toBeTruthy()
+        expect(screen.getByLabelText(/Meal: Dinner/)).toBeTruthy()
+        expect(screen.getByLabelText(/Meal: Snack/)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('search functionality', () => {
+    it('shows foods matching search query', async () => {
+      const screen = renderSearch()
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken')
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Chicken Breast/)).toBeTruthy()
+      })
+    })
+
+    it('hides non-matching foods', async () => {
+      const screen = renderSearch()
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken')
+
+      await waitFor(() => {
+        expect(screen.queryByLabelText(/Brown Rice/)).toBeNull()
+      })
+    })
+  })
+
+  describe('food item expansion and macros', () => {
+    it('expands food item showing multiplier and log button', async () => {
+      const screen = renderSearch()
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken breast')
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast/)
+      fireEvent.press(foodCard)
+
+      await waitFor(() => {
+        expect(screen.getByText('0.5x')).toBeTruthy()
+        expect(screen.getByText('1x')).toBeTruthy()
+        expect(screen.getByText('1.5x')).toBeTruthy()
+        expect(screen.getByText('2x')).toBeTruthy()
+        expect(screen.getByLabelText('Log food')).toBeTruthy()
+      })
+    })
+
+    it('updates scaled macros when multiplier changes', async () => {
+      const screen = renderSearch()
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken breast')
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast/)
+      fireEvent.press(foodCard)
+
+      const twoX = await screen.findByText('2x')
+      fireEvent.press(twoX)
+
+      await waitFor(() => {
+        expect(screen.getByText(/330 cal/)).toBeTruthy()
+        expect(screen.getByText(/62\.0p/)).toBeTruthy()
+      })
+    })
+
+    it('shows serving multiplier input with accessible label', async () => {
+      const screen = renderSearch()
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken breast')
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast/)
+      fireEvent.press(foodCard)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Serving multiplier/)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('favorites toggle', () => {
+    it('shows save as favorite button when food is expanded', async () => {
+      const screen = renderSearch()
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken breast')
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast/)
+      fireEvent.press(foodCard)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Save as favorite')).toBeTruthy()
+      })
+    })
+
+    it('toggles favorite label when pressed', async () => {
+      const screen = renderSearch()
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken breast')
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast/)
+      fireEvent.press(foodCard)
+
+      const favBtn = await screen.findByLabelText('Save as favorite')
+      fireEvent.press(favBtn)
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('Remove from favorites')).toBeTruthy()
+      })
+    })
+  })
+
+  describe('logging flow', () => {
+    it('calls addFoodEntry and addDailyLog when logging food', async () => {
+      const screen = renderSearch()
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken breast')
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast/)
+      fireEvent.press(foodCard)
+
+      const logBtn = await screen.findByLabelText('Log food')
+      fireEvent.press(logBtn)
+
+      await waitFor(() => {
+        expect(mockAddFoodEntry).toHaveBeenCalledWith(
+          'Chicken Breast (grilled)',
+          165, 31, 0, 3.6,
+          '100g',
+          false
+        )
+        expect(mockAddDailyLog).toHaveBeenCalled()
+      })
+    })
+
+    it('logs with correct multiplier', async () => {
+      const screen = renderSearch()
+      const searchInput = await screen.findByLabelText('Search foods')
+      fireEvent.changeText(searchInput, 'chicken breast')
+
+      const foodCard = await screen.findByLabelText(/Chicken Breast/)
+      fireEvent.press(foodCard)
+
+      const twoX = await screen.findByText('2x')
+      fireEvent.press(twoX)
+
+      const logBtn = await screen.findByLabelText('Log food')
+      fireEvent.press(logBtn)
+
+      await waitFor(() => {
+        expect(mockAddDailyLog).toHaveBeenCalledWith(
+          'fe-1',
+          '2026-01-15',
+          'snack',
+          2
+        )
+      })
+    })
+  })
+})

--- a/__tests__/acceptance/online-food-search.acceptance.test.tsx
+++ b/__tests__/acceptance/online-food-search.acceptance.test.tsx
@@ -1,0 +1,216 @@
+jest.setTimeout(10000)
+
+/**
+ * BLD-248 / BLD-318: Online Food Search acceptance tests.
+ * Tests online search flow, dedup+favorite, and error states
+ * via InlineFoodSearch component.
+ */
+
+import React from 'react'
+import { fireEvent, waitFor, act } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+import { resetIds } from '../helpers/factories'
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    router: { back: jest.fn(), push: jest.fn(), setParams: jest.fn() },
+    useRouter: () => ({ back: jest.fn(), push: jest.fn() }),
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/nutrition',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
+jest.mock('../../lib/errors', () => ({ logError: jest.fn() }))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn() }))
+
+const mockAddFoodEntry = jest.fn().mockResolvedValue({
+  id: 'fe-1', name: 'Test Food', calories: 200, protein: 10,
+  carbs: 25, fat: 8, serving_size: '1 cup (240ml)', is_favorite: false, created_at: Date.now(),
+})
+const mockAddDailyLog = jest.fn().mockResolvedValue({ id: 'dl-1' })
+const mockGetFavoriteFoods = jest.fn().mockResolvedValue([])
+const mockDeleteDailyLog = jest.fn().mockResolvedValue(undefined)
+const mockFindDuplicate = jest.fn().mockResolvedValue(null)
+const mockToggleFavorite = jest.fn().mockResolvedValue(undefined)
+
+jest.mock('../../lib/db', () => ({
+  addFoodEntry: (...args: unknown[]) => mockAddFoodEntry(...args),
+  addDailyLog: (...args: unknown[]) => mockAddDailyLog(...args),
+  getFavoriteFoods: (...args: unknown[]) => mockGetFavoriteFoods(...args),
+  deleteDailyLog: (...args: unknown[]) => mockDeleteDailyLog(...args),
+  findDuplicateFoodEntry: (...args: unknown[]) => mockFindDuplicate(...args),
+  toggleFavorite: (...args: unknown[]) => mockToggleFavorite(...args),
+}))
+
+const mockFetchWithTimeout = jest.fn()
+
+jest.mock('../../lib/openfoodfacts', () => ({
+  fetchWithTimeout: (...args: unknown[]) => mockFetchWithTimeout(...args),
+  lookupBarcodeWithTimeout: jest.fn().mockResolvedValue({ ok: false, error: 'timeout' }),
+}))
+
+import InlineFoodSearch from '../../components/InlineFoodSearch'
+
+const mockOnFoodLogged = jest.fn()
+const mockOnSnack = jest.fn()
+
+function renderSearch() {
+  return renderScreen(
+    <InlineFoodSearch dateKey="2026-01-15" onFoodLogged={mockOnFoodLogged} onSnack={mockOnSnack} />
+  )
+}
+
+describe('Online Food Search (BLD-248)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    resetIds()
+    mockGetFavoriteFoods.mockResolvedValue([])
+    mockFetchWithTimeout.mockResolvedValue({ ok: true, foods: [] })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('search flow', () => {
+    it('fires online search after debounce for queries >= 2 chars', async () => {
+      mockFetchWithTimeout.mockResolvedValue({
+        ok: true,
+        foods: [{
+          name: 'Chobani Greek Yogurt',
+          calories: 100, protein: 15, carbs: 6, fat: 2,
+          servingLabel: '1 cup (150g)', isPerServing: true,
+        }],
+      })
+
+      const screen = renderSearch()
+      const input = await screen.findByLabelText('Search foods')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'yogurt')
+        jest.advanceTimersByTime(500)
+      })
+
+      await waitFor(() => {
+        expect(mockFetchWithTimeout).toHaveBeenCalledWith('yogurt', expect.anything())
+      })
+    })
+
+    it('shows no results message when search returns empty', async () => {
+      mockFetchWithTimeout.mockResolvedValue({ ok: true, foods: [] })
+
+      const screen = renderSearch()
+      const input = await screen.findByLabelText('Search foods')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'zznonexistent')
+        jest.advanceTimersByTime(500)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(/No foods found/)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('dedup and favorite', () => {
+    it('toggles favorite when dedup reuses unfavorited entry with saveFav=true', async () => {
+      const existingEntry = {
+        id: 'existing-1', name: 'Test Food', calories: 200, protein: 10,
+        carbs: 25, fat: 8, serving_size: '1 cup', is_favorite: false, created_at: Date.now(),
+      }
+      mockFindDuplicate.mockResolvedValue(existingEntry)
+
+      mockFetchWithTimeout.mockResolvedValue({
+        ok: true,
+        foods: [{
+          name: 'Test Food', calories: 200, protein: 10, carbs: 25, fat: 8,
+          servingLabel: '1 cup', isPerServing: true,
+        }],
+      })
+
+      const screen = renderSearch()
+      const input = await screen.findByLabelText('Search foods')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'test food')
+        jest.advanceTimersByTime(500)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Test Food, 200 calories/)).toBeTruthy()
+      })
+
+      const resultCard = screen.getByLabelText(/Test Food, 200 calories/)
+      await act(async () => {
+        fireEvent.press(resultCard)
+      })
+
+      // Toggle favorite
+      const favChip = await screen.findByLabelText('Save as favorite')
+      await act(async () => {
+        fireEvent.press(favChip)
+      })
+
+      // Log food
+      const logBtn = screen.getByLabelText('Log food')
+      await act(async () => {
+        fireEvent.press(logBtn)
+        jest.advanceTimersByTime(100)
+      })
+
+      await waitFor(() => {
+        expect(mockFindDuplicate).toHaveBeenCalled()
+        expect(mockToggleFavorite).toHaveBeenCalledWith('existing-1')
+        expect(mockAddFoodEntry).not.toHaveBeenCalled()
+        expect(mockAddDailyLog).toHaveBeenCalledWith('existing-1', '2026-01-15', 'snack', 1)
+      })
+    })
+  })
+
+  describe('error states', () => {
+    it('shows timeout error', async () => {
+      mockFetchWithTimeout.mockResolvedValue({ ok: false, error: 'timeout' })
+
+      const screen = renderSearch()
+      const input = await screen.findByLabelText('Search foods')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'test')
+        jest.advanceTimersByTime(500)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(/timed out/)).toBeTruthy()
+      })
+    })
+
+    it('shows network error message', async () => {
+      mockFetchWithTimeout.mockResolvedValue({ ok: false, error: 'offline' })
+
+      const screen = renderSearch()
+      const input = await screen.findByLabelText('Search foods')
+
+      await act(async () => {
+        fireEvent.changeText(input, 'test')
+        jest.advanceTimersByTime(500)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(/Could not reach food database/)).toBeTruthy()
+      })
+    })
+  })
+})

--- a/__tests__/acceptance/owner-ux-batch.acceptance.test.tsx
+++ b/__tests__/acceptance/owner-ux-batch.acceptance.test.tsx
@@ -38,6 +38,31 @@ jest.mock('../../lib/db/body', () => ({
   getLatestBodyWeight: jest.fn().mockResolvedValue({ weight: 75 }),
 }))
 
+describe('Issue 1: Barcode scanner header icon', () => {
+  it('nutrition tab _layout.tsx includes barcode-scan icon config', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../app/(tabs)/_layout.tsx'),
+      'utf8'
+    )
+    expect(source).toContain('barcode-scan')
+    expect(source).toContain('/nutrition?scan=true')
+    expect(source).toContain('Scan food barcode')
+  })
+
+  it('nutrition tab reads scan param and passes scanOnMount to InlineFoodSearch', () => {
+    const fs = require('fs')
+    const path = require('path')
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../app/(tabs)/nutrition.tsx'),
+      'utf8'
+    )
+    expect(source).toContain('scan')
+    expect(source).toContain('scanOnMount')
+  })
+})
+
 describe('Issue 2: Stat card padding', () => {
   it('statCard style includes paddingHorizontal', () => {
     const fs = require('fs')

--- a/__tests__/app/nutrition/tablet-inline-search.test.tsx
+++ b/__tests__/app/nutrition/tablet-inline-search.test.tsx
@@ -9,8 +9,9 @@ import type { DailyLog } from '../../../lib/types'
 jest.mock('expo-router', () => {
   const RealReact = require('react')
   return {
-    router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
+    router: { push: jest.fn(), replace: jest.fn(), back: jest.fn(), setParams: jest.fn() },
     useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: () => ({}),
     useFocusEffect: (cb: () => (() => void) | void) => {
       RealReact.useEffect(() => {
         const cleanup = cb()

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -45,6 +45,16 @@ export default function TabLayout() {
         options={{
           title: "Nutrition",
           headerTitle: renderHeaderTitle("food-apple", "Nutrition"),
+          headerRight: () => (
+            <TouchableOpacity
+              onPress={() => router.push("/nutrition?scan=true")}
+              accessibilityLabel="Scan food barcode"
+              accessibilityRole="button"
+              style={{ minWidth: 48, minHeight: 48, alignItems: "center", justifyContent: "center" }}
+            >
+              <MaterialCommunityIcons name="barcode-scan" size={24} color={colors.onSurface} />
+            </TouchableOpacity>
+          ),
         }}
       />
       <Tabs.Screen

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { FAB } from "@/components/ui/fab";
 import { Progress } from "@/components/ui/progress";
 import { useToast } from "@/components/ui/bna-toast";
-import { router, useFocusEffect } from "expo-router";
+import { router, useFocusEffect, useLocalSearchParams } from "expo-router";
 import InlineFoodSearch from "../../components/InlineFoodSearch";
 import {
   getDailyLogs,
@@ -47,6 +47,8 @@ export default function Nutrition() {
   const { info } = useToast();
   const deleted = useRef<{ log: DailyLog; timer: ReturnType<typeof setTimeout> } | null>(null);
   const [showAddCard, setShowAddCard] = useState(false);
+  const { scan } = useLocalSearchParams<{ scan?: string }>();
+  const shouldScan = scan === "true";
 
   const load = useCallback(async () => {
     const ds = formatDateKey(date.getTime());
@@ -63,7 +65,11 @@ export default function Nutrition() {
   useFocusEffect(
     useCallback(() => {
       load();
-    }, [load])
+      if (shouldScan) {
+        setShowAddCard(true);
+        router.setParams({ scan: undefined });
+      }
+    }, [load, shouldScan])
   );
 
   const prev = () => { setDate((d) => new Date(d.getTime() - DAY_MS)); setShowAddCard(false); };
@@ -209,6 +215,7 @@ export default function Nutrition() {
               dateKey={formatDateKey(date.getTime())}
               onFoodLogged={handleFoodLogged}
               onSnack={handleSnack}
+              scanOnMount={shouldScan}
             />
           </View>
         </View>
@@ -226,6 +233,7 @@ export default function Nutrition() {
             dateKey={formatDateKey(date.getTime())}
             onFoodLogged={handleFoodLogged}
             onSnack={handleSnack}
+            scanOnMount={shouldScan}
           />
         </View>
       )}

--- a/components/FoodResultItem.tsx
+++ b/components/FoodResultItem.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { Chip } from "@/components/ui/chip";
+import { Input } from "@/components/ui/input";
+import { radii } from "../constants/design-tokens";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { BuiltinFood } from "../lib/types";
+import type { ParsedFood } from "../lib/openfoodfacts";
+import type { SearchResult } from "@/hooks/useFoodSearch";
+
+type Props = {
+  item: SearchResult;
+  index: number;
+  expandedKey: string | null;
+  multiplier: string;
+  mult: number;
+  validMult: boolean;
+  saveFav: boolean;
+  saving: boolean;
+  onExpand: (key: string) => void;
+  onSetMultiplier: (v: string) => void;
+  onToggleFav: () => void;
+  onLogLocal: (food: BuiltinFood) => void;
+  onLogOnline: (food: ParsedFood) => void;
+};
+
+export default function FoodResultItem({
+  item, index, expandedKey, multiplier, mult, validMult,
+  saveFav, saving, onExpand, onSetMultiplier, onToggleFav, onLogLocal, onLogOnline,
+}: Props) {
+  const colors = useThemeColors();
+  const isLocal = item.type === "local";
+  const food = item.food;
+  const key = isLocal ? `local-${(food as BuiltinFood).id}` : `online-${food.name}-${food.calories}-${index}`;
+  const isOpen = expandedKey === key;
+  const serving = isLocal ? (food as BuiltinFood).serving : (food as ParsedFood).servingLabel;
+  const scaled = {
+    calories: (food.calories * mult).toFixed(0),
+    protein: (food.protein * mult).toFixed(1),
+    carbs: (food.carbs * mult).toFixed(1),
+    fat: (food.fat * mult).toFixed(1),
+  };
+
+  return (
+    <Pressable
+      style={[styles.resultItem, { backgroundColor: colors.surfaceVariant }]}
+      onPress={() => onExpand(key)}
+      disabled={saving}
+      accessibilityLabel={`${food.name}, ${food.calories} calories per ${serving}`}
+      accessibilityState={{ expanded: isOpen }}
+      role="button"
+    >
+      <Text variant="body" numberOfLines={isLocal ? 1 : 2} style={{ color: colors.onSurface }}>
+        {food.name}
+      </Text>
+      <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+        {food.calories} cal · {food.protein}p · {food.carbs}c · {food.fat}f{!isLocal ? ` · per ${serving}` : ""}
+      </Text>
+      {isOpen && (
+        <View style={[styles.detailView, { borderTopColor: colors.outlineVariant }]}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginBottom: 4 }}>
+            Serving multiplier
+          </Text>
+          <View style={styles.multChips}>
+            {[0.5, 1, 1.5, 2].map((v) => (
+              <Chip
+                key={v}
+                selected={multiplier === String(v)}
+                onPress={() => onSetMultiplier(String(v))}
+                style={styles.multChip}
+                accessibilityLabel={`${v}x serving`}
+                role="button"
+                accessibilityState={{ selected: multiplier === String(v) }}
+              >
+                {`${v}x`}
+              </Chip>
+            ))}
+          </View>
+          <Input
+            variant="outline"
+            value={multiplier}
+            onChangeText={onSetMultiplier}
+            keyboardType="numeric"
+            containerStyle={styles.multInput}
+            accessibilityLabel="Serving multiplier"
+          />
+          {validMult && (
+            <Text variant="caption" style={[styles.scaledMacros, { color: colors.onSurfaceVariant }]}>
+              {scaled.calories} cal · {scaled.protein}p · {scaled.carbs}c · {scaled.fat}f
+            </Text>
+          )}
+          <Chip
+            selected={saveFav}
+            onPress={onToggleFav}
+            style={styles.favToggleChip}
+            accessibilityLabel={saveFav ? "Remove from favorites" : "Save as favorite"}
+            role="button"
+            accessibilityState={{ selected: saveFav }}
+          >
+            ★ Save as favorite
+          </Chip>
+          <Button
+            variant="default"
+            onPress={() => isLocal ? onLogLocal(food as BuiltinFood) : onLogOnline(food as ParsedFood)}
+            loading={saving}
+            disabled={saving || !validMult}
+            accessibilityLabel="Log food"
+          >
+            Log Food
+          </Button>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  resultItem: { paddingHorizontal: 12, paddingVertical: 10, borderRadius: radii.sm, marginBottom: 4 },
+  detailView: { marginTop: 8, paddingTop: 8, borderTopWidth: 1 },
+  multChips: { flexDirection: "row", flexWrap: "wrap", gap: 6, marginBottom: 8 },
+  multChip: { marginRight: 0 },
+  multInput: { marginBottom: 8 },
+  scaledMacros: { marginBottom: 8 },
+  favToggleChip: { marginBottom: 12, alignSelf: "flex-start" },
+});

--- a/components/InlineFoodSearch.tsx
+++ b/components/InlineFoodSearch.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useState } from "react";
 import {
   FlatList,
   Keyboard,
@@ -15,402 +15,137 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Chip } from "@/components/ui/chip";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
-import BottomSheet, { BottomSheetBackdrop, BottomSheetView } from "@gorhom/bottom-sheet";
-import {
-  addFoodEntry,
-  addDailyLog,
-  deleteDailyLog,
-  getFavoriteFoods,
-  findDuplicateFoodEntry,
-} from "../lib/db";
-import { searchFoods } from "../lib/foods";
-import {
-  fetchWithTimeout,
-  lookupBarcodeWithTimeout,
-  type ParsedFood,
-  type BarcodeResult,
-} from "../lib/openfoodfacts";
-import type { FoodEntry, Meal, BuiltinFood } from "../lib/types";
+import type { Meal } from "../lib/types";
 import { MEALS, MEAL_LABELS } from "../lib/types";
 import BarcodeScanner from "./BarcodeScanner";
+import ManualFoodEntry from "./ManualFoodEntry";
+import FoodResultItem from "./FoodResultItem";
 import { ScanBarcode } from "lucide-react-native";
 import { radii } from "../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
-
-// Unified result type for combined local + online search
-type SearchResult =
-  | { type: "local"; food: BuiltinFood }
-  | { type: "online"; food: ParsedFood };
+import { useFoodLogger } from "@/hooks/useFoodLogger";
+import { useFoodSearch, type SearchResult } from "@/hooks/useFoodSearch";
 
 type Props = {
   dateKey: string;
   onFoodLogged: () => void;
   onSnack: (message: string, undoFn?: () => Promise<void>) => void;
+  scanOnMount?: boolean;
 };
 
-export default function InlineFoodSearch({ dateKey, onFoodLogged, onSnack }: Props) {
+const keyExtractor = (item: SearchResult, index: number) =>
+  item.type === "local"
+    ? `local-${item.food.id}`
+    : `online-${item.food.name}-${item.food.calories}-${index}`;
+
+function BarcodeStatus({ loading, error, productName, onRetry }: {
+  loading: boolean; error: string | null; productName: string | null; onRetry: () => void;
+}) {
   const colors = useThemeColors();
-
-  // Search state
-  const [query, setQuery] = useState("");
-  const [meal, setMeal] = useState<Meal>("snack");
-  const [favorites, setFavorites] = useState<FoodEntry[]>([]);
-  const [localResults, setLocalResults] = useState<BuiltinFood[]>([]);
-  const [onlineResults, setOnlineResults] = useState<ParsedFood[]>([]);
-  const [onlineLoading, setOnlineLoading] = useState(false);
-  const [onlineError, setOnlineError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-
-  // Barcode scanner
-  const [scannerVisible, setScannerVisible] = useState(false);
-  const [barcodeLoading, setBarcodeLoading] = useState(false);
-  const [barcodeError, setBarcodeError] = useState<string | null>(null);
-  const [scannedProductName, setScannedProductName] = useState<string | null>(null);
-
-  // Manual entry bottom sheet
-  const manualSheetRef = useRef<BottomSheet>(null);
-  const [manualName, setManualName] = useState("");
-  const [manualCalories, setManualCalories] = useState("");
-  const [manualProtein, setManualProtein] = useState("");
-  const [manualCarbs, setManualCarbs] = useState("");
-  const [manualFat, setManualFat] = useState("");
-  const [manualServing, setManualServing] = useState("1 serving");
-  const [manualFavorite, setManualFavorite] = useState(false);
-
-  // Refs for cleanup
-  const abortRef = useRef<AbortController | null>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const barcodeAbortRef = useRef<AbortController | null>(null);
-  const cacheRef = useRef<Map<string, ParsedFood[]>>(new Map());
-
-  // Load favorites on mount
-  useEffect(() => {
-    getFavoriteFoods().then(setFavorites).catch(() => {});
-  }, []);
-
-  // Local search (synchronous, immediate)
-  useEffect(() => {
-    if (!query.trim()) {
-      setLocalResults([]);
-      return;
-    }
-    setLocalResults(searchFoods(query));
-  }, [query]);
-
-  // Online search (debounced)
-  useEffect(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (abortRef.current) abortRef.current.abort();
-
-    setOnlineError(null);
-
-    if (!query.trim() || query.trim().length < 2) {
-      setOnlineResults([]);
-      return;
-    }
-
-    const cached = cacheRef.current.get(query.trim().toLowerCase());
-    if (cached) {
-      setOnlineResults(cached);
-      return;
-    }
-
-    debounceRef.current = setTimeout(() => {
-      const controller = new AbortController();
-      abortRef.current = controller;
-      setOnlineLoading(true);
-
-      fetchWithTimeout(query.trim(), controller.signal).then((result) => {
-        if (controller.signal.aborted) return;
-        setOnlineLoading(false);
-        if (result.ok) {
-          setOnlineResults(result.foods);
-          const cache = cacheRef.current;
-          const key = query.trim().toLowerCase();
-          cache.set(key, result.foods);
-          if (cache.size > 10) {
-            const first = cache.keys().next().value;
-            if (first !== undefined) cache.delete(first);
-          }
-        } else {
-          setOnlineResults([]);
-          if (result.error === "timeout") {
-            setOnlineError("Search timed out. Try again.");
-          } else {
-            setOnlineError("Could not reach food database.");
-          }
-        }
-      });
-    }, 400);
-
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [query]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      if (abortRef.current) abortRef.current.abort();
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      if (barcodeAbortRef.current) barcodeAbortRef.current.abort();
-    };
-  }, []);
-
-  const combinedResults: SearchResult[] = useMemo(() => {
-    const items: SearchResult[] = [];
-    localResults.forEach((food) => items.push({ type: "local", food }));
-    onlineResults.forEach((food) => items.push({ type: "online", food }));
-    return items;
-  }, [localResults, onlineResults]);
-
-  const logLocalFood = useCallback(async (food: BuiltinFood) => {
-    setSaving(true);
-    try {
-      const entry = await addFoodEntry(
-        food.name,
-        food.calories,
-        food.protein,
-        food.carbs,
-        food.fat,
-        food.serving,
-        false,
-      );
-      const log = await addDailyLog(entry.id, dateKey, meal, 1);
-      onFoodLogged();
-      onSnack(`${food.name} logged`, async () => {
-        await deleteDailyLog(log.id);
-        onFoodLogged();
-      });
-    } catch {
-      onSnack("Failed to log food. Please try again.");
-    } finally {
-      setSaving(false);
-    }
-  }, [dateKey, meal, onFoodLogged, onSnack]);
-
-  const logOnlineFood = useCallback(async (food: ParsedFood) => {
-    setSaving(true);
-    try {
-      const existing = await findDuplicateFoodEntry(
-        food.name,
-        food.calories,
-        food.protein,
-        food.carbs,
-        food.fat,
-      );
-      const entry = existing ?? await addFoodEntry(
-        food.name,
-        food.calories,
-        food.protein,
-        food.carbs,
-        food.fat,
-        food.servingLabel,
-        false,
-      );
-      const log = await addDailyLog(entry.id, dateKey, meal, 1);
-      onFoodLogged();
-      onSnack(`${food.name} logged`, async () => {
-        await deleteDailyLog(log.id);
-        onFoodLogged();
-      });
-    } catch {
-      onSnack("Failed to log food. Please try again.");
-    } finally {
-      setSaving(false);
-    }
-  }, [dateKey, meal, onFoodLogged, onSnack]);
-
-  const logFavorite = useCallback(async (food: FoodEntry) => {
-    setSaving(true);
-    try {
-      const log = await addDailyLog(food.id, dateKey, meal, 1);
-      onFoodLogged();
-      onSnack(`${food.name} logged`, async () => {
-        await deleteDailyLog(log.id);
-        onFoodLogged();
-      });
-    } catch {
-      onSnack("Failed to log food. Please try again.");
-    } finally {
-      setSaving(false);
-    }
-  }, [dateKey, meal, onFoodLogged, onSnack]);
-
-  // Barcode handling
-  const handleBarcodeScanned = useCallback(async (barcode: string) => {
-    setScannerVisible(false);
-    setBarcodeError(null);
-    setBarcodeLoading(true);
-    setScannedProductName(null);
-
-    if (barcodeAbortRef.current) barcodeAbortRef.current.abort();
-    const controller = new AbortController();
-    barcodeAbortRef.current = controller;
-
-    const result: BarcodeResult = await lookupBarcodeWithTimeout(barcode, controller.signal);
-    if (controller.signal.aborted) return;
-    setBarcodeLoading(false);
-
-    if (!result.ok) {
-      setBarcodeError(
-        result.error === "timeout"
-          ? "Lookup timed out. Please try again."
-          : "Could not look up barcode. Check your connection."
-      );
-      return;
-    }
-    if (result.status === "not_found") {
-      setBarcodeError("Product not found. Try searching by name.");
-      return;
-    }
-    if (result.status === "incomplete") {
-      setBarcodeError("Product found but nutrition data is incomplete.");
-      return;
-    }
-
-    setScannedProductName(result.food.name);
-    setOnlineResults([result.food]);
-    setLocalResults([]);
-    setQuery("");
-  }, []);
-
-  const openScanner = () => {
-    Keyboard.dismiss();
-    setBarcodeError(null);
-    setScannerVisible(true);
-  };
-
-  // Manual entry
-  const openManualEntry = () => {
-    Keyboard.dismiss();
-    manualSheetRef.current?.expand();
-  };
-
-  const resetManualForm = () => {
-    setManualName("");
-    setManualCalories("");
-    setManualProtein("");
-    setManualCarbs("");
-    setManualFat("");
-    setManualServing("1 serving");
-    setManualFavorite(false);
-  };
-
-  const saveManualEntry = async () => {
-    if (!manualName.trim()) return;
-    setSaving(true);
-    try {
-      const entry = await addFoodEntry(
-        manualName.trim(),
-        Math.max(0, parseFloat(manualCalories) || 0),
-        Math.max(0, parseFloat(manualProtein) || 0),
-        Math.max(0, parseFloat(manualCarbs) || 0),
-        Math.max(0, parseFloat(manualFat) || 0),
-        manualServing.trim() || "1 serving",
-        manualFavorite,
-      );
-      const log = await addDailyLog(entry.id, dateKey, meal, 1);
-      const foodName = manualName.trim();
-      resetManualForm();
-      manualSheetRef.current?.close();
-      onFoodLogged();
-      getFavoriteFoods().then(setFavorites).catch(() => {});
-      onSnack(`${foodName} logged`, async () => {
-        await deleteDailyLog(log.id);
-        onFoodLogged();
-      });
-    } catch {
-      onSnack("Failed to save entry. Please try again.");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const renderBackdrop = useCallback(
-    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
-      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />
-    ),
-    [],
-  );
-
-  const renderItem = useCallback(({ item }: { item: SearchResult }) => {
-    if (item.type === "local") {
-      const food = item.food;
-      return (
-        <Pressable
-          style={[styles.resultItem, { backgroundColor: colors.surfaceVariant }]}
-          onPress={() => logLocalFood(food)}
-          disabled={saving}
-          accessibilityLabel={`Log ${food.name}, ${food.calories} calories`}
-          role="button"
+  return (
+    <>
+      {loading && (
+        <View style={styles.statusRow} accessibilityLiveRegion="polite">
+          <View style={{ marginRight: 8 }}><Spinner size="sm" /></View>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Looking up barcode...</Text>
+        </View>
+      )}
+      {error && (
+        <View style={styles.statusRow} accessibilityLiveRegion="polite">
+          <Text variant="caption" style={{ color: colors.error, flex: 1 }}>{error}</Text>
+          <Button variant="ghost" onPress={onRetry} accessibilityLabel="Retry barcode scan">Retry</Button>
+        </View>
+      )}
+      {productName && (
+        <Text
+          variant="caption"
+          style={{ color: colors.onSurfaceVariant, marginBottom: 4 }}
+          accessibilityLiveRegion="polite"
+          accessibilityLabel={`Found: ${productName}`}
         >
-          <Text variant="body" numberOfLines={1} style={{ color: colors.onSurface }}>
-            {food.name}
-          </Text>
-          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-            {food.calories} cal · {food.protein}p · {food.carbs}c · {food.fat}f
-          </Text>
-        </Pressable>
-      );
-    }
-
-    const food = item.food;
-    return (
-      <Pressable
-        style={[styles.resultItem, { backgroundColor: colors.surfaceVariant }]}
-        onPress={() => logOnlineFood(food)}
-        disabled={saving}
-        accessibilityLabel={`Log ${food.name}, ${food.calories} calories`}
-        role="button"
-      >
-        <Text variant="body" numberOfLines={2} style={{ color: colors.onSurface }}>
-          {food.name}
+          Found: {productName}
         </Text>
-        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-          {food.calories} cal · {food.protein}p · {food.carbs}c · {food.fat}f · per {food.servingLabel}
-        </Text>
-      </Pressable>
-    );
-  }, [colors, saving, logLocalFood, logOnlineFood]);
-
-  const keyExtractor = useCallback(
-    (item: SearchResult, index: number) =>
-      item.type === "local"
-        ? `local-${item.food.id}`
-        : `online-${item.food.name}-${item.food.calories}-${index}`,
-    [],
+      )}
+    </>
   );
+}
+
+// eslint-disable-next-line complexity -- orchestrating search + barcode + favorites + expand UI inherently requires branching
+export default function InlineFoodSearch({ dateKey, onFoodLogged, onSnack, scanOnMount }: Props) {
+  const colors = useThemeColors();
+  const [meal, setMeal] = useState<Meal>("snack");
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const [multiplier, setMultiplier] = useState("1");
+  const [saveFav, setSaveFav] = useState(false);
+
+  const {
+    query, setQuery, favorites, setFavorites,
+    localResults, onlineResults, onlineLoading, onlineError, combinedResults,
+    scannerVisible, barcodeLoading, barcodeError, scannedProductName,
+    handleBarcodeScanned, openScanner, closeScanner,
+  } = useFoodSearch(scanOnMount);
+
+  const clearExpand = useCallback(() => setExpandedKey(null), []);
+  const { saving, logLocalFood, logOnlineFood, logFavorite, logManualFood } = useFoodLogger({
+    dateKey, meal, onFoodLogged, onSnack, onAfterLog: clearExpand,
+  });
+
+  const mult = Math.max(0, parseFloat(multiplier) || 0);
+  const validMult = mult >= 0.25;
+  const isNative = Platform.OS !== "web";
+  const hasBarcodeStatus = barcodeLoading || barcodeError != null || scannedProductName != null;
+
+  const expandResult = useCallback((key: string) => {
+    setExpandedKey((prev) => {
+      if (prev === key) return null;
+      setMultiplier("1");
+      setSaveFav(false);
+      return key;
+    });
+  }, []);
+
+  const renderItem = useCallback(({ item, index }: { item: SearchResult; index: number }) => (
+    <FoodResultItem
+      item={item}
+      index={index}
+      expandedKey={expandedKey}
+      multiplier={multiplier}
+      mult={mult}
+      validMult={validMult}
+      saveFav={saveFav}
+      saving={saving}
+      onExpand={expandResult}
+      onSetMultiplier={setMultiplier}
+      onToggleFav={() => setSaveFav((p) => !p)}
+      onLogLocal={(food) => logLocalFood(food, mult, saveFav)}
+      onLogOnline={(food) => logOnlineFood(food, mult, saveFav)}
+    />
+  ), [expandedKey, multiplier, mult, validMult, saveFav, saving, expandResult, logLocalFood, logOnlineFood]);
 
   const showSeparator = localResults.length > 0 && onlineResults.length > 0;
   const separatorIndex = localResults.length;
 
-  // Wrap renderItem with separator between local and online results.
-  // Uses View (not Fragment) because FlashList requires a single View-based root.
   const renderItemWithSeparator = useCallback(({ item, index }: { item: SearchResult; index: number }) => {
     if (showSeparator && index === separatorIndex) {
       return (
         <View>
-          <Text
-            variant="caption"
-            style={[styles.separator, { color: colors.onSurfaceVariant }]}
-          >
+          <Text variant="caption" style={[styles.separator, { color: colors.onSurfaceVariant }]}>
             Online Results
           </Text>
-          {renderItem({ item })}
+          {renderItem({ item, index })}
         </View>
       );
     }
-    return renderItem({ item });
+    return renderItem({ item, index });
   }, [renderItem, showSeparator, separatorIndex, colors]);
 
   const hasResults = combinedResults.length > 0;
-  const showEmptyMessage = query.trim().length >= 2 && !hasResults && !onlineLoading && !onlineError;
+  const hasMinQuery = query.trim().length >= 2;
+  const showEmptyMessage = hasMinQuery && !hasResults && !onlineLoading && !onlineError;
 
   return (
     <Card style={StyleSheet.flatten([styles.card, { backgroundColor: colors.surface }])}>
       <CardContent style={styles.content}>
-        {/* Meal selector */}
         <FlatList
           horizontal
           showsHorizontalScrollIndicator={false}
@@ -432,7 +167,6 @@ export default function InlineFoodSearch({ dateKey, onFoodLogged, onSnack }: Pro
           )}
         />
 
-        {/* Favorites row */}
         {favorites.length > 0 ? (
           <FlatList
             horizontal
@@ -455,15 +189,11 @@ export default function InlineFoodSearch({ dateKey, onFoodLogged, onSnack }: Pro
             )}
           />
         ) : (
-          <Text
-            variant="caption"
-            style={[styles.favHint, { color: colors.onSurfaceVariant }]}
-          >
+          <Text variant="caption" style={[styles.favHint, { color: colors.onSurfaceVariant }]}>
             ★ Star foods to add them here
           </Text>
         )}
 
-        {/* Search input */}
         <Input
           variant="outline"
           placeholder="Search foods..."
@@ -472,75 +202,40 @@ export default function InlineFoodSearch({ dateKey, onFoodLogged, onSnack }: Pro
           containerStyle={styles.searchInput}
           accessibilityLabel="Search foods"
           rightComponent={
-            <Pressable onPress={openScanner} accessibilityLabel="Scan barcode" style={{ padding: 4 }}>
-              <ScanBarcode size={20} color={colors.onSurfaceVariant} />
-            </Pressable>
+            isNative ? (
+              <Pressable
+                onPress={() => { Keyboard.dismiss(); openScanner(); }}
+                accessibilityLabel="Scan barcode"
+                style={{ padding: 4 }}
+              >
+                <ScanBarcode size={20} color={colors.onSurfaceVariant} />
+              </Pressable>
+            ) : undefined
           }
         />
 
-        {/* Barcode loading/error */}
-        {barcodeLoading && (
-          <View style={styles.statusRow} accessibilityLiveRegion="polite">
-            <View style={{ marginRight: 8 }}><Spinner size="sm" /></View>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-              Looking up barcode...
-            </Text>
-          </View>
-        )}
-        {barcodeError && (
-          <View style={styles.statusRow} accessibilityLiveRegion="polite">
-            <Text variant="caption" style={{ color: colors.error, flex: 1 }}>
-              {barcodeError}
-            </Text>
-            <Button
-              variant="ghost"
-              onPress={() => { setBarcodeError(null); setScannerVisible(true); }}
-              accessibilityLabel="Retry barcode scan"
-            >
-              Retry
-            </Button>
-          </View>
-        )}
-        {scannedProductName && (
-          <Text
-            variant="caption"
-            style={{ color: colors.onSurfaceVariant, marginBottom: 4 }}
-            accessibilityLiveRegion="polite"
-          >
-            Found: {scannedProductName}
-          </Text>
+        {hasBarcodeStatus && (
+          <BarcodeStatus
+            loading={barcodeLoading}
+            error={barcodeError}
+            productName={scannedProductName}
+            onRetry={openScanner}
+          />
         )}
 
-        {/* Action buttons row */}
         <View style={styles.actionRow}>
-          <Button
-            variant="outline"
-            onPress={openManualEntry}
-            style={styles.actionBtn}
-            accessibilityLabel="Manual entry"
-          >
-            Manual Entry
-          </Button>
+          <ManualFoodEntry saving={saving} onSave={logManualFood} onFavoritesChanged={setFavorites} />
         </View>
 
-        {/* Search results */}
-        <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : undefined}
-          style={styles.resultsList}
-        >
+        <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : undefined} style={styles.resultsList}>
           {onlineLoading && (
             <View style={{ marginVertical: 8 }} accessibilityLabel="Searching online..."><Spinner size="sm" /></View>
           )}
           {onlineError && (
-            <Text variant="caption" style={{ color: colors.error, marginBottom: 4 }}>
-              {onlineError}
-            </Text>
+            <Text variant="caption" style={{ color: colors.error, marginBottom: 4 }}>{onlineError}</Text>
           )}
           {showEmptyMessage && (
-            <Text
-              variant="caption"
-              style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 8 }}
-            >
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant, textAlign: "center", padding: 8 }}>
               No foods found. Try different terms or use Manual Entry.
             </Text>
           )}
@@ -555,183 +250,23 @@ export default function InlineFoodSearch({ dateKey, onFoodLogged, onSnack }: Pro
         </KeyboardAvoidingView>
       </CardContent>
 
-      {/* Barcode scanner modal */}
-      <BarcodeScanner
-        visible={scannerVisible}
-        onClose={() => {
-          setScannerVisible(false);
-          if (barcodeAbortRef.current) barcodeAbortRef.current.abort();
-        }}
-        onBarcodeScanned={handleBarcodeScanned}
-      />
-
-      {/* Manual entry bottom sheet */}
-      <BottomSheet
-        ref={manualSheetRef}
-        index={-1}
-        snapPoints={["70%"]}
-        enablePanDownToClose
-        backdropComponent={renderBackdrop}
-        onClose={resetManualForm}
-        backgroundStyle={{ backgroundColor: colors.surface }}
-        handleIndicatorStyle={{ backgroundColor: colors.onSurfaceVariant }}
-      >
-        <BottomSheetView
-          style={styles.sheetContent}
-          accessibilityViewIsModal
-        >
-          <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
-            Manual Food Entry
-          </Text>
-          <Input
-            label="Food name"
-            value={manualName}
-            onChangeText={setManualName}
-            variant="outline"
-            containerStyle={styles.sheetInput}
-          />
-          <Input
-            label="Calories"
-            value={manualCalories}
-            onChangeText={setManualCalories}
-            keyboardType="numeric"
-            variant="outline"
-            containerStyle={styles.sheetInput}
-          />
-          <View style={styles.macroRow}>
-            <Input
-              label="Protein (g)"
-              value={manualProtein}
-              onChangeText={setManualProtein}
-              keyboardType="numeric"
-              variant="outline"
-              containerStyle={StyleSheet.flatten([styles.sheetInput, styles.flex])}
-            />
-            <View style={{ width: 8 }} />
-            <Input
-              label="Carbs (g)"
-              value={manualCarbs}
-              onChangeText={setManualCarbs}
-              keyboardType="numeric"
-              variant="outline"
-              containerStyle={StyleSheet.flatten([styles.sheetInput, styles.flex])}
-            />
-            <View style={{ width: 8 }} />
-            <Input
-              label="Fat (g)"
-              value={manualFat}
-              onChangeText={setManualFat}
-              keyboardType="numeric"
-              variant="outline"
-              containerStyle={StyleSheet.flatten([styles.sheetInput, styles.flex])}
-            />
-          </View>
-          <Input
-            label="Serving size"
-            value={manualServing}
-            onChangeText={setManualServing}
-            variant="outline"
-            containerStyle={styles.sheetInput}
-          />
-          <Chip
-            selected={manualFavorite}
-            onPress={() => setManualFavorite(!manualFavorite)}
-            style={styles.sheetFavChip}
-            accessibilityLabel={manualFavorite ? "Remove from favorites" : "Save as favorite"}
-            role="button"
-            accessibilityState={{ selected: manualFavorite }}
-          >
-            Save as favorite
-          </Chip>
-          <Button
-            variant="default"
-            onPress={saveManualEntry}
-            loading={saving}
-            disabled={saving || !manualName.trim()}
-            accessibilityLabel="Log food"
-          >
-            Log Food
-          </Button>
-        </BottomSheetView>
-      </BottomSheet>
+      <BarcodeScanner visible={scannerVisible} onClose={closeScanner} onBarcodeScanned={handleBarcodeScanned} />
     </Card>
   );
 }
 
 const styles = StyleSheet.create({
-  card: {
-    marginHorizontal: 16,
-    marginBottom: 8,
-    borderRadius: radii.md,
-  },
-  content: {
-    paddingVertical: 12,
-  },
-  mealRow: {
-    marginBottom: 8,
-  },
-  mealChip: {
-    marginRight: 6,
-  },
-  favRow: {
-    marginBottom: 8,
-  },
-  favRowContent: {
-    gap: 6,
-  },
-  favChip: {
-    marginRight: 0,
-  },
-  favHint: {
-    marginBottom: 8,
-    fontStyle: "italic",
-  },
-  searchInput: {
-    marginBottom: 8,
-  },
-  statusRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: 4,
-  },
-  actionRow: {
-    flexDirection: "row",
-    marginBottom: 8,
-    gap: 8,
-  },
-  actionBtn: {
-    flex: 0,
-  },
-  resultsList: {
-    minHeight: 0,
-  },
-  resultItem: {
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    borderRadius: radii.sm,
-    marginBottom: 4,
-  },
-  separator: {
-    paddingVertical: 6,
-    paddingHorizontal: 4,
-    fontWeight: "600",
-  },
-  // Bottom sheet styles
-  sheetContent: {
-    paddingHorizontal: 16,
-    paddingBottom: 32,
-  },
-  sheetInput: {
-    marginBottom: 12,
-  },
-  macroRow: {
-    flexDirection: "row",
-  },
-  flex: {
-    flex: 1,
-  },
-  sheetFavChip: {
-    marginBottom: 16,
-    alignSelf: "flex-start",
-  },
+  card: { marginHorizontal: 16, marginBottom: 8, borderRadius: radii.md },
+  content: { paddingVertical: 12 },
+  mealRow: { marginBottom: 8 },
+  mealChip: { marginRight: 6 },
+  favRow: { marginBottom: 8 },
+  favRowContent: { gap: 6 },
+  favChip: { marginRight: 0 },
+  favHint: { marginBottom: 8, fontStyle: "italic" },
+  searchInput: { marginBottom: 8 },
+  statusRow: { flexDirection: "row", alignItems: "center", marginBottom: 4 },
+  actionRow: { flexDirection: "row", marginBottom: 8, gap: 8 },
+  resultsList: { minHeight: 0 },
+  separator: { paddingVertical: 6, paddingHorizontal: 4, fontWeight: "600" },
 });

--- a/components/ManualFoodEntry.tsx
+++ b/components/ManualFoodEntry.tsx
@@ -1,0 +1,167 @@
+import React, { useCallback, useRef, useState } from "react";
+import { StyleSheet, View } from "react-native";
+import BottomSheet, { BottomSheetBackdrop, BottomSheetView } from "@gorhom/bottom-sheet";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { Chip } from "@/components/ui/chip";
+import { Input } from "@/components/ui/input";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { getFavoriteFoods } from "../lib/db";
+import type { FoodEntry } from "../lib/types";
+
+type Props = {
+  saving: boolean;
+  onSave: (
+    name: string, calories: number, protein: number, carbs: number, fat: number,
+    serving: string, favorite: boolean,
+  ) => Promise<boolean>;
+  onFavoritesChanged: (favs: FoodEntry[]) => void;
+};
+
+export default function ManualFoodEntry({ saving, onSave, onFavoritesChanged }: Props) {
+  const colors = useThemeColors();
+  const sheetRef = useRef<BottomSheet>(null);
+
+  const [name, setName] = useState("");
+  const [calories, setCalories] = useState("");
+  const [protein, setProtein] = useState("");
+  const [carbs, setCarbs] = useState("");
+  const [fat, setFat] = useState("");
+  const [serving, setServing] = useState("1 serving");
+  const [favorite, setFavorite] = useState(false);
+
+  const reset = () => {
+    setName(""); setCalories(""); setProtein(""); setCarbs(""); setFat("");
+    setServing("1 serving"); setFavorite(false);
+  };
+
+  const handleSave = async () => {
+    if (!name.trim()) return;
+    const ok = await onSave(
+      name.trim(),
+      Math.max(0, parseFloat(calories) || 0),
+      Math.max(0, parseFloat(protein) || 0),
+      Math.max(0, parseFloat(carbs) || 0),
+      Math.max(0, parseFloat(fat) || 0),
+      serving.trim() || "1 serving",
+      favorite,
+    );
+    if (ok) {
+      reset();
+      sheetRef.current?.close();
+      getFavoriteFoods().then(onFavoritesChanged).catch(() => {});
+    }
+  };
+
+  const open = useCallback(() => sheetRef.current?.expand(), []);
+
+  const renderBackdrop = useCallback(
+    (props: React.ComponentProps<typeof BottomSheetBackdrop>) => (
+      <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} />
+    ),
+    [],
+  );
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        onPress={open}
+        style={styles.actionBtn}
+        accessibilityLabel="Manual entry"
+      >
+        Manual Entry
+      </Button>
+
+      <BottomSheet
+        ref={sheetRef}
+        index={-1}
+        snapPoints={["70%"]}
+        enablePanDownToClose
+        backdropComponent={renderBackdrop}
+        onClose={reset}
+        backgroundStyle={{ backgroundColor: colors.surface }}
+        handleIndicatorStyle={{ backgroundColor: colors.onSurfaceVariant }}
+      >
+        <BottomSheetView style={styles.sheetContent} accessibilityViewIsModal>
+          <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
+            Manual Food Entry
+          </Text>
+          <Input
+            label="Food name" value={name} onChangeText={setName}
+            variant="outline" containerStyle={styles.sheetInput}
+          />
+          <Input
+            label="Calories" value={calories} onChangeText={setCalories}
+            keyboardType="numeric" variant="outline" containerStyle={styles.sheetInput}
+          />
+          <View style={styles.macroRow}>
+            <Input
+              label="Protein (g)" value={protein} onChangeText={setProtein}
+              keyboardType="numeric" variant="outline"
+              containerStyle={StyleSheet.flatten([styles.sheetInput, styles.flex])}
+            />
+            <View style={{ width: 8 }} />
+            <Input
+              label="Carbs (g)" value={carbs} onChangeText={setCarbs}
+              keyboardType="numeric" variant="outline"
+              containerStyle={StyleSheet.flatten([styles.sheetInput, styles.flex])}
+            />
+            <View style={{ width: 8 }} />
+            <Input
+              label="Fat (g)" value={fat} onChangeText={setFat}
+              keyboardType="numeric" variant="outline"
+              containerStyle={StyleSheet.flatten([styles.sheetInput, styles.flex])}
+            />
+          </View>
+          <Input
+            label="Serving size" value={serving} onChangeText={setServing}
+            variant="outline" containerStyle={styles.sheetInput}
+          />
+          <Chip
+            selected={favorite}
+            onPress={() => setFavorite(!favorite)}
+            style={styles.sheetFavChip}
+            accessibilityLabel={favorite ? "Remove manual entry from favorites" : "Save manual entry as favorite"}
+            role="button"
+            accessibilityState={{ selected: favorite }}
+          >
+            Save as favorite
+          </Chip>
+          <Button
+            variant="default"
+            onPress={handleSave}
+            loading={saving}
+            disabled={saving || !name.trim()}
+            accessibilityLabel="Log manual entry"
+          >
+            Log Food
+          </Button>
+        </BottomSheetView>
+      </BottomSheet>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  actionBtn: {
+    flex: 1,
+  },
+  sheetContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 24,
+  },
+  sheetInput: {
+    marginBottom: 8,
+  },
+  macroRow: {
+    flexDirection: "row",
+  },
+  flex: {
+    flex: 1,
+  },
+  sheetFavChip: {
+    alignSelf: "flex-start",
+    marginBottom: 12,
+  },
+});

--- a/e2e/design-quality.spec.ts
+++ b/e2e/design-quality.spec.ts
@@ -49,7 +49,6 @@ const STANDALONE_SCREENS: Screen[] = [
   { name: "Body Measurements", path: "/body/measurements" },
   { name: "Body Goals", path: "/body/goals" },
   { name: "Macro Targets", path: "/nutrition/targets" },
-  { name: "Add Food", path: "/nutrition/add" },
   { name: "New Exercise", path: "/exercise/create" },
   { name: "New Template", path: "/template/create" },
   { name: "New Program", path: "/program/create" },

--- a/e2e/screen-registry.ts
+++ b/e2e/screen-registry.ts
@@ -31,7 +31,6 @@ export const STANDALONE_SCREENS: Screen[] = [
   { name: "Body Measurements", path: "/body/measurements" },
   { name: "Body Goals", path: "/body/goals" },
   { name: "Macro Targets", path: "/nutrition/targets" },
-  { name: "Add Food", path: "/nutrition/add" },
   { name: "New Exercise", path: "/exercise/create" },
   { name: "New Template", path: "/template/create" },
   { name: "New Program", path: "/program/create" },

--- a/hooks/useFoodLogger.ts
+++ b/hooks/useFoodLogger.ts
@@ -1,0 +1,110 @@
+import { useCallback, useState } from "react";
+import {
+  addFoodEntry,
+  addDailyLog,
+  deleteDailyLog,
+  findDuplicateFoodEntry,
+  toggleFavorite,
+} from "../lib/db";
+import type { FoodEntry, Meal, BuiltinFood } from "../lib/types";
+import type { ParsedFood } from "../lib/openfoodfacts";
+
+type FoodLoggerOpts = {
+  dateKey: string;
+  meal: Meal;
+  onFoodLogged: () => void;
+  onSnack: (message: string, undoFn?: () => Promise<void>) => void;
+  onAfterLog?: () => void;
+};
+
+export function useFoodLogger({ dateKey, meal, onFoodLogged, onSnack, onAfterLog }: FoodLoggerOpts) {
+  const [saving, setSaving] = useState(false);
+
+  const logLocalFood = useCallback(async (food: BuiltinFood, servingMult: number, favorite: boolean) => {
+    setSaving(true);
+    try {
+      const entry = await addFoodEntry(
+        food.name, food.calories, food.protein, food.carbs, food.fat,
+        food.serving, favorite,
+      );
+      const log = await addDailyLog(entry.id, dateKey, meal, servingMult);
+      onAfterLog?.();
+      onFoodLogged();
+      onSnack(`${food.name} logged`, async () => {
+        await deleteDailyLog(log.id);
+        onFoodLogged();
+      });
+    } catch {
+      onSnack("Failed to log food. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }, [dateKey, meal, onFoodLogged, onSnack, onAfterLog]);
+
+  const logOnlineFood = useCallback(async (food: ParsedFood, servingMult: number, favorite: boolean) => {
+    setSaving(true);
+    try {
+      const existing = await findDuplicateFoodEntry(
+        food.name, food.calories, food.protein, food.carbs, food.fat,
+      );
+      const entry = existing ?? await addFoodEntry(
+        food.name, food.calories, food.protein, food.carbs, food.fat,
+        food.servingLabel, favorite,
+      );
+      if (existing && favorite && !existing.is_favorite) {
+        await toggleFavorite(existing.id);
+      }
+      const log = await addDailyLog(entry.id, dateKey, meal, servingMult);
+      onAfterLog?.();
+      onFoodLogged();
+      onSnack(`${food.name} logged`, async () => {
+        await deleteDailyLog(log.id);
+        onFoodLogged();
+      });
+    } catch {
+      onSnack("Failed to log food. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }, [dateKey, meal, onFoodLogged, onSnack, onAfterLog]);
+
+  const logFavorite = useCallback(async (food: FoodEntry) => {
+    setSaving(true);
+    try {
+      const log = await addDailyLog(food.id, dateKey, meal, 1);
+      onFoodLogged();
+      onSnack(`${food.name} logged`, async () => {
+        await deleteDailyLog(log.id);
+        onFoodLogged();
+      });
+    } catch {
+      onSnack("Failed to log food. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }, [dateKey, meal, onFoodLogged, onSnack]);
+
+  const logManualFood = useCallback(async (
+    name: string, calories: number, protein: number, carbs: number, fat: number,
+    serving: string, favorite: boolean,
+  ) => {
+    setSaving(true);
+    try {
+      const entry = await addFoodEntry(name, calories, protein, carbs, fat, serving, favorite);
+      const log = await addDailyLog(entry.id, dateKey, meal, 1);
+      onFoodLogged();
+      onSnack(`${name} logged`, async () => {
+        await deleteDailyLog(log.id);
+        onFoodLogged();
+      });
+      return true;
+    } catch {
+      onSnack("Failed to save entry. Please try again.");
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, [dateKey, meal, onFoodLogged, onSnack]);
+
+  return { saving, logLocalFood, logOnlineFood, logFavorite, logManualFood };
+}

--- a/hooks/useFoodSearch.ts
+++ b/hooks/useFoodSearch.ts
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Platform } from "react-native";
+import { searchFoods } from "../lib/foods";
+import { getFavoriteFoods } from "../lib/db";
+import {
+  fetchWithTimeout,
+  lookupBarcodeWithTimeout,
+  type ParsedFood,
+  type BarcodeResult,
+} from "../lib/openfoodfacts";
+import type { FoodEntry, BuiltinFood } from "../lib/types";
+
+export type SearchResult =
+  | { type: "local"; food: BuiltinFood }
+  | { type: "online"; food: ParsedFood };
+
+export function useFoodSearch(scanOnMount?: boolean) {
+  const [query, setQuery] = useState("");
+  const [favorites, setFavorites] = useState<FoodEntry[]>([]);
+  const [onlineResults, setOnlineResults] = useState<ParsedFood[]>([]);
+  const [onlineLoading, setOnlineLoading] = useState(false);
+  const [onlineError, setOnlineError] = useState<string | null>(null);
+
+  // Barcode state
+  const [scannerVisible, setScannerVisible] = useState(false);
+  const [barcodeLoading, setBarcodeLoading] = useState(false);
+  const [barcodeError, setBarcodeError] = useState<string | null>(null);
+  const [scannedProductName, setScannedProductName] = useState<string | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const barcodeAbortRef = useRef<AbortController | null>(null);
+  const cacheRef = useRef<Map<string, ParsedFood[]>>(new Map());
+
+  useEffect(() => {
+    getFavoriteFoods().then(setFavorites).catch(() => {});
+  }, []);
+
+  const localResults = useMemo(() => {
+    if (!query.trim()) return [];
+    return searchFoods(query);
+  }, [query]);
+
+  // Derive onlineError reset from query changes via ref
+  const prevQueryRef = useRef(query);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (abortRef.current) abortRef.current.abort();
+
+    const trimmed = query.trim();
+    const queryChanged = prevQueryRef.current !== query;
+    prevQueryRef.current = query;
+
+    if (!trimmed || trimmed.length < 2) {
+      if (queryChanged) {
+        // Defer state updates to avoid synchronous setState in effect
+        queueMicrotask(() => {
+          setOnlineResults([]);
+          setOnlineError(null);
+        });
+      }
+      return;
+    }
+
+    const cached = cacheRef.current.get(trimmed.toLowerCase());
+    if (cached) {
+      queueMicrotask(() => {
+        setOnlineResults(cached);
+        setOnlineError(null);
+      });
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setOnlineLoading(true);
+      setOnlineError(null);
+      fetchWithTimeout(trimmed, controller.signal).then((result) => {
+        if (controller.signal.aborted) return;
+        setOnlineLoading(false);
+        if (result.ok) {
+          setOnlineResults(result.foods);
+          const cache = cacheRef.current;
+          cache.set(trimmed.toLowerCase(), result.foods);
+          if (cache.size > 10) {
+            const first = cache.keys().next().value;
+            if (first !== undefined) cache.delete(first);
+          }
+        } else {
+          setOnlineResults([]);
+          setOnlineError(result.error === "timeout" ? "Search timed out. Try again." : "Could not reach food database.");
+        }
+      });
+    }, 400);
+
+    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, [query]);
+
+  useEffect(() => {
+    return () => {
+      if (abortRef.current) abortRef.current.abort();
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (barcodeAbortRef.current) barcodeAbortRef.current.abort();
+    };
+  }, []);
+
+  const scanMountTriggered = useRef(false);
+  useEffect(() => {
+    if (scanOnMount && !scanMountTriggered.current && Platform.OS !== "web") {
+      scanMountTriggered.current = true;
+      queueMicrotask(() => setScannerVisible(true));
+    }
+  }, [scanOnMount]);
+
+  const combinedResults: SearchResult[] = useMemo(() => {
+    const items: SearchResult[] = [];
+    localResults.forEach((food) => items.push({ type: "local", food }));
+    onlineResults.forEach((food) => items.push({ type: "online", food }));
+    return items;
+  }, [localResults, onlineResults]);
+
+  const handleBarcodeScanned = useCallback(async (barcode: string) => {
+    setScannerVisible(false);
+    setBarcodeError(null);
+    setBarcodeLoading(true);
+    setScannedProductName(null);
+
+    if (barcodeAbortRef.current) barcodeAbortRef.current.abort();
+    const controller = new AbortController();
+    barcodeAbortRef.current = controller;
+
+    const result: BarcodeResult = await lookupBarcodeWithTimeout(barcode, controller.signal);
+    if (controller.signal.aborted) return;
+    setBarcodeLoading(false);
+
+    if (!result.ok) {
+      setBarcodeError(result.error === "timeout" ? "Lookup timed out. Please try again." : "Could not look up barcode. Check your connection.");
+      return;
+    }
+    if (result.status === "not_found") { setBarcodeError("Product not found. Try searching by name."); return; }
+    if (result.status === "incomplete") { setBarcodeError("Product found but nutrition data is incomplete."); return; }
+
+    setScannedProductName(result.food.name);
+    setOnlineResults([result.food]);
+    setQuery("");
+  }, []);
+
+  const openScanner = useCallback(() => {
+    setBarcodeError(null);
+    setScannerVisible(true);
+  }, []);
+
+  const closeScanner = useCallback(() => {
+    setScannerVisible(false);
+    if (barcodeAbortRef.current) barcodeAbortRef.current.abort();
+  }, []);
+
+  return {
+    query, setQuery,
+    favorites, setFavorites,
+    localResults, onlineResults,
+    onlineLoading, onlineError,
+    combinedResults,
+    scannerVisible, barcodeLoading, barcodeError, scannedProductName,
+    handleBarcodeScanned, openScanner, closeScanner,
+  };
+}


### PR DESCRIPTION
## Summary

Consolidates the food-add flow into the InlineFoodSearch component by adding an expand-on-tap pattern for search results. Users now tap a result to expand it with multiplier chips, scaled macro preview, favorite toggle, and log button — replacing the deleted `app/nutrition/add.tsx` modal.

## Changes

- **InlineFoodSearch**: Added expand-on-tap pattern with serving multiplier chips (0.5x, 1x, 1.5x, 2x), custom multiplier input, scaled macros preview, save-as-favorite toggle
- **InlineFoodSearch**: Added `scanOnMount` prop for barcode auto-open when navigated with scan param
- **InlineFoodSearch**: Hide scan barcode button on web platform
- **InlineFoodSearch**: Differentiated manual entry a11y labels from search result labels
- **InlineFoodSearch**: Added a11y label to scanned product announcement
- **nutrition tab**: Read `scan` query param and pass `scanOnMount` to InlineFoodSearch
- **_layout.tsx**: Route header barcode icon to `/nutrition?scan=true` instead of `/nutrition/add`
- **app/_layout.tsx**: Removed `nutrition/add` Stack.Screen route
- **Tests**: Rewrote 3 acceptance test suites (food-database, online-food-search, barcode-scanner) to test InlineFoodSearch
- **Tests**: Updated owner-ux-batch, programme-padding-audit, tablet-inline-search tests
- **E2E**: Removed `/nutrition/add` from screen registry

## Testing

- TypeScript: 0 errors
- Jest: 105 suites, 1605 tests — all pass

## Issue

Resolves BLD-318