### PR TITLE
perf: replace RN Image with expo-image in PhotoGrid (BLD-359)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -45,6 +45,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     ],
     "expo-web-browser",
     "expo-secure-store",
+    "expo-image",
     [
       "expo-build-properties",
       {

--- a/components/PhotoGrid.tsx
+++ b/components/PhotoGrid.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback } from "react";
 import {
-  Image,
   Pressable,
   StyleSheet,
   View,
   useWindowDimensions,
 } from "react-native";
+import { Image } from "expo-image";
 import { Text } from "@/components/ui/text";
 import { FlashList } from "@shopify/flash-list";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
@@ -66,7 +66,9 @@ export default function PhotoGrid({
           <Image
             source={{ uri: item.thumbnail_path || item.file_path }}
             style={styles.image}
-            resizeMode="cover"
+            contentFit="cover"
+            cachePolicy="disk"
+            transition={200}
           />
           {/* Date overlay — white text for WCAG AA contrast on photo backgrounds */}
           <View style={styles.dateOverlay}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fitforge",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fitforge",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.9",
@@ -29,6 +29,7 @@
         "expo-file-system": "~55.0.16",
         "expo-haptics": "~55.0.14",
         "expo-health-connect": "^0.1.1",
+        "expo-image": "~55.0.8",
         "expo-image-manipulator": "~55.0.15",
         "expo-image-picker": "~55.0.18",
         "expo-keep-awake": "~55.0.6",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "expo-file-system": "~55.0.16",
     "expo-haptics": "~55.0.14",
     "expo-health-connect": "^0.1.1",
+    "expo-image": "~55.0.8",
     "expo-image-manipulator": "~55.0.15",
     "expo-image-picker": "~55.0.18",
     "expo-keep-awake": "~55.0.6",


### PR DESCRIPTION
## Summary
Replace react-native `Image` with `expo-image` in PhotoGrid for better image loading performance — disk caching, smooth transitions, and memory optimization.

## Changes
- `package.json` / `package-lock.json`: Add `expo-image` dependency
- `app.config.ts`: Add `expo-image` Expo config plugin
- `components/PhotoGrid.tsx`: Replace RN Image with expo-image Image
  - `resizeMode="cover"` → `contentFit="cover"`
  - Add `cachePolicy="disk"` for persistent disk caching
  - Add `transition={200}` for smooth loading fade-in

## Part 2 (estimatedItemSize) — Not Applicable
FlashList v2 (2.0.2) removed the `estimatedItemSize` prop — items are auto-measured. BLD-360 is not applicable with the current FlashList version.

## Testing
- `npx tsc --noEmit` — zero errors
- `npx jest --no-coverage` — 115 suites, 1806 tests pass
- `npx eslint components/PhotoGrid.tsx` — zero warnings

## Issue
Refs: BLD-359, BLD-360, BLD-365