### PR TITLE
feat: add Nutrition segment to Progress tab (BLD-339)

### DIFF
--- a/__tests__/acceptance/nutrition-progress.test.tsx
+++ b/__tests__/acceptance/nutrition-progress.test.tsx
@@ -1,0 +1,277 @@
+jest.setTimeout(10000)
+
+import React from 'react'
+import { waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+
+// ─── Mocks ─────────────────────────────────────────────────────────
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    useRouter: () => mockRouter,
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({
+  useLayout: () => ({ wide: false, width: 375, scale: 1.0, horizontalPadding: 16, atLeastMedium: false }),
+}))
+jest.mock('../../lib/errors', () => ({
+  logError: jest.fn(),
+  generateReport: jest.fn().mockResolvedValue('{}'),
+  getRecentErrors: jest.fn().mockResolvedValue([]),
+  generateGitHubURL: jest.fn().mockReturnValue('https://github.com'),
+}))
+jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+jest.mock('../../lib/query', () => ({ useFocusRefetch: jest.fn() }))
+jest.mock('../../components/ui/bna-toast', () => ({
+  ToastProvider: ({ children }: { children: unknown }) => children,
+  useToast: () => ({
+    toast: jest.fn(), success: jest.fn(), error: jest.fn(),
+    warning: jest.fn(), info: jest.fn(), dismiss: jest.fn(), dismissAll: jest.fn(),
+  }),
+}))
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native')
+  return {
+    __esModule: true,
+    default: { createAnimatedComponent: (c: unknown) => c, View },
+    useReducedMotion: () => false,
+    useSharedValue: (v: unknown) => ({ value: v }),
+    useAnimatedStyle: () => ({}),
+    withTiming: (v: unknown) => v,
+    FadeInDown: { duration: () => ({ delay: () => ({}) }) },
+    Easing: { out: () => {}, bezier: () => {} },
+    createAnimatedComponent: (c: unknown) => c,
+  }
+})
+jest.mock('victory-native', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  CartesianChart: (props: Record<string, unknown>) => null,
+  Line: () => null,
+  Bar: () => null,
+}))
+jest.mock('../../components/FloatingTabBar', () => ({
+  useFloatingTabBarHeight: () => 80,
+}))
+
+// Mock DB functions
+const mockDailyTotals = jest.fn()
+const mockWeeklyAverages = jest.fn()
+const mockAdherence = jest.fn()
+const mockTargets = jest.fn()
+
+jest.mock('../../lib/db', () => ({
+  getDailyNutritionTotals: (...args: unknown[]) => mockDailyTotals(...args),
+  getWeeklyNutritionAverages: (...args: unknown[]) => mockWeeklyAverages(...args),
+  getNutritionAdherence: (...args: unknown[]) => mockAdherence(...args),
+  getNutritionTargets: () => mockTargets(),
+}))
+
+import NutritionSegment from '../../components/progress/NutritionSegment'
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function makeDailyTotals(days: number) {
+  const totals = []
+  for (let i = 0; i < days; i++) {
+    const d = new Date()
+    d.setDate(d.getDate() - i)
+    const date = d.toISOString().slice(0, 10)
+    totals.push({ date, calories: 2000 + i * 10, protein: 150, carbs: 250, fat: 65 })
+  }
+  return totals.reverse()
+}
+
+function makeWeeklyAverages(weeks: number) {
+  const avgs = []
+  for (let i = 0; i < weeks; i++) {
+    const d = new Date()
+    d.setDate(d.getDate() - i * 7)
+    avgs.push({
+      weekStart: d.toISOString().slice(0, 10),
+      avgCalories: 2100 + i * 50,
+      avgProtein: 150,
+      avgCarbs: 250,
+      avgFat: 65,
+      daysTracked: 5,
+    })
+  }
+  return avgs.reverse()
+}
+
+const defaultTargets = {
+  id: '1', calories: 2000, protein: 150, carbs: 250, fat: 65, updated_at: Date.now(),
+}
+
+const defaultAdherence = {
+  trackedDays: 20, onTargetDays: 16, currentStreak: 5, longestStreak: 12,
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────
+
+describe('Nutrition Progress Segment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRouter.push.mockReset()
+    mockDailyTotals.mockResolvedValue(makeDailyTotals(10))
+    mockWeeklyAverages.mockResolvedValue(makeWeeklyAverages(4))
+    mockAdherence.mockResolvedValue(defaultAdherence)
+    mockTargets.mockResolvedValue(defaultTargets)
+  })
+
+  it('shows calorie trend chart with 7+ days of data', async () => {
+    const { getByText, getByLabelText } = renderScreen(<NutritionSegment />)
+
+    await waitFor(() => {
+      expect(getByText('Calorie Trend')).toBeTruthy()
+    })
+
+    // Chart container should have accessibility role image
+    const chartContainer = getByLabelText(/Calorie trend/)
+    expect(chartContainer.props.accessibilityRole).toBe('image')
+  })
+
+  it('shows empty state with Go to Nutrition button when no data', async () => {
+    mockDailyTotals.mockResolvedValue([])
+    mockWeeklyAverages.mockResolvedValue([])
+    mockAdherence.mockResolvedValue({ trackedDays: 0, onTargetDays: 0, currentStreak: 0, longestStreak: 0 })
+
+    const { getByText, getByLabelText } = renderScreen(<NutritionSegment />)
+
+    await waitFor(() => {
+      expect(getByText(/Start tracking your meals/)).toBeTruthy()
+    })
+
+    const btn = getByLabelText('Go to Nutrition tab')
+    expect(btn).toBeTruthy()
+  })
+
+  it('shows adherence card with correct percentage and streaks', async () => {
+    const { getByText, getByLabelText } = renderScreen(<NutritionSegment />)
+
+    await waitFor(() => {
+      expect(getByText('Adherence')).toBeTruthy()
+    })
+
+    // 16 of 20 = 80%
+    expect(getByText('80%')).toBeTruthy()
+    expect(getByText('16 of 20 tracked days on target')).toBeTruthy()
+
+    // Streaks
+    expect(getByLabelText('Current streak: 5 days')).toBeTruthy()
+    expect(getByLabelText('Longest streak: 12 days')).toBeTruthy()
+  })
+
+  it('shows weekly averages card with macro pills', async () => {
+    const { getByText } = renderScreen(<NutritionSegment />)
+
+    await waitFor(() => {
+      expect(getByText('Weekly Averages')).toBeTruthy()
+    })
+
+    // Should show current week calories
+    expect(getByText('This Week')).toBeTruthy()
+  })
+
+  it('shows info banner when no macro targets are set', async () => {
+    mockTargets.mockResolvedValue(null)
+    mockAdherence.mockResolvedValue(null)
+
+    const { getByText } = renderScreen(<NutritionSegment />)
+
+    await waitFor(() => {
+      expect(getByText(/Set your macro targets/)).toBeTruthy()
+    })
+  })
+
+  it('shows info text when insufficient data (< 3 days)', async () => {
+    mockDailyTotals.mockResolvedValue(makeDailyTotals(2))
+    mockWeeklyAverages.mockResolvedValue(makeWeeklyAverages(1))
+
+    const { getByText } = renderScreen(<NutritionSegment />)
+
+    await waitFor(() => {
+      expect(getByText(/Track for a few more days/)).toBeTruthy()
+    })
+  })
+
+  it('shows error state with retry button on failure', async () => {
+    mockTargets.mockRejectedValue(new Error('DB failure'))
+
+    const { getByText, getByLabelText } = renderScreen(<NutritionSegment />)
+
+    await waitFor(() => {
+      expect(getByText("Couldn't load nutrition data")).toBeTruthy()
+    })
+
+    const retryBtn = getByLabelText('Retry loading nutrition data')
+    expect(retryBtn).toBeTruthy()
+  })
+
+  it('renders period chips with 48dp min touch targets', async () => {
+    const { getByLabelText } = renderScreen(<NutritionSegment />)
+
+    await waitFor(() => {
+      const chip4W = getByLabelText('4W period')
+      expect(chip4W).toBeTruthy()
+      expect(chip4W.props.style).toBeDefined()
+    })
+
+    const chip8W = getByLabelText('8W period')
+    const chip12W = getByLabelText('12W period')
+    expect(chip8W).toBeTruthy()
+    expect(chip12W).toBeTruthy()
+  })
+
+  it('adherence progress bar has correct accessibility value', async () => {
+    const { UNSAFE_queryAllByProps } = renderScreen(<NutritionSegment />)
+
+    await waitFor(() => {
+      const progressBars = UNSAFE_queryAllByProps({ accessibilityRole: 'progressbar' })
+      expect(progressBars.length).toBeGreaterThan(0)
+      expect(progressBars[0].props.accessibilityValue).toEqual({ min: 0, max: 100, now: 80 })
+    })
+  })
+
+  it('shows celebratory icon for 100% adherence', async () => {
+    mockAdherence.mockResolvedValue({
+      trackedDays: 10, onTargetDays: 10, currentStreak: 10, longestStreak: 10,
+    })
+
+    const { getByText } = renderScreen(<NutritionSegment />)
+
+    await waitFor(() => {
+      expect(getByText('100%')).toBeTruthy()
+      expect(getByText('🎯')).toBeTruthy()
+    })
+  })
+})
+
+// ─── Data Layer Tests ──────────────────────────────────────────────
+
+describe('Nutrition Progress Data Layer', () => {
+  it('getDailyNutritionTotals calls DB with correct date range', async () => {
+    mockDailyTotals.mockResolvedValue([])
+
+    const { getDailyNutritionTotals } = require('../../lib/db')
+    await getDailyNutritionTotals('2026-01-01', '2026-01-28')
+
+    expect(mockDailyTotals).toHaveBeenCalledWith('2026-01-01', '2026-01-28')
+  })
+})

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -5,6 +5,7 @@ import { useLayout } from "../../lib/layout";
 import MuscleVolumeSegment from "../../components/MuscleVolumeSegment";
 import WorkoutSegment from "@/components/progress/WorkoutSegment";
 import BodySegment from "@/components/progress/BodySegment";
