### PR TITLE
refactor: FTA audit batch 5 — decompose session, substitution-sheet, achievements, share-card (BLD-332)

### DIFF
--- a/__tests__/app/fta-decomposition-batch5.test.ts
+++ b/__tests__/app/fta-decomposition-batch5.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Structural tests for FTA batch 5 decomposition.
+ * Verifies extracted hooks and components exist with expected exports.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+function readSrc(relPath: string): string {
+  return fs.readFileSync(path.resolve(__dirname, "../../", relPath), "utf-8");
+}
+
+describe("FTA Batch 5 — session/[id].tsx decomposition", () => {
+  const parentSrc = readSrc("app/session/[id].tsx");
+  const hookSrc = readSrc("hooks/useSessionActions.ts");
+  const headerSrc = readSrc("components/session/SessionListHeader.tsx");
+  const footerSrc = readSrc("components/session/SessionListFooter.tsx");
+
+  it("parent imports useSessionActions hook", () => {
+    expect(parentSrc).toContain("useSessionActions");
+  });
+
+  it("parent imports SessionListHeader", () => {
+    expect(parentSrc).toContain("SessionListHeader");
+  });
+
+  it("parent imports SessionListFooter", () => {
+    expect(parentSrc).toContain("SessionListFooter");
+  });
+
+  it("useSessionActions hook exports the function", () => {
+    expect(hookSrc).toContain("export function useSessionActions");
+  });
+
+  it("useSessionActions manages elapsed timer state", () => {
+    expect(hookSrc).toContain("elapsed");
+    expect(hookSrc).toContain("setElapsed");
+  });
+
+  it("SessionListHeader renders rest banner", () => {
+    expect(headerSrc).toContain("Rest Timer");
+  });
+
+  it("SessionListFooter renders finish and cancel buttons", () => {
+    expect(footerSrc).toContain("Finish Workout");
+    expect(footerSrc).toContain("Cancel Workout");
+  });
+
+  it("parent file is under 300 lines", () => {
+    const lines = parentSrc.split("\n").length;
+    expect(lines).toBeLessThan(300);
+  });
+});
+
+describe("FTA Batch 5 — SubstitutionSheet decomposition", () => {
+  const parentSrc = readSrc("components/SubstitutionSheet.tsx");
+  const itemSrc = readSrc("components/substitution/SubstitutionItem.tsx");
+  const filterSrc = readSrc("components/substitution/EquipmentFilter.tsx");
+
+  it("parent imports SubstitutionItem", () => {
+    expect(parentSrc).toContain("SubstitutionItem");
+  });
+
+  it("parent imports EquipmentFilter", () => {
+    expect(parentSrc).toContain("EquipmentFilter");
+  });
+
+  it("SubstitutionItem has matchColor helper", () => {
+    expect(itemSrc).toContain("matchColor");
+  });
+
+  it("EquipmentFilter renders chip row", () => {
+    expect(filterSrc).toContain("Chip");
+  });
+
+  it("parent file is under 260 lines", () => {
+    const lines = parentSrc.split("\n").length;
+    expect(lines).toBeLessThan(260);
+  });
+});
+
+describe("FTA Batch 5 — achievements.tsx decomposition", () => {
+  const parentSrc = readSrc("app/progress/achievements.tsx");
+  const hookSrc = readSrc("hooks/useAchievements.ts");
+  const badgeSrc = readSrc("components/achievements/AchievementBadge.tsx");
+
+  it("parent imports useAchievements hook", () => {
+    expect(parentSrc).toContain("useAchievements");
+  });
+
+  it("parent imports AchievementBadge", () => {
+    expect(parentSrc).toContain("AchievementBadge");
+  });
+
+  it("useAchievements hook exports the function", () => {
+    expect(hookSrc).toContain("export function useAchievements");
+  });
+
+  it("useAchievements exports AchievementItem type", () => {
+    expect(hookSrc).toContain("export type AchievementItem");
+  });
+
+  it("AchievementBadge renders progress bar for locked items", () => {
+    expect(badgeSrc).toContain("Progress");
+  });
+
+  it("parent file is under 200 lines", () => {
+    const lines = parentSrc.split("\n").length;
+    expect(lines).toBeLessThan(200);
+  });
+});
+
+describe("FTA Batch 5 — ShareCard decomposition", () => {
+  const parentSrc = readSrc("components/ShareCard.tsx");
+  const statsSrc = readSrc("components/share/ShareCardStats.tsx");
+  const exercisesSrc = readSrc("components/share/ShareCardExercises.tsx");
+
+  it("parent imports ShareCardStats", () => {
+    expect(parentSrc).toContain("ShareCardStats");
+  });
+
+  it("parent imports ShareCardExercises", () => {
+    expect(parentSrc).toContain("ShareCardExercises");
+  });
+
+  it("ShareCardStats renders duration, sets, volume", () => {
+    expect(statsSrc).toContain("Duration");
+    expect(statsSrc).toContain("Sets");
+    expect(statsSrc).toContain("Volume");
+  });
+
+  it("ShareCardExercises renders PR section", () => {
+    expect(exercisesSrc).toContain("New PRs");
+  });
+
+  it("parent file is under 200 lines", () => {
+    const lines = parentSrc.split("\n").length;
+    expect(lines).toBeLessThan(200);
+  });
+});

