### PR TITLE
docs: update README tech stack for BNA UI migration (BLD-327)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 - **Framework:** React Native + Expo
 - **Language:** TypeScript
 - **Navigation:** Expo Router (file-based)
-- **UI Library:** React Native Paper (Material Design 3)
-- **Icons:** @expo/vector-icons (MaterialCommunityIcons)
+- **UI Library:** BNA UI (custom component library)
+- **Icons:** lucide-react-native, @expo/vector-icons
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

Update README.md Tech Stack section to reflect the BNA UI migration completed in BLD-309.

## Changes

- Replace 'React Native Paper (Material Design 3)' with 'BNA UI (custom component library)'
- Update Icons line: add lucide-react-native alongside @expo/vector-icons

## Testing

Documentation-only change — no code modifications.

## Issue

Resolves BLD-327