### PR TITLE
fix: resolve all 22 ESLint errors — clean lint baseline (BLD-379)

### DIFF
--- a/__tests__/acceptance/body-progress.acceptance.test.tsx
+++ b/__tests__/acceptance/body-progress.acceptance.test.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import { fireEvent, waitFor } from '@testing-library/react-native'
 import { renderScreen } from '../helpers/render'
 import { createBodyWeight, createBodySettings, resetIds } from '../helpers/factories'
-import type { BodyWeight, BodySettings } from '../../lib/types'
 
 const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
 

--- a/__tests__/acceptance/onboarding.acceptance.test.tsx
+++ b/__tests__/acceptance/onboarding.acceptance.test.tsx
@@ -175,7 +175,7 @@ describe('Onboarding Acceptance', () => {
 
   describe('Error handling', () => {
     it('shows error banner when getBodySettings rejects', async () => {
-      ;(getBodySettings as jest.Mock).mockRejectedValueOnce(new Error('DB error'))
+      (getBodySettings as jest.Mock).mockRejectedValueOnce(new Error('DB error'))
 
       mockParams.weight = 'kg'
       mockParams.measurement = 'cm'

--- a/__tests__/app/feedback-share.test.ts
+++ b/__tests__/app/feedback-share.test.ts
@@ -18,7 +18,7 @@ function extractHandler(name: string): string {
   const match = src.match(pattern);
   if (!match || match.index === undefined) return "";
   let depth = 0;
-  let start = match.index + match[0].length;
+  const start = match.index + match[0].length;
   for (let i = start; i < src.length; i++) {
     if (src[i] === "{") depth++;
     if (src[i] === "}") {

--- a/__tests__/app/programme-padding-audit.test.ts
+++ b/__tests__/app/programme-padding-audit.test.ts
@@ -27,7 +27,7 @@ const sources = auditedFiles.map(({ rel, label }) => ({
 }));
 
 describe("programme padding audit (BLD-190)", () => {
-  describe.each(sources)("$label ($rel)", ({ src, label }) => {
+  describe.each(sources)("$label ($rel)", ({ src }) => {
     it("imports useLayout from lib/layout", () => {
       expect(src).toMatch(/import\s*\{[^}]*useLayout[^}]*\}\s*from\s*["'][^"']*lib\/layout["']/);
     });

--- a/__tests__/flows/onboarding.test.tsx
+++ b/__tests__/flows/onboarding.test.tsx
@@ -178,7 +178,7 @@ describe('Onboarding Flow', () => {
     })
 
     it('shows error banner when save fails', async () => {
-      ;(getBodySettings as jest.Mock).mockRejectedValueOnce(new Error('DB error'))
+      (getBodySettings as jest.Mock).mockRejectedValueOnce(new Error('DB error'))
 
       const { getByLabelText, findByText } = renderScreen(<Recommend />)
       fireEvent.press(getByLabelText(/Start with Full Body/))

--- a/__tests__/lib/feedback.test.ts
+++ b/__tests__/lib/feedback.test.ts
@@ -22,7 +22,7 @@ import {
   truncateBody,
   formatInteractions,
 } from "../../lib/errors";
-import type { ErrorEntry, Interaction, ReportType } from "../../lib/types";
+import type { ErrorEntry, Interaction } from "../../lib/types";
 
 function makeInteraction(overrides?: Partial<Interaction>): Interaction {
   return {

--- a/__tests__/lib/onboarding.test.ts
+++ b/__tests__/lib/onboarding.test.ts
@@ -117,7 +117,7 @@ describe("seedStarters existing-user migration", () => {
 
     const calls = mockDb.runAsync.mock.calls;
     const onboardingCall = calls.find(
-      (c: any[]) =>
+      (c: [string, ...unknown[]]) =>
         typeof c[0] === "string" &&
         c[0].includes("onboarding_complete")
     );
@@ -138,7 +138,7 @@ describe("seedStarters existing-user migration", () => {
 
     const calls = mockDb.runAsync.mock.calls;
     const onboardingCall = calls.find(
-      (c: any[]) =>
+      (c: [string, ...unknown[]]) =>
         typeof c[0] === "string" &&
         c[0].includes("onboarding_complete")
     );

--- a/__tests__/lib/timer.test.ts
+++ b/__tests__/lib/timer.test.ts
@@ -14,7 +14,6 @@ import {
   progress,
   duration,
   totalDuration,
-  DEFAULTS,
   type TabataConfig,
   type EmomConfig,
   type AmrapConfig,
@@ -429,7 +428,7 @@ describe("timer", () => {
     })
 
     it("mode switching resets state", () => {
-      const s1 = start(init("tabata"), 1000)
+      start(init("tabata"), 1000)
       const s2 = init("emom")
       expect(s2.status).toBe("idle")
       expect(s2.mode).toBe("emom")

--- a/__tests__/lib/training-mode.test.ts
+++ b/__tests__/lib/training-mode.test.ts
@@ -1,5 +1,5 @@
 import { TRAINING_MODE_LABELS } from '../../lib/types'
-import type { TrainingMode, WorkoutSet } from '../../lib/types'
+import type { TrainingMode } from '../../lib/types'
 import { createSet } from '../helpers/factories'
 
 describe('TrainingMode types and labels', () => {

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -10,7 +10,6 @@ import {
 } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { Chip } from "@/components/ui/chip";
 import { Text } from "@/components/ui/text";
 import { useToast } from "@/components/ui/bna-toast";
@@ -63,7 +62,7 @@ export default function ExerciseDetail() {
         catch { showToast({ description: "Failed to delete exercise" }); }
       }},
     ]);
-  }, [id, d.exercise, router]);
+  }, [id, d.exercise, router, showToast]);
 
   if (!d.exercise) {
     return (<><Stack.Screen options={{ title: "Exercise" }} /><View style={[styles.center, { backgroundColor: colors.background }]}><Text style={{ color: colors.onSurfaceVariant }}>Loading...</Text></View></>);

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -8,7 +8,7 @@ import { X } from "lucide-react-native";
 import ErrorBoundary from "../components/ErrorBoundary";
 import { useLayout } from "../lib/layout";
 import { useThemeColors } from "@/hooks/useThemeColors";
-import { useHistoryData, monthLabel } from "@/hooks/useHistoryData";
+import { useHistoryData } from "@/hooks/useHistoryData";
 import StreakAndHeatmap from "@/components/history/StreakAndHeatmap";
 import CalendarGrid from "@/components/history/CalendarGrid";
 import DayDetailPanel from "@/components/history/DayDetailPanel";

--- a/app/onboarding/recommend.tsx
+++ b/app/onboarding/recommend.tsx
@@ -1,6 +1,6 @@
 import { ScrollView, StyleSheet, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
-import { Alert as AlertComponent, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import { Alert as AlertComponent, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Chip } from "@/components/ui/chip";

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Pressable, Share, StyleSheet, TextInput, View } from "react-native";
 import { FlashList } from "@shopify/flash-list";
 import { Card, CardContent } from "@/components/ui/card";
@@ -34,20 +34,23 @@ export default function Summary() {
 
   // Sync rating/notes when session loads
   const sessionRef = useRef(session);
-  if (session && session !== sessionRef.current) {
-    sessionRef.current = session;
-    actions.setRating(session.rating ?? null);
-    actions.setNotesText(session.notes ?? "");
-    actions.setNotesExpanded(!!(session.notes && session.notes.length > 0));
-  }
+  useEffect(() => {
+    if (session && session !== sessionRef.current) {
+      sessionRef.current = session;
+      actions.setRating(session.rating ?? null);
+      actions.setNotesText(session.notes ?? "");
+      actions.setNotesExpanded(!!(session.notes && session.notes.length > 0));
+    }
+  }, [session, actions]);
 
   const duration = session?.duration_seconds ? formatTime(session.duration_seconds) : "0:00";
   const volumeDisplay = toDisplay(volume, unit);
 
+  const sessionStartedAt = session?.started_at;
   const shareCardDate = useMemo(() => {
-    if (!session?.started_at) return "";
-    return new Date(session.started_at).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
-  }, [session?.started_at]);
+    if (!sessionStartedAt) return "";
+    return new Date(sessionStartedAt).toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
+  }, [sessionStartedAt]);
 
   const shareCardPrs = useMemo((): ShareCardPR[] => {
     const items: ShareCardPR[] = prs.map((pr) => ({ name: pr.name, value: `${toDisplay(pr.weight, unit)} ${unit}` }));

--- a/components/history/CalendarGrid.tsx
+++ b/components/history/CalendarGrid.tsx
@@ -40,6 +40,7 @@ export default function CalendarGrid({
   const today = new Date();
   const todayKey = formatDateKey(today.getTime());
   const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate()).getTime();
+  const now = today.getTime();
   const total = daysInMonth(year, month);
   const offset = weekday(new Date(year, month, 1));
 
@@ -52,7 +53,7 @@ export default function CalendarGrid({
     const dayOfWeek = weekday(d);
     const scheduleEntry = scheduleMap.get(dayOfWeek);
     const isPast = d.getTime() < todayMidnight;
-    const isFuture = d.getTime() > Date.now();
+    const isFuture = d.getTime() > now;
     const isScheduled = !!scheduleEntry;
     const isMissedScheduled = isScheduled && isPast && count === 0;
 

--- a/components/home/RecentWorkoutsList.tsx
+++ b/components/home/RecentWorkoutsList.tsx
@@ -1,6 +1,5 @@
 import { FlatList, Pressable, StyleSheet, View } from "react-native";
 import Animated, { FadeInDown } from "react-native-reanimated";
-import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Text } from "@/components/ui/text";
 import { useRouter } from "expo-router";
 import { rpeColor, rpeText } from "@/lib/rpe";

--- a/lib/useFormFields.ts
+++ b/lib/useFormFields.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 type FieldErrors<T> = Partial<Record<keyof T, string>>;
 
@@ -12,7 +12,9 @@ export function useFormFields<T extends Record<string, unknown>>(options: FormOp
   const [errors, setErrors] = useState<FieldErrors<T>>({});
   const [dirty, setDirty] = useState(false);
   const validateRef = useRef(options.validate);
-  validateRef.current = options.validate;
+  useEffect(() => {
+    validateRef.current = options.validate;
+  });
 
   const setValue = useCallback(<K extends keyof T>(key: K, value: T[K]) => {
     setValues((prev) => ({ ...prev, [key]: value }));


### PR DESCRIPTION
## Summary

Fix all 22 ESLint errors to achieve a clean `npx eslint . --ext .ts,.tsx --quiet` baseline (zero errors), enabling CI lint enforcement.

## Changes

### Unused vars (10 fixes)
- Remove unused type imports (`BodyWeight`, `BodySettings`, `ReportType`, `DEFAULTS`, `WorkoutSet`, `AlertTitle`, `monthLabel`)
- Remove unused variable assignments (`label`, `s1`)
- Remove unused component imports (`Card`, `CardContent`, `MaterialCommunityIcons`)

### Style issues (3 fixes)
- Remove extra semicolons in onboarding test files
- Change `let` to `const` for never-reassigned variable

### Type safety (2 fixes)
- Replace `any[]` with `[string, ...unknown[]]` in onboarding test mock calls

### React correctness (4 fixes — real bugs)
- Move ref reads/writes from render to `useEffect` in `session/summary/[id].tsx`
- Move ref update from render to `useEffect` in `useFormFields.ts`
- Replace impure `Date.now()` during render with captured `today.getTime()` in `CalendarGrid.tsx`

### React Compiler (1 fix)
- Add missing `showToast` dependency to `useCallback` in `exercise/[id].tsx`
- Extract `session?.started_at` to variable for stable `useMemo` deps in summary

## Testing

- `npx eslint . --ext .ts,.tsx --quiet` → 0 errors ✅
- `npx tsc --noEmit` → 0 errors ✅
- `npx jest` → 1867/1867 tests pass ✅

## Issue

Resolves BLD-379