--- a/__tests__/lib/health-connect.test.ts
+++ b/__tests__/lib/health-connect.test.ts
@@ -150,8 +150,11 @@ describe("Health Connect settings integration", () => {
 describe("Health Connect session sync integration", () => {
   it("session/[id].tsx uses dynamic import for HC sync", () => {
     const fs = require("fs");
-    const source = fs.readFileSync("app/session/[id].tsx", "utf8");
-    expect(source).toContain('await import("../../lib/health-connect")');
+    const source = [
+      fs.readFileSync("app/session/[id].tsx", "utf8"),
+      fs.readFileSync("hooks/useSessionActions.ts", "utf8"),
+    ].join("\n");
+    expect(source).toContain('await import("../lib/health-connect")');
     expect(source).toContain("syncToHealthConnect");
     // HC sync must be Android-gated
     expect(source).toContain('Platform.OS === "android"');
@@ -159,7 +162,10 @@ describe("Health Connect session sync integration", () => {
 
   it("session/[id].tsx HC sync is silent (no toast on success or failure)", () => {
     const fs = require("fs");
-    const source = fs.readFileSync("app/session/[id].tsx", "utf8");
+    const source = [
+      fs.readFileSync("app/session/[id].tsx", "utf8"),
+      fs.readFileSync("hooks/useSessionActions.ts", "utf8"),
+    ].join("\n");
     // Find the HC sync block and verify no setSnackbar calls in it
     const hcBlock = source.match(
       /Health Connect sync[\s\S]*?catch\s*\{[\s\S]*?\}/

--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -22,10 +22,10 @@ const settingsSrc = [
   fs.readFileSync(path.resolve(__dirname, "../../components/settings/IntegrationsCard.tsx"), "utf-8"),
 ].join("\n");
 
-const sessionSrc = fs.readFileSync(
-  path.resolve(__dirname, "../../app/session/[id].tsx"),
-  "utf-8"
-);
+const sessionSrc = [
+  fs.readFileSync(path.resolve(__dirname, "../../app/session/[id].tsx"), "utf-8"),
+  fs.readFileSync(path.resolve(__dirname, "../../hooks/useSessionActions.ts"), "utf-8"),
+].join("\n");
 
 const layoutSrc = fs.readFileSync(
   path.resolve(__dirname, "../../app/_layout.tsx"),

--- a/app/progress/achievements.tsx
+++ b/app/progress/achievements.tsx
@@ -1,40 +1,17 @@
-import { useCallback, useState } from "react";
 import {
   FlatList,
   StyleSheet,
   View,
 } from "react-native";
 import { Card, CardContent } from "@/components/ui/card";
-import { Progress } from "@/components/ui/progress";
 import { Text } from "@/components/ui/text";
 import { Stack } from "expo-router";
-import { useFocusEffect } from "expo-router";
-import {
-  buildAchievementContext,
-  getEarnedAchievementMap,
-  saveEarnedAchievements,
-  hasSeenRetroactiveBanner,
-  markRetroactiveBannerSeen,
-} from "../../lib/db";
-import {
-  ACHIEVEMENTS,
-  getAllAchievementProgress,
-  evaluateAchievements,
-} from "../../lib/achievements";
+import { ACHIEVEMENTS } from "../../lib/achievements";
 import type { AchievementCategory } from "../../lib/achievements";
-import { radii, typography } from "../../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
-
-type AchievementItem = {
-  id: string;
-  name: string;
-  description: string;
-  category: AchievementCategory;
-  icon: string;
-  earned: boolean;
-  earnedAt: number | null;
-  progress: number;
-};
+import { useAchievements } from "@/hooks/useAchievements";
+import type { AchievementItem } from "@/hooks/useAchievements";
+import { AchievementBadge } from "@/components/achievements/AchievementBadge";
 
 const CATEGORY_LABELS: Record<AchievementCategory, string> = {
   consistency: "Consistency",
@@ -46,75 +23,7 @@ const CATEGORY_LABELS: Record<AchievementCategory, string> = {
 
 export default function AchievementsScreen() {
   const colors = useThemeColors();
-  const [items, setItems] = useState<AchievementItem[]>([]);
-  const [earnedCount, setEarnedCount] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [retroBanner, setRetroBanner] = useState<number | null>(null);
-
-  useFocusEffect(
-    useCallback(() => {
-      let cancelled = false;
-
-      (async () => {
-        try {
-          const [ctx, earnedMap] = await Promise.all([
-            buildAchievementContext(),
-            getEarnedAchievementMap(),
-          ]);
-
-          // Retroactive evaluation: earn any new achievements silently
-          const alreadyEarnedIds = new Set(earnedMap.keys());
-          const newlyEarned = evaluateAchievements(ctx, alreadyEarnedIds);
-
-          if (newlyEarned.length > 0) {
-            const now = Date.now();
-            await saveEarnedAchievements(
-              newlyEarned.map((n) => n.achievement.id),
-              now,
-            );
-            for (const n of newlyEarned) {
-              earnedMap.set(n.achievement.id, now);
-            }
-          }
-
-          // Show retroactive banner on first open
-          const seenBanner = await hasSeenRetroactiveBanner();
-          if (cancelled) return;
-          if (!seenBanner && earnedMap.size > 0) {
-            setRetroBanner(earnedMap.size);
-            await markRetroactiveBannerSeen();
-          }
-
-          const progress = getAllAchievementProgress(ctx, earnedMap);
-          if (cancelled) return;
-
-          setItems(
-            progress.map((p) => ({
-              id: p.achievement.id,
-              name: p.achievement.name,
-              description: p.achievement.description,
-              category: p.achievement.category,
-              icon: p.achievement.icon,
-              earned: p.earned,
-              earnedAt: p.earnedAt,
-              progress: p.progress,
-            })),
-          );
-          setEarnedCount(earnedMap.size);
-        } catch (e) {
-          if (__DEV__) console.warn("Achievement evaluation failed:", e);
-          if (!cancelled) setError("Could not load achievements. Please try again later.");
-        } finally {
-          if (!cancelled) setLoading(false);
-        }
-      })();
-
-      return () => {
-        cancelled = true;
-      };
-    }, []),
-  );
+  const { items, earnedCount, loading, error, retroBanner } = useAchievements();
 
   // Group items by category
   const sections = Object.entries(CATEGORY_LABELS)
@@ -163,85 +72,6 @@ export default function AchievementsScreen() {
       </>
     );
   }
-
-  const formatDate = (ts: number) => {
-    return new Date(ts).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-  };
-
-  const renderBadge = ({ item }: { item: AchievementItem }) => {
-    const badgeColor = item.earned
-      ? colors.primaryContainer
-      : colors.surfaceVariant;
-    const textColor = item.earned
-      ? colors.onPrimaryContainer
-      : colors.onSurfaceVariant;
-
-    return (
-      <Card
-        style={[styles.badge, { backgroundColor: badgeColor }]}
-        accessibilityLabel={
-          item.earned
-            ? `${item.name} achievement — Earned on ${formatDate(item.earnedAt!)}`
-            : `${item.name} achievement — Locked, ${Math.round(item.progress * 100)}% complete`
-        }
-        accessibilityRole="summary"
-      >
-        <CardContent style={styles.badgeContent}>
-          <View style={styles.iconContainer}>
-            <Text style={[styles.icon, !item.earned && styles.iconLocked]}>
-              {item.icon}
-            </Text>
-            {item.earned ? (
-              <Text style={styles.checkOverlay}>✅</Text>
-            ) : (
-              <Text style={styles.lockOverlay}>🔒</Text>
-            )}
-          </View>
-          <Text
-            variant="caption"
-            numberOfLines={1}
-            style={[styles.badgeName, { color: textColor }]}
-          >
-            {item.name}
-          </Text>
-          <Text
-            variant="caption"
-            numberOfLines={2}
-            style={[styles.badgeDesc, { color: textColor }]}
-          >
-            {item.description}
-          </Text>
-          {item.earned ? (
-            <Text variant="caption" style={{ color: textColor, marginTop: 4 }}>
-              {formatDate(item.earnedAt!)}
-            </Text>
-          ) : (
-            <View
-              style={styles.progressContainer}
-              accessibilityValue={{
-                min: 0,
-                max: 100,
-                now: Math.round(item.progress * 100),
-                text: `${Math.round(item.progress * 100)}% complete`,
-              }}
-            >
-              <Progress
-                value={item.progress * 100}
-                style={styles.progressBar}
-              />
-              <Text variant="caption" style={{ color: textColor, marginTop: 2 }}>
-                {Math.round(item.progress * 100)}%
-              </Text>
-            </View>
-          )}
-        </CardContent>
-      </Card>
-    );
-  };
 
   return (
     <>
@@ -294,7 +124,7 @@ export default function AchievementsScreen() {
               <View style={styles.grid}>
                 {section.items.map((badge) => (
                   <View key={badge.id} style={styles.gridItem}>
-                    {renderBadge({ item: badge })}
+                    <AchievementBadge item={badge} />
                   </View>
                 ))}
               </View>
@@ -335,54 +165,5 @@ const styles = StyleSheet.create({
   gridItem: {
     width: "31%",
     minWidth: 100,
-  },
-  badge: {
-    minHeight: 48,
-  },
-  badgeContent: {
-    alignItems: "center",
-    paddingVertical: 12,
-    paddingHorizontal: 4,
-  },
-  iconContainer: {
-    position: "relative",
-    marginBottom: 4,
-  },
-  icon: {
-    fontSize: typography.statValue.fontSize,
-  },
-  iconLocked: {
-    opacity: 0.4,
-  },
-  checkOverlay: {
-    position: "absolute",
-    bottom: -4,
-    right: -8,
-    fontSize: 14,
-  },
-  lockOverlay: {
-    position: "absolute",
-    bottom: -4,
-    right: -8,
-    fontSize: 14,
-  },
-  badgeName: {
-    fontWeight: "700",
-    textAlign: "center",
-    marginTop: 4,
-  },
-  badgeDesc: {
-    textAlign: "center",
-    marginTop: 2,
-  },
-  progressContainer: {
-    width: "100%",
-    marginTop: 6,
-    alignItems: "center",
-  },
-  progressBar: {
-    width: "100%",
-    height: 4,
-    borderRadius: radii.sm,
   },
 });

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -1,7 +1,6 @@
-/* eslint-disable max-lines, max-lines-per-function, react-hooks/exhaustive-deps */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+/* eslint-disable max-lines-per-function, react-hooks/exhaustive-deps */
+import React, { useEffect, useMemo } from "react";
 import {
-  AccessibilityInfo,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -9,58 +8,35 @@ import {
   View,
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import Reanimated from "react-native-reanimated";
 import { Text } from "@/components/ui/text";
-import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/bna-toast";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
-import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import * as Haptics from "expo-haptics";
+import { Stack, useLocalSearchParams } from "expo-router";
 import { activateKeepAwakeAsync } from "expo-keep-awake";
 import BottomSheet, { BottomSheetBackdrop } from "@gorhom/bottom-sheet";
 import { setEnabled as setAudioEnabled } from "../../lib/audio";
-import {
-  addSet,
-  cancelSession,
-  deleteSet,
-  completeSession,
-  completeSet,
-  getRestSecondsForLink,
-  uncompleteSet,
-  updateSet,
-  updateSetRPE,
-  updateSetNotes,
-  updateSetTrainingMode,
-  getSessionSets,
-  getAppSetting,
-} from "../../lib/db";
-import {
-  getSessionProgramDayId,
-  getProgramDayById,
-  advanceProgram,
-} from "../../lib/programs";
-import type { TrainingMode } from "../../lib/types";
+import { getAppSetting } from "../../lib/db";
 import { formatTime } from "../../lib/format";
 import { useLayout } from "../../lib/layout";
-import { confirmAction } from "../../lib/confirm";
 import ExercisePickerSheet from "../../components/ExercisePickerSheet";
 import SubstitutionSheet from "../../components/SubstitutionSheet";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useRestTimer } from "../../hooks/useRestTimer";
 import { useSessionData } from "../../hooks/useSessionData";
+import { useSessionActions } from "../../hooks/useSessionActions";
 import { useExerciseManagement } from "../../hooks/useExerciseManagement";
 import { useSetTypeActions } from "../../hooks/useSetTypeActions";
 import { ExerciseGroupCard } from "../../components/session/ExerciseGroupCard";
 import { ExerciseDetailDrawerContent } from "../../components/session/ExerciseDetailDrawer";
 import { SetTypeSheet } from "../../components/session/SetTypeSheet";
-import type { SetWithMeta } from "../../components/session/types";
+import { SessionListHeader } from "../../components/session/SessionListHeader";
+import { SessionListFooter } from "../../components/session/SessionListFooter";
 
 export default function ActiveSession() {
   useEffect(() => {
     activateKeepAwakeAsync().catch(() => {});
   }, []);
   const colors = useThemeColors();
-  const router = useRouter();
   const layout = useLayout();
   const { id, templateId, sourceSessionId } = useLocalSearchParams<{
     id: string;
@@ -108,28 +84,19 @@ export default function ActiveSession() {
     handleCycleSetType, handleLongPressSetType, handleSelectSetType,
   } = useSetTypeActions({ groups, setGroups, maxes });
 
-  const [elapsed, setElapsed] = useState(0);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-  const [exerciseNotesOpen, setExerciseNotesOpen] = useState<Record<string, boolean>>({});
-  const [exerciseNotesDraft, setExerciseNotesDraft] = useState<Record<string, string>>({});
-  const [halfStep, setHalfStep] = useState<{ setId: string; base: number } | null>(null);
-  const [nextHint, setNextHint] = useState<string | null>(null);
-  const hintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const {
+    elapsed, exerciseNotesOpen, exerciseNotesDraft, halfStep, nextHint, hintTimer,
+    handleUpdate, handleCheck, handleAddSet, handleModeChange,
+    handleRPE, handleHalfStep, handleHalfStepClear, handleHalfStepOpen,
+    handleDelete, handleExerciseNotes, handleExerciseNotesDraftChange,
+    toggleExerciseNotes, finish, cancel,
+  } = useSessionActions({
+    id, groups, setGroups, modes, setModes,
+    updateGroupSet, startRest, startRestWithDuration, session,
+    showToast, showError,
+  });
 
   const detailSnapPoints = useMemo(() => ["40%", "90%"], []);
-
-  // Timer
-  useEffect(() => {
-    if (!session) return;
-    const update = () => {
-      setElapsed(Math.floor((Date.now() - session.started_at) / 1000));
-    };
-    update();
-    timer.current = setInterval(update, 1000);
-    return () => {
-      if (timer.current) clearInterval(timer.current);
-    };
-  }, [session]);
 
   // Cleanup timers
   useEffect(() => {
@@ -141,217 +108,6 @@ export default function ActiveSession() {
       if (cleanupRefs.deleteCountdownInterval.current) clearInterval(cleanupRefs.deleteCountdownInterval.current);
     };
   }, []);
-
-  const handleUpdate = useCallback(async (
-    setId: string,
-    field: "weight" | "reps",
-    val: string
-  ) => {
-    let resolvedSet: SetWithMeta | undefined;
-    setGroups((prev) => {
-      for (const g of prev) {
-        const s = g.sets.find((s) => s.id === setId);
-        if (s) { resolvedSet = s; break; }
-      }
-      return prev;
-    });
-    if (!resolvedSet) return;
-
-    const num = val === "" ? null : parseFloat(val);
-    if (field === "weight") {
-      updateGroupSet(setId, { weight: num });
-      await updateSet(setId, num, resolvedSet.reps);
-    } else {
-      const rounded = num !== null ? Math.round(num) : null;
-      updateGroupSet(setId, { reps: rounded });
-      await updateSet(setId, resolvedSet.weight, rounded);
-    }
-  }, [updateGroupSet]);
-
-  const handleCheck = useCallback(async (set: SetWithMeta) => {
-    if (set.completed) {
-      updateGroupSet(set.id, { completed: false, completed_at: null });
-      await uncompleteSet(set.id);
-    } else {
-      const now = Date.now();
-      updateGroupSet(set.id, { completed: true, completed_at: now });
-      await completeSet(set.id);
-
-      if (set.link_id) {
-        const linked = groups.filter((g) => g.link_id === set.link_id);
-        const idx = linked.findIndex((g) => g.exercise_id === set.exercise_id);
-        const next = idx >= 0 && idx < linked.length - 1 ? linked[idx + 1] : null;
-
-        if (next) {
-          setNextHint(`Next: ${next.name}`);
-          AccessibilityInfo.announceForAccessibility(`Next: ${next.name}`);
-          if (hintTimer.current) clearTimeout(hintTimer.current);
-          hintTimer.current = setTimeout(() => setNextHint(null), 1500);
-        } else {
-          setNextHint(null);
-          const secs = await getRestSecondsForLink(id!, set.link_id);
-          startRestWithDuration(secs);
-        }
-      } else {
-        startRest(set.exercise_id);
-      }
-    }
-  }, [updateGroupSet, groups, id, startRest, startRestWithDuration]);
-
-  const handleAddSet = useCallback(async (exerciseId: string) => {
-    const group = groups.find((g) => g.exercise_id === exerciseId);
-    const num = (group?.sets.length ?? 0) + 1;
-    const fallback = group?.is_voltra && group.training_modes.length > 1 ? group.training_modes[0] : null;
-    const mode = modes[exerciseId] ?? fallback;
-    const newSet = await addSet(id!, exerciseId, num, null, null, mode, null);
-    setGroups((prev) =>
-      prev.map((g) =>
-        g.exercise_id === exerciseId
-          ? { ...g, sets: [...g.sets, { ...newSet, previous: "-" }] }
-          : g
-      )
-    );
-  }, [id, groups, modes]);
-
-  const handleModeChange = useCallback(async (exerciseId: string, mode: TrainingMode) => {
-    setModes((prev) => ({ ...prev, [exerciseId]: mode }));
-    const group = groups.find((g) => g.exercise_id === exerciseId);
-    if (!group) return;
-    setGroups((prev) =>
-      prev.map((g) =>
-        g.exercise_id === exerciseId
-          ? { ...g, sets: g.sets.map((s) => (s.completed ? s : { ...s, training_mode: mode })) }
-          : g
-      )
-    );
-    for (const set of group.sets) {
-      if (!set.completed) {
-        await updateSetTrainingMode(set.id, mode);
-      }
-    }
-  }, [groups]);
-
-  const handleRPE = useCallback(async (set: SetWithMeta, val: number) => {
-    const next = set.rpe === val ? null : val;
-    updateGroupSet(set.id, { rpe: next });
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    await updateSetRPE(set.id, next);
-  }, [updateGroupSet]);
-
-  const handleHalfStep = useCallback(async (setId: string, val: number) => {
-    updateGroupSet(setId, { rpe: val });
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setHalfStep(null);
-    await updateSetRPE(setId, val);
-  }, [updateGroupSet]);
-
-  const handleDelete = useCallback(async (setId: string) => {
-    setGroups((prev) =>
-      prev.map((g) => ({
-        ...g,
-        sets: g.sets.filter((s) => s.id !== setId)
-          .map((s, i) => ({ ...s, set_number: i + 1 })),
-      })).filter((g) => g.sets.length > 0)
-    );
-    await deleteSet(setId);
-  }, []);
-
-  const handleHalfStepClear = useCallback(() => setHalfStep(null), []);
-  const handleHalfStepOpen = useCallback((setId: string, base: number) => {
-    setHalfStep({ setId, base });
-  }, []);
-
-  const handleExerciseNotes = useCallback(async (exerciseId: string, text: string) => {
-    const group = groups.find((g) => g.exercise_id === exerciseId);
-    if (!group || group.sets.length === 0) return;
-    const firstSetId = group.sets[0].id;
-    updateGroupSet(firstSetId, { notes: text });
-    setExerciseNotesDraft((prev) => { const next = { ...prev }; delete next[exerciseId]; return next; });
-    await updateSetNotes(firstSetId, text);
-  }, [updateGroupSet, groups]);
-
-  const handleExerciseNotesDraftChange = useCallback((exerciseId: string, text: string) => {
-    setExerciseNotesDraft((prev) => ({ ...prev, [exerciseId]: text }));
-  }, []);
-
-  const toggleExerciseNotes = useCallback((exerciseId: string) => {
-    setExerciseNotesOpen((prev) => ({ ...prev, [exerciseId]: !prev[exerciseId] }));
-  }, []);
-
-  const finish = () => {
-    confirmAction(
-      "Complete Workout?",
-      `Duration: ${formatTime(elapsed)}`,
-      async () => {
-        await completeSession(id!);
-
-        // Strava sync (non-blocking — never prevents workout completion)
-        try {
-          const { syncSessionToStrava } = await import("../../lib/strava");
-          const synced = await syncSessionToStrava(id!);
-          if (synced) {
-            showToast("Synced to Strava ✓");
-          }
-        } catch {
-          showError("Strava sync failed");
-        }
-
-        // Health Connect sync (non-blocking, silent — no toast on success or failure)
-        if (Platform.OS === "android") {
-          try {
-            const { syncToHealthConnect } = await import("../../lib/health-connect");
-            await syncToHealthConnect(id!);
-          } catch {
-            // HC sync is silent
-          }
-        }
-
-        try {
-          const dayId = await getSessionProgramDayId(id!);
-          if (dayId) {
-            const day = await getProgramDayById(dayId);
-            if (day) {
-              const result = await advanceProgram(day.program_id, dayId, id!);
-              if (result.wrapped) {
-                showToast(`Cycle ${result.cycle} complete!`);
-                AccessibilityInfo.announceForAccessibility(
-                  `Cycle ${result.cycle} complete! Program wrapping to day 1.`
-                );
-                await new Promise((r) => setTimeout(r, 1500));
-              } else {
-                AccessibilityInfo.announceForAccessibility(
-                  "Workout complete. Program advanced to next day."
-                );
-              }
-            }
-          }
-        } catch {
-          // Program advance failed — session already saved
-        }
-
-        const allSets = await getSessionSets(id!);
-        const done = allSets.filter((s) => s.completed);
-        if (done.length === 0) {
-          router.replace("/(tabs)");
-        } else {
-          router.replace(`/session/summary/${id}`);
-        }
-      },
-      false
-    );
-  };
-
-  const cancel = () => {
-    confirmAction(
-      "Discard Workout?",
-      "All logged sets will be lost.",
-      async () => {
-        await cancelSession(id!);
-        router.back();
-      },
-      true
-    );
-  };
 
   if (!session) {
     return (
@@ -417,67 +173,21 @@ export default function ActiveSession() {
         contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: 48 }}
         keyboardShouldPersistTaps="handled"
         ListHeaderComponent={
-          <>
-            {rest > 0 && (
-              <Reanimated.View
-                style={[styles.restBanner, restFlashStyle]}
-                accessibilityLiveRegion="polite"
-              >
-                <Text variant="heading" style={{ color: colors.onPrimaryContainer, fontWeight: "700" }} accessibilityLabel={`Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds`}>
-                  {String(Math.floor(rest / 60)).padStart(2, "0")}:{String(rest % 60).padStart(2, "0")}
-                </Text>
-                <Text variant="caption" style={{ color: colors.onPrimaryContainer, marginTop: 4 }}>
-                  Rest Timer
-                </Text>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onPress={dismissRest}
-                  textStyle={{ color: colors.onPrimaryContainer }}
-                  style={{ marginTop: 4 }}
-                  accessibilityLabel="Skip rest timer"
-                  label="Skip"
-                />
-              </Reanimated.View>
-            )}
-            {nextHint && (
-              <View style={[styles.nextBanner, { backgroundColor: colors.secondaryContainer }]} accessibilityLiveRegion="polite">
-                <Text variant="subtitle" style={{ color: colors.onSecondaryContainer, fontWeight: "700" }}>
-                  {nextHint}
-                </Text>
-              </View>
-            )}
-          </>
+          <SessionListHeader
+            rest={rest}
+            restFlashStyle={restFlashStyle}
+            dismissRest={dismissRest}
+            nextHint={nextHint}
+            colors={colors}
+          />
         }
         ListFooterComponent={
-          <>
-            <Button
-              variant="outline"
-              onPress={handleAddExercise}
-              style={styles.addExercise}
-              accessibilityLabel="Add exercise to workout"
-            >
-              <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
-                <MaterialCommunityIcons name="plus" size={18} color={colors.primary} />
-                <Text style={{ color: colors.primary, fontWeight: "600" }}>Add Exercise</Text>
-              </View>
-            </Button>
-            <Button
-              variant="default"
-              onPress={finish}
-              style={styles.finishBtn}
-              accessibilityLabel="Finish workout"
-              label="Finish Workout"
-            />
-            <Button
-              variant="ghost"
-              onPress={cancel}
-              textStyle={{ color: colors.error }}
-              style={styles.cancelBtn}
-              accessibilityLabel="Cancel workout"
-              label="Cancel Workout"
-            />
-          </>
+          <SessionListFooter
+            onAddExercise={handleAddExercise}
+            onFinish={finish}
+            onCancel={cancel}
+            colors={colors}
+          />
         }
       />
       </KeyboardAvoidingView>
@@ -546,27 +256,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-  },
-  restBanner: {
-    alignItems: "center",
-    padding: 16,
-    borderRadius: 12,
-    marginBottom: 16,
-  },
-  nextBanner: {
-    alignItems: "center",
-    padding: 12,
-    borderRadius: 8,
-    marginBottom: 12,
-  },
-  addExercise: {
-    marginTop: 8,
-  },
-  finishBtn: {
-    marginTop: 24,
-  },
-  cancelBtn: {
-    marginTop: 8,
   },
   detailHeader: {
     flexDirection: "row",

--- a/components/ShareCard.tsx
+++ b/components/ShareCard.tsx
@@ -1,10 +1,12 @@
 import React from "react";
-import { Platform, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { spacing } from "../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useColorScheme } from "@/hooks/useColorScheme";
+import { ShareCardStats } from "./share/ShareCardStats";
+import { ShareCardExercises } from "./share/ShareCardExercises";
 
 export type ShareCardExercise = {
   name: string;
@@ -30,7 +32,6 @@ export type ShareCardProps = {
   exercises: ShareCardExercise[];
 };
 
-const MAX_EXERCISES = 6;
 const CARD_WIDTH = 1080;
 
 function StarRow({ rating }: { rating: number }) {
@@ -54,9 +55,6 @@ export default function ShareCard(props: ShareCardProps) {
   const isDark = useColorScheme() === "dark";
   const { name, date, duration, sets, volume, unit, rating, prs, exercises } =
     props;
-
-  const displayExercises = exercises.slice(0, MAX_EXERCISES);
-  const remaining = exercises.length - MAX_EXERCISES;
 
   return (
     <View
@@ -100,46 +98,12 @@ export default function ShareCard(props: ShareCardProps) {
         </Text>
       </View>
 
-      {/* Stats row */}
-      <View
-        style={[
-          cardStyles.statsContainer,
-          { backgroundColor: colors.surfaceVariant },
-        ]}
-      >
-        <View style={cardStyles.statItem}>
-          <Text style={[cardStyles.statValue, { color: colors.onSurface }]}>
-            {duration}
-          </Text>
-          <Text
-            style={[cardStyles.statLabel, { color: colors.onSurfaceVariant }]}
-          >
-            Duration
-          </Text>
-        </View>
-        <View style={[cardStyles.statDivider, { backgroundColor: colors.outline }]} />
-        <View style={cardStyles.statItem}>
-          <Text style={[cardStyles.statValue, { color: colors.onSurface }]}>
-            {sets}
-          </Text>
-          <Text
-            style={[cardStyles.statLabel, { color: colors.onSurfaceVariant }]}
-          >
-            Sets
-          </Text>
-        </View>
-        <View style={[cardStyles.statDivider, { backgroundColor: colors.outline }]} />
-        <View style={cardStyles.statItem}>
-          <Text style={[cardStyles.statValue, { color: colors.onSurface }]}>
-            {volume}
-          </Text>
-          <Text
-            style={[cardStyles.statLabel, { color: colors.onSurfaceVariant }]}
-          >
-            Volume ({unit})
-          </Text>
-        </View>
-      </View>
+      <ShareCardStats
+        duration={duration}
+        sets={sets}
+        volume={volume}
+        unit={unit}
+      />
 
       {/* Rating */}
       {rating != null && rating >= 1 && (
@@ -148,85 +112,7 @@ export default function ShareCard(props: ShareCardProps) {
         </View>
       )}
 
-      {/* PRs */}
-      {prs.length > 0 && (
-        <View
-          style={[
-            cardStyles.prSection,
-            { backgroundColor: colors.primaryContainer },
-          ]}
-        >
-          <View style={cardStyles.prHeader}>
-            <Text style={[cardStyles.prTitle, { color: colors.onPrimaryContainer }]}>
-              🏆 New PRs
-            </Text>
-          </View>
-          {prs.map((pr, i) => (
-            <View key={i} style={cardStyles.prRow}>
-              <Text
-                style={[cardStyles.prName, { color: colors.onPrimaryContainer }]}
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {pr.name}
-              </Text>
-              <Text
-                style={[cardStyles.prValue, { color: colors.onPrimaryContainer }]}
-              >
-                {pr.value}
-              </Text>
-            </View>
-          ))}
-        </View>
-      )}
-
-      {/* Exercises */}
-      {displayExercises.length > 0 && (
-        <View style={cardStyles.exerciseSection}>
-          <Text
-            style={[
-              cardStyles.exerciseSectionTitle,
-              { color: colors.onSurfaceVariant },
-            ]}
-          >
-            Exercises
-          </Text>
-          {displayExercises.map((ex, i) => (
-            <View key={i} style={cardStyles.exerciseRow}>
-              <Text
-                style={[
-                  cardStyles.exerciseName,
-                  { color: colors.onSurface },
-                ]}
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {ex.name}
-              </Text>
-              <Text
-                style={[
-                  cardStyles.exerciseDetail,
-                  { color: colors.onSurfaceVariant },
-                ]}
-              >
-                {ex.weight
-                  ? `${ex.sets}×${ex.reps} @ ${ex.weight}`
-                  : `${ex.sets}×${ex.reps}`}
-              </Text>
-            </View>
-          ))}
-          {remaining > 0 && (
-            <Text
-              style={[
-                cardStyles.moreText,
-                { color: colors.onSurfaceVariant },
-              ]}
-            >
-              and {remaining} more
-            </Text>
-          )}
-        </View>
-      )}
+      <ShareCardExercises exercises={exercises} prs={prs} />
 
       {/* Footer */}
       <View
@@ -275,36 +161,6 @@ const cardStyles = StyleSheet.create({
     fontSize: 18,
     lineHeight: 24,
   },
-  statsContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    borderRadius: 16,
-    paddingVertical: spacing.lg,
-    paddingHorizontal: spacing.xl,
-    marginBottom: spacing.lg,
-  },
-  statItem: {
-    flex: 1,
-    alignItems: "center",
-  },
-  statValue: {
-    fontSize: 24,
-    fontWeight: "700",
-    ...Platform.select({
-      ios: { fontVariant: ["tabular-nums"] },
-      android: { fontVariant: ["tabular-nums"] },
-      default: {},
-    }),
-  },
-  statLabel: {
-    fontSize: 13,
-    marginTop: 2,
-  },
-  statDivider: {
-    width: 1,
-    height: 32,
-    marginHorizontal: spacing.sm,
-  },
   ratingSection: {
     alignItems: "center",
     marginBottom: spacing.lg,
@@ -312,65 +168,6 @@ const cardStyles = StyleSheet.create({
   starRow: {
     flexDirection: "row",
     gap: spacing.xs,
-  },
-  prSection: {
-    borderRadius: 16,
-    padding: spacing.lg,
-    marginBottom: spacing.lg,
-  },
-  prHeader: {
-    marginBottom: spacing.sm,
-  },
-  prTitle: {
-    fontSize: 18,
-    fontWeight: "700",
-  },
-  prRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: spacing.xs,
-  },
-  prName: {
-    fontSize: 16,
-    fontWeight: "500",
-    flex: 1,
-    marginRight: spacing.sm,
-  },
-  prValue: {
-    fontSize: 16,
-    fontWeight: "700",
-  },
-  exerciseSection: {
-    marginBottom: spacing.lg,
-  },
-  exerciseSectionTitle: {
-    fontSize: 14,
-    fontWeight: "600",
-    textTransform: "uppercase",
-    letterSpacing: 1,
-    marginBottom: spacing.sm,
-  },
-  exerciseRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: spacing.xs + 2,
-  },
-  exerciseName: {
-    fontSize: 16,
-    fontWeight: "500",
-    flex: 1,
-    marginRight: spacing.sm,
-  },
-  exerciseDetail: {
-    fontSize: 14,
-    fontWeight: "500",
-  },
-  moreText: {
-    fontSize: 14,
-    fontStyle: "italic",
-    marginTop: spacing.xs,
   },
   footer: {
     borderTopWidth: 1,

--- a/components/SubstitutionSheet.tsx
+++ b/components/SubstitutionSheet.tsx
@@ -1,19 +1,19 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Alert, Platform, Pressable, StyleSheet, View } from "react-native";
+import { Alert, Platform, StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
-import { Chip } from "@/components/ui/chip";
 import BottomSheet, {
   BottomSheetBackdrop,
   BottomSheetFlatList,
 } from "@gorhom/bottom-sheet";
 import type { Exercise, Equipment } from "../lib/types";
-import { EQUIPMENT_LABELS, DIFFICULTY_LABELS, MUSCLE_LABELS } from "../lib/types";
+import { MUSCLE_LABELS } from "../lib/types";
 import {
   findSubstitutions,
   type SubstitutionScore,
 } from "../lib/exercise-substitutions";
-import { radii } from "../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { SubstitutionItem } from "./substitution/SubstitutionItem";
+import { EquipmentFilter } from "./substitution/EquipmentFilter";
 
 type Props = {
   sheetRef: React.RefObject<BottomSheet | null>;
@@ -22,106 +22,6 @@ type Props = {
   onSelect: (exercise: Exercise) => void;
   onDismiss: () => void;
 };
-
-function matchColor(score: number): string {
-  if (score >= 80) return "#2e7d32";
-  if (score >= 60) return "#f57f17";
-  return "#c62828";
-}
-
-function matchBgColor(score: number): string {
-  if (score >= 80) return "#e8f5e9";
-  if (score >= 60) return "#fff8e1";
-  return "#ffebee";
-}
-
-function SubstitutionItem({
-  item,
-  onPress,
-}: {
-  item: SubstitutionScore;
-  onPress: (exercise: Exercise) => void;
-}) {
-  const colors = useThemeColors();
-  const ex = item.exercise;
-
-  return (
-    <Pressable
-      style={[styles.item, { backgroundColor: colors.surface }]}
-      onPress={() => onPress(ex)}
-      accessibilityRole="button"
-      accessibilityLabel={`${ex.name}, ${item.score}% match, ${EQUIPMENT_LABELS[ex.equipment]}, ${DIFFICULTY_LABELS[ex.difficulty]}`}
-    >
-      <View style={styles.itemHeader}>
-        <Text
-          variant="body"
-          numberOfLines={1}
-          style={[styles.itemName, { color: colors.onSurface, fontWeight: "600" }]}
-        >
-          {ex.name}
-        </Text>
-        <View
-          style={[
-            styles.matchBadge,
-            { backgroundColor: matchBgColor(item.score) },
-          ]}
-        >
-          <Text variant="caption" style={[styles.matchText, { color: matchColor(item.score) }]}>
-            {item.score}%
-          </Text>
-        </View>
-      </View>
-      <View style={styles.itemMeta}>
-        <View
-          style={[
-            styles.equipBadge,
-            { backgroundColor: colors.surfaceVariant },
-          ]}
-        >
-          <Text variant="caption"
-            style={[styles.equipText, { color: colors.onSurfaceVariant }]}
-          >
-            {EQUIPMENT_LABELS[ex.equipment]}
-          </Text>
-        </View>
-        <View
-          style={[
-            styles.equipBadge,
-            { backgroundColor: colors.surfaceVariant },
-          ]}
-        >
-          <Text variant="caption"
-            style={[styles.equipText, { color: colors.onSurfaceVariant }]}
-          >
-            {DIFFICULTY_LABELS[ex.difficulty]}
-          </Text>
-        </View>
-      </View>
-      {ex.primary_muscles.length > 0 && (
-        <View style={styles.muscleRow}>
-          {ex.primary_muscles.map((m) => (
-            <View
-              key={m}
-              style={[
-                styles.muscleChip,
-                { backgroundColor: colors.secondaryContainer },
-              ]}
-            >
-              <Text variant="caption"
-                style={[
-                  styles.muscleText,
-                  { color: colors.onSecondaryContainer },
-                ]}
-              >
-                {MUSCLE_LABELS[m]}
-              </Text>
-            </View>
-          ))}
-        </View>
-      )}
-    </Pressable>
-  );
-}
 
 export default function SubstitutionSheet({
   sheetRef,
@@ -265,33 +165,11 @@ export default function SubstitutionSheet({
             </View>
           ) : (
             <>
-              {availableEquipment.length > 1 && (
-                <View style={styles.filterRow} accessibilityRole="toolbar" accessibilityLabel="Equipment filter">
-                  <Chip
-                    selected={equipmentFilter === null}
-                    onPress={() => setEquipmentFilter(null)}
-                    compact
-                    style={styles.filterChip}
-                    accessibilityLabel="Show all equipment"
-                  >
-                    All
-                  </Chip>
-                  {availableEquipment.map((eq) => (
-                    <Chip
-                      key={eq}
-                      selected={equipmentFilter === eq}
-                      onPress={() =>
-                        setEquipmentFilter(equipmentFilter === eq ? null : eq)
-                      }
-                      compact
-                      style={styles.filterChip}
-                      accessibilityLabel={`Filter by ${EQUIPMENT_LABELS[eq]}`}
-                    >
-                      {EQUIPMENT_LABELS[eq]}
-                    </Chip>
-                  ))}
-                </View>
-              )}
+              <EquipmentFilter
+                availableEquipment={availableEquipment}
+                equipmentFilter={equipmentFilter}
+                onFilterChange={setEquipmentFilter}
+              />
 
               {scored.length === 0 ? (
                 <View style={styles.emptyState}>
@@ -351,53 +229,8 @@ const styles = StyleSheet.create({
   muscleText: {
     lineHeight: 16,
   },
-  filterRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 6,
-    marginBottom: 12,
-  },
-  filterChip: {
-    marginBottom: 2,
-  },
   listContent: {
     paddingBottom: 32,
-  },
-  item: {
-    padding: 12,
-    borderRadius: radii.md,
-    marginBottom: 8,
-  },
-  itemHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    marginBottom: 4,
-  },
-  itemName: {
-    flex: 1,
-    fontWeight: "600",
-    marginRight: 8,
-  },
-  matchBadge: {
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 12,
-  },
-  matchText: {
-    fontWeight: "700",
-  },
-  itemMeta: {
-    flexDirection: "row",
-    gap: 6,
-    marginBottom: 4,
-  },
-  equipBadge: {
-    paddingHorizontal: 6,
-    paddingVertical: 2,
-    borderRadius: 8,
-  },
-  equipText: {
   },
   emptyState: {
     paddingVertical: 48,

--- a/components/achievements/AchievementBadge.tsx
+++ b/components/achievements/AchievementBadge.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Card, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Text } from "@/components/ui/text";
+import { radii, typography } from "../../constants/design-tokens";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { AchievementItem } from "../../hooks/useAchievements";
+
+function formatDate(ts: number) {
+  return new Date(ts).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function AchievementBadge({ item }: { item: AchievementItem }) {
+  const colors = useThemeColors();
+  const badgeColor = item.earned
+    ? colors.primaryContainer
+    : colors.surfaceVariant;
+  const textColor = item.earned
+    ? colors.onPrimaryContainer
+    : colors.onSurfaceVariant;
+
+  return (
+    <Card
+      style={[styles.badge, { backgroundColor: badgeColor }]}
+      accessibilityLabel={
+        item.earned
+          ? `${item.name} achievement — Earned on ${formatDate(item.earnedAt!)}`
+          : `${item.name} achievement — Locked, ${Math.round(item.progress * 100)}% complete`
+      }
+      accessibilityRole="summary"
+    >
+      <CardContent style={styles.badgeContent}>
+        <View style={styles.iconContainer}>
+          <Text style={[styles.icon, !item.earned && styles.iconLocked]}>
+            {item.icon}
+          </Text>
+          {item.earned ? (
+            <Text style={styles.checkOverlay}>✅</Text>
+          ) : (
+            <Text style={styles.lockOverlay}>🔒</Text>
+          )}
+        </View>
+        <Text
+          variant="caption"
+          numberOfLines={1}
+          style={[styles.badgeName, { color: textColor }]}
+        >
+          {item.name}
+        </Text>
+        <Text
+          variant="caption"
+          numberOfLines={2}
+          style={[styles.badgeDesc, { color: textColor }]}
+        >
+          {item.description}
+        </Text>
+        {item.earned ? (
+          <Text variant="caption" style={{ color: textColor, marginTop: 4 }}>
+            {formatDate(item.earnedAt!)}
+          </Text>
+        ) : (
+          <View
+            style={styles.progressContainer}
+            accessibilityValue={{
+              min: 0,
+              max: 100,
+              now: Math.round(item.progress * 100),
+              text: `${Math.round(item.progress * 100)}% complete`,
+            }}
+          >
+            <Progress
+              value={item.progress * 100}
+              style={styles.progressBar}
+            />
+            <Text variant="caption" style={{ color: textColor, marginTop: 2 }}>
+              {Math.round(item.progress * 100)}%
+            </Text>
+          </View>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    minHeight: 48,
+  },
+  badgeContent: {
+    alignItems: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+  },
+  iconContainer: {
+    position: "relative",
+    marginBottom: 4,
+  },
+  icon: {
+    fontSize: typography.statValue.fontSize,
+  },
+  iconLocked: {
+    opacity: 0.4,
+  },
+  checkOverlay: {
+    position: "absolute",
+    bottom: -4,
+    right: -8,
+    fontSize: 14,
+  },
+  lockOverlay: {
+    position: "absolute",
+    bottom: -4,
+    right: -8,
+    fontSize: 14,
+  },
+  badgeName: {
+    fontWeight: "700",
+    textAlign: "center",
+    marginTop: 4,
+  },
+  badgeDesc: {
+    textAlign: "center",
+    marginTop: 2,
+  },
+  progressContainer: {
+    width: "100%",
+    marginTop: 6,
+    alignItems: "center",
+  },
+  progressBar: {
+    width: "100%",
+    height: 4,
+    borderRadius: radii.sm,
+  },
+});

--- a/components/session/SessionListFooter.tsx
+++ b/components/session/SessionListFooter.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import type { ThemeColors } from "@/hooks/useThemeColors";
+
+type Props = {
+  onAddExercise: () => void;
+  onFinish: () => void;
+  onCancel: () => void;
+  colors: ThemeColors;
+};
+
+export function SessionListFooter({ onAddExercise, onFinish, onCancel, colors }: Props) {
+  return (
+    <>
+      <Button
+        variant="outline"
+        onPress={onAddExercise}
+        style={styles.addExercise}
+        accessibilityLabel="Add exercise to workout"
+      >
+        <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+          <MaterialCommunityIcons name="plus" size={18} color={colors.primary} />
+          <Text style={{ color: colors.primary, fontWeight: "600" }}>Add Exercise</Text>
+        </View>
+      </Button>
+      <Button
+        variant="default"
+        onPress={onFinish}
+        style={styles.finishBtn}
+        accessibilityLabel="Finish workout"
+        label="Finish Workout"
+      />
+      <Button
+        variant="ghost"
+        onPress={onCancel}
+        textStyle={{ color: colors.error }}
+        style={styles.cancelBtn}
+        accessibilityLabel="Cancel workout"
+        label="Cancel Workout"
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  addExercise: {
+    marginTop: 8,
+  },
+  finishBtn: {
+    marginTop: 24,
+  },
+  cancelBtn: {
+    marginTop: 8,
+  },
+});

--- a/components/session/SessionListHeader.tsx
+++ b/components/session/SessionListHeader.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import Reanimated from "react-native-reanimated";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import type { ThemeColors } from "@/hooks/useThemeColors";
+
+type Props = {
+  rest: number;
+  restFlashStyle: any;
+  dismissRest: () => void;
+  nextHint: string | null;
+  colors: ThemeColors;
+};
+
+export function SessionListHeader({ rest, restFlashStyle, dismissRest, nextHint, colors }: Props) {
+  return (
+    <>
+      {rest > 0 && (
+        <Reanimated.View
+          style={[styles.restBanner, restFlashStyle]}
+          accessibilityLiveRegion="polite"
+        >
+          <Text variant="heading" style={{ color: colors.onPrimaryContainer, fontWeight: "700" }} accessibilityLabel={`Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds`}>
+            {String(Math.floor(rest / 60)).padStart(2, "0")}:{String(rest % 60).padStart(2, "0")}
+          </Text>
+          <Text variant="caption" style={{ color: colors.onPrimaryContainer, marginTop: 4 }}>
+            Rest Timer
+          </Text>
+          <Button
+            variant="ghost"
+            size="sm"
+            onPress={dismissRest}
+            textStyle={{ color: colors.onPrimaryContainer }}
+            style={{ marginTop: 4 }}
+            accessibilityLabel="Skip rest timer"
+            label="Skip"
+          />
+        </Reanimated.View>
+      )}
+      {nextHint && (
+        <View style={[styles.nextBanner, { backgroundColor: colors.secondaryContainer }]} accessibilityLiveRegion="polite">
+          <Text variant="subtitle" style={{ color: colors.onSecondaryContainer, fontWeight: "700" }}>
+            {nextHint}
+          </Text>
+        </View>
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  restBanner: {
+    alignItems: "center",
+    padding: 16,
+    borderRadius: 12,
+    marginBottom: 16,
+  },
+  nextBanner: {
+    alignItems: "center",
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+});

--- a/components/share/ShareCardExercises.tsx
+++ b/components/share/ShareCardExercises.tsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { spacing } from "../../constants/design-tokens";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { ShareCardExercise, ShareCardPR } from "../ShareCard";
+
+type Props = {
+  exercises: ShareCardExercise[];
+  prs: ShareCardPR[];
+  maxExercises?: number;
+};
+
+export function ShareCardExercises({
+  exercises,
+  prs,
+  maxExercises = 6,
+}: Props) {
+  const colors = useThemeColors();
+  const displayExercises = exercises.slice(0, maxExercises);
+  const remaining = exercises.length - maxExercises;
+
+  return (
+    <>
+      {/* PRs */}
+      {prs.length > 0 && (
+        <View
+          style={[
+            styles.prSection,
+            { backgroundColor: colors.primaryContainer },
+          ]}
+        >
+          <View style={styles.prHeader}>
+            <Text
+              style={[styles.prTitle, { color: colors.onPrimaryContainer }]}
+            >
+              🏆 New PRs
+            </Text>
+          </View>
+          {prs.map((pr, i) => (
+            <View key={i} style={styles.prRow}>
+              <Text
+                style={[styles.prName, { color: colors.onPrimaryContainer }]}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {pr.name}
+              </Text>
+              <Text
+                style={[styles.prValue, { color: colors.onPrimaryContainer }]}
+              >
+                {pr.value}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {/* Exercises */}
+      {displayExercises.length > 0 && (
+        <View style={styles.exerciseSection}>
+          <Text
+            style={[
+              styles.exerciseSectionTitle,
+              { color: colors.onSurfaceVariant },
+            ]}
+          >
+            Exercises
+          </Text>
+          {displayExercises.map((ex, i) => (
+            <View key={i} style={styles.exerciseRow}>
+              <Text
+                style={[
+                  styles.exerciseName,
+                  { color: colors.onSurface },
+                ]}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {ex.name}
+              </Text>
+              <Text
+                style={[
+                  styles.exerciseDetail,
+                  { color: colors.onSurfaceVariant },
+                ]}
+              >
+                {ex.weight
+                  ? `${ex.sets}×${ex.reps} @ ${ex.weight}`
+                  : `${ex.sets}×${ex.reps}`}
+              </Text>
+            </View>
+          ))}
+          {remaining > 0 && (
+            <Text
+              style={[
+                styles.moreText,
+                { color: colors.onSurfaceVariant },
+              ]}
+            >
+              and {remaining} more
+            </Text>
+          )}
+        </View>
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  prSection: {
+    borderRadius: 16,
+    padding: spacing.lg,
+    marginBottom: spacing.lg,
+  },
+  prHeader: {
+    marginBottom: spacing.sm,
+  },
+  prTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+  },
+  prRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: spacing.xs,
+  },
+  prName: {
+    fontSize: 16,
+    fontWeight: "500",
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  prValue: {
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  exerciseSection: {
+    marginBottom: spacing.lg,
+  },
+  exerciseSectionTitle: {
+    fontSize: 14,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: spacing.sm,
+  },
+  exerciseRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: spacing.xs + 2,
+  },
+  exerciseName: {
+    fontSize: 16,
+    fontWeight: "500",
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  exerciseDetail: {
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  moreText: {
+    fontSize: 14,
+    fontStyle: "italic",
+    marginTop: spacing.xs,
+  },
+});

--- a/components/share/ShareCardStats.tsx
+++ b/components/share/ShareCardStats.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { Platform, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { spacing } from "../../constants/design-tokens";
+import { useThemeColors } from "@/hooks/useThemeColors";
+
+type Props = {
+  duration: string;
+  sets: number;
+  volume: string;
+  unit: string;
+};
+
+export function ShareCardStats({ duration, sets, volume, unit }: Props) {
+  const colors = useThemeColors();
+
+  return (
+    <View
+      style={[
+        styles.statsContainer,
+        { backgroundColor: colors.surfaceVariant },
+      ]}
+    >
+      <View style={styles.statItem}>
+        <Text style={[styles.statValue, { color: colors.onSurface }]}>
+          {duration}
+        </Text>
+        <Text
+          style={[styles.statLabel, { color: colors.onSurfaceVariant }]}
+        >
+          Duration
+        </Text>
+      </View>
+      <View style={[styles.statDivider, { backgroundColor: colors.outline }]} />
+      <View style={styles.statItem}>
+        <Text style={[styles.statValue, { color: colors.onSurface }]}>
+          {sets}
+        </Text>
+        <Text
+          style={[styles.statLabel, { color: colors.onSurfaceVariant }]}
+        >
+          Sets
+        </Text>
+      </View>
+      <View style={[styles.statDivider, { backgroundColor: colors.outline }]} />
+      <View style={styles.statItem}>
+        <Text style={[styles.statValue, { color: colors.onSurface }]}>
+          {volume}
+        </Text>
+        <Text
+          style={[styles.statLabel, { color: colors.onSurfaceVariant }]}
+        >
+          Volume ({unit})
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  statsContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderRadius: 16,
+    paddingVertical: spacing.lg,
+    paddingHorizontal: spacing.xl,
+    marginBottom: spacing.lg,
+  },
+  statItem: {
+    flex: 1,
+    alignItems: "center",
+  },
+  statValue: {
+    fontSize: 24,
+    fontWeight: "700",
+    ...Platform.select({
+      ios: { fontVariant: ["tabular-nums"] },
+      android: { fontVariant: ["tabular-nums"] },
+      default: {},
+    }),
+  },
+  statLabel: {
+    fontSize: 13,
+    marginTop: 2,
+  },
+  statDivider: {
+    width: 1,
+    height: 32,
+    marginHorizontal: spacing.sm,
+  },
+});

--- a/components/substitution/EquipmentFilter.tsx
+++ b/components/substitution/EquipmentFilter.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Chip } from "@/components/ui/chip";
+import type { Equipment } from "../../lib/types";
+import { EQUIPMENT_LABELS } from "../../lib/types";
+
+type Props = {
+  availableEquipment: Equipment[];
+  equipmentFilter: Equipment | null;
+  onFilterChange: (filter: Equipment | null) => void;
+};
+
+export function EquipmentFilter({ availableEquipment, equipmentFilter, onFilterChange }: Props) {
+  if (availableEquipment.length <= 1) return null;
+
+  return (
+    <View style={styles.filterRow} accessibilityRole="toolbar" accessibilityLabel="Equipment filter">
+      <Chip
+        selected={equipmentFilter === null}
+        onPress={() => onFilterChange(null)}
+        compact
+        style={styles.filterChip}
+        accessibilityLabel="Show all equipment"
+      >
+        All
+      </Chip>
+      {availableEquipment.map((eq) => (
+        <Chip
+          key={eq}
+          selected={equipmentFilter === eq}
+          onPress={() =>
+            onFilterChange(equipmentFilter === eq ? null : eq)
+          }
+          compact
+          style={styles.filterChip}
+          accessibilityLabel={`Filter by ${EQUIPMENT_LABELS[eq]}`}
+        >
+          {EQUIPMENT_LABELS[eq]}
+        </Chip>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  filterRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+    marginBottom: 12,
+  },
+  filterChip: {
+    marginBottom: 2,
+  },
+});

--- a/components/substitution/SubstitutionItem.tsx
+++ b/components/substitution/SubstitutionItem.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import type { Exercise } from "../../lib/types";
+import { EQUIPMENT_LABELS, DIFFICULTY_LABELS, MUSCLE_LABELS } from "../../lib/types";
+import type { SubstitutionScore } from "../../lib/exercise-substitutions";
+import { radii } from "../../constants/design-tokens";
+import { useThemeColors } from "@/hooks/useThemeColors";
+
+export function matchColor(score: number): string {
+  if (score >= 80) return "#2e7d32";
+  if (score >= 60) return "#f57f17";
+  return "#c62828";
+}
+
+export function matchBgColor(score: number): string {
+  if (score >= 80) return "#e8f5e9";
+  if (score >= 60) return "#fff8e1";
+  return "#ffebee";
+}
+
+export function SubstitutionItem({
+  item,
+  onPress,
+}: {
+  item: SubstitutionScore;
+  onPress: (exercise: Exercise) => void;
+}) {
+  const colors = useThemeColors();
+  const ex = item.exercise;
+
+  return (
+    <Pressable
+      style={[styles.item, { backgroundColor: colors.surface }]}
+      onPress={() => onPress(ex)}
+      accessibilityRole="button"
+      accessibilityLabel={`${ex.name}, ${item.score}% match, ${EQUIPMENT_LABELS[ex.equipment]}, ${DIFFICULTY_LABELS[ex.difficulty]}`}
+    >
+      <View style={styles.itemHeader}>
+        <Text
+          variant="body"
+          numberOfLines={1}
+          style={[styles.itemName, { color: colors.onSurface, fontWeight: "600" }]}
+        >
+          {ex.name}
+        </Text>
+        <View
+          style={[
+            styles.matchBadge,
+            { backgroundColor: matchBgColor(item.score) },
+          ]}
+        >
+          <Text variant="caption" style={[styles.matchText, { color: matchColor(item.score) }]}>
+            {item.score}%
+          </Text>
+        </View>
+      </View>
+      <View style={styles.itemMeta}>
+        <View
+          style={[
+            styles.equipBadge,
+            { backgroundColor: colors.surfaceVariant },
+          ]}
+        >
+          <Text variant="caption"
+            style={[styles.equipText, { color: colors.onSurfaceVariant }]}
+          >
+            {EQUIPMENT_LABELS[ex.equipment]}
+          </Text>
+        </View>
+        <View
+          style={[
+            styles.equipBadge,
+            { backgroundColor: colors.surfaceVariant },
+          ]}
+        >
+          <Text variant="caption"
+            style={[styles.equipText, { color: colors.onSurfaceVariant }]}
+          >
+            {DIFFICULTY_LABELS[ex.difficulty]}
+          </Text>
+        </View>
+      </View>
+      {ex.primary_muscles.length > 0 && (
+        <View style={styles.muscleRow}>
+          {ex.primary_muscles.map((m) => (
+            <View
+              key={m}
+              style={[
+                styles.muscleChip,
+                { backgroundColor: colors.secondaryContainer },
+              ]}
+            >
+              <Text variant="caption"
+                style={[
+                  styles.muscleText,
+                  { color: colors.onSecondaryContainer },
+                ]}
+              >
+                {MUSCLE_LABELS[m]}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  item: {
+    padding: 12,
+    borderRadius: radii.md,
+    marginBottom: 8,
+  },
+  itemHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 4,
+  },
+  itemName: {
+    flex: 1,
+    fontWeight: "600",
+    marginRight: 8,
+  },
+  matchBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+  },
+  matchText: {
+    fontWeight: "700",
+  },
+  itemMeta: {
+    flexDirection: "row",
+    gap: 6,
+    marginBottom: 4,
+  },
+  equipBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  equipText: {
+  },
+  muscleRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 4,
+    marginBottom: 8,
+  },
+  muscleChip: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 12,
+  },
+  muscleText: {
+    lineHeight: 16,
+  },
+});

--- a/hooks/useAchievements.ts
+++ b/hooks/useAchievements.ts
@@ -1,0 +1,99 @@
+import { useCallback, useState } from "react";
+import { useFocusEffect } from "expo-router";
+import {
+  buildAchievementContext,
+  getEarnedAchievementMap,
+  saveEarnedAchievements,
+  hasSeenRetroactiveBanner,
+  markRetroactiveBannerSeen,
+} from "../lib/db";
+import {
+  getAllAchievementProgress,
+  evaluateAchievements,
+} from "../lib/achievements";
+import type { AchievementCategory } from "../lib/achievements";
+
+export type AchievementItem = {
+  id: string;
+  name: string;
+  description: string;
+  category: AchievementCategory;
+  icon: string;
+  earned: boolean;
+  earnedAt: number | null;
+  progress: number;
+};
+
+export function useAchievements() {
+  const [items, setItems] = useState<AchievementItem[]>([]);
+  const [earnedCount, setEarnedCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retroBanner, setRetroBanner] = useState<number | null>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false;
+
+      (async () => {
+        try {
+          const [ctx, earnedMap] = await Promise.all([
+            buildAchievementContext(),
+            getEarnedAchievementMap(),
+          ]);
+
+          // Retroactive evaluation: earn any new achievements silently
+          const alreadyEarnedIds = new Set(earnedMap.keys());
+          const newlyEarned = evaluateAchievements(ctx, alreadyEarnedIds);
+
+          if (newlyEarned.length > 0) {
+            const now = Date.now();
+            await saveEarnedAchievements(
+              newlyEarned.map((n) => n.achievement.id),
+              now,
+            );
+            for (const n of newlyEarned) {
+              earnedMap.set(n.achievement.id, now);
+            }
+          }
+
+          // Show retroactive banner on first open
+          const seenBanner = await hasSeenRetroactiveBanner();
+          if (cancelled) return;
+          if (!seenBanner && earnedMap.size > 0) {
+            setRetroBanner(earnedMap.size);
+            await markRetroactiveBannerSeen();
+          }
+
+          const progress = getAllAchievementProgress(ctx, earnedMap);
+          if (cancelled) return;
+
+          setItems(
+            progress.map((p) => ({
+              id: p.achievement.id,
+              name: p.achievement.name,
+              description: p.achievement.description,
+              category: p.achievement.category,
+              icon: p.achievement.icon,
+              earned: p.earned,
+              earnedAt: p.earnedAt,
+              progress: p.progress,
+            })),
+          );
+          setEarnedCount(earnedMap.size);
+        } catch (e) {
+          if (__DEV__) console.warn("Achievement evaluation failed:", e);
+          if (!cancelled) setError("Could not load achievements. Please try again later.");
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    }, []),
+  );
+
+  return { items, earnedCount, loading, error, retroBanner };
+}

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -1,0 +1,323 @@
+/* eslint-disable max-lines-per-function, react-hooks/exhaustive-deps */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AccessibilityInfo, Platform } from "react-native";
+import { useRouter } from "expo-router";
+import * as Haptics from "expo-haptics";
+import {
+  addSet,
+  cancelSession,
+  deleteSet,
+  completeSession,
+  completeSet,
+  getRestSecondsForLink,
+  uncompleteSet,
+  updateSet,
+  updateSetRPE,
+  updateSetNotes,
+  updateSetTrainingMode,
+  getSessionSets,
+} from "../lib/db";
+import {
+  getSessionProgramDayId,
+  getProgramDayById,
+  advanceProgram,
+} from "../lib/programs";
+import type { TrainingMode } from "../lib/types";
+import { formatTime } from "../lib/format";
+import { confirmAction } from "../lib/confirm";
+import type { SetWithMeta, ExerciseGroup } from "../components/session/types";
+
+type Params = {
+  id: string | undefined;
+  groups: ExerciseGroup[];
+  setGroups: React.Dispatch<React.SetStateAction<ExerciseGroup[]>>;
+  modes: Record<string, TrainingMode>;
+  setModes: React.Dispatch<React.SetStateAction<Record<string, TrainingMode>>>;
+  updateGroupSet: (setId: string, updates: Partial<SetWithMeta>) => void;
+  startRest: (exerciseId: string) => void;
+  startRestWithDuration: (secs: number) => void;
+  session: { started_at: number; name: string } | null;
+  showToast: (msg: string) => void;
+  showError: (msg: string) => void;
+};
+
+export function useSessionActions({
+  id,
+  groups,
+  setGroups,
+  modes,
+  setModes,
+  updateGroupSet,
+  startRest,
+  startRestWithDuration,
+  session,
+  showToast,
+  showError,
+}: Params) {
+  const router = useRouter();
+
+  // --- local state ---
+  const [elapsed, setElapsed] = useState(0);
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [exerciseNotesOpen, setExerciseNotesOpen] = useState<Record<string, boolean>>({});
+  const [exerciseNotesDraft, setExerciseNotesDraft] = useState<Record<string, string>>({});
+  const [halfStep, setHalfStep] = useState<{ setId: string; base: number } | null>(null);
+  const [nextHint, setNextHint] = useState<string | null>(null);
+  const hintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Timer
+  useEffect(() => {
+    if (!session) return;
+    const update = () => {
+      setElapsed(Math.floor((Date.now() - session.started_at) / 1000));
+    };
+    update();
+    timer.current = setInterval(update, 1000);
+    return () => {
+      if (timer.current) clearInterval(timer.current);
+    };
+  }, [session]);
+
+  // Cleanup hint timer
+  useEffect(() => {
+    return () => {
+      if (hintTimer.current) clearTimeout(hintTimer.current);
+    };
+  }, []);
+
+  // --- handlers ---
+
+  const handleUpdate = useCallback(async (
+    setId: string,
+    field: "weight" | "reps",
+    val: string
+  ) => {
+    let resolvedSet: SetWithMeta | undefined;
+    setGroups((prev) => {
+      for (const g of prev) {
+        const s = g.sets.find((s) => s.id === setId);
+        if (s) { resolvedSet = s; break; }
+      }
+      return prev;
+    });
+    if (!resolvedSet) return;
+
+    const num = val === "" ? null : parseFloat(val);
+    if (field === "weight") {
+      updateGroupSet(setId, { weight: num });
+      await updateSet(setId, num, resolvedSet.reps);
+    } else {
+      const rounded = num !== null ? Math.round(num) : null;
+      updateGroupSet(setId, { reps: rounded });
+      await updateSet(setId, resolvedSet.weight, rounded);
+    }
+  }, [updateGroupSet]);
+
+  const handleCheck = useCallback(async (set: SetWithMeta) => {
+    if (set.completed) {
+      updateGroupSet(set.id, { completed: false, completed_at: null });
+      await uncompleteSet(set.id);
+    } else {
+      const now = Date.now();
+      updateGroupSet(set.id, { completed: true, completed_at: now });
+      await completeSet(set.id);
+
+      if (set.link_id) {
+        const linked = groups.filter((g) => g.link_id === set.link_id);
+        const idx = linked.findIndex((g) => g.exercise_id === set.exercise_id);
+        const next = idx >= 0 && idx < linked.length - 1 ? linked[idx + 1] : null;
+
+        if (next) {
+          setNextHint(`Next: ${next.name}`);
+          AccessibilityInfo.announceForAccessibility(`Next: ${next.name}`);
+          if (hintTimer.current) clearTimeout(hintTimer.current);
+          hintTimer.current = setTimeout(() => setNextHint(null), 1500);
+        } else {
+          setNextHint(null);
+          const secs = await getRestSecondsForLink(id!, set.link_id);
+          startRestWithDuration(secs);
+        }
+      } else {
+        startRest(set.exercise_id);
+      }
+    }
+  }, [updateGroupSet, groups, id, startRest, startRestWithDuration]);
+
+  const handleAddSet = useCallback(async (exerciseId: string) => {
+    const group = groups.find((g) => g.exercise_id === exerciseId);
+    const num = (group?.sets.length ?? 0) + 1;
+    const fallback = group?.is_voltra && group.training_modes.length > 1 ? group.training_modes[0] : null;
+    const mode = modes[exerciseId] ?? fallback;
+    const newSet = await addSet(id!, exerciseId, num, null, null, mode, null);
+    setGroups((prev) =>
+      prev.map((g) =>
+        g.exercise_id === exerciseId
+          ? { ...g, sets: [...g.sets, { ...newSet, previous: "-" }] }
+          : g
+      )
+    );
+  }, [id, groups, modes]);
+
+  const handleModeChange = useCallback(async (exerciseId: string, mode: TrainingMode) => {
+    setModes((prev) => ({ ...prev, [exerciseId]: mode }));
+    const group = groups.find((g) => g.exercise_id === exerciseId);
+    if (!group) return;
+    setGroups((prev) =>
+      prev.map((g) =>
+        g.exercise_id === exerciseId
+          ? { ...g, sets: g.sets.map((s) => (s.completed ? s : { ...s, training_mode: mode })) }
+          : g
+      )
+    );
+    for (const set of group.sets) {
+      if (!set.completed) {
+        await updateSetTrainingMode(set.id, mode);
+      }
+    }
+  }, [groups]);
+
+  const handleRPE = useCallback(async (set: SetWithMeta, val: number) => {
+    const next = set.rpe === val ? null : val;
+    updateGroupSet(set.id, { rpe: next });
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    await updateSetRPE(set.id, next);
+  }, [updateGroupSet]);
+
+  const handleHalfStep = useCallback(async (setId: string, val: number) => {
+    updateGroupSet(setId, { rpe: val });
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setHalfStep(null);
+    await updateSetRPE(setId, val);
+  }, [updateGroupSet]);
+
+  const handleDelete = useCallback(async (setId: string) => {
+    setGroups((prev) =>
+      prev.map((g) => ({
+        ...g,
+        sets: g.sets.filter((s) => s.id !== setId)
+          .map((s, i) => ({ ...s, set_number: i + 1 })),
+      })).filter((g) => g.sets.length > 0)
+    );
+    await deleteSet(setId);
+  }, []);
+
+  const handleHalfStepClear = useCallback(() => setHalfStep(null), []);
+  const handleHalfStepOpen = useCallback((setId: string, base: number) => {
+    setHalfStep({ setId, base });
+  }, []);
+
+  const handleExerciseNotes = useCallback(async (exerciseId: string, text: string) => {
+    const group = groups.find((g) => g.exercise_id === exerciseId);
+    if (!group || group.sets.length === 0) return;
+    const firstSetId = group.sets[0].id;
+    updateGroupSet(firstSetId, { notes: text });
+    setExerciseNotesDraft((prev) => { const n = { ...prev }; delete n[exerciseId]; return n; });
+    await updateSetNotes(firstSetId, text);
+  }, [updateGroupSet, groups]);
+
+  const handleExerciseNotesDraftChange = useCallback((exerciseId: string, text: string) => {
+    setExerciseNotesDraft((prev) => ({ ...prev, [exerciseId]: text }));
+  }, []);
+
+  const toggleExerciseNotes = useCallback((exerciseId: string) => {
+    setExerciseNotesOpen((prev) => ({ ...prev, [exerciseId]: !prev[exerciseId] }));
+  }, []);
+
+  const finish = () => {
+    confirmAction(
+      "Complete Workout?",
+      `Duration: ${formatTime(elapsed)}`,
+      async () => {
+        await completeSession(id!);
+
+        // Strava sync (non-blocking — never prevents workout completion)
+        try {
+          const { syncSessionToStrava } = await import("../lib/strava");
+          const synced = await syncSessionToStrava(id!);
+          if (synced) {
+            showToast("Synced to Strava ✓");
+          }
+        } catch {
+          showError("Strava sync failed");
+        }
+
+        // Health Connect sync (non-blocking, silent)
+        if (Platform.OS === "android") {
+          try {
+            const { syncToHealthConnect } = await import("../lib/health-connect");
+            await syncToHealthConnect(id!);
+          } catch {
+            // HC sync is silent
+          }
+        }
+
+        try {
+          const dayId = await getSessionProgramDayId(id!);
+          if (dayId) {
+            const day = await getProgramDayById(dayId);
+            if (day) {
+              const result = await advanceProgram(day.program_id, dayId, id!);
+              if (result.wrapped) {
+                showToast(`Cycle ${result.cycle} complete!`);
+                AccessibilityInfo.announceForAccessibility(
+                  `Cycle ${result.cycle} complete! Program wrapping to day 1.`
+                );
+                await new Promise((r) => setTimeout(r, 1500));
+              } else {
+                AccessibilityInfo.announceForAccessibility(
+                  "Workout complete. Program advanced to next day."
+                );
+              }
+            }
+          }
+        } catch {
+          // Program advance failed — session already saved
+        }
+
+        const allSets = await getSessionSets(id!);
+        const done = allSets.filter((s) => s.completed);
+        if (done.length === 0) {
+          router.replace("/(tabs)");
+        } else {
+          router.replace(`/session/summary/${id}`);
+        }
+      },
+      false
+    );
+  };
+
+  const cancel = () => {
+    confirmAction(
+      "Discard Workout?",
+      "All logged sets will be lost.",
+      async () => {
+        await cancelSession(id!);
+        router.back();
+      },
+      true
+    );
+  };
+
+  return {
+    elapsed,
+    exerciseNotesOpen,
+    exerciseNotesDraft,
+    halfStep,
+    nextHint,
+    hintTimer,
+    handleUpdate,
+    handleCheck,
+    handleAddSet,
+    handleModeChange,
+    handleRPE,
+    handleHalfStep,
+    handleHalfStepClear,
+    handleHalfStepOpen,
+    handleDelete,
+    handleExerciseNotes,
+    handleExerciseNotesDraftChange,
+    toggleExerciseNotes,
+    finish,
+    cancel,
+  };
+}


### PR DESCRIPTION
## Summary

Batch 5 of the FTA complexity audit. Decomposes 4 large files by extracting hooks and sub-components.

## Changes

### app/session/[id].tsx (578 → 267 lines)
- Extract `useSessionActions` hook (all callback handlers + local state)
- Extract `SessionListHeader` (rest banner + next hint)
- Extract `SessionListFooter` (add exercise, finish, cancel buttons)

### components/SubstitutionSheet.tsx (406 → 239 lines)
- Extract `SubstitutionItem` (list item with match score)
- Extract `EquipmentFilter` (chip filter row)

### app/progress/achievements.tsx (388 → 169 lines)
- Extract `useAchievements` hook (data loading + evaluation)
- Extract `AchievementBadge` (badge card with progress)

### components/ShareCard.tsx (385 → 182 lines)
- Extract `ShareCardStats` (stats row)
- Extract `ShareCardExercises` (PRs + exercise list)

### Test updates
- Updated 2 source-reading tests (strava, health-connect) to include extracted hook
- Added 24 structural tests for batch 5

## Testing

- All 109 test suites pass (1712 tests)
- TypeScript: zero errors
- ESLint: zero warnings

## Issue

Part of BLD-332