### PR TITLE
refactor: FTA audit batch 7 — decompose usePhotoActions, ExercisePickerSheet, BodyCards, recommend (BLD-332)

### DIFF
--- a/__tests__/app/fta-decomposition-batch7.test.ts
+++ b/__tests__/app/fta-decomposition-batch7.test.ts
@@ -1,0 +1,91 @@
+/**
+ * FTA Decomposition Batch 7 — structural tests
+ * Verifies extraction of sub-modules from usePhotoActions, ExercisePickerSheet,
+ * BodyCards, and recommend.tsx
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const root = path.resolve(__dirname, "../..");
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(root, rel), "utf-8");
+}
+
+function lines(rel: string): number {
+  return read(rel).split("\n").length;
+}
+
+describe("Batch 7 — usePhotoActions decomposition", () => {
+  test("usePhotoActions.ts imports from photo-processing", () => {
+    expect(read("hooks/usePhotoActions.ts")).toContain("from \"../lib/photo-processing\"");
+  });
+
+  test("usePhotoActions.ts imports usePhotoPermissions", () => {
+    expect(read("hooks/usePhotoActions.ts")).toContain("from \"./usePhotoPermissions\"");
+  });
+
+  test("lib/photo-processing.ts exports processImage and today", () => {
+    const src = read("lib/photo-processing.ts");
+    expect(src).toContain("export async function processImage");
+    expect(src).toContain("export function today");
+  });
+
+  test("hooks/usePhotoPermissions.ts exports usePhotoPermissions", () => {
+    expect(read("hooks/usePhotoPermissions.ts")).toContain("export function usePhotoPermissions");
+  });
+
+  test("usePhotoActions.ts reduced below 320 lines", () => {
+    expect(lines("hooks/usePhotoActions.ts")).toBeLessThan(320);
+  });
+});
+
+describe("Batch 7 — ExercisePickerSheet decomposition", () => {
+  test("ExercisePickerSheet imports ExerciseItem", () => {
+    expect(read("components/ExercisePickerSheet.tsx")).toContain("from \"./exercise-picker/ExerciseItem\"");
+  });
+
+  test("ExerciseItem.tsx exports ITEM_HEIGHT and default memo component", () => {
+    const src = read("components/exercise-picker/ExerciseItem.tsx");
+    expect(src).toContain("export const ITEM_HEIGHT");
+    expect(src).toContain("React.memo");
+  });
+
+  test("ExercisePickerSheet.tsx reduced below 300 lines", () => {
+    expect(lines("components/ExercisePickerSheet.tsx")).toBeLessThan(300);
+  });
+});
+
+describe("Batch 7 — BodyCards decomposition", () => {
+  test("BodyCards.tsx re-exports ChartCard and GoalsCard", () => {
+    const src = read("components/progress/BodyCards.tsx");
+    expect(src).toContain("export { ChartCard }");
+    expect(src).toContain("export { GoalsCard }");
+  });
+
+  test("ChartCard.tsx exports ChartCard function", () => {
+    expect(read("components/progress/ChartCard.tsx")).toContain("export function ChartCard");
+  });
+
+  test("GoalsCard.tsx exports GoalsCard function", () => {
+    expect(read("components/progress/GoalsCard.tsx")).toContain("export function GoalsCard");
+  });
+
+  test("BodyCards.tsx reduced below 180 lines", () => {
+    expect(lines("components/progress/BodyCards.tsx")).toBeLessThan(180);
+  });
+});
+
+describe("Batch 7 — recommend.tsx decomposition", () => {
+  test("recommend.tsx imports RecommendCard", () => {
+    expect(read("app/onboarding/recommend.tsx")).toContain("from \"@/components/onboarding/RecommendCard\"");
+  });
+
+  test("RecommendCard.tsx exports RecommendCard", () => {
+    expect(read("components/onboarding/RecommendCard.tsx")).toContain("export function RecommendCard");
+  });
+
+  test("recommend.tsx reduced below 260 lines", () => {
+    expect(lines("app/onboarding/recommend.tsx")).toBeLessThan(260);
+  });
+});

--- a/app/onboarding/recommend.tsx
+++ b/app/onboarding/recommend.tsx
@@ -1,9 +1,8 @@
-import { ScrollView, StyleSheet, View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Alert as AlertComponent, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import { Alert as AlertComponent, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Chip } from "@/components/ui/chip";
 import { Text } from "@/components/ui/text";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useState } from "react";
@@ -16,6 +15,7 @@ import {
 } from "../../lib/starter-templates";
 import { useCompleteOnboarding } from "../../lib/onboarding-context";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { RecommendCard } from "@/components/onboarding/RecommendCard";
 
 type Level = "beginner" | "intermediate" | "advanced";
 
@@ -88,123 +88,58 @@ export default function Recommend() {
 
   if (level === "beginner") {
     return (
-      <ScrollView
-        style={{ flex: 1, backgroundColor: colors.background }}
-        contentContainerStyle={styles.scroll}
-      >
-        {errorBanner}
-        <Text variant="heading" style={[styles.title, { color: colors.onBackground }]}>
-          We Recommend
-        </Text>
-        <Card style={StyleSheet.flatten([styles.recCard, { backgroundColor: colors.surface }])}>
-          <CardContent>
-            <View style={styles.recHeader}>
-              <Text variant="title" style={{ color: colors.onSurface }}>
-                {FULL_BODY.name}
-              </Text>
-              <Chip
-                compact
-                style={{ backgroundColor: colors.primaryContainer }}
-              >
-                Recommended
-              </Chip>
-            </View>
-            <Text variant="body" style={[styles.recDesc, { color: colors.onSurfaceVariant }]}>
-              This {FULL_BODY.duration} workout covers all major muscle groups — perfect for building a
-              foundation.
+      <RecommendCard
+        name={FULL_BODY.name}
+        description={`This ${FULL_BODY.duration} workout covers all major muscle groups — perfect for building a foundation.`}
+        chipLabel="Recommended"
+        chipColor={colors.primaryContainer}
+        meta={
+          <>
+            <MaterialCommunityIcons name="clock-outline" size={16} color={colors.onSurfaceVariant} />
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
+              {FULL_BODY.duration}
             </Text>
-            <View style={styles.meta}>
-              <MaterialCommunityIcons name="clock-outline" size={16} color={colors.onSurfaceVariant} />
-              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
-                {FULL_BODY.duration}
-              </Text>
-              <MaterialCommunityIcons
-                name="dumbbell"
-                size={16}
-                color={colors.onSurfaceVariant}
-                style={{ marginLeft: 12 }}
-              />
-              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
-                {FULL_BODY.exercises.length} exercises
-              </Text>
-            </View>
-          </CardContent>
-        </Card>
-        <Button
-          variant="default"
-          onPress={() => finish("template")}
-          style={styles.btn}
-          loading={saving}
-          disabled={saving}
-          accessibilityLabel={`Start with ${FULL_BODY.name}`}
-        >
-          Start with {FULL_BODY.name}
-        </Button>
-        <Button
-          variant="ghost"
-          onPress={() => finish()}
-          style={styles.skip}
-          disabled={saving}
-          accessibilityLabel="Skip recommendation and explore on your own"
-          label="I'll explore on my own"
-        />
-      </ScrollView>
+            <MaterialCommunityIcons
+              name="dumbbell"
+              size={16}
+              color={colors.onSurfaceVariant}
+              style={{ marginLeft: 12 }}
+            />
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
+              {FULL_BODY.exercises.length} exercises
+            </Text>
+          </>
+        }
+        onStart={() => finish("template")}
+        onSkip={() => finish()}
+        saving={saving}
+        startLabel={`Start with ${FULL_BODY.name}`}
+        errorBanner={errorBanner}
+      />
     );
   }
 
   if (level === "intermediate") {
     return (
-      <ScrollView
-        style={{ flex: 1, backgroundColor: colors.background }}
-        contentContainerStyle={styles.scroll}
-      >
-        {errorBanner}
-        <Text variant="heading" style={[styles.title, { color: colors.onBackground }]}>
-          We Recommend
-        </Text>
-        <Card style={StyleSheet.flatten([styles.recCard, { backgroundColor: colors.surface }])}>
-          <CardContent>
-            <View style={styles.recHeader}>
-              <Text variant="title" style={{ color: colors.onSurface }}>
-                {PPL.name}
-              </Text>
-              <Chip
-                compact
-                style={{ backgroundColor: colors.secondaryContainer }}
-              >
-                Program
-              </Chip>
-            </View>
-            <Text variant="body" style={[styles.recDesc, { color: colors.onSurfaceVariant }]}>
-              {PPL.description}
+      <RecommendCard
+        name={PPL.name}
+        description={PPL.description}
+        chipLabel="Program"
+        chipColor={colors.secondaryContainer}
+        meta={
+          <>
+            <MaterialCommunityIcons name="calendar-sync" size={16} color={colors.onSurfaceVariant} />
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
+              {PPL.days.length}-day cycle
             </Text>
-            <View style={styles.meta}>
-              <MaterialCommunityIcons name="calendar-sync" size={16} color={colors.onSurfaceVariant} />
-              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
-                {PPL.days.length}-day cycle
-              </Text>
-            </View>
-          </CardContent>
-        </Card>
-        <Button
-          variant="default"
-          onPress={() => finish("program")}
-          style={styles.btn}
-          loading={saving}
-          disabled={saving}
-          accessibilityLabel={`Start with ${PPL.name}`}
-        >
-          Start with {PPL.name}
-        </Button>
-        <Button
-          variant="ghost"
-          onPress={() => finish()}
-          style={styles.skip}
-          disabled={saving}
-          accessibilityLabel="Skip recommendation and explore on your own"
-          label="I'll explore on my own"
-        />
-      </ScrollView>
+          </>
+        }
+        onStart={() => finish("program")}
+        onSkip={() => finish()}
+        saving={saving}
+        startLabel={`Start with ${PPL.name}`}
+        errorBanner={errorBanner}
+      />
     );
   }
 
@@ -277,12 +212,6 @@ export default function Recommend() {
 }
 
 const styles = StyleSheet.create({
-  scroll: {
-    flexGrow: 1,
-    padding: 24,
-    paddingTop: 80,
-    paddingBottom: 48,
-  },
   title: {
     textAlign: "center",
     marginBottom: 8,
@@ -291,18 +220,11 @@ const styles = StyleSheet.create({
     textAlign: "center",
     marginBottom: 24,
   },
-  recCard: {
-    marginBottom: 24,
-    borderRadius: 12,
-  },
   recHeader: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
     marginBottom: 8,
-  },
-  recDesc: {
-    marginBottom: 12,
   },
   meta: {
     flexDirection: "row",
@@ -315,10 +237,6 @@ const styles = StyleSheet.create({
   btn: {
     marginTop: 16,
     borderRadius: 8,
-  },
-  btnContent: {
-    paddingVertical: 8,
-    minHeight: 48,
   },
   skip: {
     marginTop: 8,

--- a/components/ExercisePickerSheet.tsx
+++ b/components/ExercisePickerSheet.tsx
@@ -28,6 +28,7 @@ import {
 } from "../lib/types";
 import { duration as durationTokens, elevation } from "../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import ExerciseItem, { ITEM_HEIGHT } from "./exercise-picker/ExerciseItem";
 
 type Props = {
   visible: boolean;
@@ -36,7 +37,6 @@ type Props = {
 };
 
 const SPRING_CONFIG = { damping: 20, stiffness: 200, mass: 0.8 };
-const ITEM_HEIGHT = 64;
 
 export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Props) {
   const colors = useThemeColors();
@@ -140,49 +140,9 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
 
   const renderItem = useCallback(
     ({ item }: { item: Exercise }) => (
-      <Pressable
-        onPress={() => handlePick(item)}
-        style={({ pressed }) => [
-          styles.item,
-          {
-            backgroundColor: colors.surface,
-            borderBottomColor: colors.outlineVariant,
-          },
-          pressed && { opacity: 0.7 },
-        ]}
-        accessibilityLabel={`Select ${item.name}${item.is_custom ? " (Custom)" : ""}, ${CATEGORY_LABELS[item.category]}, ${item.equipment}`}
-        accessibilityRole="button"
-      >
-        <View>
-          <Text
-            variant="body"
-            numberOfLines={1}
-            style={{ color: colors.onSurface, fontWeight: "600" }}
-          >
-            {item.name}{item.is_custom ? " (Custom)" : ""}
-          </Text>
-          <View style={styles.row}>
-            <View
-              style={[
-                styles.badge,
-                { backgroundColor: colors.primaryContainer },
-              ]}
-            >
-              <Text style={[styles.chipText, { color: colors.onPrimaryContainer }]}>
-                {CATEGORY_LABELS[item.category]}
-              </Text>
-            </View>
-            <Text
-              variant="caption"
-              style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}
-            >
-              {item.equipment}
-            </Text>
-          </View>
-        </View>
-      </Pressable>
+      <ExerciseItem item={item} onPick={handlePick} />
     ),
-    [colors, handlePick],
+    [handlePick],
   );
 
   if (!mounted) return null;
@@ -323,27 +283,6 @@ const styles = StyleSheet.create({
   },
   list: {
     flex: 1,
-  },
-  item: {
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    minHeight: ITEM_HEIGHT,
-    justifyContent: "center",
-  },
-  row: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginTop: 4,
-  },
-  badge: {
-    borderRadius: 8,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-  },
-  chipText: {
-    fontSize: 12,
-    fontWeight: "500",
   },
   empty: {
     alignItems: "center",

--- a/components/exercise-picker/ExerciseItem.tsx
+++ b/components/exercise-picker/ExerciseItem.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { CATEGORY_LABELS, type Exercise } from "../../lib/types";
+import { useThemeColors } from "@/hooks/useThemeColors";
+
+export const ITEM_HEIGHT = 64;
+
+interface ExerciseItemProps {
+  item: Exercise;
+  onPick: (exercise: Exercise) => void;
+}
+
+function ExerciseItem({ item, onPick }: ExerciseItemProps) {
+  const colors = useThemeColors();
+
+  return (
+    <Pressable
+      onPress={() => onPick(item)}
+      style={({ pressed }) => [
+        styles.item,
+        {
+          backgroundColor: colors.surface,
+          borderBottomColor: colors.outlineVariant,
+        },
+        pressed && { opacity: 0.7 },
+      ]}
+      accessibilityLabel={`Select ${item.name}${item.is_custom ? " (Custom)" : ""}, ${CATEGORY_LABELS[item.category]}, ${item.equipment}`}
+      accessibilityRole="button"
+    >
+      <View>
+        <Text
+          variant="body"
+          numberOfLines={1}
+          style={{ color: colors.onSurface, fontWeight: "600" }}
+        >
+          {item.name}{item.is_custom ? " (Custom)" : ""}
+        </Text>
+        <View style={styles.row}>
+          <View
+            style={[
+              styles.badge,
+              { backgroundColor: colors.primaryContainer },
+            ]}
+          >
+            <Text style={[styles.chipText, { color: colors.onPrimaryContainer }]}>
+              {CATEGORY_LABELS[item.category]}
+            </Text>
+          </View>
+          <Text
+            variant="caption"
+            style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}
+          >
+            {item.equipment}
+          </Text>
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  item: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    minHeight: ITEM_HEIGHT,
+    justifyContent: "center",
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 4,
+  },
+  badge: {
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+  },
+  chipText: {
+    fontSize: 12,
+    fontWeight: "500",
+  },
+});
+
+export default React.memo(ExerciseItem);

--- a/components/onboarding/RecommendCard.tsx
+++ b/components/onboarding/RecommendCard.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Chip } from "@/components/ui/chip";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+
+export interface RecommendCardProps {
+  name: string;
+  description: string;
+  chipLabel: string;
+  chipColor: string;
+  meta: React.ReactNode;
+  onStart: () => void;
+  onSkip: () => void;
+  saving: boolean;
+  startLabel: string;
+  errorBanner: React.ReactNode;
+}
+
+export function RecommendCard({
+  name,
+  description,
+  chipLabel,
+  chipColor,
+  meta,
+  onStart,
+  onSkip,
+  saving,
+  startLabel,
+  errorBanner,
+}: RecommendCardProps) {
+  const colors = useThemeColors();
+
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: colors.background }}
+      contentContainerStyle={styles.scroll}
+    >
+      {errorBanner}
+      <Text variant="heading" style={[styles.title, { color: colors.onBackground }]}>
+        We Recommend
+      </Text>
+      <Card style={StyleSheet.flatten([styles.recCard, { backgroundColor: colors.surface }])}>
+        <CardContent>
+          <View style={styles.recHeader}>
+            <Text variant="title" style={{ color: colors.onSurface }}>
+              {name}
+            </Text>
+            <Chip compact style={{ backgroundColor: chipColor }}>
+              {chipLabel}
+            </Chip>
+          </View>
+          <Text variant="body" style={[styles.recDesc, { color: colors.onSurfaceVariant }]}>
+            {description}
+          </Text>
+          <View style={styles.meta}>{meta}</View>
+        </CardContent>
+      </Card>
+      <Button
+        variant="default"
+        onPress={onStart}
+        style={styles.btn}
+        loading={saving}
+        disabled={saving}
+        accessibilityLabel={startLabel}
+      >
+        {startLabel}
+      </Button>
+      <Button
+        variant="ghost"
+        onPress={onSkip}
+        style={styles.skip}
+        disabled={saving}
+        accessibilityLabel="Skip recommendation and explore on your own"
+        label="I'll explore on my own"
+      />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    flexGrow: 1,
+    padding: 24,
+    paddingTop: 80,
+    paddingBottom: 48,
+  },
+  title: {
+    textAlign: "center",
+    marginBottom: 8,
+  },
+  recCard: {
+    marginBottom: 24,
+    borderRadius: 12,
+  },
+  recHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  recDesc: {
+    marginBottom: 12,
+  },
+  meta: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  btn: {
+    marginTop: 16,
+    borderRadius: 8,
+  },
+  skip: {
+    marginTop: 8,
+  },
+});

--- a/components/progress/BodyCards.tsx
+++ b/components/progress/BodyCards.tsx
@@ -1,15 +1,14 @@
-import { Pressable, StyleSheet, View, useWindowDimensions } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { Progress as ProgressBar } from "@/components/ui/progress";
 import { Text } from "@/components/ui/text";
 import { useRouter } from "expo-router";
-import { CartesianChart, Line } from "victory-native";
-import type { BodyWeight, BodySettings, BodyMeasurements } from "../../lib/types";
-import { useLayout } from "../../lib/layout";
+import type { BodyWeight, BodyMeasurements } from "../../lib/types";
 import { toDisplay } from "../../lib/units";
-import { movingAvg } from "../../lib/format";
 import { useThemeColors } from "@/hooks/useThemeColors";
+
+export { ChartCard } from "./ChartCard";
+export { GoalsCard } from "./GoalsCard";
 
 type WeightCardProps = {
   latest: BodyWeight;
@@ -60,168 +59,6 @@ export function WeightCard({ latest, delta, deltaLabel, unit, onToggleUnit }: We
       >
         {latest.date}
       </Text>
-    </Card>
-  );
-}
-
-type GoalsCardProps = {
-  settings: BodySettings;
-  latest: BodyWeight | null;
-  measurements: BodyMeasurements | null;
-  unit: "kg" | "lb";
-};
-
-export function GoalsCard({ settings, latest, measurements, unit }: GoalsCardProps) {
-  const colors = useThemeColors();
-  const router = useRouter();
-
-  if (!settings.weight_goal && !settings.body_fat_goal) {
-    return (
-      <Card style={styles.card}>
-        <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 8 }}>
-          Goals
-        </Text>
-        <Button
-          variant="outline"
-          onPress={() => router.push("/body/goals")}
-          accessibilityLabel="Set body goals"
-          label="Set Goals"
-        />
-      </Card>
-    );
-  }
-
-  return (
-    <Card style={styles.card}>
-      <View style={styles.cardHeader}>
-        <Text variant="subtitle" style={{ color: colors.onSurface }}>
-          Goals
-        </Text>
-        <Button
-          variant="ghost"
-          size="sm"
-          onPress={() => router.push("/body/goals")}
-          accessibilityLabel="Edit body goals"
-          label="Edit"
-        />
-      </View>
-      {settings.weight_goal && latest && (
-        <View style={{ marginTop: 8 }}>
-          <Text style={{ color: colors.onSurface }}>
-            Weight: {toDisplay(latest.weight, unit)} →{" "}
-            {toDisplay(settings.weight_goal, unit)} {unit}
-          </Text>
-          <ProgressBar
-            value={Math.min(
-              100,
-              Math.max(
-                0,
-                (1 -
-                  Math.abs(latest.weight - settings.weight_goal) /
-                    Math.max(latest.weight, 1)) *
-                  100,
-              ),
-            )}
-            style={{ marginTop: 8 }}
-            height={6}
-          />
-        </View>
-      )}
-      {settings.body_fat_goal && measurements?.body_fat && (
-        <View style={{ marginTop: 12 }}>
-          <Text style={{ color: colors.onSurface }}>
-            Body fat: {measurements.body_fat}% → {settings.body_fat_goal}%
-          </Text>
-          <ProgressBar
-            value={Math.min(
-              100,
-              Math.max(
-                0,
-                (1 -
-                  Math.abs(measurements.body_fat - settings.body_fat_goal) /
-                    Math.max(measurements.body_fat, 1)) *
-                  100,
-              ),
-            )}
-            style={{ marginTop: 8 }}
-            height={6}
-          />
-        </View>
-      )}
-    </Card>
-  );
-}
-
-type ChartCardProps = {
-  chart: { date: string; weight: number }[];
-  unit: "kg" | "lb";
-};
-
-export function ChartCard({ chart, unit }: ChartCardProps) {
-  const colors = useThemeColors();
-  const layout = useLayout();
-  const { width: screenWidth } = useWindowDimensions();
-
-  const chartWidth = layout.atLeastMedium
-    ? (screenWidth - 96) / 2 - 32
-    : screenWidth - 48;
-
-  const avg = movingAvg(chart);
-
-  const paddedLabels = chart.map((d, i) => {
-    if (chart.length <= 8) return d.date.slice(5);
-    if (i % Math.ceil(chart.length / 6) === 0 || i === chart.length - 1)
-      return d.date.slice(5);
-    return "";
-  });
-
-  return (
-    <Card style={styles.card}>
-      <Text
-        variant="subtitle"
-        style={{ color: colors.onSurface, marginBottom: 12 }}
-      >
-        Weight Trend
-      </Text>
-      <View style={{ width: chartWidth, height: 200 }}>
-        <CartesianChart
-          data={chart.map((d, i) => ({
-            date: paddedLabels[i] || "",
-            weight: toDisplay(d.weight, unit),
-            avg: avg[i]
-              ? toDisplay(avg[i].avg, unit)
-              : toDisplay(d.weight, unit),
-          }))}
-          xKey="date"
-          yKeys={["weight", "avg"]}
-          domainPadding={{ left: 10, right: 10 }}
-        >
-          {({ points }) => (
-            <>
-              <Line
-                points={points.weight}
-                color={colors.primary}
-                strokeWidth={2}
-                curveType="natural"
-              />
-              <Line
-                points={points.avg}
-                color={colors.tertiary}
-                strokeWidth={2}
-                curveType="natural"
-              />
-            </>
-          )}
-        </CartesianChart>
-      </View>
-      <View style={{ flexDirection: "row", gap: 16, marginTop: 8 }}>
-        <Text variant="caption" style={{ color: colors.primary }}>
-          ● Actual
-        </Text>
-        <Text variant="caption" style={{ color: colors.tertiary }}>
-          ● 7-day avg
-        </Text>
-      </View>
     </Card>
   );
 }

--- a/components/progress/ChartCard.tsx
+++ b/components/progress/ChartCard.tsx
@@ -1,0 +1,87 @@
+import { StyleSheet, View, useWindowDimensions } from "react-native";
+import { CartesianChart, Line } from "victory-native";
+import { useLayout } from "../../lib/layout";
+import { toDisplay } from "../../lib/units";
+import { movingAvg } from "../../lib/format";
+import { Text } from "@/components/ui/text";
+import { Card } from "@/components/ui/card";
+import { useThemeColors } from "@/hooks/useThemeColors";
+type ChartCardProps = {
+  chart: { date: string; weight: number }[];
+  unit: "kg" | "lb";
+};
+
+export function ChartCard({ chart, unit }: ChartCardProps) {
+  const colors = useThemeColors();
+  const layout = useLayout();
+  const { width: screenWidth } = useWindowDimensions();
+
+  const chartWidth = layout.atLeastMedium
+    ? (screenWidth - 96) / 2 - 32
+    : screenWidth - 48;
+
+  const avg = movingAvg(chart);
+
+  const paddedLabels = chart.map((d, i) => {
+    if (chart.length <= 8) return d.date.slice(5);
+    if (i % Math.ceil(chart.length / 6) === 0 || i === chart.length - 1)
+      return d.date.slice(5);
+    return "";
+  });
+
+  return (
+    <Card style={styles.card}>
+      <Text
+        variant="subtitle"
+        style={{ color: colors.onSurface, marginBottom: 12 }}
+      >
+        Weight Trend
+      </Text>
+      <View style={{ width: chartWidth, height: 200 }}>
+        <CartesianChart
+          data={chart.map((d, i) => ({
+            date: paddedLabels[i] || "",
+            weight: toDisplay(d.weight, unit),
+            avg: avg[i]
+              ? toDisplay(avg[i].avg, unit)
+              : toDisplay(d.weight, unit),
+          }))}
+          xKey="date"
+          yKeys={["weight", "avg"]}
+          domainPadding={{ left: 10, right: 10 }}
+        >
+          {({ points }) => (
+            <>
+              <Line
+                points={points.weight}
+                color={colors.primary}
+                strokeWidth={2}
+                curveType="natural"
+              />
+              <Line
+                points={points.avg}
+                color={colors.tertiary}
+                strokeWidth={2}
+                curveType="natural"
+              />
+            </>
+          )}
+        </CartesianChart>
+      </View>
+      <View style={{ flexDirection: "row", gap: 16, marginTop: 8 }}>
+        <Text variant="caption" style={{ color: colors.primary }}>
+          ● Actual
+        </Text>
+        <Text variant="caption" style={{ color: colors.tertiary }}>
+          ● 7-day avg
+        </Text>
+      </View>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+  },
+});

--- a/components/progress/GoalsCard.tsx
+++ b/components/progress/GoalsCard.tsx
@@ -1,0 +1,108 @@
+import { View, StyleSheet } from "react-native";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Progress as ProgressBar } from "@/components/ui/progress";
+import { Text } from "@/components/ui/text";
+import { useRouter } from "expo-router";
+import { toDisplay } from "../../lib/units";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { BodyWeight, BodySettings, BodyMeasurements } from "../../lib/types";
+
+type GoalsCardProps = {
+  settings: BodySettings;
+  latest: BodyWeight | null;
+  measurements: BodyMeasurements | null;
+  unit: "kg" | "lb";
+};
+
+export function GoalsCard({ settings, latest, measurements, unit }: GoalsCardProps) {
+  const colors = useThemeColors();
+  const router = useRouter();
+
+  if (!settings.weight_goal && !settings.body_fat_goal) {
+    return (
+      <Card style={styles.card}>
+        <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 8 }}>
+          Goals
+        </Text>
+        <Button
+          variant="outline"
+          onPress={() => router.push("/body/goals")}
+          accessibilityLabel="Set body goals"
+          label="Set Goals"
+        />
+      </Card>
+    );
+  }
+
+  return (
+    <Card style={styles.card}>
+      <View style={styles.cardHeader}>
+        <Text variant="subtitle" style={{ color: colors.onSurface }}>
+          Goals
+        </Text>
+        <Button
+          variant="ghost"
+          size="sm"
+          onPress={() => router.push("/body/goals")}
+          accessibilityLabel="Edit body goals"
+          label="Edit"
+        />
+      </View>
+      {settings.weight_goal && latest && (
+        <View style={{ marginTop: 8 }}>
+          <Text style={{ color: colors.onSurface }}>
+            Weight: {toDisplay(latest.weight, unit)} →{" "}
+            {toDisplay(settings.weight_goal, unit)} {unit}
+          </Text>
+          <ProgressBar
+            value={Math.min(
+              100,
+              Math.max(
+                0,
+                (1 -
+                  Math.abs(latest.weight - settings.weight_goal) /
+                    Math.max(latest.weight, 1)) *
+                  100,
+              ),
+            )}
+            style={{ marginTop: 8 }}
+            height={6}
+          />
+        </View>
+      )}
+      {settings.body_fat_goal && measurements?.body_fat && (
+        <View style={{ marginTop: 12 }}>
+          <Text style={{ color: colors.onSurface }}>
+            Body fat: {measurements.body_fat}% → {settings.body_fat_goal}%
+          </Text>
+          <ProgressBar
+            value={Math.min(
+              100,
+              Math.max(
+                0,
+                (1 -
+                  Math.abs(measurements.body_fat - settings.body_fat_goal) /
+                    Math.max(measurements.body_fat, 1)) *
+                  100,
+              ),
+            )}
+            style={{ marginTop: 8 }}
+            height={6}
+          />
+        </View>
+      )}
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+  },
+  cardHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+});

--- a/hooks/usePhotoActions.ts
+++ b/hooks/usePhotoActions.ts
@@ -1,11 +1,9 @@
 /* eslint-disable max-lines-per-function, react-hooks/exhaustive-deps */
 import { useCallback, useRef, useState } from "react";