+import NutritionSegment from "@/components/progress/NutritionSegment";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
 export default function Progress() {
@@ -22,6 +23,7 @@ export default function Progress() {
             { value: "workouts", label: "Workouts", accessibilityLabel: "Workouts progress" },
             { value: "body", label: "Body", accessibilityLabel: "Body metrics" },
             { value: "muscles", label: "Muscles", accessibilityLabel: "Muscle volume analysis" },
+            { value: "nutrition", label: "Nutrition", accessibilityLabel: "Nutrition trends" },
           ]}
         />
       </View>
@@ -29,7 +31,9 @@ export default function Progress() {
         ? <WorkoutSegment />
         : segment === "body"
           ? <BodySegment />
-          : <MuscleVolumeSegment />}
+          : segment === "muscles"
+            ? <MuscleVolumeSegment />
+            : <NutritionSegment />}
     </View>
   );
 }

--- a/components/progress/NutritionCards.tsx
+++ b/components/progress/NutritionCards.tsx
@@ -1,0 +1,391 @@
+import { StyleSheet, View } from "react-native";
+import { Card } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
+import { CartesianChart, Line } from "victory-native";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { semantic } from "../../constants/theme";
+import type { DailyNutritionTotal, WeeklyNutritionAverage, NutritionAdherence } from "../../lib/db";
+
+// ─── Calorie Trend Card ────────────────────────────────────────────
+
+type CalorieTrendCardProps = {
+  dailyTotals: DailyNutritionTotal[];
+  calorieTarget: number | null;
+  chartWidth: number;
+  reducedMotion: boolean;
+  style?: object;
+};
+
+export function CalorieTrendCard({
+  dailyTotals,
+  calorieTarget,
+  chartWidth,
+  reducedMotion,
+  style,
+}: CalorieTrendCardProps) {
+  const colors = useThemeColors();
+
+  const chartData = dailyTotals.map((d, i) => ({
+    x: i,
+    calories: d.calories,
+    target: calorieTarget ?? 0,
+  }));
+
+  const avgCalories = dailyTotals.length > 0
+    ? Math.round(dailyTotals.reduce((s, d) => s + d.calories, 0) / dailyTotals.length)
+    : 0;
+
+  const summaryLabel = calorieTarget
+    ? `Calorie trend: averaging ${avgCalories} calories over ${dailyTotals.length} days, target is ${calorieTarget}`
+    : `Calorie trend: averaging ${avgCalories} calories over ${dailyTotals.length} days`;
+
+  return (
+    <Card style={[styles.card, style]}>
+      <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
+        Calorie Trend
+      </Text>
+      <View
+        style={{ width: chartWidth, height: 180 }}
+        accessibilityRole="image"
+        accessibilityLabel={summaryLabel}
+      >
+        {chartData.length >= 2 ? (
+          <CartesianChart
+            data={chartData}
+            xKey="x"
+            yKeys={calorieTarget ? ["calories", "target"] : ["calories"]}
+            domainPadding={{ left: 10, right: 10 }}
+          >
+            {({ points }) => (
+              <>
+                <Line
+                  points={points.calories}
+                  color={colors.primary}
+                  strokeWidth={2}
+                  curveType="natural"
+                  animate={reducedMotion ? undefined : { type: "timing", duration: 300 }}
+                />
+                {calorieTarget && points.target ? (
+                  <Line
+                    points={points.target}
+                    color={colors.outline}
+                    strokeWidth={1}
+                    curveType="linear"
+                  />
+                ) : null}
+              </>
+            )}
+          </CartesianChart>
+        ) : (
+          <View style={styles.chartEmpty}>
+            <Text style={{ color: colors.onSurfaceVariant, textAlign: "center" }}>
+              Need at least 2 days of data for chart
+            </Text>
+          </View>
+        )}
+      </View>
+    </Card>
+  );
+}
+
+// ─── Weekly Averages Card ──────────────────────────────────────────
+
+type WeeklyAveragesCardProps = {
+  weeklyAverages: WeeklyNutritionAverage[];
+  style?: object;
+};
+
+function formatDelta(calDelta: number, calDeltaPct: number): string {
+  const direction = calDelta > 0 ? "increased" : "decreased";
+  return `${direction} by ${Math.abs(calDelta)} calories (${Math.abs(calDeltaPct)}%)`;
+}
+
+function deltaArrow(calDelta: number): string {
+  if (calDelta > 0) return "↑";
+  if (calDelta < 0) return "↓";
+  return "";
+}
+
+export function WeeklyAveragesCard({ weeklyAverages, style }: WeeklyAveragesCardProps) {
+  const colors = useThemeColors();
+
+  if (weeklyAverages.length === 0) return null;
+
+  const thisWeek = weeklyAverages[weeklyAverages.length - 1];
+  const lastWeek = weeklyAverages.length >= 2 ? weeklyAverages[weeklyAverages.length - 2] : null;
+
+  const calDelta = lastWeek ? thisWeek.avgCalories - lastWeek.avgCalories : null;
+  const calDeltaPct = lastWeek && lastWeek.avgCalories > 0
+    ? Math.round((calDelta! / lastWeek.avgCalories) * 100)
+    : null;
+
+  const arrow = calDelta !== null ? deltaArrow(calDelta) : "";
+  const deltaLabelText = calDelta !== null ? formatDelta(calDelta, calDeltaPct ?? 0) : "";
+
+  return (
+    <Card style={[styles.card, style]}>
+      <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
+        Weekly Averages
+      </Text>
+      <View style={styles.weekCompare}>
+        <View style={{ flex: 1 }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>This Week</Text>
+          <Text style={{ color: colors.onSurface, fontSize: 20, fontWeight: "600" }}>
+            {thisWeek.avgCalories} cal
+          </Text>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+            {thisWeek.daysTracked} days tracked
+          </Text>
+        </View>
+        {lastWeek && (
+          <View style={{ flex: 1 }}>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Last Week</Text>
+            <Text style={{ color: colors.onSurface, fontSize: 20, fontWeight: "600" }}>
+              {lastWeek.avgCalories} cal
+            </Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+              {lastWeek.daysTracked} days tracked
+            </Text>
+          </View>
+        )}
+      </View>
+      {calDelta !== null && (
+        <Text
+          style={{ color: calDelta > 0 ? colors.error : colors.primary, marginTop: 8 }}
+          accessibilityLabel={deltaLabelText}
+        >
+          {arrow} {Math.abs(calDelta)} cal ({Math.abs(calDeltaPct ?? 0)}%)
+        </Text>
+      )}
+      <View style={[styles.macroRow, { marginTop: 12 }]}>
+        <MacroPill label="P" value={thisWeek.avgProtein} unit="g" color={semantic.protein} />
+        <MacroPill label="C" value={thisWeek.avgCarbs} unit="g" color={semantic.carbs} />
+        <MacroPill label="F" value={thisWeek.avgFat} unit="g" color={semantic.fat} />
+      </View>
+    </Card>
+  );
+}
+
+function MacroPill({ label, value, unit, color }: { label: string; value: number; unit: string; color: string }) {
+  return (
+    <View style={[styles.macroPill, { borderColor: color }]}>
+      <Text style={{ color, fontWeight: "600", fontSize: 12 }}>{label}</Text>
+      <Text style={{ color, fontSize: 14, fontWeight: "600", marginLeft: 4 }}>{value}{unit}</Text>
+    </View>
+  );
+}
+
+// ─── Adherence Card ────────────────────────────────────────────────
+
+type AdherenceCardProps = {
+  adherence: NutritionAdherence;
+  style?: object;
+};
+
+export function AdherenceCard({ adherence, style }: AdherenceCardProps) {
+  const colors = useThemeColors();
+
+  const pct = adherence.trackedDays > 0
+    ? Math.round((adherence.onTargetDays / adherence.trackedDays) * 100)
+    : 0;
+
+  const barColor = pct >= 80 ? colors.primary : pct >= 50 ? semantic.carbs : colors.error;
+  const isPerfect = pct === 100;
+
+  return (
+    <Card style={[styles.card, style]}>
+      <View style={styles.cardHeader}>
+        <Text variant="subtitle" style={{ color: colors.onSurface }}>
+          Adherence
+        </Text>
+        {isPerfect && <Text style={{ fontSize: 18 }}>🎯</Text>}
+      </View>
+
+      <Text
+        style={{ color: colors.onSurface, fontSize: 28, fontWeight: "700", marginTop: 4 }}
+        accessibilityLabel={`${pct}% of tracked days on target`}
+      >
+        {pct}%
+      </Text>
+      <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginBottom: 8 }}>
+        {adherence.onTargetDays} of {adherence.trackedDays} tracked days on target
+      </Text>
+
+      <View
+        style={[styles.progressTrack, { backgroundColor: colors.surfaceVariant }]}
+        accessibilityRole="progressbar"
+        accessibilityValue={{ min: 0, max: 100, now: pct }}
+      >
+        <View style={[styles.progressFill, { width: `${pct}%`, backgroundColor: barColor }]} />
+      </View>
+
+      <View style={[styles.streakRow, { marginTop: 12 }]}>
+        <View style={{ flex: 1 }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Current Streak</Text>
+          <Text
+            style={{ color: colors.onSurface, fontWeight: "600" }}
+            accessibilityLabel={`Current streak: ${adherence.currentStreak} days`}
+          >
+            {adherence.currentStreak} {adherence.currentStreak === 1 ? "day" : "days"}
+          </Text>
+        </View>
+        <View style={{ flex: 1 }}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Longest Streak</Text>
+          <Text
+            style={{ color: colors.onSurface, fontWeight: "600" }}
+            accessibilityLabel={`Longest streak: ${adherence.longestStreak} days`}
+          >
+            {adherence.longestStreak} {adherence.longestStreak === 1 ? "day" : "days"}
+          </Text>
+        </View>
+      </View>
+    </Card>
+  );
+}
+
+// ─── Macro Trend Card ──────────────────────────────────────────────
+
+type MacroTrendCardProps = {
+  weeklyAverages: WeeklyNutritionAverage[];
+  chartWidth: number;
+  reducedMotion: boolean;
+  style?: object;
+};
+
+export function MacroTrendCard({ weeklyAverages, chartWidth, reducedMotion, style }: MacroTrendCardProps) {
+  const colors = useThemeColors();
+
+  if (weeklyAverages.length < 2) return null;
+
+  const chartData = weeklyAverages.map((w, i) => ({
+    x: i,
+    protein: w.avgProtein,
+    carbs: w.avgCarbs,
+    fat: w.avgFat,
+  }));
+
+  const latestWeek = weeklyAverages[weeklyAverages.length - 1];
+  const summaryLabel = `Macro trends: latest week averages ${latestWeek.avgProtein}g protein, ${latestWeek.avgCarbs}g carbs, ${latestWeek.avgFat}g fat`;
+
+  return (
+    <Card style={[styles.card, style]}>
+      <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 8 }}>
+        Macro Trends
+      </Text>
+      <View style={styles.legendRow}>
+        <LegendDot color={semantic.protein} label="Protein" />
+        <LegendDot color={semantic.carbs} label="Carbs" />
+        <LegendDot color={semantic.fat} label="Fat" />
+      </View>
+      <View
+        style={{ width: chartWidth, height: 180 }}
+        accessibilityRole="image"
+        accessibilityLabel={summaryLabel}
+      >
+        <CartesianChart
+          data={chartData}
+          xKey="x"
+          yKeys={["protein", "carbs", "fat"]}
+          domainPadding={{ left: 10, right: 10 }}
+        >
+          {({ points }) => (
+            <>
+              <Line
+                points={points.protein}
+                color={semantic.protein}
+                strokeWidth={2}
+                curveType="natural"
+                animate={reducedMotion ? undefined : { type: "timing", duration: 300 }}
+              />
+              <Line
+                points={points.carbs}
+                color={semantic.carbs}
+                strokeWidth={2}
+                curveType="natural"
+                animate={reducedMotion ? undefined : { type: "timing", duration: 300 }}
+              />
+              <Line
+                points={points.fat}
+                color={semantic.fat}
+                strokeWidth={2}
+                curveType="natural"
+                animate={reducedMotion ? undefined : { type: "timing", duration: 300 }}
+              />
+            </>
+          )}
+        </CartesianChart>
+      </View>
+    </Card>
+  );
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <View style={styles.legendItem}>
+      <View style={[styles.legendDot, { backgroundColor: color }]} />
+      <Text style={{ fontSize: 12, color }}>{label}</Text>
+    </View>
+  );
+}
+
+// ─── Styles ────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+  },
+  cardHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  chartEmpty: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  weekCompare: {
+    flexDirection: "row",
+    gap: 16,
+  },
+  macroRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  macroPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
+  progressTrack: {
+    height: 8,
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: 4,
+  },
+  streakRow: {
+    flexDirection: "row",
+    gap: 16,
+  },
+  legendRow: {
+    flexDirection: "row",
+    gap: 16,
+    marginBottom: 8,
+  },
+  legendItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+  legendDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+});

