### PR TITLE
fix: template header alignment + swipe-to-delete improvements

### DIFF
--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -72,7 +72,7 @@ export default function EditTemplate() {
       <View style={[styles.container, { backgroundColor: colors.background, paddingHorizontal: layout.horizontalPadding }]}>
         <View style={styles.section}>
           <View style={styles.headerRow}>
-            <Text variant="title" style={{ color: colors.onBackground }}>
+            <Text variant="title" style={{ color: colors.onBackground, flexShrink: 1 }}>
               Exercises ({exercises.length})
             </Text>
             {starter && (
@@ -126,7 +126,7 @@ const styles = StyleSheet.create({
   container: { flex: 1, paddingVertical: 16 },
   center: { flex: 1, alignItems: "center", justifyContent: "center" },
   section: { marginBottom: 8 },
-  headerRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+  headerRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", gap: 8 },
   list: { flex: 1 },
   addBtn: { marginTop: 8 },
   doneBtn: { marginTop: 16 },

--- a/components/SwipeToDelete.tsx
+++ b/components/SwipeToDelete.tsx
@@ -1,11 +1,13 @@
-import React from "react";
-import { StyleSheet, View } from "react-native";
+import React, { useEffect } from "react";
+import { StyleSheet, useWindowDimensions, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
   withSpring,
   withTiming,
+  withDelay,
+  withSequence,
   runOnJS,
 } from "react-native-reanimated";
 import { Button } from "@/components/ui/button";
@@ -17,18 +19,36 @@ interface SwipeToDeleteProps {
   children: React.ReactNode;
   onDelete: () => void;
   enabled?: boolean;
+  /** Show a brief swipe-hint animation on mount */
+  showHint?: boolean;
 }
 
-const THRESHOLD = -80;
-const DISMISS_THRESHOLD = -160;
+const REVEAL_THRESHOLD = -80;
 
 export default function SwipeToDelete({
   children,
   onDelete,
   enabled = true,
+  showHint = false,
 }: SwipeToDeleteProps) {
   const colors = useThemeColors();
+  const { width: screenWidth } = useWindowDimensions();
   const translateX = useSharedValue(0);
+
+  // Dismiss requires swiping past 40% of screen width
+  const dismissThreshold = -(screenWidth * 0.4);
+
+  useEffect(() => {
+    if (showHint && enabled) {
+      translateX.value = withDelay(
+        600,
+        withSequence(
+          withTiming(-40, { duration: 300 }),
+          withSpring(0, { damping: 15, stiffness: 200 }),
+        ),
+      );
+    }
+  }, [showHint, enabled, translateX]);
 
   const panGesture = Gesture.Pan()
     .enabled(enabled)
@@ -37,12 +57,12 @@ export default function SwipeToDelete({
       translateX.value = Math.min(0, e.translationX);
     })
     .onEnd((e) => {
-      if (e.translationX < DISMISS_THRESHOLD) {
-        translateX.value = withTiming(-500, { duration: durationTokens.fast }, () => {
+      if (e.translationX < dismissThreshold) {
+        translateX.value = withTiming(-screenWidth, { duration: durationTokens.fast }, () => {
           runOnJS(onDelete)();
         });
-      } else if (e.translationX < THRESHOLD) {
-        translateX.value = withSpring(THRESHOLD, { damping: 20, stiffness: 200 });
+      } else if (e.translationX < REVEAL_THRESHOLD) {
+        translateX.value = withSpring(REVEAL_THRESHOLD, { damping: 20, stiffness: 200 });
       } else {
         translateX.value = withSpring(0, { damping: 20, stiffness: 200 });
       }

--- a/components/template/TemplateExerciseRow.tsx
+++ b/components/template/TemplateExerciseRow.tsx
@@ -112,7 +112,7 @@ export function TemplateExerciseRow({
         </View>
       )}
 
-      <SwipeToDelete onDelete={() => onRemove(item.id)} enabled={!selecting}>
+      <SwipeToDelete onDelete={() => onRemove(item.id)} enabled={!selecting} showHint={index === 0}>
         <Pressable
           onPress={() => {
             if (selecting) {
@@ -193,9 +193,7 @@ export function TemplateExerciseRow({
               <TouchableOpacity onPress={() => onMove(index, 1)} disabled={index === exercises.length - 1} accessibilityLabel={`Move ${item.exercise?.name ?? "exercise"} down`} hitSlop={8} style={{ padding: 8 }}>
                 <MaterialCommunityIcons name="arrow-down" size={18} color={colors.onSurface} />
               </TouchableOpacity>
-              <TouchableOpacity onPress={() => onRemove(item.id)} accessibilityLabel={`Remove ${item.exercise?.name ?? "exercise"}`} hitSlop={8} style={{ padding: 8 }}>
-                <MaterialCommunityIcons name="close" size={18} color={colors.onSurface} />
-              </TouchableOpacity>
+
             </View>
           )}
         </Pressable>


### PR DESCRIPTION
## Summary
Fix template screen header alignment and improve swipe-to-delete UX.

## Changes
- `app/template/[id].tsx`: Add `flexShrink: 1` to title text and `gap: 8` to header row — prevents STARTER chip from wrapping to second line on narrow screens
- `components/template/TemplateExerciseRow.tsx`: Remove explicit delete (X) button from row actions — swipe-to-delete is the primary affordance now. Add `showHint` on first row.
- `components/SwipeToDelete.tsx`: Use screen-width-relative dismiss threshold (40% of screen width) instead of fixed 160px. Add `showHint` prop that plays a subtle bounce animation on mount for discoverability.

## Testing
- `npx tsc --noEmit` — zero errors
- `npx jest --no-coverage` — all 1798 tests pass
- `npx eslint` — zero warnings on changed files

## Edge Cases
- Starter templates: no swipe (read-only) — unchanged
- During superset selection: swipe disabled — unchanged
- Nutrition screens using SwipeToDelete: unaffected (showHint defaults to false, new threshold scales properly)

## Issue
Refs: BLD-346