### PR TITLE
feat: include meal templates in backup/restore (BLD-335)

### DIFF
--- a/__tests__/lib/db/import-export.test.ts
+++ b/__tests__/lib/db/import-export.test.ts
@@ -40,7 +40,7 @@ describe("exportAllData", () => {
     expect(result.app_version).toBeDefined();
   });
 
-  it("includes all 18 tables", async () => {
+  it("includes all 20 tables", async () => {
     mockDb.getAllAsync.mockResolvedValue([]);
     const result = await exportAllData();
     for (const table of IMPORT_TABLE_ORDER) {
@@ -53,7 +53,7 @@ describe("exportAllData", () => {
     mockDb.getAllAsync.mockResolvedValue([]);
     const progress: string[] = [];
     await exportAllData((p) => progress.push(p.table));
-    // Should have 18 table calls plus "done"
+    // Should have 20 table calls plus "done"
     expect(progress.length).toBe(IMPORT_TABLE_ORDER.length + 1);
     expect(progress[progress.length - 1]).toBe("done");
   });
@@ -432,9 +432,110 @@ describe("importData", () => {
     expect(inserted).toContain("weekly_schedule");
     expect(inserted).toContain("program_schedule");
   });
+  it("imports meal_templates and meal_template_items", async () => {
+    const inserted: string[] = [];
+    mockDb.runAsync.mockImplementation(async (sql: string) => {
+      const match = sql.match(/INSERT OR IGNORE INTO (\w+)/);
+      if (match) inserted.push(match[1]);
+      return { changes: 1 };
+    });
+
+    const data = {
+      version: 6,
+      data: {
+        meal_templates: [
+          { id: "mt1", name: "Breakfast Bowl", meal: "breakfast", cached_calories: 500, cached_protein: 30, cached_carbs: 60, cached_fat: 15, last_used_at: null, created_at: 1000, updated_at: 1000 },
+        ],
+        meal_template_items: [
+          { id: "mti1", template_id: "mt1", food_entry_id: "f1", servings: 2, sort_order: 0 },
+          { id: "mti2", template_id: "mt1", food_entry_id: "f2", servings: 1, sort_order: 1 },
+        ],
+      },
+    };
+
+    await importData(data);
+    expect(inserted).toContain("meal_templates");
+    expect(inserted).toContain("meal_template_items");
+  });
+
+  it("imports meal_templates before meal_template_items (FK order)", async () => {
+    const importOrder: string[] = [];
+    mockDb.runAsync.mockImplementation(async (sql: string) => {
+      const match = sql.match(/INSERT OR IGNORE INTO (\w+)/);
+      if (match) importOrder.push(match[1]);
+      return { changes: 1 };
+    });
+
+    const data = {
+      version: 6,
+      data: {
+        meal_templates: [{ id: "mt1", name: "Lunch", meal: "lunch", cached_calories: 0, cached_protein: 0, cached_carbs: 0, cached_fat: 0, last_used_at: null, created_at: 1, updated_at: 1 }],
+        meal_template_items: [{ id: "mti1", template_id: "mt1", food_entry_id: "f1", servings: 1, sort_order: 0 }],
+      },
+    };
+
+    await importData(data);
+    const mtIdx = importOrder.indexOf("meal_templates");
+    const mtiIdx = importOrder.indexOf("meal_template_items");
+    expect(mtIdx).toBeGreaterThanOrEqual(0);
+    expect(mtiIdx).toBeGreaterThanOrEqual(0);
+    expect(mtIdx).toBeLessThan(mtiIdx);
+  });
+
+  it("handles old backups without meal template tables gracefully", async () => {
+    mockDb.runAsync.mockResolvedValue({ changes: 1 });
+
+    const data = {
+      version: 5,
+      data: {
+        exercises: [{ id: "e1", name: "Bench", category: "chest", primary_muscles: "", secondary_muscles: "", equipment: "barbell", instructions: "", difficulty: "beginner", is_custom: 0 }],
+      },
+    };
+
+    const result = await importData(data);
+    expect(result.perTable.meal_templates).toEqual({ inserted: 0, skipped: 0 });
+    expect(result.perTable.meal_template_items).toEqual({ inserted: 0, skipped: 0 });
+  });
+
+  it("defaults cached macros to 0 for meal_templates with missing fields", async () => {
+    const sqlCalls: { sql: string; params: unknown[] }[] = [];
+    mockDb.runAsync.mockImplementation(async (sql: string, params?: unknown[]) => {
+      sqlCalls.push({ sql, params: params ?? [] });
+      return { changes: 1 };
+    });
+
+    const data = {
+      version: 6,
+      data: {
+        meal_templates: [{ id: "mt1", name: "Quick Meal", meal: "dinner", created_at: 1, updated_at: 1 }],
+      },
+    };
+
+    await importData(data);
+    const mtInserts = sqlCalls.filter((c) => c.sql.includes("INSERT OR IGNORE INTO meal_templates"));
+    expect(mtInserts).toHaveLength(1);
+    // cached_calories (idx 3), cached_protein (idx 4), cached_carbs (idx 5), cached_fat (idx 6) should default to 0
+    expect(mtInserts[0].params[3]).toBe(0);
+    expect(mtInserts[0].params[4]).toBe(0);
+    expect(mtInserts[0].params[5]).toBe(0);
+    expect(mtInserts[0].params[6]).toBe(0);
+  });
 });
 
-// ---- estimateExportSize ----
+// ---- Meal Template in IMPORT_TABLE_ORDER ----
+
+describe("IMPORT_TABLE_ORDER includes meal templates", () => {
+  it("contains meal_templates and meal_template_items", () => {
+    expect(IMPORT_TABLE_ORDER).toContain("meal_templates");
+    expect(IMPORT_TABLE_ORDER).toContain("meal_template_items");
+  });
+
+  it("has meal_templates before meal_template_items", () => {
+    const mtIdx = IMPORT_TABLE_ORDER.indexOf("meal_templates");
+    const mtiIdx = IMPORT_TABLE_ORDER.indexOf("meal_template_items");
+    expect(mtIdx).toBeLessThan(mtiIdx);
+  });
+});
 
 describe("estimateExportSize", () => {
   it("returns size estimate based on row counts", async () => {

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -10,6 +10,8 @@ import type {
   Program,
   ProgramDay,
   ProgramLog,
+  MealTemplate,
+  MealTemplateItem,
 } from "../types";
 import { getDatabase } from "./helpers";
 
@@ -33,7 +35,9 @@ export type BackupTableName =
   | "daily_log"
   | "program_log"
   | "weekly_schedule"
-  | "program_schedule";
+  | "program_schedule"
+  | "meal_templates"
+  | "meal_template_items";
 
 export const BACKUP_TABLE_LABELS: Record<BackupTableName, string> = {
   exercises: "Exercises",
@@ -54,6 +58,8 @@ export const BACKUP_TABLE_LABELS: Record<BackupTableName, string> = {
   program_log: "Program Log",
   weekly_schedule: "Weekly Schedule",
   program_schedule: "Program Schedule",
+  meal_templates: "Meal Templates",
+  meal_template_items: "Meal Template Items",
 };
 
 // FK-dependency order for import — parents before children
@@ -76,6 +82,8 @@ export const IMPORT_TABLE_ORDER: BackupTableName[] = [
   "program_log",
   "weekly_schedule",
   "program_schedule",
+  "meal_templates",
+  "meal_template_items",
 ];
 
 export type AppSettingRow = { key: string; value: string };
@@ -102,6 +110,8 @@ export type BackupV3Data = {
   weekly_schedule: WeeklyScheduleRow[];
   program_schedule: ProgramScheduleRow[];
   achievements_earned: AchievementEarnedRow[];
+  meal_templates: MealTemplate[];
+  meal_template_items: MealTemplateItem[];
 };
 
 export type BackupV3 = {
@@ -494,6 +504,20 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
       const r = await database.runAsync(
         "INSERT OR IGNORE INTO program_schedule (program_id, day_of_week, template_id) VALUES (?, ?, ?)",
         [row.program_id, row.day_of_week, row.template_id]
+      );
+      return r.changes > 0;
+    }
+    case "meal_templates": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO meal_templates (id, name, meal, cached_calories, cached_protein, cached_carbs, cached_fat, last_used_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.name, row.meal, row.cached_calories ?? 0, row.cached_protein ?? 0, row.cached_carbs ?? 0, row.cached_fat ?? 0, row.last_used_at ?? null, row.created_at, row.updated_at]
+      );
+      return r.changes > 0;
+    }
+    case "meal_template_items": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO meal_template_items (id, template_id, food_entry_id, servings, sort_order) VALUES (?, ?, ?, ?, ?)",
+        [row.id, row.template_id, row.food_entry_id, row.servings ?? 1, row.sort_order ?? 0]
       );
       return r.changes > 0;
     }


### PR DESCRIPTION
## Summary

Add meal_templates and meal_template_items to the backup/restore system so users don't lose saved meal templates when exporting and reimporting data.

## Changes

- Add meal_templates and meal_template_items to BackupTableName union type
- Add labels to BACKUP_TABLE_LABELS  
- Add to IMPORT_TABLE_ORDER in correct FK-dependency order
- Add insertRow cases with proper defaults for cached macros
- Add MealTemplate/MealTemplateItem to BackupV3Data type
- Backward compatible: old backups without these tables import gracefully

## Testing

- 6 new tests covering: import, FK order, backward compatibility, defaults
- All 38 import-export tests pass
- TypeScript typecheck passes with zero errors

## Issue

Resolves BLD-335