### PR TITLE
perf: memoize home screen callbacks and session FlashList renderItem (BLD-368)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Alert, FlatList, Pressable, ScrollView, StyleSheet, View } from "react-native";
-import Animated, { FadeInDown } from "react-native-reanimated";
 import { Button } from "@/components/ui/button";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { Text } from "@/components/ui/text";
@@ -15,14 +14,12 @@ import {
   getTemplates, getTodaySchedule, getWeekAdherence, isTodayCompleted, startSession,
 } from "../../lib/db";
 import type { Program, WorkoutTemplate } from "../../lib/types";
-import { rpeColor, rpeText } from "../../lib/rpe";
 import { STARTER_TEMPLATES } from "../../lib/starter-templates";
 import { computeStreak } from "../../lib/format";
 import { FlowCard, difficultyBadge, type MetaBadge } from "../../components/FlowCard";
 import { useFocusRefetch, bumpQueryVersion } from "../../lib/query";
 import { useToast } from "../../components/ui/bna-toast";
 import { useLayout } from "../../lib/layout";
-import { flowCardStyle } from "../../components/ui/FlowContainer";
 import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
 import HomeBanners from "../../components/home/HomeBanners";
 import AdherenceBar from "../../components/home/AdherenceBar";
@@ -56,8 +53,8 @@ export default function Workouts() {
   const { data } = useQuery({ queryKey: ["home"], queryFn: loadHomeData });
   useFocusRefetch(["home"]);
 
-  const templates = data?.templates ?? [];
-  const programs = data?.programs ?? [];
+  const templates = useMemo(() => data?.templates ?? [], [data?.templates]);
+  const programs = useMemo(() => data?.programs ?? [], [data?.programs]);
   const dayCounts = data?.dayCounts ?? {};
   const sessions = data?.sessions ?? [];
   const counts = data?.counts ?? {};
@@ -70,55 +67,58 @@ export default function Workouts() {
   const segment = userSegment ?? (nextWorkout ? "programs" : "templates");
   const todaySchedule = data?.todaySchedule ?? null;
   const todayDone = data?.todayDone ?? false;
-  const adherence = data?.adherence ?? [];
+  const adherence = useMemo(() => data?.adherence ?? [], [data?.adherence]);
 
-  const reload = () => queryClient.invalidateQueries({ queryKey: ["home"] });
-  const starterMeta = (id: string) => STARTER_TEMPLATES.find((s) => s.id === id);
+  const reload = useCallback(() => queryClient.invalidateQueries({ queryKey: ["home"] }), [queryClient]);
+  const starterMeta = useCallback((id: string) => STARTER_TEMPLATES.find((s) => s.id === id), []);
 
-  const quickStart = async () => { const s = await startSession(null, "Quick Workout"); bumpQueryVersion("home"); router.push(`/session/${s.id}`); };
-  const startFromTemplate = async (tpl: WorkoutTemplate) => { const s = await startSession(tpl.id, tpl.name); bumpQueryVersion("home"); router.push(`/session/${s.id}?templateId=${tpl.id}`); };
-  const startNextWorkout = async () => {
+  const quickStart = useCallback(async () => { const s = await startSession(null, "Quick Workout"); bumpQueryVersion("home"); router.push(`/session/${s.id}`); }, [router]);
+  const startFromTemplate = useCallback(async (tpl: WorkoutTemplate) => { const s = await startSession(tpl.id, tpl.name); bumpQueryVersion("home"); router.push(`/session/${s.id}?templateId=${tpl.id}`); }, [router]);
+  const startNextWorkout = useCallback(async () => {
     if (!nextWorkout) return;
     if (!nextWorkout.day.template_id) { info("Template no longer exists"); return; }
     const s = await startSession(nextWorkout.day.template_id, nextWorkout.day.label || nextWorkout.day.template_name || nextWorkout.program.name, nextWorkout.day.id);
     router.push(`/session/${s.id}?templateId=${nextWorkout.day.template_id}`);
-  };
-  const startFromSchedule = async () => {
+  }, [nextWorkout, info, router]);
+  const startFromSchedule = useCallback(async () => {
     if (!todaySchedule) return;
     const s = await startSession(todaySchedule.template_id, todaySchedule.template_name);
     router.push(`/session/${s.id}?templateId=${todaySchedule.template_id}`);
-  };
+  }, [todaySchedule, router]);
 
-  const confirmDelete = (tpl: WorkoutTemplate) => {
+  const confirmDelete = useCallback((tpl: WorkoutTemplate) => {
     if (tpl.is_starter) return;
     Alert.alert("Delete Template", `Delete "${tpl.name}"? Past workout data will be preserved.`, [
       { text: "Cancel", style: "cancel" },
       { text: "Delete", style: "destructive", onPress: async () => { await deleteTemplate(tpl.id); bumpQueryVersion("home"); reload(); } },
     ]);
-  };
-  const confirmDeleteProgram = (prog: Program) => {
+  }, [reload]);
+  const confirmDeleteProgram = useCallback((prog: Program) => {
     if (prog.is_starter) return;
     Alert.alert("Delete Program", `Delete "${prog.name}"? Past workout data will be preserved.`, [
       { text: "Cancel", style: "cancel" },
       { text: "Delete", style: "destructive", onPress: async () => { await softDeleteProgram(prog.id); bumpQueryVersion("home"); reload(); } },
     ]);
-  };
-  const handleDuplicateTemplate = async (tpl: WorkoutTemplate) => { const id = await duplicateTemplate(tpl.id); bumpQueryVersion("home"); reload(); router.push(`/template/${id}`); };
-  const handleDuplicateProgram = async (prog: Program) => { const id = await duplicateProgram(prog.id); bumpQueryVersion("home"); reload(); router.push(`/program/${id}`); };
-  const showTemplateOptions = (item: WorkoutTemplate) => {
+  }, [reload]);
+  const handleDuplicateTemplate = useCallback(async (tpl: WorkoutTemplate) => { const id = await duplicateTemplate(tpl.id); bumpQueryVersion("home"); reload(); router.push(`/template/${id}`); }, [reload, router]);
+  const handleDuplicateProgram = useCallback(async (prog: Program) => { const id = await duplicateProgram(prog.id); bumpQueryVersion("home"); reload(); router.push(`/program/${id}`); }, [reload, router]);
+  const showTemplateOptions = useCallback((item: WorkoutTemplate) => {
     const meta = starterMeta(item.id);
     Alert.alert(meta?.name || item.name, undefined, [{ text: "Duplicate", onPress: () => handleDuplicateTemplate(item) }, { text: "Cancel", style: "cancel" }]);
-  };
-  const showProgramOptions = (item: Program) => {
+  }, [starterMeta, handleDuplicateTemplate]);
+  const showProgramOptions = useCallback((item: Program) => {
     Alert.alert(item.name, undefined, [{ text: "Duplicate", onPress: () => handleDuplicateProgram(item) }, { text: "Cancel", style: "cancel" }]);
-  };
+  }, [handleDuplicateProgram]);
 
-  const allTemplates = [...templates.filter((t) => !t.is_starter), ...templates.filter((t) => t.is_starter)];
-  const allPrograms = [...programs.filter((p) => !p.is_starter), ...programs.filter((p) => p.is_starter)];
+  const allTemplates = useMemo(() => [...templates.filter((t) => !t.is_starter), ...templates.filter((t) => t.is_starter)], [templates]);
+  const allPrograms = useMemo(() => [...programs.filter((p) => !p.is_starter), ...programs.filter((p) => p.is_starter)], [programs]);
+
+  const weekDone = useMemo(() => adherence.filter((a) => a.completed).length, [adherence]);
+  const scheduled = useMemo(() => adherence.filter((a) => a.scheduled), [adherence]);
 
   return (
     <ScrollView style={[styles.container, { backgroundColor: colors.background }]} contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: tabBarHeight + 16 }}>
-      <StatsRow colors={colors} streak={streak} weekDone={adherence.filter((a) => a.completed).length} scheduled={adherence.filter((a) => a.scheduled)} prCount={recentPRs.length} />
+      <StatsRow colors={colors} streak={streak} weekDone={weekDone} scheduled={scheduled} prCount={recentPRs.length} />
       <HomeBanners colors={colors} active={active} todaySchedule={todaySchedule} todayDone={todayDone} adherence={adherence} nextWorkout={nextWorkout} onResumeSession={(id) => router.push(`/session/${id}`)} onStartFromSchedule={startFromSchedule} onStartNextWorkout={startNextWorkout} />
       <AdherenceBar colors={colors} adherence={adherence} />
 

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -131,6 +131,52 @@ export default function ActiveSession() {
     };
   }, []);
 
