### PR TITLE
feat: rest timer background resilience & completion notification (BLD-381)

### DIFF
--- a/__tests__/hooks/useRestTimer.test.ts
+++ b/__tests__/hooks/useRestTimer.test.ts
@@ -1,0 +1,260 @@
+import { renderHook, act } from "@testing-library/react-native";
+import { AppState } from "react-native";
+import { useRestTimer } from "../../hooks/useRestTimer";
+
+// Use the global reanimated mock from __mocks__/react-native-reanimated.js
+// (no need to re-mock here)
+
+// Mock expo-haptics
+jest.mock("expo-haptics", () => ({
+  notificationAsync: jest.fn().mockResolvedValue(undefined),
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  NotificationFeedbackType: { Warning: "warning" },
+  ImpactFeedbackStyle: { Heavy: "heavy" },
+}));
+
+// Mock audio
+jest.mock("../../lib/audio", () => ({
+  play: jest.fn(),
+}));
+
+// Mock notifications
+const mockScheduleRestComplete = jest.fn().mockResolvedValue("notif-id-1");
+const mockCancelRestComplete = jest.fn().mockResolvedValue(undefined);
+const mockIsAvailable = jest.fn().mockReturnValue(true);
+jest.mock("../../lib/notifications", () => ({
+  isAvailable: () => mockIsAvailable(),
+  scheduleRestComplete: (...args: unknown[]) => mockScheduleRestComplete(...args),
+  cancelRestComplete: (...args: unknown[]) => mockCancelRestComplete(...args),
+}));
+
+// Mock db
+const mockGetRestSeconds = jest.fn().mockResolvedValue(60);
+const mockGetAppSetting = jest.fn().mockResolvedValue("true");
+jest.mock("../../lib/db", () => ({
+  getRestSecondsForExercise: (...args: unknown[]) => mockGetRestSeconds(...args),
+  getAppSetting: (...args: unknown[]) => mockGetAppSetting(...args),
+}));
+
+// Track AppState listeners
+let appStateListeners: Array<(state: string) => void> = [];
+const mockAddEventListener = jest.fn((event: string, handler: (state: string) => void) => {
+  if (event === "change") appStateListeners.push(handler);
+  return { remove: () => { appStateListeners = appStateListeners.filter(h => h !== handler); } };
+});
+jest.spyOn(AppState, "addEventListener").mockImplementation(mockAddEventListener as unknown as typeof AppState.addEventListener);
+
+const defaultOptions = {
+  sessionId: "session-1",
+  colors: { primaryContainer: "#eee", primary: "#333" },
+};
+
+describe("useRestTimer", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    appStateListeners = [];
+    mockGetAppSetting.mockResolvedValue("true");
+    mockIsAvailable.mockReturnValue(true);
+    mockScheduleRestComplete.mockResolvedValue("notif-id-1");
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts with rest = 0", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+    expect(result.current.rest).toBe(0);
+  });
+
+  it("startRestWithDuration sets rest and counts down using absolute timestamps", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    act(() => {
+      result.current.startRestWithDuration(5);
+    });
+    expect(result.current.rest).toBe(5);
+
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current.rest).toBe(4);
+
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current.rest).toBe(3);
+  });
+
+  it("counts down to 0 and stops", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    act(() => {
+      result.current.startRestWithDuration(3);
+    });
+
+    act(() => { jest.advanceTimersByTime(3000); });
+    expect(result.current.rest).toBe(0);
+
+    // Timer should be cleared
+    act(() => { jest.advanceTimersByTime(2000); });
+    expect(result.current.rest).toBe(0);
+  });
+
+  it("dismissRest cancels timer and notification", async () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    await act(async () => {
+      result.current.startRestWithDuration(60);
+      // Allow the async scheduleNotification to resolve
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.rest).toBe(60);
+
+    act(() => {
+      result.current.dismissRest();
+    });
+    expect(result.current.rest).toBe(0);
+    // Notification should have been cancelled
+    expect(mockCancelRestComplete).toHaveBeenCalledWith("notif-id-1");
+  });
+
+  it("startRest fetches rest seconds from DB", async () => {
+    mockGetRestSeconds.mockResolvedValue(90);
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    await act(async () => {
+      await result.current.startRest("exercise-1");
+    });
+
+    expect(mockGetRestSeconds).toHaveBeenCalledWith("session-1", "exercise-1");
+    expect(result.current.rest).toBe(90);
+  });
+
+  it("schedules notification on rest start when enabled", async () => {
+    mockGetAppSetting.mockResolvedValue("true");
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    await act(async () => {
+      result.current.startRestWithDuration(60);
+      // Allow the async scheduleNotification to resolve
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockScheduleRestComplete).toHaveBeenCalledWith(60, "session-1");
+  });
+
+  it("does NOT schedule notification when setting is disabled", async () => {
+    mockGetAppSetting.mockResolvedValue("false");
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    await act(async () => {
+      result.current.startRestWithDuration(60);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockScheduleRestComplete).not.toHaveBeenCalled();
+  });
+
+  it("cancels notification when timer reaches 0 in-app", async () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    await act(async () => {
+      result.current.startRestWithDuration(2);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => { jest.advanceTimersByTime(2000); });
+    expect(result.current.rest).toBe(0);
+    expect(mockCancelRestComplete).toHaveBeenCalled();
+  });
+
+  it("new startRestWithDuration cancels previous notification", async () => {
+    mockScheduleRestComplete
+      .mockResolvedValueOnce("notif-1")
+      .mockResolvedValueOnce("notif-2");
+
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    await act(async () => {
+      result.current.startRestWithDuration(60);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Starting a new timer should cancel the previous notification
+    await act(async () => {
+      result.current.startRestWithDuration(30);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockCancelRestComplete).toHaveBeenCalledWith("notif-1");
+  });
+
+  it("recalculates remaining time when app resumes from background", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    act(() => {
+      result.current.startRestWithDuration(90);
+    });
+    expect(result.current.rest).toBe(90);
+
+    // Simulate 60 seconds passing while backgrounded (no intervals fire)
+    jest.setSystemTime(Date.now() + 60000);
+
+    // Simulate app coming back to foreground
+    act(() => {
+      for (const listener of appStateListeners) {
+        listener("active");
+      }
+    });
+
+    expect(result.current.rest).toBe(30);
+  });
+
+  it("shows 0 and cleans up when app resumes after timer would have expired", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    act(() => {
+      result.current.startRestWithDuration(60);
+    });
+
+    // Simulate 90 seconds passing
+    jest.setSystemTime(Date.now() + 90000);
+
+    act(() => {
+      for (const listener of appStateListeners) {
+        listener("active");
+      }
+    });
+
+    expect(result.current.rest).toBe(0);
+  });
+
+  it("does nothing on AppState change when no timer is running", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    act(() => {
+      for (const listener of appStateListeners) {
+        listener("active");
+      }
+    });
+
+    expect(result.current.rest).toBe(0);
+  });
+
+  it("does not schedule notification when notifications unavailable", async () => {
+    mockIsAvailable.mockReturnValue(false);
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    await act(async () => {
+      result.current.startRestWithDuration(60);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockScheduleRestComplete).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/notifications.test.ts
+++ b/__tests__/lib/notifications.test.ts
@@ -9,11 +9,12 @@ jest.mock("expo-notifications", () => {
     getPermissionsAsync: jest.fn().mockResolvedValue({ status: "granted" }),
     requestPermissionsAsync: jest.fn().mockResolvedValue({ status: "granted" }),
     cancelAllScheduledNotificationsAsync: jest.fn().mockResolvedValue(undefined),
+    cancelScheduledNotificationAsync: jest.fn().mockResolvedValue(undefined),
     scheduleNotificationAsync: jest.fn().mockResolvedValue("notif-id"),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setNotificationHandler: jest.fn((h: any) => { handler = h; }),
     addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
-    SchedulableTriggerInputTypes: { WEEKLY: "weekly" },
+    SchedulableTriggerInputTypes: { WEEKLY: "weekly", TIME_INTERVAL: "timeInterval" },
     _getHandler: () => handler,
   };
 });
@@ -25,6 +26,7 @@ jest.mock("../../lib/db", () => ({
   getTemplateById: jest.fn().mockResolvedValue(null),
 }));
 
+// eslint-disable-next-line max-lines-per-function
 describe("notifications", () => {
   let notifications: typeof import("../../lib/notifications");
   let Notifications: typeof import("expo-notifications");
@@ -42,11 +44,12 @@ describe("notifications", () => {
         getPermissionsAsync: jest.fn().mockResolvedValue({ status: "granted" }),
         requestPermissionsAsync: jest.fn().mockResolvedValue({ status: "granted" }),
         cancelAllScheduledNotificationsAsync: jest.fn().mockResolvedValue(undefined),
+        cancelScheduledNotificationAsync: jest.fn().mockResolvedValue(undefined),
         scheduleNotificationAsync: jest.fn().mockResolvedValue("notif-id"),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         setNotificationHandler: jest.fn((h: any) => { handler = h; }),
         addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
-        SchedulableTriggerInputTypes: { WEEKLY: "weekly" },
+        SchedulableTriggerInputTypes: { WEEKLY: "weekly", TIME_INTERVAL: "timeInterval" },
         _getHandler: () => handler,
       };
     });
@@ -222,6 +225,63 @@ describe("notifications", () => {
         shouldShowBanner: true,
         shouldShowList: true,
       });
+    });
+  });
+
+  describe("scheduleRestComplete", () => {
+    it("schedules a time-interval notification", async () => {
+      const id = await notifications.scheduleRestComplete(60, "session-1");
+      expect(id).toBe("notif-id");
+      expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+        content: {
+          title: "Rest Complete",
+          body: "Time for your next set 💪",
+          sound: "default",
+          data: { sessionId: "session-1", type: "rest_complete" },
+        },
+        trigger: {
+          type: "timeInterval",
+          seconds: 60,
+          repeats: false,
+        },
+      });
+    });
+
+    it("returns null when schedule throws", async () => {
+      (Notifications.scheduleNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error("fail"));
+      const id = await notifications.scheduleRestComplete(60, "s1");
+      expect(id).toBeNull();
+    });
+  });
+
+  describe("cancelRestComplete", () => {
+    it("cancels a specific scheduled notification", async () => {
+      await notifications.cancelRestComplete("notif-123");
+      expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith("notif-123");
+    });
+
+    it("does not throw when cancel fails", async () => {
+      (Notifications.cancelScheduledNotificationAsync as jest.Mock).mockRejectedValueOnce(new Error("gone"));
+      await expect(notifications.cancelRestComplete("notif-123")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("handleResponse — rest_complete", () => {
+    const navigate = jest.fn();
+    const showSnackbar = jest.fn();
+
+    beforeEach(() => {
+      navigate.mockClear();
+      showSnackbar.mockClear();
+    });
+
+    it("navigates to session on rest_complete notification tap", async () => {
+      const response = {
+        notification: { request: { content: { data: { type: "rest_complete", sessionId: "sess-42" } } } },
+      };
+      await notifications.handleResponse(response, navigate, showSnackbar);
+      expect(navigate).toHaveBeenCalledWith("/session/sess-42");
+      expect(showSnackbar).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -50,6 +50,7 @@ export default function Settings() {
   const [loading, setLoading] = useState(false);
   const [count, setCount] = useState(0);
   const [soundEnabled, setSoundEnabled] = useState(true);
+  const [restNotifications, setRestNotifications] = useState(true);
   const [reminders, setReminders] = useState(false);
   const [reminderTime, setReminderTime] = useState("08:00");
   const [permDenied, setPermDenied] = useState(false);
@@ -79,6 +80,9 @@ export default function Settings() {
         setSoundEnabled(on);
         setAudioEnabled(on);
       }).catch(() => { setSoundEnabled(true); setAudioEnabled(true); toast.error("Could not load sound setting"); });
+      getAppSetting("rest_notification_enabled").then((val) => {
+        setRestNotifications(val !== "false");
+      }).catch(() => { setRestNotifications(true); });
       Promise.all([getAppSetting("reminders_enabled"), getAppSetting("reminder_time"), getPermissionStatus(), getSchedule()])
         .then(([enabled, time, perm, sched]) => {
           setReminders(enabled === "true" && perm === "granted");
@@ -169,7 +173,7 @@ export default function Settings() {
       <FlowContainer gap={16}>
         <UnitsCard colors={colors} toast={toast} weightUnit={weightUnit} setWeightUnit={setWeightUnit} measureUnit={measureUnit} setMeasureUnit={setMeasureUnit} weightGoal={weightGoal} fatGoal={fatGoal} />
         <BodyProfileCard />
-        <PreferencesCard colors={colors} toast={toast} reminders={reminders} setReminders={setReminders} reminderTime={reminderTime} setReminderTime={setReminderTime} permDenied={permDenied} setPermDenied={setPermDenied} scheduleCount={scheduleCount} soundEnabled={soundEnabled} setSoundEnabled={setSoundEnabled} />
+        <PreferencesCard colors={colors} toast={toast} reminders={reminders} setReminders={setReminders} reminderTime={reminderTime} setReminderTime={setReminderTime} permDenied={permDenied} setPermDenied={setPermDenied} scheduleCount={scheduleCount} soundEnabled={soundEnabled} setSoundEnabled={setSoundEnabled} restNotifications={restNotifications} setRestNotifications={setRestNotifications} />
         <IntegrationsCard colors={colors} toast={toast} stravaAthlete={stravaAthlete} setStravaAthlete={setStravaAthlete} stravaLoading={stravaLoading} setStravaLoading={setStravaLoading} hcEnabled={hcEnabled} setHcEnabled={setHcEnabled} hcLoading={hcLoading} setHcLoading={setHcLoading} hcSdkStatus={hcSdkStatus} />
         <DataManagementCard colors={colors} loading={loading} exportProgress={exportProgress} onExport={handleExport} onImport={handleImport} onImportStrong={() => router.push("/settings/import-strong")} />
         <CSVExportCard colors={colors} />

--- a/components/settings/PreferencesCard.tsx
+++ b/components/settings/PreferencesCard.tsx
@@ -21,6 +21,8 @@ type Props = {
   scheduleCount: number;
   soundEnabled: boolean;
   setSoundEnabled: (v: boolean) => void;
+  restNotifications: boolean;
+  setRestNotifications: (v: boolean) => void;
 };
 
 export default function PreferencesCard({
@@ -28,6 +30,7 @@ export default function PreferencesCard({
   reminders, setReminders, reminderTime, setReminderTime,
   permDenied, setPermDenied, scheduleCount,
   soundEnabled, setSoundEnabled,
+  restNotifications, setRestNotifications,
 }: Props) {
   return (
     <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
@@ -119,6 +122,43 @@ export default function PreferencesCard({
           />
         </View>
         <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Audio cues for interval timers and rest countdowns.</Text>
+
+        <View style={[styles.row, { marginTop: 16 }]}>
+          <View style={{ flex: 1 }}>
+            <Text variant="body" style={{ color: colors.onSurface }}>Rest Timer Notifications</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Get notified when rest is done while using other apps</Text>
+          </View>
+          <Switch
+            value={restNotifications}
+            onValueChange={async (val) => {
+              if (val) {
+                try {
+                  const granted = await requestPermission();
+                  if (!granted) {
+                    setPermDenied(true);
+                    toast.error("Notification permission denied. Tap 'Open Settings' below to enable.");
+                    return;
+                  }
+                  setPermDenied(false);
+                  await setAppSetting("rest_notification_enabled", "true");
+                  setRestNotifications(true);
+                } catch {
+                  toast.error("Couldn't enable rest notifications. Try again later.");
+                }
+              } else {
+                try {
+                  await setAppSetting("rest_notification_enabled", "false");
+                  setRestNotifications(false);
+                } catch {
+                  toast.error("Couldn't disable rest notifications. Try again later.");
+                }
+              }
+            }}
+            accessibilityLabel="Rest Timer Notifications"
+            accessibilityRole="switch"
+            accessibilityHint="Enable or disable push notifications when rest timer completes while app is in background"
+          />
+        </View>
       </CardContent>
     </Card>
   );

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { AppState, type AppStateStatus } from "react-native";
 import {
   useSharedValue,
   useAnimatedStyle,
@@ -7,7 +8,8 @@ import {
 } from "react-native-reanimated";
 import * as Haptics from "expo-haptics";
 import { play as playAudio } from "../lib/audio";
-import { getRestSecondsForExercise } from "../lib/db";
+import { getRestSecondsForExercise, getAppSetting } from "../lib/db";
+import { isAvailable, scheduleRestComplete, cancelRestComplete } from "../lib/notifications";
 import { duration as durationTokens } from "../constants/design-tokens";
 
 type UseRestTimerOptions = {
@@ -18,6 +20,8 @@ type UseRestTimerOptions = {
 export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
   const [rest, setRest] = useState(0);
   const restRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const endAtRef = useRef<number | null>(null);
+  const notificationIdRef = useRef<string | null>(null);
   const restFlash = useSharedValue(0);
   const restFlashStyle = useAnimatedStyle(() => ({
     backgroundColor: interpolateColor(
@@ -29,42 +33,90 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
   const restHapticTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const prevRest = useRef(0);
 
+  const cancelNotification = useCallback(() => {
+    if (notificationIdRef.current) {
+      cancelRestComplete(notificationIdRef.current);
+      notificationIdRef.current = null;
+    }
+  }, []);
+
+  const scheduleNotification = useCallback(async (seconds: number) => {
+    if (!sessionId || seconds <= 0) return;
+    try {
+      const setting = await getAppSetting("rest_notification_enabled");
+      if (setting === "false") return;
+      if (!isAvailable()) return;
+      const id = await scheduleRestComplete(seconds, sessionId);
+      notificationIdRef.current = id;
+    } catch {
+      // Non-critical — timer still works without notification
+    }
+  }, [sessionId]);
+
   const startRest = useCallback(async (exerciseId: string) => {
     if (restRef.current) clearInterval(restRef.current);
+    cancelNotification();
     const secs = await getRestSecondsForExercise(sessionId!, exerciseId);
+    const endAt = Date.now() + secs * 1000;
+    endAtRef.current = endAt;
     setRest(secs);
+    scheduleNotification(secs);
     restRef.current = setInterval(() => {
-      setRest((prev) => {
-        if (prev <= 1) {
-          if (restRef.current) clearInterval(restRef.current);
-          restRef.current = null;
-          return 0;
-        }
-        return prev - 1;
-      });
+      const remaining = Math.max(0, Math.ceil((endAtRef.current! - Date.now()) / 1000));
+      setRest(remaining);
+      if (remaining <= 0) {
+        if (restRef.current) clearInterval(restRef.current);
+        restRef.current = null;
+        endAtRef.current = null;
+        cancelNotification();
+      }
     }, 1000);
-  }, [sessionId]);
+  }, [sessionId, cancelNotification, scheduleNotification]);
 
   const startRestWithDuration = useCallback((secs: number) => {
     if (restRef.current) clearInterval(restRef.current);
+    cancelNotification();
+    const endAt = Date.now() + secs * 1000;
+    endAtRef.current = endAt;
     setRest(secs);
+    scheduleNotification(secs);
     restRef.current = setInterval(() => {
-      setRest((prev) => {
-        if (prev <= 1) {
-          if (restRef.current) clearInterval(restRef.current);
-          restRef.current = null;
-          return 0;
-        }
-        return prev - 1;
-      });
+      const remaining = Math.max(0, Math.ceil((endAtRef.current! - Date.now()) / 1000));
+      setRest(remaining);
+      if (remaining <= 0) {
+        if (restRef.current) clearInterval(restRef.current);
+        restRef.current = null;
+        endAtRef.current = null;
+        cancelNotification();
+      }
     }, 1000);
-  }, []);
+  }, [cancelNotification, scheduleNotification]);
 
   const dismissRest = useCallback(() => {
     if (restRef.current) clearInterval(restRef.current);
     restRef.current = null;
+    endAtRef.current = null;
+    cancelNotification();
     setRest(0);
-  }, []);
+  }, [cancelNotification]);
+
+  // AppState listener: recalculate remaining time on foreground resume
+  useEffect(() => {
+    const handleAppState = (nextState: AppStateStatus) => {
+      if (nextState === "active" && endAtRef.current) {
+        const remaining = Math.max(0, Math.ceil((endAtRef.current - Date.now()) / 1000));
+        setRest(remaining);
+        if (remaining <= 0) {
+          if (restRef.current) clearInterval(restRef.current);
+          restRef.current = null;
+          endAtRef.current = null;
+          cancelNotification();
+        }
+      }
+    };
+    const sub = AppState.addEventListener("change", handleAppState);
+    return () => sub.remove();
+  }, [cancelNotification]);
 
   // Haptic + audio feedback on rest timer completion and countdown
   useEffect(() => {
@@ -98,7 +150,9 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
     return () => {
       if (restRef.current) clearInterval(restRef.current);
       for (const t of restHapticTimers.current) clearTimeout(t);
+      cancelNotification();
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return {

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -97,6 +97,13 @@ export async function handleResponse(
   const data = response.notification.request.content.data as
     | Record<string, unknown>
     | undefined;
+
+  // Handle rest-complete notification: navigate to active session
+  if (data?.type === "rest_complete" && typeof data.sessionId === "string") {
+    navigate(`/session/${data.sessionId}`);
+    return;
+  }
+
   const id = data?.templateId;
   if (typeof id !== "string") {
     navigate("/");
@@ -138,5 +145,50 @@ export function addNotificationResponseReceivedListener(
     return mod.addNotificationResponseReceivedListener(listener);
   } catch {
     return null;
+  }
+}
+
+/**
+ * Schedule a "Rest Complete" notification to fire after `seconds` seconds.
+ * Returns the notification identifier for later cancellation, or null if unavailable.
+ */
+export async function scheduleRestComplete(
+  seconds: number,
+  sessionId: string
+): Promise<string | null> {
+  const mod = getModule();
+  if (!mod) return null;
+  try {
+    const id = await mod.scheduleNotificationAsync({
+      content: {
+        title: "Rest Complete",
+        body: "Time for your next set 💪",
+        sound: "default",
+        data: { sessionId, type: "rest_complete" },
+      },
+      trigger: {
+        type: mod.SchedulableTriggerInputTypes.TIME_INTERVAL,
+        seconds,
+        repeats: false,
+      },
+    });
+    return id;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cancel a previously scheduled rest-complete notification by its identifier.
+ */
+export async function cancelRestComplete(
+  notificationId: string
+): Promise<void> {
+  const mod = getModule();
+  if (!mod) return;
+  try {
+    await mod.cancelScheduledNotificationAsync(notificationId);
+  } catch {
+    // Notification may already have fired or been dismissed
   }
 }


### PR DESCRIPTION
## Summary

Refactors the rest timer from a flawed `setInterval + prev - 1` countdown to absolute timestamps, adds AppState listener for foreground resume, and schedules local push notifications when rest completes while the app is backgrounded.

## Changes

- **hooks/useRestTimer.ts**: Core refactor — absolute timestamps (`endAt = Date.now() + secs * 1000`), AppState listener recalculates remaining time on foreground, 1000ms interval (whole seconds only)
- **lib/notifications.ts**: New `scheduleRestComplete()` and `cancelRestComplete()` helpers using expo-notifications TIME_INTERVAL trigger; updated `handleResponse()` to navigate to session on rest_complete notification tap
- **components/settings/PreferencesCard.tsx**: New "Rest Timer Notifications" toggle with subtitle and permission request flow
- **app/(tabs)/settings.tsx**: Load/pass `rest_notification_enabled` setting to PreferencesCard

## Testing

- 13 new unit tests for `useRestTimer` (countdown, AppState resume, notification scheduling/cancellation, edge cases)
- 5 new tests for notification helpers (`scheduleRestComplete`, `cancelRestComplete`, `handleResponse` rest_complete)
- All 1885 tests pass (121 suites), 0 regressions
- `tsc --noEmit` → 0 errors
- `eslint --quiet` → 0 warnings

## Issue

Resolves BLD-381