### PR TITLE
fix: workout toolbox crash — Chip renders bare numbers outside Text (BLD-344)

### DIFF
--- a/__tests__/acceptance/tools.acceptance.test.tsx
+++ b/__tests__/acceptance/tools.acceptance.test.tsx
@@ -74,6 +74,14 @@ describe('Plate Calculator Acceptance', () => {
     expect(await findByText(/lb per side/)).toBeTruthy()
   })
 
+  it('renders bar weight preset chips without crash (BLD-344)', async () => {
+    const { findByLabelText } = renderScreen(<PlateCalculator />)
+
+    // Bar preset chips render numeric children — previously crashed
+    // with "Text strings must be rendered within a <Text> component"
+    expect(await findByLabelText('20 kilograms bar')).toBeTruthy()
+  })
+
   it('shows appropriate state for empty and invalid weight', async () => {
     const { findByText, findByLabelText } = renderScreen(<PlateCalculator />)
 

--- a/__tests__/components/chip.test.tsx
+++ b/__tests__/components/chip.test.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { View } from "react-native";
+import { render } from "@testing-library/react-native";
+
+jest.mock("@/hooks/useColor", () => ({
+  useColor: () => "#000000",
+}));
+
+import { Chip } from "../../components/ui/chip";
+
+describe("Chip component (BLD-344)", () => {
+  it("renders string children inside Text", () => {
+    const { getByText } = render(<Chip>Hello</Chip>);
+    expect(getByText("Hello")).toBeTruthy();
+  });
+
+  it("renders number children inside Text without crash", () => {
+    const { getByText } = render(<Chip>{20}</Chip>);
+    expect(getByText("20")).toBeTruthy();
+  });
+
+  it("renders JSX children directly without crash", () => {
+    const { getByTestId } = render(
+      <Chip><View testID="inner" /></Chip>,
+    );
+    expect(getByTestId("inner")).toBeTruthy();
+  });
+});

--- a/app/tools/plates.tsx
+++ b/app/tools/plates.tsx
@@ -176,7 +176,7 @@ export function PlateCalculatorContent({ initialWeight }: { initialWeight?: stri
               accessibilityRole="radio"
               accessibilityState={{ selected: custom === "" && bar === p }}
               accessibilityLabel={p + " " + label + " bar"}
-            >{p}</Chip>
+            >{`${p}`}</Chip>
           ))}
         </View>
       </View>

--- a/components/ui/chip.tsx
+++ b/components/ui/chip.tsx
@@ -60,7 +60,7 @@ export function Chip({
       ]}
     >
       {icon && <>{icon}</>}
-      {typeof children === "string" ? (
+      {typeof children === "string" || typeof children === "number" ? (
         <Text
           style={{
             fontSize: 14,


### PR DESCRIPTION
## Summary

Fixes the workout toolbox crash reported in GitHub #198. The root cause is the Chip component only wrapping `string` children in `<Text>`, while the PlateCalculator passes numeric bar weight presets as children. In React Native, bare numbers rendered outside `<Text>` crash with `Text strings must be rendered within a <Text> component`.

## Changes

- **components/ui/chip.tsx**: Accept `number` children in addition to `string`, wrapping both in `<Text>`
- **app/tools/plates.tsx**: Convert numeric preset values to strings via template literal at call site
- **__tests__/components/chip.test.tsx**: New unit tests for Chip with string, number, and JSX children
- **__tests__/acceptance/tools.acceptance.test.tsx**: Add acceptance test verifying bar weight preset chips render

## Testing

- `npx tsc --noEmit` — zero errors
- `npx jest --no-coverage` — all 27 relevant tests pass (4 suites)
- `eslint --max-warnings=0` — passes via lint-staged pre-commit hook

## Issue

Resolves BLD-344