+  const renderExerciseGroup = useCallback(({ item: group }: { item: typeof groups[number] }) => (
+    <ExerciseGroupCard
+      group={group}
+      step={step}
+      unit={unit}
+      suggestions={suggestions}
+      modes={modes}
+      exerciseNotesOpen={!!exerciseNotesOpen[group.exercise_id]}
+      exerciseNotesDraft={exerciseNotesDraft[group.exercise_id]}
+      halfStep={halfStep}
+      linkIds={linkIds}
+      groups={groups}
+      palette={palette}
+      onUpdate={handleUpdate}
+      onCheck={handleCheck}
+      onDelete={handleDelete}
+      onAddSet={handleAddSet}
+      onModeChange={handleModeChange}
+      onRPE={handleRPE}
+      onHalfStep={handleHalfStep}
+      onHalfStepClear={handleHalfStepClear}
+      onHalfStepOpen={handleHalfStepOpen}
+      onExerciseNotes={handleExerciseNotes}
+      onExerciseNotesDraftChange={handleExerciseNotesDraftChange}
+      onToggleExerciseNotes={toggleExerciseNotes}
+      onCycleSetType={handleCycleSetType}
+      onLongPressSetType={handleLongPressSetType}
+      onShowDetail={handleShowDetail}
+      onSwap={handleSwapOpen}
+      onDeleteExercise={handleDeleteExercise}
+    />
+  ), [step, unit, suggestions, modes, exerciseNotesOpen, exerciseNotesDraft, halfStep, linkIds, groups, palette, handleUpdate, handleCheck, handleDelete, handleAddSet, handleModeChange, handleRPE, handleHalfStep, handleHalfStepClear, handleHalfStepOpen, handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes, handleCycleSetType, handleLongPressSetType, handleShowDetail, handleSwapOpen, handleDeleteExercise]);
+
+  const listHeader = useMemo(() => (
+    <SessionListHeader nextHint={nextHint} colors={colors} />
+  ), [nextHint, colors]);
+
+  const listFooter = useMemo(() => (
+    <SessionListFooter
+      onAddExercise={handleAddExerciseWrapped}
+      onFinish={finish}
+      onCancel={cancel}
+      colors={colors}
+    />
+  ), [handleAddExerciseWrapped, finish, cancel, colors]);
+
   if (!session) {
     return (
       <>
@@ -186,55 +232,12 @@ export default function ActiveSession() {
       <KeyboardAvoidingView style={styles.container} behavior={Platform.OS === "ios" ? "padding" : undefined} keyboardVerticalOffset={100}>
       <FlashList
         data={groups}
-        renderItem={({ item: group }) => (
-          <ExerciseGroupCard
-            group={group}
-            step={step}
-            unit={unit}
-            suggestions={suggestions}
-            modes={modes}
-            exerciseNotesOpen={!!exerciseNotesOpen[group.exercise_id]}
-            exerciseNotesDraft={exerciseNotesDraft[group.exercise_id]}
-            halfStep={halfStep}
-            linkIds={linkIds}
-            groups={groups}
-            palette={palette}
-            onUpdate={handleUpdate}
-            onCheck={handleCheck}
-            onDelete={handleDelete}
-            onAddSet={handleAddSet}
-            onModeChange={handleModeChange}
-            onRPE={handleRPE}
-            onHalfStep={handleHalfStep}
-            onHalfStepClear={handleHalfStepClear}
-            onHalfStepOpen={handleHalfStepOpen}
-            onExerciseNotes={handleExerciseNotes}
-            onExerciseNotesDraftChange={handleExerciseNotesDraftChange}
-            onToggleExerciseNotes={toggleExerciseNotes}
-            onCycleSetType={handleCycleSetType}
-            onLongPressSetType={handleLongPressSetType}
-            onShowDetail={handleShowDetail}
-            onSwap={handleSwapOpen}
-            onDeleteExercise={handleDeleteExercise}
-          />
-        )}
+        renderItem={renderExerciseGroup}
         keyExtractor={(item) => item.exercise_id}
         contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: 48 }}
         keyboardShouldPersistTaps="handled"
-        ListHeaderComponent={
-          <SessionListHeader
-            nextHint={nextHint}
-            colors={colors}
-          />
-        }
-        ListFooterComponent={
-          <SessionListFooter
-            onAddExercise={handleAddExerciseWrapped}
-            onFinish={finish}
-            onCancel={cancel}
-            colors={colors}
-          />
-        }
+        ListHeaderComponent={listHeader}
+        ListFooterComponent={listFooter}
       />
       </KeyboardAvoidingView>
       {!!setTypeSheetSetId && (


### PR DESCRIPTION
## Summary
Memoize callbacks and computed values on the home screen and active session screen to reduce unnecessary re-renders.

## Changes
- `app/(tabs)/index.tsx`: Wrap all callbacks with `useCallback`, computed arrays with `useMemo`, stabilize data refs, extract adherence filters, remove unused imports
- `app/session/[id].tsx`: Extract FlashList `renderItem` to `useCallback`, memoize `ListHeaderComponent` and `ListFooterComponent` to prevent re-renders on timer ticks

## Testing
- `npx tsc --noEmit` — zero errors
- `npx jest --no-coverage` — 1829/1829 tests pass
- `npx eslint --max-warnings=0` — zero warnings on changed files

## Issue
Refs: BLD-356, BLD-357, BLD-368