--- a/components/progress/NutritionSegment.tsx
+++ b/components/progress/NutritionSegment.tsx
@@ -1,0 +1,263 @@
+import { useCallback } from "react";
+import { ScrollView, StyleSheet, View, useWindowDimensions } from "react-native";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Chip } from "@/components/ui/chip";
+import { Text } from "@/components/ui/text";
+import { useFocusEffect, useRouter } from "expo-router";
+import { useLayout } from "../../lib/layout";
+import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { useNutritionProgress, type NutritionPeriod } from "@/hooks/useNutritionProgress";
+import {
+  CalorieTrendCard,
+  WeeklyAveragesCard,
+  AdherenceCard,
+  MacroTrendCard,
+} from "./NutritionCards";
+
+const PERIODS: { value: NutritionPeriod; label: string }[] = [
+  { value: 4, label: "4W" },
+  { value: 8, label: "8W" },
+  { value: 12, label: "12W" },
+];
+
+export default function NutritionSegment() {
+  const colors = useThemeColors();
+  const layout = useLayout();
+  const tabBarHeight = useFloatingTabBarHeight();
+  const router = useRouter();
+  const { width: screenWidth } = useWindowDimensions();
+
+  const {
+    dailyTotals,
+    weeklyAverages,
+    adherence,
+    targets,
+    period,
+    setPeriod,
+    loading,
+    error,
+    refetch,
+    reducedMotion,
+  } = useNutritionProgress();
+
+  useFocusEffect(
+    useCallback(() => {
+      refetch();
+    }, [refetch]),
+  );
+
+  const chartWidth = layout.atLeastMedium
+    ? (screenWidth - 96) / 2 - 32
+    : screenWidth - 48;
+
+  // Error state
+  if (error) {
+    return (
+      <View style={[styles.center, { flex: 1 }]}>
+        <Card style={styles.errorCard}>
+          <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 8 }}>
+            Couldn&apos;t load nutrition data
+          </Text>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginBottom: 16 }}>
+            {error.message}
+          </Text>
+          <Button
+            variant="outline"
+            onPress={refetch}
+            accessibilityLabel="Retry loading nutrition data"
+            label="Retry"
+          />
+        </Card>
+      </View>
+    );
+  }
+
+  // Loading state — skeleton placeholders
+  if (loading) {
+    return (
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={[styles.content, { paddingBottom: tabBarHeight + 16 }]}
+      >
+        <SkeletonCard colors={colors} height={40} />
+        <SkeletonCard colors={colors} height={200} />
+        <SkeletonCard colors={colors} height={120} />
+        <SkeletonCard colors={colors} height={160} />
+        <SkeletonCard colors={colors} height={180} />
+      </ScrollView>
+    );
+  }
+
+  // Empty state — no nutrition data at all
+  if (dailyTotals.length === 0) {
+    return (
+      <View style={[styles.center, { flex: 1 }]}>
+        <Text style={{ fontSize: 40, marginBottom: 8 }}>🥗</Text>
+        <Text
+          style={{
+            color: colors.onSurfaceVariant,
+            textAlign: "center",
+            padding: 16,
+            maxWidth: 280,
+          }}
+        >
+          Start tracking your meals in the Nutrition tab to see trends here.
+        </Text>
+        <Button
+          variant="default"
+          onPress={() => router.push("/(tabs)/nutrition")}
+          accessibilityLabel="Go to Nutrition tab"
+          label="Go to Nutrition"
+          style={{ marginTop: 8 }}
+        />
+      </View>
+    );
+  }
+
+  const insufficientData = dailyTotals.length < 3;
+  const noTargets = !targets;
+  const wideCard = layout.atLeastMedium ? styles.wideCard : undefined;
+
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={[styles.content, { paddingBottom: tabBarHeight + 16 }]}
+    >
+      {/* Period selector */}
+      <View style={styles.periodRow}>
+        {PERIODS.map((p) => (
+          <Chip
+            key={p.value}
+            selected={period === p.value}
+            onPress={() => setPeriod(p.value)}
+            accessibilityLabel={`${p.label} period`}
+            accessibilityRole="button"
+            accessibilityState={{ selected: period === p.value }}
+            style={{ minWidth: 48, minHeight: 48 }}
+          >
+            {p.label}
+          </Chip>
+        ))}
+      </View>
+
+      {/* Info banners */}
+      {insufficientData && (
+        <Card style={[styles.infoBanner, { backgroundColor: colors.surfaceVariant }]}>
+          <Text style={{ color: colors.onSurfaceVariant }}>
+            Track for a few more days to see meaningful trends.
+          </Text>
+        </Card>
+      )}
+      {noTargets && (
+        <Card style={[styles.infoBanner, { backgroundColor: colors.surfaceVariant }]}>
+          <Text style={{ color: colors.onSurfaceVariant }}>
+            Set your macro targets to see adherence tracking.
+          </Text>
+          <Button
+            variant="ghost"
+            size="sm"
+            onPress={() => router.push("/(tabs)/nutrition")}
+            label="Set Targets"
+            style={{ marginTop: 4, alignSelf: "flex-start" }}
+          />
+        </Card>
+      )}
+
+      {/* Cards */}
+      {layout.atLeastMedium ? (
+        <>
+          <View style={styles.grid}>
+            <CalorieTrendCard
+              dailyTotals={dailyTotals}
+              calorieTarget={targets?.calories ?? null}
+              chartWidth={chartWidth}
+              reducedMotion={reducedMotion}
+              style={wideCard}
+            />
+            <WeeklyAveragesCard
+              weeklyAverages={weeklyAverages}
+              style={wideCard}
+            />
+          </View>
+          <View style={styles.grid}>
+            {adherence && <AdherenceCard adherence={adherence} style={wideCard} />}
+            <MacroTrendCard
+              weeklyAverages={weeklyAverages}
+              chartWidth={chartWidth}
+              reducedMotion={reducedMotion}
+              style={wideCard}
+            />
+          </View>
+        </>
+      ) : (
+        <>
+          <CalorieTrendCard
+            dailyTotals={dailyTotals}
+            calorieTarget={targets?.calories ?? null}
+            chartWidth={chartWidth}
+            reducedMotion={reducedMotion}
+          />
+          <WeeklyAveragesCard weeklyAverages={weeklyAverages} />
+          {adherence && <AdherenceCard adherence={adherence} />}
+          <MacroTrendCard
+            weeklyAverages={weeklyAverages}
+            chartWidth={chartWidth}
+            reducedMotion={reducedMotion}
+          />
+        </>
+      )}
+    </ScrollView>
+  );
+}
+
+function SkeletonCard({ colors, height }: { colors: ReturnType<typeof useThemeColors>; height: number }) {
+  return (
+    <View
+      style={[
+        styles.skeleton,
+        {
+          height,
+          backgroundColor: colors.surfaceVariant,
+        },
+      ]}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 80,
+  },
+  periodRow: {
+    flexDirection: "row",
+    gap: 8,
+    marginBottom: 16,
+  },
+  infoBanner: {
+    marginBottom: 12,
+    padding: 12,
+  },
+  grid: {
+    flexDirection: "row",
+    gap: 16,
+  },
+  wideCard: {
+    flex: 1,
+  },
+  errorCard: {
+    margin: 32,
+    alignItems: "center",
+  },
+  skeleton: {
+    borderRadius: 12,
+    marginBottom: 16,
+    opacity: 0.5,
+  },
+});

