### PR TITLE
fix: improve activity level dropdown readability (BLD-345)

### DIFF
--- a/__tests__/components/activity-dropdown.test.tsx
+++ b/__tests__/components/activity-dropdown.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { fireEvent } from "@testing-library/react-native";
+import { renderScreen } from "../helpers/render";
+
+jest.mock("expo-router", () => {
+  const RealReact = require("react");
+  return {
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: () => ({}),
+    usePathname: () => "/test",
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb();
+        return typeof cleanup === "function" ? cleanup : undefined;
+      }, []);
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  };
+});
+
+jest.mock("../../lib/db", () => ({
+  getBodySettings: jest.fn().mockResolvedValue({ weight_unit: "kg", height_unit: "cm" }),
+  getNutritionProfile: jest.fn().mockResolvedValue(null),
+  saveNutritionProfile: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { ActivityDropdown } from "../../components/profile/ActivityDropdown";
+import { ACTIVITY_LABELS, ACTIVITY_DESCRIPTIONS } from "../../lib/nutrition-calc";
+
+describe("ActivityDropdown (BLD-345)", () => {
+  it("displays selected level label and description", () => {
+    const { getByText } = renderScreen(
+      <ActivityDropdown
+        value="moderately_active"
+        onChange={jest.fn()}
+        visible={false}
+        onToggle={jest.fn()}
+      />,
+    );
+
+    expect(getByText("Moderately Active")).toBeTruthy();
+    expect(getByText("Moderate exercise 3–5 days/week")).toBeTruthy();
+  });
+
+  it("shows all options with descriptions when expanded", () => {
+    const { getAllByText, getByText } = renderScreen(
+      <ActivityDropdown
+        value="sedentary"
+        onChange={jest.fn()}
+        visible={true}
+        onToggle={jest.fn()}
+      />,
+    );
+
+    // Selected level appears in trigger + list
+    expect(getAllByText("Sedentary").length).toBeGreaterThanOrEqual(2);
+    // Other labels visible in list
+    expect(getByText("Lightly Active")).toBeTruthy();
+    expect(getByText("Very Active")).toBeTruthy();
+    expect(getByText("Extra Active")).toBeTruthy();
+
+    // Descriptions visible
+    expect(getAllByText("Little or no exercise, desk job").length).toBeGreaterThanOrEqual(1);
+    expect(getByText("Hard exercise 6–7 days/week")).toBeTruthy();
+  });
+
+  it("calls onChange when an option is pressed", () => {
+    const onChange = jest.fn();
+    const { getByText } = renderScreen(
+      <ActivityDropdown
+        value="sedentary"
+        onChange={onChange}
+        visible={true}
+        onToggle={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(getByText("Very Active"));
+    expect(onChange).toHaveBeenCalledWith("very_active");
+  });
+
+  it("ACTIVITY_DESCRIPTIONS has entries for all activity levels", () => {
+    const levels = Object.keys(ACTIVITY_LABELS);
+    for (const level of levels) {
+      expect(ACTIVITY_DESCRIPTIONS[level as keyof typeof ACTIVITY_DESCRIPTIONS]).toBeTruthy();
+    }
+  });
+});

--- a/components/profile/ActivityDropdown.tsx
+++ b/components/profile/ActivityDropdown.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
-import { ACTIVITY_LABELS, type ActivityLevel } from "../../lib/nutrition-calc";
+import { ACTIVITY_LABELS, ACTIVITY_DESCRIPTIONS, type ActivityLevel } from "../../lib/nutrition-calc";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
 type Props = {
@@ -23,10 +23,15 @@ export function ActivityDropdown({ value, onChange, visible, onToggle }: Props) 
         accessibilityRole="button"
         accessibilityState={{ expanded: visible }}
       >
-        <Text variant="body" style={{ color: colors.onSurface, flex: 1 }}>
-          {ACTIVITY_LABELS[value]}
-        </Text>
-        <Text style={{ color: colors.onSurfaceVariant }}>{visible ? "▲" : "▼"}</Text>
+        <View style={styles.selectedContent}>
+          <Text variant="body" style={{ color: colors.onSurface }} numberOfLines={1}>
+            {ACTIVITY_LABELS[value]}
+          </Text>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1}>
+            {ACTIVITY_DESCRIPTIONS[value]}
+          </Text>
+        </View>
+        <Text style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}>{visible ? "▲" : "▼"}</Text>
       </Pressable>
       {visible && (
         <View style={[styles.dropdownList, { borderColor: colors.outline, backgroundColor: colors.surface }]}>
@@ -38,7 +43,7 @@ export function ActivityDropdown({ value, onChange, visible, onToggle }: Props) 
                 styles.dropdownItem,
                 key === value ? { backgroundColor: colors.primaryContainer } : undefined,
               ]}
-              accessibilityLabel={ACTIVITY_LABELS[key]}
+              accessibilityLabel={`${ACTIVITY_LABELS[key]}: ${ACTIVITY_DESCRIPTIONS[key]}`}
               accessibilityRole="radio"
               accessibilityState={{ selected: key === value }}
             >
@@ -47,6 +52,12 @@ export function ActivityDropdown({ value, onChange, visible, onToggle }: Props) 
                 style={{ color: key === value ? colors.onPrimaryContainer : colors.onSurface }}
               >
                 {ACTIVITY_LABELS[key]}
+              </Text>
+              <Text
+                variant="caption"
+                style={{ color: key === value ? colors.onPrimaryContainer : colors.onSurfaceVariant, opacity: key === value ? 0.8 : 1 }}
+              >
+                {ACTIVITY_DESCRIPTIONS[key]}
               </Text>
             </Pressable>
           ))}
@@ -61,22 +72,27 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     borderWidth: 1,
-    borderRadius: 4,
+    borderRadius: 8,
     paddingHorizontal: 16,
     paddingVertical: 14,
     marginBottom: 8,
-    minHeight: 48,
+    minHeight: 56,
+  },
+  selectedContent: {
+    flex: 1,
+    gap: 2,
   },
   dropdownList: {
     borderWidth: 1,
-    borderRadius: 4,
+    borderRadius: 8,
     marginBottom: 8,
     overflow: "hidden",
   },
   dropdownItem: {
     paddingHorizontal: 16,
-    paddingVertical: 12,
-    minHeight: 44,
+    paddingVertical: 14,
+    minHeight: 52,
     justifyContent: "center",
+    gap: 2,
   },
 });