-import { Alert, Linking } from "react-native";
+import { Alert } from "react-native";
 import { useToast } from "@/components/ui/bna-toast";
 import { useFocusEffect } from "expo-router";
 import * as ImagePicker from "expo-image-picker";
-import * as ImageManipulator from "expo-image-manipulator";
-import { File, Directory, Paths } from "expo-file-system";
 import * as LocalAuthentication from "expo-local-authentication";
 
 import {
@@ -16,15 +14,13 @@ import {
   restorePhoto,
   cleanupDeletedPhotos,
   cleanupOrphanFiles,
-  ensurePhotoDirs,
 } from "../lib/db/photos";
 import type { ProgressPhoto, PoseCategory } from "../lib/db/photos";
 import { getAppSetting, setAppSetting } from "../lib/db";
-import { uuid } from "../lib/uuid";
+import { processImage, today } from "../lib/photo-processing";
+import { usePhotoPermissions } from "./usePhotoPermissions";
 
 export const PAGE_SIZE = 20;
-const MAX_DIMENSION = 1200;
-const THUMB_SIZE = 300;
 
 export const POSE_OPTIONS: { label: string; value: PoseCategory }[] = [
   { label: "Front", value: "front" },
@@ -33,11 +29,8 @@ export const POSE_OPTIONS: { label: string; value: PoseCategory }[] = [
   { label: "Side R", value: "side_right" },
 ];
 
-function today(): string {
-  return new Date().toISOString().slice(0, 10);
-}
-
 export function usePhotoActions({ router }: { router: ReturnType<typeof import("expo-router").useRouter> }) {
+  const { requestCameraPermission, requestGalleryPermission } = usePhotoPermissions();
   const [photos, setPhotos] = useState<ProgressPhoto[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(false);
@@ -123,75 +116,16 @@ export function usePhotoActions({ router }: { router: ReturnType<typeof import("
     setPrivacyModal(false);
   };
 
-  const requestCameraPermission = async (): Promise<boolean> => {
-    const { status } = await ImagePicker.requestCameraPermissionsAsync();
-    if (status !== "granted") {
-      Alert.alert(
-        "Camera Permission Required",
-        "Please enable camera access in your device settings to take progress photos.",
-        [
-          { text: "Cancel", style: "cancel" },
-          { text: "Open Settings", onPress: () => Linking.openSettings() },
-        ]
-      );
-      return false;
-    }
-    return true;
-  };
-
-  const requestGalleryPermission = async (): Promise<boolean> => {
-    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    if (status !== "granted") {
-      Alert.alert(
-        "Gallery Permission Required",
-        "Please enable photo library access in your device settings to import progress photos.",
-        [
-          { text: "Cancel", style: "cancel" },
-          { text: "Open Settings", onPress: () => Linking.openSettings() },
-        ]
-      );
-      return false;
-    }
-    return true;
-  };
-
   const processAndSave = async (uri: string) => {
-    const resized = await ImageManipulator.manipulateAsync(
-      uri,
-      [{ resize: { width: MAX_DIMENSION } }],
-      { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG }
-    );
-
-    const thumb = await ImageManipulator.manipulateAsync(
-      resized.uri,
-      [{ resize: { width: THUMB_SIZE } }],
-      { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG }
-    );
-
-    ensurePhotoDirs();
-
-    const photoId = uuid();
-    const fileName = `${photoId}.jpg`;
-    const thumbName = `thumb_${photoId}.jpg`;
-    const photoDir = new Directory(Paths.document, "progress-photos");
-    const thumbDir = new Directory(Paths.document, "progress-photos", "thumbnails");
-    const destFile = new File(photoDir, fileName);
-    const thumbFile = new File(thumbDir, thumbName);
-
-    const resizedFile = new File(resized.uri);
-    resizedFile.move(destFile);
-    const thumbSrcFile = new File(thumb.uri);
-    thumbSrcFile.move(thumbFile);
-
-    setPendingUri(destFile.uri);
-    setPendingWidth(resized.width);
-    setPendingHeight(resized.height);
+    const result = await processImage(uri);
+    setPendingUri(result.fullUri);
+    setPendingWidth(result.width);
+    setPendingHeight(result.height);
     setMetaDate(today());
     setMetaPose(null);
     setMetaNote("");
     setMetaModal(true);
-
-    (pendingThumbRef as React.MutableRefObject<string>).current = thumbFile.uri;
+    (pendingThumbRef as React.MutableRefObject<string>).current = result.thumbUri;
   };
 
   const handleTakePhoto = async () => {

--- a/hooks/usePhotoPermissions.ts
+++ b/hooks/usePhotoPermissions.ts
@@ -1,0 +1,39 @@
+import { useCallback } from "react";
+import { Alert, Linking } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+
+export function usePhotoPermissions() {
+  const requestCameraPermission = useCallback(async (): Promise<boolean> => {
+    const { status } = await ImagePicker.requestCameraPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert(
+        "Camera Permission Required",
+        "Please enable camera access in your device settings to take progress photos.",
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Open Settings", onPress: () => Linking.openSettings() },
+        ]
+      );
+      return false;
+    }
+    return true;
+  }, []);
+
+  const requestGalleryPermission = useCallback(async (): Promise<boolean> => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== "granted") {
+      Alert.alert(
+        "Gallery Permission Required",
+        "Please enable photo library access in your device settings to import progress photos.",
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Open Settings", onPress: () => Linking.openSettings() },
+        ]
+      );
+      return false;
+    }
+    return true;
+  }, []);
+
+  return { requestCameraPermission, requestGalleryPermission };
+}

--- a/lib/photo-processing.ts
+++ b/lib/photo-processing.ts
@@ -1,0 +1,50 @@
+import * as ImageManipulator from "expo-image-manipulator";
+import { File, Directory, Paths } from "expo-file-system";
+
+import { ensurePhotoDirs } from "./db/photos";
+import { uuid } from "./uuid";
+
+export const MAX_DIMENSION = 1200;
+export const THUMB_SIZE = 300;
+
+export function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function processImage(
+  uri: string
+): Promise<{ fullUri: string; thumbUri: string; width: number; height: number }> {
+  const resized = await ImageManipulator.manipulateAsync(
+    uri,
+    [{ resize: { width: MAX_DIMENSION } }],
+    { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG }
+  );
+
+  const thumb = await ImageManipulator.manipulateAsync(
+    resized.uri,
+    [{ resize: { width: THUMB_SIZE } }],
+    { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG }
+  );
+
+  ensurePhotoDirs();
+
+  const photoId = uuid();
+  const fileName = `${photoId}.jpg`;
+  const thumbName = `thumb_${photoId}.jpg`;
+  const photoDir = new Directory(Paths.document, "progress-photos");
+  const thumbDir = new Directory(Paths.document, "progress-photos", "thumbnails");
+  const destFile = new File(photoDir, fileName);
+  const thumbFile = new File(thumbDir, thumbName);
+
+  const resizedFile = new File(resized.uri);
+  resizedFile.move(destFile);
+  const thumbSrcFile = new File(thumb.uri);
+  thumbSrcFile.move(thumbFile);
+
+  return {
+    fullUri: destFile.uri,
+    thumbUri: thumbFile.uri,
+    width: resized.width,
+    height: resized.height,
+  };
+}


### PR DESCRIPTION
## Summary

FTA audit batch 7: decompose 4 files by extracting sub-modules to reduce complexity scores.

## Changes

- **usePhotoActions.ts** (375→309L, -18%): Extract `lib/photo-processing.ts` (image resize/save) + `hooks/usePhotoPermissions.ts` (camera/gallery permissions)
- **ExercisePickerSheet.tsx** (352→291L, -17%): Extract `components/exercise-picker/ExerciseItem.tsx` (memoized list item)
- **BodyCards.tsx** (333→170L, -49%): Extract `components/progress/ChartCard.tsx` + `GoalsCard.tsx`
- **recommend.tsx** (326→244L, -25%): Extract `components/onboarding/RecommendCard.tsx` (shared beginner/intermediate card)

## Testing

- TypeScript: zero errors
- ESLint: zero warnings (--max-warnings=0)
- All 111 suites / 1753 tests pass (npx jest --no-coverage)
- 15 new structural tests in fta-decomposition-batch7.test.ts

## Issue

Part of BLD-332