--- a/components/progress/NutritionSegment.tsx
+++ b/components/progress/NutritionSegment.tsx
@@ -16,11 +16,7 @@ import {
   MacroTrendCard,
 } from "./NutritionCards";
 
-const PERIODS: { value: NutritionPeriod; label: string }[] = [
-  { value: 4, label: "4W" },
-  { value: 8, label: "8W" },
-  { value: 12, label: "12W" },
-];
+
 
 export default function NutritionSegment() {
   const colors = useThemeColors();
@@ -126,21 +122,7 @@ export default function NutritionSegment() {
       contentContainerStyle={[styles.content, { paddingBottom: tabBarHeight + 16 }]}
     >
       {/* Period selector */}
-      <View style={styles.periodRow}>
-        {PERIODS.map((p) => (
-          <Chip
-            key={p.value}
-            selected={period === p.value}
-            onPress={() => setPeriod(p.value)}
-            accessibilityLabel={`${p.label} period`}
-            accessibilityRole="button"
-            accessibilityState={{ selected: period === p.value }}
-            style={{ minWidth: 48, minHeight: 48 }}
-          >
-            {p.label}
-          </Chip>
-        ))}
-      </View>
+      <PeriodSelector period={period} onSelect={setPeriod} />
 
       {/* Info banners */}
       {insufficientData && (
@@ -209,6 +191,49 @@ export default function NutritionSegment() {
         </>
       )}
     </ScrollView>
+  );
+}
+
+function PeriodSelector({
+  period,
+  onSelect,
+}: {
+  period: NutritionPeriod;
+  onSelect: (p: NutritionPeriod) => void;
+}) {
+  return (
+    <View style={styles.periodRow}>
+      <Chip
+        selected={period === 4}
+        onPress={() => onSelect(4)}
+        accessibilityLabel="4W period"
+        accessibilityRole="button"
+        accessibilityState={{ selected: period === 4 }}
+        style={{ minWidth: 48, minHeight: 48 }}
+      >
+        {"4W"}
+      </Chip>
+      <Chip
+        selected={period === 8}
+        onPress={() => onSelect(8)}
+        accessibilityLabel="8W period"
+        accessibilityRole="button"
+        accessibilityState={{ selected: period === 8 }}
+        style={{ minWidth: 48, minHeight: 48 }}
+      >
+        {"8W"}
+      </Chip>
+      <Chip
+        selected={period === 12}
+        onPress={() => onSelect(12)}
+        accessibilityLabel="12W period"
+        accessibilityRole="button"
+        accessibilityState={{ selected: period === 12 }}
+        style={{ minWidth: 48, minHeight: 48 }}
+      >
+        {"12W"}
+      </Chip>
+    </View>
   );
 }
 

--- a/hooks/useNutritionProgress.ts
+++ b/hooks/useNutritionProgress.ts
@@ -1,0 +1,104 @@
+import { useCallback, useState } from "react";
+import { useReducedMotion } from "react-native-reanimated";
+import {
+  getDailyNutritionTotals,
+  getWeeklyNutritionAverages,
+  getNutritionAdherence,
+  getNutritionTargets,
+} from "../lib/db";
+import type {
+  DailyNutritionTotal,
+  WeeklyNutritionAverage,
+  NutritionAdherence,
+} from "../lib/db";
+import type { MacroTargets } from "../lib/types";
+
+export type NutritionPeriod = 4 | 8 | 12;
+
+export type NutritionProgressData = {
+  dailyTotals: DailyNutritionTotal[];
+  weeklyAverages: WeeklyNutritionAverage[];
+  adherence: NutritionAdherence | null;
+  targets: MacroTargets | null;
+  period: NutritionPeriod;
+  setPeriod: (p: NutritionPeriod) => void;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => void;
+  reducedMotion: boolean;
+};
+
+function dateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function useNutritionProgress(): NutritionProgressData {
+  const [period, setPeriod] = useState<NutritionPeriod>(4);
+  const [dailyTotals, setDailyTotals] = useState<DailyNutritionTotal[]>([]);
+  const [weeklyAverages, setWeeklyAverages] = useState<WeeklyNutritionAverage[]>([]);
+  const [adherence, setAdherence] = useState<NutritionAdherence | null>(null);
+  const [targets, setTargets] = useState<MacroTargets | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const reducedMotion = useReducedMotion() ?? false;
+
+  const fetchData = useCallback(async (weeks: NutritionPeriod) => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const today = new Date();
+      const endDate = dateKey(today);
+      const start = new Date(today);
+      start.setDate(start.getDate() - weeks * 7);
+      const startDate = dateKey(start);
+
+      const t = await getNutritionTargets();
+      setTargets(t);
+
+      const [daily, weekly] = await Promise.all([
+        getDailyNutritionTotals(startDate, endDate),
+        getWeeklyNutritionAverages(weeks),
+      ]);
+
+      setDailyTotals(daily);
+      setWeeklyAverages(weekly);
+
+      if (t) {
+        const adh = await getNutritionAdherence(weeks * 7, t.calories);
+        setAdherence(adh);
+      } else {
+        setAdherence(null);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error("Failed to load nutrition data"));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const load = useCallback(() => {
+    fetchData(period);
+  }, [fetchData, period]);
+
+  const handleSetPeriod = useCallback((p: NutritionPeriod) => {
+    setPeriod(p);
+    fetchData(p);
+  }, [fetchData]);
+
+  return {
+    dailyTotals,
+    weeklyAverages,
+    adherence,
+    targets,
+    period,
+    setPeriod: handleSetPeriod,
+    loading,
+    error,
+    refetch: load,
+    reducedMotion,
+  };
+}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -238,6 +238,18 @@ export {
 export type { HCSyncLog, HCSyncStatus } from "./health-connect";
 
 export {
+  getDailyNutritionTotals,
+  getWeeklyNutritionAverages,
+  getNutritionAdherence,
+  getNutritionTargets,
+} from "./nutrition-progress";
+export type {
+  DailyNutritionTotal,
+  WeeklyNutritionAverage,
+  NutritionAdherence,
+} from "./nutrition-progress";
+
+export {
   createMealTemplate,
   getMealTemplates,
   getMealTemplateById,

--- a/lib/db/nutrition-progress.ts
+++ b/lib/db/nutrition-progress.ts
@@ -1,0 +1,207 @@
+import { query, queryOne } from "./helpers";
+import type { MacroTargets } from "../types";
+import { NUTRITION_ON_TARGET_TOLERANCE } from "./weekly-summary";
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export type DailyNutritionTotal = {
+  date: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+};
+
+export type WeeklyNutritionAverage = {
+  weekStart: string;
+  avgCalories: number;
+  avgProtein: number;
+  avgCarbs: number;
+  avgFat: number;
+  daysTracked: number;
+};
+
+export type NutritionAdherence = {
+  trackedDays: number;
+  onTargetDays: number;
+  currentStreak: number;
+  longestStreak: number;
+};
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function dateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function generateDateRange(startDate: string, endDate: string): string[] {
+  const dates: string[] = [];
+  const current = new Date(startDate + "T00:00:00");
+  const end = new Date(endDate + "T00:00:00");
+  while (current <= end) {
+    dates.push(dateKey(current));
+    current.setDate(current.getDate() + 1);
+  }
+  return dates;
+}
+
+function mondayOfWeek(d: Date): string {
+  const copy = new Date(d);
+  const day = copy.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  copy.setDate(copy.getDate() + diff);
+  return dateKey(copy);
+}
+
+// ─── Query Functions ───────────────────────────────────────────────
+
+/**
+ * Get daily nutrition totals for a date range.
+ * Only returns days with at least one food entry (tracked days).
+ */
+export async function getDailyNutritionTotals(
+  startDate: string,
+  endDate: string,
+): Promise<DailyNutritionTotal[]> {
+  return query<DailyNutritionTotal>(
+    `SELECT dl.date,
+            SUM(f.calories * dl.servings) AS calories,
+            SUM(f.protein * dl.servings) AS protein,
+            SUM(f.carbs * dl.servings) AS carbs,
+            SUM(f.fat * dl.servings) AS fat
+     FROM daily_log dl
+     JOIN food_entries f ON dl.food_entry_id = f.id
+     WHERE dl.date BETWEEN ? AND ?
+     GROUP BY dl.date
+     ORDER BY dl.date ASC`,
+    [startDate, endDate],
+  );
+}
+
+/**
+ * Get weekly nutrition averages for a given number of weeks back from today.
+ */
+export async function getWeeklyNutritionAverages(
+  weeks: number,
+): Promise<WeeklyNutritionAverage[]> {
+  const today = new Date();
+  const endDate = dateKey(today);
+  const start = new Date(today);
+  start.setDate(start.getDate() - weeks * 7);
+  const startDate = dateKey(start);
+
+  const dailyTotals = await getDailyNutritionTotals(startDate, endDate);
+  if (dailyTotals.length === 0) return [];
+
+  // Group by week (Monday start)
+  const weekMap = new Map<string, DailyNutritionTotal[]>();
+  for (const dt of dailyTotals) {
+    const wk = mondayOfWeek(new Date(dt.date + "T00:00:00"));
+    const arr = weekMap.get(wk) ?? [];
+    arr.push(dt);
+    weekMap.set(wk, arr);
+  }
+
+  const result: WeeklyNutritionAverage[] = [];
+  const sortedWeeks = [...weekMap.keys()].sort();
+  for (const wk of sortedWeeks) {
+    const days = weekMap.get(wk)!;
+    const n = days.length;
+    result.push({
+      weekStart: wk,
+      avgCalories: Math.round(days.reduce((s, d) => s + d.calories, 0) / n),
+      avgProtein: Math.round(days.reduce((s, d) => s + d.protein, 0) / n),
+      avgCarbs: Math.round(days.reduce((s, d) => s + d.carbs, 0) / n),
+      avgFat: Math.round(days.reduce((s, d) => s + d.fat, 0) / n),
+      daysTracked: n,
+    });
+  }
+  return result;
+}
+
+/**
+ * Calculate adherence stats for a given number of days.
+ * Only counts days with ≥1 food entry. Streak is calorie-only (within ±tolerance).
+ */
+export async function getNutritionAdherence(
+  days: number,
+  calorieTarget: number,
+  tolerancePercent: number = NUTRITION_ON_TARGET_TOLERANCE,
+): Promise<NutritionAdherence> {
+  const today = new Date();
+  const endDate = dateKey(today);
+  const start = new Date(today);
+  start.setDate(start.getDate() - days + 1);
+  const startDate = dateKey(start);
+
+  const dailyTotals = await getDailyNutritionTotals(startDate, endDate);
+
+  if (dailyTotals.length === 0) {
+    return { trackedDays: 0, onTargetDays: 0, currentStreak: 0, longestStreak: 0 };
+  }
+
+  const trackedDays = dailyTotals.length;
+  const onTargetDays = dailyTotals.filter((d) => {
+    const diff = Math.abs(d.calories - calorieTarget) / calorieTarget;
+    return diff <= tolerancePercent;
+  }).length;
+
+  // Compute streaks — iterate sorted dates
+  // Build a set of tracked dates for lookup
+  const trackedSet = new Set(dailyTotals.map((d) => d.date));
+  const calorieByDate = new Map(dailyTotals.map((d) => [d.date, d.calories]));
+
+  // Generate full date range and iterate backwards for current streak, forward for longest
+  const allDates = generateDateRange(startDate, endDate);
+
+  let currentStreak = 0;
+  let longestStreak = 0;
+  let streak = 0;
+
+  // Iterate forward for longest streak (consecutive tracked days on target)
+  for (const date of allDates) {
+    if (!trackedSet.has(date)) {
+      // Untracked day breaks the streak
+      streak = 0;
+      continue;
+    }
+    const cal = calorieByDate.get(date)!;
+    const diff = Math.abs(cal - calorieTarget) / calorieTarget;
+    if (diff <= tolerancePercent) {
+      streak++;
+      longestStreak = Math.max(longestStreak, streak);
+    } else {
+      streak = 0;
+    }
+  }
+
+  // Current streak: iterate backward from today
+  currentStreak = 0;
+  for (let i = allDates.length - 1; i >= 0; i--) {
+    const date = allDates[i];
+    if (!trackedSet.has(date)) {
+      break; // untracked day ends current streak
+    }
+    const cal = calorieByDate.get(date)!;
+    const diff = Math.abs(cal - calorieTarget) / calorieTarget;
+    if (diff <= tolerancePercent) {
+      currentStreak++;
+    } else {
+      break;
+    }
+  }
+
+  return { trackedDays, onTargetDays, currentStreak, longestStreak };
+}
+
+/**
+ * Get macro targets. Returns null if no targets are set.
+ */
+export async function getNutritionTargets(): Promise<MacroTargets | null> {
+  return queryOne<MacroTargets>(
+    "SELECT * FROM macro_targets LIMIT 1",
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fitforge",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fitforge",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.9",


### PR DESCRIPTION
## Summary

Adds a 4th "Nutrition" segment to the Progress tab, allowing users to visualize their nutrition trends over time with calorie charts, macro breakdowns, adherence tracking, and streak metrics.

## Changes

- **lib/db/nutrition-progress.ts**: New data layer with `getDailyNutritionTotals`, `getWeeklyNutritionAverages`, `getNutritionAdherence`, `getNutritionTargets`
- **hooks/useNutritionProgress.ts**: State management hook with useFocusEffect pattern, period switching, loading/error states
- **components/progress/NutritionCards.tsx**: CalorieTrendCard (line chart), WeeklyAveragesCard, AdherenceCard (progress bar + streaks), MacroTrendCard (multi-line)
- **components/progress/NutritionSegment.tsx**: Main container with period selector, empty/loading/error/insufficient data states, info banners
- **app/(tabs)/progress.tsx**: Added "Nutrition" to SegmentedControl
- **lib/db/index.ts**: Barrel exports for new functions and types
- **__tests__/acceptance/nutrition-progress.test.tsx**: 11 acceptance tests

## Accessibility

- Chart containers: `accessibilityRole="image"` with summary labels
- Progress bar: `accessibilityRole="progressbar"` with `accessibilityValue`
- Delta arrows: natural-language `accessibilityLabel`
- Period chips: 48dp min touch targets
- Streak/adherence values announced via `accessibilityLabel`

## Testing

- 11 new acceptance tests covering all states (data, empty, error, insufficient, no targets, adherence, streaks, 100% adherence)
- All 1770 tests pass (was 1759)
- `tsc --noEmit` passes (zero errors)
- ESLint passes with zero warnings

## Issue

Resolves BLD-339