### PR TITLE
fix: improve workout tools crash prevention (BLD-338)

### DIFF
--- a/__tests__/app/tools/tools-hub-error-boundary.test.tsx
+++ b/__tests__/app/tools/tools-hub-error-boundary.test.tsx
@@ -1,6 +1,7 @@
 jest.setTimeout(10000)
 
 import React from 'react'
+import { fireEvent } from '@testing-library/react-native'
 import { renderScreen } from '../../helpers/render'
 
 jest.mock('expo-router', () => {
@@ -91,15 +92,15 @@ describe('ToolsHub', () => {
     expect(await findByText('Plate Calculator')).toBeTruthy()
   })
 
-  it('contains error boundary that catches tool render failures', async () => {
-    // Verify ToolErrorBoundary is structurally present by checking
-    // that the component source wraps children in ToolErrorBoundary
+  it('contains error boundary with componentDidCatch for error logging', () => {
     const source = require('fs').readFileSync(
       require('path').resolve(__dirname, '../../../app/tools/index.tsx'),
       'utf8'
     )
     expect(source).toContain('ToolErrorBoundary')
     expect(source).toContain('getDerivedStateFromError')
+    expect(source).toContain('componentDidCatch')
+    expect(source).toContain('logError')
   })
 })
 
@@ -108,7 +109,6 @@ describe('ToolsHub error isolation', () => {
     const db = require('../../../lib/db')
     db.getBodySettings.mockRejectedValueOnce(new Error('DB unavailable'))
 
-    // Should not throw — unhandled promise rejection would crash
     const { findByText } = renderScreen(<ToolsHub />)
     expect(await findByText('1RM Calculator')).toBeTruthy()
   })
@@ -119,5 +119,70 @@ describe('ToolsHub error isolation', () => {
 
     const { findByText } = renderScreen(<ToolsHub />)
     expect(await findByText('Plate Calculator')).toBeTruthy()
+  })
+
+  it('db failure in getAppSetting does not crash TimerContent', async () => {
+    const db = require('../../../lib/db')
+    db.getAppSetting.mockRejectedValueOnce(new Error('DB unavailable'))
+
+    const { findByText } = renderScreen(<ToolsHub />)
+    expect(await findByText('Interval Timer')).toBeTruthy()
+  })
+
+  it('error boundary shows fallback and retry button when child throws', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Make Timer throw by breaking a hook it depends on
+    const reanimated = require('react-native-reanimated')
+    const origUseSharedValue = reanimated.useSharedValue
+    reanimated.useSharedValue = () => { throw new Error('Reanimated crash') }
+
+    const { findByText } = renderScreen(<ToolsHub />)
+
+    // Timer should show error fallback
+    expect(await findByText('Interval Timer failed to load.')).toBeTruthy()
+    expect(await findByText('Tap to retry')).toBeTruthy()
+
+    // Other tools should still render
+    expect(await findByText('1RM Calculator')).toBeTruthy()
+    expect(await findByText('Plate Calculator')).toBeTruthy()
+
+    // Error should be logged
+    const errors = require('../../../lib/errors')
+    expect(errors.logError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ component: 'ToolsHub/Interval Timer', fatal: false })
+    )
+
+    reanimated.useSharedValue = origUseSharedValue
+    spy.mockRestore()
+  })
+
+  it('retry button resets error state and re-renders child', async () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const reanimated = require('react-native-reanimated')
+    const origUseSharedValue = reanimated.useSharedValue
+
+    let throwCount = 0
+    reanimated.useSharedValue = (v: number) => {
+      throwCount++
+      if (throwCount <= 3) throw new Error('Reanimated crash')
+      return { value: v }
+    }
+
+    const { findByText, findByLabelText } = renderScreen(<ToolsHub />)
+
+    expect(await findByText('Interval Timer failed to load.')).toBeTruthy()
+    const retryButton = await findByLabelText('Retry loading Interval Timer')
+
+    // Reset the throw so retry succeeds
+    reanimated.useSharedValue = origUseSharedValue
+
+    fireEvent.press(retryButton)
+
+    // After retry, the timer card header should still be present
+    expect(await findByText('Interval Timer')).toBeTruthy()
+
+    spy.mockRestore()
   })
 })

--- a/app/tools/index.tsx
+++ b/app/tools/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Card, CardContent } from "@/components/ui/card";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
@@ -9,6 +9,7 @@ import { PlateCalculatorContent } from "./plates";
 import { RMCalculatorContent } from "./rm";
 import { TimerContent } from "./timer";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { logError } from "../../lib/errors";
 
 export default function ToolsHub() {
   const colors = useThemeColors();
@@ -76,12 +77,30 @@ class ToolErrorBoundary extends React.Component<BoundaryProps, BoundaryState> {
     return { hasError: true };
   }
 
+  componentDidCatch(error: Error) {
+    logError(error, { component: `ToolsHub/${this.props.name}`, fatal: false });
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false });
+  };
+
   render() {
     if (this.state.hasError) {
       return (
-        <Text style={{ textAlign: "center", opacity: 0.6 }}>
-          {this.props.name} failed to load. Try opening it from the standalone screen.
-        </Text>
+        <View style={styles.errorContainer}>
+          <Text style={{ textAlign: "center", opacity: 0.6 }}>
+            {this.props.name} failed to load.
+          </Text>
+          <Pressable
+            onPress={this.handleRetry}
+            accessibilityRole="button"
+            accessibilityLabel={`Retry loading ${this.props.name}`}
+            style={styles.retryButton}
+          >
+            <Text style={{ textAlign: "center", fontWeight: "600" }}>Tap to retry</Text>
+          </Pressable>
+        </View>
       );
     }
     return this.props.children;
@@ -99,5 +118,14 @@ const styles = StyleSheet.create({
   },
   icon: {
     marginRight: 12,
+  },
+  errorContainer: {
+    alignItems: "center",
+    gap: 12,
+    paddingVertical: 16,
+  },
+  retryButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
   },
 });


### PR DESCRIPTION
## Summary

Improves the workout tools crash prevention originally added in PR #145 (BLD-272). Adds proper error logging, user-facing retry capability, and comprehensive tests.

## Changes

- Add `componentDidCatch` to `ToolErrorBoundary` — errors now logged via `logError()` with component context
- Add retry button to error fallback so users can recover without restarting the app
- Add test: error boundary catches thrown child and renders fallback message
- Add test: retry button resets error state and re-renders child
- Add test: DB failure in `getAppSetting` does not crash `TimerContent`

## Testing

- All 1759 tests pass (`npx jest --no-coverage`)
- `npx tsc --noEmit` clean
- `eslint --max-warnings=0` clean
- New tests verify error boundary behavior with actual component throws

## Issue

Resolves BLD-338 (parent: BLD-272, GitHub #141)