### PR TITLE
feat: Workout Calendar View (BLD-341)

### DIFF
--- a/__tests__/calendar.test.ts
+++ b/__tests__/calendar.test.ts
@@ -1,0 +1,229 @@
+import {
+  calculateStreaks,
+  getMonthDays,
+  getFirstDayOfWeek,
+  generateCalendarGrid,
+  getWeekDayLabels,
+  formatMonthYear,
+  dateToISO,
+} from "../lib/db/calendar";
+
+// --- calculateStreaks ---
+
+describe("calculateStreaks", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns 0/0 for empty array", () => {
+    const result = calculateStreaks([]);
+    expect(result).toEqual({ currentStreak: 0, longestStreak: 0 });
+  });
+
+  it("returns current streak of 1 when only today", () => {
+    jest.setSystemTime(new Date(2026, 3, 18)); // April 18, 2026
+    const result = calculateStreaks(["2026-04-18"]);
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(1);
+  });
+
+  it("returns current streak of 1 when only yesterday", () => {
+    jest.setSystemTime(new Date(2026, 3, 18));
+    const result = calculateStreaks(["2026-04-17"]);
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(1);
+  });
+
+  it("returns current streak 0 when last workout was 2 days ago", () => {
+    jest.setSystemTime(new Date(2026, 3, 18));
+    const result = calculateStreaks(["2026-04-16"]);
+    expect(result.currentStreak).toBe(0);
+    expect(result.longestStreak).toBe(1);
+  });
+
+  it("calculates consecutive streak from today", () => {
+    jest.setSystemTime(new Date(2026, 3, 18));
+    const dates = [
+      "2026-04-18",
+      "2026-04-17",
+      "2026-04-16",
+      "2026-04-15",
+    ];
+    const result = calculateStreaks(dates);
+    expect(result.currentStreak).toBe(4);
+    expect(result.longestStreak).toBe(4);
+  });
+
+  it("calculates consecutive streak from yesterday", () => {
+    jest.setSystemTime(new Date(2026, 3, 18));
+    const dates = [
+      "2026-04-17",
+      "2026-04-16",
+      "2026-04-15",
+    ];
+    const result = calculateStreaks(dates);
+    expect(result.currentStreak).toBe(3);
+    expect(result.longestStreak).toBe(3);
+  });
+
+  it("breaks streak with a gap", () => {
+    jest.setSystemTime(new Date(2026, 3, 18));
+    const dates = [
+      "2026-04-18",
+      "2026-04-17",
+      // gap on April 16
+      "2026-04-15",
+      "2026-04-14",
+      "2026-04-13",
+    ];
+    const result = calculateStreaks(dates);
+    expect(result.currentStreak).toBe(2);
+    expect(result.longestStreak).toBe(3);
+  });
+
+  it("finds longest streak in the past", () => {
+    jest.setSystemTime(new Date(2026, 3, 18));
+    const dates = [
+      "2026-04-18",
+      // gap
+      "2026-04-10",
+      "2026-04-09",
+      "2026-04-08",
+      "2026-04-07",
+      "2026-04-06",
+    ];
+    const result = calculateStreaks(dates);
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(5);
+  });
+
+  it("handles single-day workouts scattered", () => {
+    jest.setSystemTime(new Date(2026, 3, 18));
+    const dates = [
+      "2026-04-18",
+      "2026-04-14",
+      "2026-04-10",
+      "2026-04-05",
+    ];
+    const result = calculateStreaks(dates);
+    expect(result.currentStreak).toBe(1);
+    expect(result.longestStreak).toBe(1);
+  });
+});
+
+// --- getMonthDays ---
+
+describe("getMonthDays", () => {
+  it("returns 31 for January", () => {
+    expect(getMonthDays(2026, 0)).toBe(31);
+  });
+
+  it("returns 28 for February 2026 (non-leap)", () => {
+    expect(getMonthDays(2026, 1)).toBe(28);
+  });
+
+  it("returns 29 for February 2024 (leap year)", () => {
+    expect(getMonthDays(2024, 1)).toBe(29);
+  });
+
+  it("returns 30 for April", () => {
+    expect(getMonthDays(2026, 3)).toBe(30);
+  });
+});
+
+// --- getFirstDayOfWeek ---
+
+describe("getFirstDayOfWeek", () => {
+  it("returns correct offset for Sunday start", () => {
+    // April 2026 starts on Wednesday (day 3 from Sunday=0)
+    expect(getFirstDayOfWeek(2026, 3, 0)).toBe(3);
+  });
+
+  it("returns correct offset for Monday start", () => {
+    // April 2026 starts on Wednesday; offset from Monday=1: (3-1+7)%7 = 2
+    expect(getFirstDayOfWeek(2026, 3, 1)).toBe(2);
+  });
+
+  it("returns 0 when month starts on week start day", () => {
+    // June 2026 starts on Monday (day 1)
+    expect(getFirstDayOfWeek(2026, 5, 1)).toBe(0);
+  });
+});
+
+// --- generateCalendarGrid ---
+
+describe("generateCalendarGrid", () => {
+  it("generates correct grid for April 2026 Sunday start", () => {
+    const grid = generateCalendarGrid(2026, 3, 0);
+    // April 2026 starts on Wednesday, so 3 nulls then 1-30
+    expect(grid.slice(0, 3)).toEqual([null, null, null]);
+    expect(grid[3]).toBe(1);
+    expect(grid[grid.length - 1]).toBe(30);
+    expect(grid.length).toBe(33); // 3 + 30
+  });
+
+  it("generates correct grid for April 2026 Monday start", () => {
+    const grid = generateCalendarGrid(2026, 3, 1);
+    // Offset of 2 (Wednesday from Monday)
+    expect(grid.slice(0, 2)).toEqual([null, null]);
+    expect(grid[2]).toBe(1);
+    expect(grid.length).toBe(32); // 2 + 30
+  });
+
+  it("handles February leap year", () => {
+    const grid = generateCalendarGrid(2024, 1, 0);
+    // Feb 2024 starts on Thursday (offset 4 from Sunday)
+    const days = grid.filter((d) => d !== null);
+    expect(days.length).toBe(29);
+  });
+});
+
+// --- getWeekDayLabels ---
+
+describe("getWeekDayLabels", () => {
+  it("returns Sunday-first labels for weekStartDay=0", () => {
+    const labels = getWeekDayLabels(0);
+    expect(labels).toEqual(["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]);
+  });
+
+  it("returns Monday-first labels for weekStartDay=1", () => {
+    const labels = getWeekDayLabels(1);
+    expect(labels).toEqual(["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]);
+  });
+
+  it("returns Saturday-first labels for weekStartDay=6", () => {
+    const labels = getWeekDayLabels(6);
+    expect(labels[0]).toBe("Sat");
+    expect(labels[6]).toBe("Fri");
+  });
+});
+
+// --- formatMonthYear ---
+
+describe("formatMonthYear", () => {
+  it("formats April 2026", () => {
+    const result = formatMonthYear(2026, 3);
+    // Locale-dependent, but should contain "April" and "2026"
+    expect(result).toContain("2026");
+  });
+});
+
+// --- dateToISO ---
+
+describe("dateToISO", () => {
+  it("formats single-digit month and day", () => {
+    expect(dateToISO(2026, 0, 5)).toBe("2026-01-05");
+  });
+
+  it("formats double-digit month and day", () => {
+    expect(dateToISO(2026, 11, 25)).toBe("2026-12-25");
+  });
+
+  it("handles month index correctly (0-based)", () => {
+    expect(dateToISO(2026, 3, 18)).toBe("2026-04-18");
+  });
+});

--- a/components/progress/CalendarDayDetail.tsx
+++ b/components/progress/CalendarDayDetail.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import {
+  getDaySessionDetails,
+  getDayMuscleGroups,
+  type DayDetail,
+} from "@/lib/db/calendar";
+import { formatDuration } from "@/lib/format";
+
+type Props = {
+  dateStr: string;
+};
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "loaded"; sessions: DayDetail[]; muscles: string[] };
+
+function useDayData(dateStr: string): LoadState {
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [currentDate, setCurrentDate] = useState(dateStr);
+
+  // Reset to loading when dateStr changes
+  if (dateStr !== currentDate) {
+    setCurrentDate(dateStr);
+    setState({ status: "loading" });
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const [s, m] = await Promise.all([
+          getDaySessionDetails(dateStr),
+          getDayMuscleGroups(dateStr),
+        ]);
+        if (!cancelled) {
+          setState({ status: "loaded", sessions: s, muscles: m });
+        }
+      } catch {
+        if (!cancelled) {
+          setState({ status: "error" });
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dateStr]);
+
+  return state;
+}
+
+export default function CalendarDayDetail({ dateStr }: Props) {
+  const colors = useThemeColors();
+  const state = useDayData(dateStr);
+
+  const displayDate = formatDisplayDate(dateStr);
+
+  if (state.status === "loading") {
+    return (
+      <View
+        style={[styles.container, { backgroundColor: colors.surface }]}
+        accessibilityLiveRegion="polite"
+      >
+        <ActivityIndicator size="small" color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <View
+        style={[styles.container, { backgroundColor: colors.surface }]}
+        accessibilityLiveRegion="polite"
+      >
+        <Text style={{ color: colors.error }}>
+          Could not load workout details
+        </Text>
+      </View>
+    );
+  }
+
+  const { sessions, muscles } = state;
+
+  if (sessions.length === 0) {
+    return (
+      <View
+        style={[styles.container, { backgroundColor: colors.surface }]}
+        accessibilityLiveRegion="polite"
+      >
+        <Text variant="subtitle" style={{ color: colors.onSurface }}>
+          {displayDate}
+        </Text>
+        <Text
+          variant="caption"
+          style={{ color: colors.onSurfaceVariant, marginTop: 4 }}
+        >
+          No workouts
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: colors.surface }]}
+      accessibilityLiveRegion="polite"
+    >
+      <Text variant="subtitle" style={{ color: colors.onSurface }}>
+        {displayDate}
+      </Text>
+
+      {sessions.map((session) => (
+        <View key={session.id} style={styles.sessionRow}>
+          <Text style={[styles.sessionName, { color: colors.onSurface }]}>
+            {session.name}
+          </Text>
+          <Text
+            variant="caption"
+            style={{ color: colors.onSurfaceVariant, marginTop: 2 }}
+          >
+            {formatDuration(session.duration_seconds)} · {session.exercise_count}{" "}
+            exercise{session.exercise_count !== 1 ? "s" : ""} · {session.set_count}{" "}
+            set{session.set_count !== 1 ? "s" : ""}
+          </Text>
+        </View>
+      ))}
+
+      {muscles.length > 0 && (
+        <View style={styles.muscleRow}>
+          <Text
+            variant="caption"
+            style={{ color: colors.primary, fontWeight: "600" }}
+          >
+            {muscles.join(", ")}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function formatDisplayDate(dateStr: string): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString(undefined, {
+    month: "long",
+    day: "numeric",
+  });
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: 12,
+    padding: 16,
+    marginTop: 12,
+  },
+  sessionRow: {
+    marginTop: 8,
+  },
+  sessionName: {
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  muscleRow: {
+    marginTop: 10,
+    paddingTop: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "rgba(128,128,128,0.2)",
+  },
+});

--- a/components/progress/CalendarGrid.tsx
+++ b/components/progress/CalendarGrid.tsx
@@ -1,0 +1,183 @@
+import { Pressable, StyleSheet, View, useWindowDimensions } from "react-native";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import {
+  generateCalendarGrid,
+  getWeekDayLabels,
+  dateToISO,
+} from "@/lib/db/calendar";
+
+type Props = {
+  year: number;
+  month: number;
+  weekStartDay: number;
+  workoutDates: Set<string>;
+  selectedDate: string | null;
+  todayStr: string;
+  onSelectDate: (dateStr: string, day: number) => void;
+};
+
+export default function CalendarGrid({
+  year,
+  month,
+  weekStartDay,
+  workoutDates,
+  selectedDate,
+  todayStr,
+  onSelectDate,
+}: Props) {
+  const colors = useThemeColors();
+  const { width: screenWidth } = useWindowDimensions();
+  const cellSize = Math.floor(screenWidth / 7);
+  const effectiveCellSize = Math.max(cellSize, 48);
+
+  const grid = generateCalendarGrid(year, month, weekStartDay);
+  const weekDayLabels = getWeekDayLabels(weekStartDay);
+
+  const today = new Date();
+  const isFutureDay = (day: number) => {
+    const d = new Date(year, month, day);
+    d.setHours(23, 59, 59, 999);
+    return d > today;
+  };
+
+  const handlePress = (day: number) => {
+    if (isFutureDay(day)) return;
+    const dateStr = dateToISO(year, month, day);
+    onSelectDate(dateStr, day);
+  };
+
+  return (
+    <View>
+      {/* Week day headers */}
+      <View style={styles.row}>
+        {weekDayLabels.map((label) => (
+          <View
+            key={label}
+            style={[styles.headerCell, { width: cellSize }]}
+          >
+            <Text
+              variant="caption"
+              style={[styles.headerText, { color: colors.onSurfaceVariant }]}
+            >
+              {label}
+            </Text>
+          </View>
+        ))}
+      </View>
+
+      {/* Day cells */}
+      <View style={styles.gridWrap}>
+        {grid.map((day, index) => {
+          if (day === null) {
+            return (
+              <View
+                key={`empty-${index}`}
+                style={[styles.cell, { width: cellSize, height: effectiveCellSize }]}
+              />
+            );
+          }
+
+          const dateStr = dateToISO(year, month, day);
+          const isToday = dateStr === todayStr;
+          const isSelected = dateStr === selectedDate;
+          const hasWorkout = workoutDates.has(dateStr);
+          const isFuture = isFutureDay(day);
+
+          const accessLabel = isFuture
+            ? `${monthName(month)} ${day}, future date`
+            : hasWorkout
+              ? `${monthName(month)} ${day}, workout completed`
+              : `${monthName(month)} ${day}, no workout`;
+
+          return (
+            <Pressable
+              key={day}
+              style={[
+                styles.cell,
+                { width: cellSize, height: effectiveCellSize },
+                isSelected && {
+                  backgroundColor: colors.primaryContainer,
+                  borderRadius: 8,
+                },
+                isToday && !isSelected && {
+                  borderWidth: 2,
+                  borderColor: colors.primary,
+                  borderRadius: 8,
+                },
+              ]}
+              onPress={() => handlePress(day)}
+              disabled={isFuture}
+              hitSlop={{ top: 4, bottom: 4 }}
+              accessibilityRole="button"
+              accessibilityLabel={accessLabel}
+              accessibilityState={{
+                selected: isSelected,
+                disabled: isFuture,
+              }}
+            >
+              <Text
+                style={[
+                  styles.dayText,
+                  { color: colors.onSurface },
+                  isFuture && { color: colors.disabled, opacity: 0.4 },
+                  isToday && { fontWeight: "700" },
+                  isSelected && { color: colors.onPrimaryContainer },
+                ]}
+              >
+                {day}
+              </Text>
+              {hasWorkout && !isFuture && (
+                <View
+                  style={[
+                    styles.dot,
+                    { backgroundColor: colors.primary },
+                    isSelected && { backgroundColor: colors.onPrimaryContainer },
+                  ]}
+                />
+              )}
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+function monthName(month: number): string {
+  return new Date(2024, month, 1).toLocaleDateString(undefined, {
+    month: "long",
+  });
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+  },
+  headerCell: {
+    alignItems: "center",
+    paddingVertical: 8,
+  },
+  headerText: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  gridWrap: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+  cell: {
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 48,
+  },
+  dayText: {
+    fontSize: 14,
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    marginTop: 2,
+  },
+});

--- a/components/progress/CalendarStreaks.tsx
+++ b/components/progress/CalendarStreaks.tsx
@@ -1,0 +1,70 @@
+import { StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+
+type Props = {
+  currentStreak: number;
+  longestStreak: number;
+};
+
+export default function CalendarStreaks({
+  currentStreak,
+  longestStreak,
+}: Props) {
+  const colors = useThemeColors();
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: colors.surface }]}
+      accessibilityLabel={`Current training streak: ${currentStreak} day${currentStreak !== 1 ? "s" : ""}. Longest streak: ${longestStreak} day${longestStreak !== 1 ? "s" : ""}`}
+    >
+      <View style={styles.streakItem}>
+        <Text style={[styles.streakValue, { color: colors.primary }]}>
+          {currentStreak}
+        </Text>
+        <Text
+          variant="caption"
+          style={{ color: colors.onSurfaceVariant }}
+        >
+          Current streak (days)
+        </Text>
+      </View>
+      <View
+        style={[styles.divider, { backgroundColor: colors.outlineVariant }]}
+      />
+      <View style={styles.streakItem}>
+        <Text style={[styles.streakValue, { color: colors.onSurface }]}>
+          {longestStreak}
+        </Text>
+        <Text
+          variant="caption"
+          style={{ color: colors.onSurfaceVariant }}
+        >
+          Longest streak (days)
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+  },
+  streakItem: {
+    flex: 1,
+    alignItems: "center",
+  },
+  streakValue: {
+    fontSize: 24,
+    fontWeight: "700",
+    marginBottom: 4,
+  },
+  divider: {
+    width: 1,
+    marginHorizontal: 12,
+  },
+});

--- a/components/progress/CalendarView.tsx
+++ b/components/progress/CalendarView.tsx
@@ -1,0 +1,299 @@
+import { useCallback, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
+import { Text } from "@/components/ui/text";
+import { useFocusEffect } from "expo-router";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { useFloatingTabBarHeight } from "@/components/FloatingTabBar";
+import {
+  getMonthlyWorkoutDates,
+  getWorkoutDatesForStreak,
+  calculateStreaks,
+  formatMonthYear,
+  dateToISO,
+  type WorkoutDay,
+} from "@/lib/db/calendar";
+import CalendarGrid from "./CalendarGrid";
+import CalendarDayDetail from "./CalendarDayDetail";
+import CalendarStreaks from "./CalendarStreaks";
+
+type Props = {
+  weekStartDay: number;
+};
+
+export default function CalendarView({ weekStartDay }: Props) {
+  const colors = useThemeColors();
+  const tabBarHeight = useFloatingTabBarHeight();
+
+  const now = new Date();
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth());
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [workoutDays, setWorkoutDays] = useState<WorkoutDay[]>([]);
+  const [currentStreak, setCurrentStreak] = useState(0);
+  const [longestStreak, setLongestStreak] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const todayDate = new Date();
+  const todayStr = dateToISO(
+    todayDate.getFullYear(),
+    todayDate.getMonth(),
+    todayDate.getDate()
+  );
+
+  const isCurrentMonth =
+    year === now.getFullYear() && month === now.getMonth();
+
+  const workoutDateSet = new Set(workoutDays.map((d) => d.workout_date));
+
+  const loadData = async (y: number, m: number) => {
+    setLoading(true);
+    setError(false);
+    try {
+      const [days, streakDates] = await Promise.all([
+        getMonthlyWorkoutDates(y, m),
+        getWorkoutDatesForStreak(),
+      ]);
+      setWorkoutDays(days);
+      const { currentStreak: cs, longestStreak: ls } =
+        calculateStreaks(streakDates);
+      setCurrentStreak(cs);
+      setLongestStreak(ls);
+      setLoading(false);
+    } catch {
+      setError(true);
+      setLoading(false);
+    }
+  };
+
+  useFocusEffect(
+    // eslint-disable-next-line react-hooks/preserve-manual-memoization
+    useCallback(() => {
+      loadData(year, month);
+    }, [year, month])
+  );
+
+  const goToPrevMonth = () => {
+    setSelectedDate(null);
+    if (month === 0) {
+      setYear(year - 1);
+      setMonth(11);
+    } else {
+      setMonth(month - 1);
+    }
+  };
+
+  const goToNextMonth = () => {
+    if (isCurrentMonth) return;
+    setSelectedDate(null);
+    if (month === 11) {
+      setYear(year + 1);
+      setMonth(0);
+    } else {
+      setMonth(month + 1);
+    }
+  };
+
+  const goToToday = () => {
+    const t = new Date();
+    setYear(t.getFullYear());
+    setMonth(t.getMonth());
+    setSelectedDate(null);
+  };
+
+  const handleSelectDate = (dateStr: string) => {
+    setSelectedDate(selectedDate === dateStr ? null : dateStr);
+  };
+
+  if (loading) {
+    return (
+      <View style={[styles.centered, { flex: 1 }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.centered, { flex: 1 }]}>
+        <Text style={{ color: colors.error, textAlign: "center", marginBottom: 12 }}>
+          Could not load calendar data
+        </Text>
+        <Pressable
+          onPress={() => loadData(year, month)}
+          style={[styles.retryButton, { borderColor: colors.primary }]}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading calendar"
+        >
+          <Text style={{ color: colors.primary, fontWeight: "600" }}>
+            Retry
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={[
+        styles.container,
+        { paddingBottom: tabBarHeight + 16 },
+      ]}
+    >
+      {/* Month navigation header */}
+      <View style={styles.header}>
+        <View style={styles.navRow}>
+          <Pressable
+            onPress={goToPrevMonth}
+            accessibilityRole="button"
+            accessibilityLabel="Previous month"
+            hitSlop={12}
+            style={styles.navButton}
+          >
+            <Text style={[styles.navArrow, { color: colors.onSurface }]}>
+              {"<"}
+            </Text>
+          </Pressable>
+
+          <Text
+            variant="subtitle"
+            style={[styles.monthTitle, { color: colors.onSurface }]}
+          >
+            {formatMonthYear(year, month)}
+          </Text>
+
+          <Pressable
+            onPress={goToNextMonth}
+            disabled={isCurrentMonth}
+            accessibilityRole="button"
+            accessibilityLabel="Next month"
+            hitSlop={12}
+            style={styles.navButton}
+          >
+            <Text
+              style={[
+                styles.navArrow,
+                { color: isCurrentMonth ? colors.disabled : colors.onSurface },
+              ]}
+            >
+              {">"}
+            </Text>
+          </Pressable>
+        </View>
+
+        {!isCurrentMonth && (
+          <Pressable
+            onPress={goToToday}
+            accessibilityRole="button"
+            accessibilityLabel="Go to current month"
+            style={[styles.todayButton, { borderColor: colors.primary }]}
+          >
+            <Text
+              variant="caption"
+              style={{ color: colors.primary, fontWeight: "600" }}
+            >
+              Today
+            </Text>
+          </Pressable>
+        )}
+      </View>
+
+      {/* Calendar grid */}
+      <CalendarGrid
+        year={year}
+        month={month}
+        weekStartDay={weekStartDay}
+        workoutDates={workoutDateSet}
+        selectedDate={selectedDate}
+        todayStr={todayStr}
+        onSelectDate={handleSelectDate}
+      />
+
+      {/* Streaks */}
+      <View style={styles.streaksWrap}>
+        <CalendarStreaks
+          currentStreak={currentStreak}
+          longestStreak={longestStreak}
+        />
+      </View>
+
+      {/* Day detail */}
+      {selectedDate && <CalendarDayDetail dateStr={selectedDate} />}
+
+      {/* Empty state */}
+      {workoutDays.length === 0 && !selectedDate && (
+        <View style={[styles.emptyState, { backgroundColor: colors.surface }]}>
+          <Text
+            style={{
+              color: colors.onSurfaceVariant,
+              textAlign: "center",
+            }}
+          >
+            No workouts this month. Start your first workout to see your
+            calendar fill up!
+          </Text>
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  centered: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 12,
+  },
+  navRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    flex: 1,
+  },
+  navButton: {
+    padding: 8,
+  },
+  navArrow: {
+    fontSize: 20,
+    fontWeight: "700",
+  },
+  monthTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    marginHorizontal: 12,
+  },
+  todayButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  retryButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  streaksWrap: {
+    marginTop: 12,
+  },
+  emptyState: {
+    borderRadius: 12,
+    padding: 24,
+    marginTop: 12,
+  },
+});

--- a/components/progress/WorkoutSegment.tsx
+++ b/components/progress/WorkoutSegment.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   FlatList,
   Pressable,
@@ -19,6 +19,27 @@ import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
 import WeeklySummary from "../../components/WeeklySummary";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { WorkoutChartCard, PRCard, SessionsCard } from "./WorkoutCards";
+import CalendarView from "./CalendarView";
+
+let cachedWeekStart: number | null = null;
+function getWeekStartDay(): number {
+  if (cachedWeekStart !== null) return cachedWeekStart;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { getCalendars } = require("expo-localization");
+    const calendars = getCalendars();
+    if (calendars.length > 0 && calendars[0].firstWeekday != null) {
+      // expo-localization firstWeekday: 1 = Sunday, 2 = Monday, ...
+      // We need 0 = Sunday, 1 = Monday, ...
+      cachedWeekStart = (calendars[0].firstWeekday - 1) % 7;
+      return cachedWeekStart;
+    }
+  } catch {
+    // expo-localization not available (e.g. testing), default Sunday
+  }
+  cachedWeekStart = 0;
+  return 0;
+}
 
 type PR = {
   exercise_id: string;
@@ -39,6 +60,8 @@ export default function WorkoutSegment() {
   const tabBarHeight = useFloatingTabBarHeight();
   const router = useRouter();
   const { width: screenWidth } = useWindowDimensions();
+  const [viewMode, setViewMode] = useState<"list" | "calendar">("list");
+  const weekStartDay = useMemo(() => getWeekStartDay(), []);
 
   const [freq, setFreq] = useState<{ week: string; count: number }[]>([]);
   const [vol, setVol] = useState<{ week: string; volume: number }[]>([]);
@@ -68,9 +91,34 @@ export default function WorkoutSegment() {
 
   const empty = sessions.length === 0 && freq.length === 0;
 
+  const toggleButton = (
+    <Pressable
+      onPress={() => setViewMode((m) => (m === "list" ? "calendar" : "list"))}
+      style={[styles.toggleButton, { borderColor: colors.outlineVariant }]}
+      accessibilityRole="button"
+      accessibilityLabel={
+        viewMode === "list" ? "Switch to calendar view" : "Switch to list view"
+      }
+    >
+      <Text style={{ color: colors.onSurface, fontSize: 16 }}>
+        {viewMode === "list" ? "📅" : "📋"}
+      </Text>
+    </Pressable>
+  );
+
+  if (viewMode === "calendar") {
+    return (
+      <View style={{ flex: 1 }}>
+        <View style={styles.toggleRow}>{toggleButton}</View>
+        <CalendarView weekStartDay={weekStartDay} />
+      </View>
+    );
+  }
+
   if (empty) {
     return (
       <View style={{ flex: 1 }}>
+        <View style={styles.toggleRow}>{toggleButton}</View>
         <View style={{ padding: 16 }}>
           <WeeklySummary />
         </View>
@@ -154,6 +202,7 @@ export default function WorkoutSegment() {
       ListHeaderComponent={
         layout.atLeastMedium ? (
           <>
+            <View style={styles.toggleRow}>{toggleButton}</View>
             <WeeklySummary />
             {achievementsCard}
             <View style={styles.grid}>
@@ -167,6 +216,7 @@ export default function WorkoutSegment() {
           </>
         ) : (
           <>
+            <View style={styles.toggleRow}>{toggleButton}</View>
             <WeeklySummary />
             {achievementsCard}
             {freqCard}
@@ -195,6 +245,20 @@ const styles = StyleSheet.create({
   },
   card: {
     marginBottom: 16,
+  },
+  toggleRow: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    paddingHorizontal: 16,
+    paddingTop: 8,
+  },
+  toggleButton: {
+    borderWidth: 1,
+    borderRadius: 8,
+    width: 36,
+    height: 36,
+    alignItems: "center",
+    justifyContent: "center",
   },
   wideCard: {
     flex: 1,

--- a/lib/db/calendar.ts
+++ b/lib/db/calendar.ts
@@ -1,0 +1,221 @@
+import { query } from "./helpers";
+
+// --- Types ---
+
+export type WorkoutDay = {
+  workout_date: string; // YYYY-MM-DD
+  session_count: number;
+  total_duration: number;
+};
+
+export type DayDetail = {
+  id: string;
+  name: string;
+  started_at: number;
+  duration_seconds: number | null;
+  set_count: number;
+  exercise_count: number;
+};
+
+// --- Monthly workout dates ---
+
+export async function getMonthlyWorkoutDates(
+  year: number,
+  month: number
+): Promise<WorkoutDay[]> {
+  const start = new Date(year, month, 1).getTime();
+  const end = new Date(year, month + 1, 1).getTime();
+
+  return query<WorkoutDay>(
+    `SELECT date(started_at / 1000, 'unixepoch', 'localtime') as workout_date,
+            COUNT(*) as session_count,
+            COALESCE(SUM(duration_seconds), 0) as total_duration
+     FROM workout_sessions
+     WHERE completed_at IS NOT NULL
+       AND started_at >= ? AND started_at < ?
+     GROUP BY workout_date`,
+    [start, end]
+  );
+}
+
+// --- Day detail: sessions for a specific date ---
+
+export async function getDaySessionDetails(
+  dateStr: string
+): Promise<DayDetail[]> {
+  return query<DayDetail>(
+    `SELECT s.id, s.name, s.started_at, s.duration_seconds,
+            (SELECT COUNT(*) FROM workout_sets ws WHERE ws.session_id = s.id AND ws.completed = 1) as set_count,
+            (SELECT COUNT(DISTINCT ws.exercise_id) FROM workout_sets ws WHERE ws.session_id = s.id AND ws.completed = 1) as exercise_count
+     FROM workout_sessions s
+     WHERE s.completed_at IS NOT NULL
+       AND date(s.started_at / 1000, 'unixepoch', 'localtime') = ?
+     ORDER BY s.started_at ASC`,
+    [dateStr]
+  );
+}
+
+// --- Muscle groups for a specific date ---
+
+export async function getDayMuscleGroups(dateStr: string): Promise<string[]> {
+  const rows = await query<{ primary_muscles: string }>(
+    `SELECT e.primary_muscles
+     FROM workout_sets ws
+     JOIN workout_sessions s ON ws.session_id = s.id
+     JOIN exercises e ON ws.exercise_id = e.id
+     WHERE date(s.started_at / 1000, 'unixepoch', 'localtime') = ?
+       AND s.completed_at IS NOT NULL
+       AND ws.completed = 1`,
+    [dateStr]
+  );
+
+  const all: string[] = [];
+  for (const row of rows) {
+    try {
+      const parsed = JSON.parse(row.primary_muscles);
+      if (Array.isArray(parsed)) {
+        all.push(...parsed);
+      }
+    } catch {
+      // skip malformed rows
+    }
+  }
+  return [...new Set(all)];
+}
+
+// --- Streak data ---
+
+export async function getWorkoutDatesForStreak(): Promise<string[]> {
+  const cutoff = Date.now() - 365 * 24 * 60 * 60 * 1000;
+
+  const rows = await query<{ d: string }>(
+    `SELECT DISTINCT date(started_at / 1000, 'unixepoch', 'localtime') as d
+     FROM workout_sessions
+     WHERE completed_at IS NOT NULL
+       AND started_at >= ?
+     ORDER BY d DESC`,
+    [cutoff]
+  );
+
+  return rows.map((r) => r.d);
+}
+
+// --- Pure streak calculation (exported for testing) ---
+
+export function calculateStreaks(sortedDatesDesc: string[]): {
+  currentStreak: number;
+  longestStreak: number;
+} {
+  if (sortedDatesDesc.length === 0) {
+    return { currentStreak: 0, longestStreak: 0 };
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const todayStr = formatDateISO(today);
+  const yesterdayStr = formatDateISO(
+    new Date(today.getTime() - 24 * 60 * 60 * 1000)
+  );
+
+  // Current streak: must include today or yesterday
+  let currentStreak = 0;
+  const firstDate = sortedDatesDesc[0];
+  if (firstDate === todayStr || firstDate === yesterdayStr) {
+    currentStreak = 1;
+    for (let i = 1; i < sortedDatesDesc.length; i++) {
+      const prev = parseDate(sortedDatesDesc[i - 1]);
+      const curr = parseDate(sortedDatesDesc[i]);
+      const diffMs = prev.getTime() - curr.getTime();
+      if (diffMs === 24 * 60 * 60 * 1000) {
+        currentStreak++;
+      } else {
+        break;
+      }
+    }
+  }
+
+  // Longest streak
+  let longestStreak = 1;
+  let streak = 1;
+  for (let i = 1; i < sortedDatesDesc.length; i++) {
+    const prev = parseDate(sortedDatesDesc[i - 1]);
+    const curr = parseDate(sortedDatesDesc[i]);
+    const diffMs = prev.getTime() - curr.getTime();
+    if (diffMs === 24 * 60 * 60 * 1000) {
+      streak++;
+      longestStreak = Math.max(longestStreak, streak);
+    } else {
+      streak = 1;
+    }
+  }
+
+  return { currentStreak, longestStreak };
+}
+
+function parseDate(dateStr: string): Date {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function formatDateISO(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+// --- Calendar date utilities (exported for testing) ---
+
+export function getMonthDays(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+export function getFirstDayOfWeek(
+  year: number,
+  month: number,
+  weekStartDay: number
+): number {
+  // weekStartDay: 0 = Sunday, 1 = Monday, etc.
+  const firstDay = new Date(year, month, 1).getDay(); // 0-6, Sunday=0
+  return (firstDay - weekStartDay + 7) % 7;
+}
+
+export function generateCalendarGrid(
+  year: number,
+  month: number,
+  weekStartDay: number
+): (number | null)[] {
+  const daysInMonth = getMonthDays(year, month);
+  const offset = getFirstDayOfWeek(year, month, weekStartDay);
+
+  const grid: (number | null)[] = [];
+  // Leading empty cells
+  for (let i = 0; i < offset; i++) {
+    grid.push(null);
+  }
+  // Day numbers
+  for (let d = 1; d <= daysInMonth; d++) {
+    grid.push(d);
+  }
+  return grid;
+}
+
+export function getWeekDayLabels(weekStartDay: number): string[] {
+  const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const labels: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    labels.push(days[(weekStartDay + i) % 7]);
+  }
+  return labels;
+}
+
+export function formatMonthYear(year: number, month: number): string {
+  const date = new Date(year, month, 1);
+  return date.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+}
+
+export function dateToISO(year: number, month: number, day: number): string {
+  const m = String(month + 1).padStart(2, "0");
+  const d = String(day).padStart(2, "0");
+  return `${year}-${m}-${d}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "expo-keep-awake": "~55.0.6",
         "expo-linking": "~55.0.13",
         "expo-local-authentication": "~55.0.13",
+        "expo-localization": "~55.0.13",
         "expo-modules-core": "~55.0.22",
         "expo-notifications": "~55.0.19",
         "expo-router": "~55.0.12",
@@ -7837,6 +7838,19 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-localization": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-55.0.13.tgz",
+      "integrity": "sha512-fXiEUUihIrXmAEzoneaTOFcQ7TKmr25RR/ymrB/MvYTVnmevFA1zY2KI0VSiXY+NKKjZ8mG65YSn1wh4gEYKxA==",
+      "license": "MIT",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-manifests": {
       "version": "55.0.15",
       "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-55.0.15.tgz",
@@ -14389,6 +14403,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "expo-keep-awake": "~55.0.6",
     "expo-linking": "~55.0.13",
     "expo-local-authentication": "~55.0.13",
+    "expo-localization": "~55.0.13",
     "expo-modules-core": "~55.0.22",
     "expo-notifications": "~55.0.19",
     "expo-router": "~55.0.12",


### PR DESCRIPTION
## Summary

Add a calendar/list view toggle inside the Workouts segment of the Progress tab. Shows a month grid with workout day indicators, tap-to-expand day details with muscle groups, and current/longest streak display.

## Changes

- **lib/db/calendar.ts** — DB queries for monthly workout dates, day details, muscle groups, streak data; pure utility functions for calendar grid generation and streak calculation
- **components/progress/CalendarView.tsx** — Main calendar view with month navigation, Today button, error/empty states
- **components/progress/CalendarGrid.tsx** — Month grid with day cells, workout dots, today indicator, future day dimming
- **components/progress/CalendarDayDetail.tsx** — Tapped-day workout summary with session details and muscle groups
- **components/progress/CalendarStreaks.tsx** — Current and longest streak display card
- **components/progress/WorkoutSegment.tsx** — Added calendar/list toggle button using expo-localization for locale-aware week start
- **__tests__/calendar.test.ts** — 26 unit tests covering streak calculation, date utilities, calendar grid generation

## Accessibility

- All day cells: accessibilityRole='button', accessibilityState, descriptive labels
- Month navigation: accessibilityRole='button', accessibilityLabel
- Today button: accessibilityRole='button', accessibilityLabel='Go to current month'
- Streaks: accessibilityLabel without emoji
- Day detail: accessibilityLiveRegion='polite'
- Future dates: disabled state, not tappable

## Testing

- 26 new unit tests all passing
- Full test suite: 1798 tests, 0 failures
- TypeScript: 0 errors
- ESLint: 0 errors, 0 warnings

## Issue

Resolves BLD-341