--- a/lib/nutrition-calc.ts
+++ b/lib/nutrition-calc.ts
@@ -134,6 +134,14 @@ export const ACTIVITY_LABELS: Record<ActivityLevel, string> = {
   extra_active: "Extra Active",
 };
 
+export const ACTIVITY_DESCRIPTIONS: Record<ActivityLevel, string> = {
+  sedentary: "Little or no exercise, desk job",
+  lightly_active: "Light exercise 1–3 days/week",
+  moderately_active: "Moderate exercise 3–5 days/week",
+  very_active: "Hard exercise 6–7 days/week",
+  extra_active: "Very hard exercise, physical job",
+};
+
 export const GOAL_LABELS: Record<Goal, string> = {
   cut: "Cut",
   maintain: "Maintain",


### PR DESCRIPTION
## Summary

Improves the activity level selector readability reported in GitHub #200. The dropdown now shows description subtitles for each activity level (e.g. 'Moderate exercise 3–5 days/week') and has increased padding/spacing for better touch targets on foldable devices.

## Changes

- **lib/nutrition-calc.ts**: Add `ACTIVITY_DESCRIPTIONS` map with exercise frequency descriptions for each level
- **components/profile/ActivityDropdown.tsx**: Show descriptions in both trigger button and dropdown items; increase padding, min heights, and border radius
- **__tests__/components/activity-dropdown.test.tsx**: New tests for dropdown rendering and descriptions

## Testing

- `npx tsc --noEmit` — zero errors
- `npx jest --no-coverage` — all tests pass (137 relevant tests across 12 suites)
- `eslint --max-warnings=0` — passes

## Issue

Resolves BLD-345
Closes #200