### PR TITLE
feat: add recovery readiness badges on template cards (BLD-385)

### DIFF
--- a/__tests__/acceptance/dashboard.test.tsx
+++ b/__tests__/acceptance/dashboard.test.tsx
@@ -141,6 +141,7 @@ jest.mock('../../lib/db', () => ({
   startSession: (...args: unknown[]) => mockStartSession(...args),
   getTemplateExerciseCount: (...args: unknown[]) => mockGetTemplateExerciseCount(...args),
   getTemplateExerciseCounts: jest.fn().mockResolvedValue({}),
+  getTemplatePrimaryMuscles: jest.fn().mockResolvedValue({}),
   getSessionSetCount: (...args: unknown[]) => mockGetSessionSetCount(...args),
   getSessionSetCounts: jest.fn().mockResolvedValue({}),
   getSessionAvgRPE: (...args: unknown[]) => mockGetSessionAvgRPE(...args),

--- a/__tests__/acceptance/program-lifecycle.acceptance.test.tsx
+++ b/__tests__/acceptance/program-lifecycle.acceptance.test.tsx
@@ -71,6 +71,7 @@ jest.mock('../../lib/db', () => ({
   getSessionSetCounts: jest.fn().mockResolvedValue({}),
   getTemplateExerciseCount: (...args: unknown[]) => mockGetTemplateExerciseCount(...args),
   getTemplateExerciseCounts: jest.fn().mockResolvedValue({}),
+  getTemplatePrimaryMuscles: jest.fn().mockResolvedValue({}),
   startSession: (...args: unknown[]) => mockStartSession(...args),
   getTodaySchedule: (...args: unknown[]) => mockGetTodaySchedule(...args),
   isTodayCompleted: (...args: unknown[]) => mockIsTodayCompleted(...args),

--- a/__tests__/acceptance/template-sections-merge.acceptance.test.tsx
+++ b/__tests__/acceptance/template-sections-merge.acceptance.test.tsx
@@ -66,6 +66,7 @@ jest.mock('../../lib/db', () => ({
   getSessionSetCounts: jest.fn().mockResolvedValue({}),
   getTemplateExerciseCount: jest.fn().mockResolvedValue(0),
   getTemplateExerciseCounts: jest.fn().mockResolvedValue({}),
+  getTemplatePrimaryMuscles: jest.fn().mockResolvedValue({}),
   startSession: jest.fn().mockResolvedValue({ id: 'qs-1', template_id: 't1', name: 'Test', started_at: Date.now(), sets: [] }),
   getTodaySchedule: jest.fn().mockResolvedValue(null),
   isTodayCompleted: jest.fn().mockResolvedValue(false),

--- a/__tests__/lib/recovery-readiness.test.ts
+++ b/__tests__/lib/recovery-readiness.test.ts
@@ -1,0 +1,188 @@
+import {
+  computeTemplateReadiness,
+  getReadinessBadge,
+  buildRecoveryMap,
+  hasWorkoutHistory,
+  computeAllTemplateReadiness,
+} from "../../lib/recovery-readiness";
+import type { MuscleRecoveryStatus } from "../../lib/db/recovery";
+import type { MuscleGroup } from "../../lib/types";
+
+describe("recovery-readiness", () => {
+  const makeRecovery = (
+    muscle: MuscleGroup,
+    status: "recovered" | "partial" | "fatigued" | "no_data"
+  ): MuscleRecoveryStatus => ({
+    muscle,
+    lastTrainedAt: status === "no_data" ? null : Date.now() - 24 * 60 * 60 * 1000,
+    hoursAgo: status === "no_data" ? null : 24,
+    status,
+  });
+
+  describe("buildRecoveryMap", () => {
+    it("builds a map from recovery status array", () => {
+      const statuses = [
+        makeRecovery("chest", "recovered"),
+        makeRecovery("back", "fatigued"),
+      ];
+      const map = buildRecoveryMap(statuses);
+      expect(map.get("chest")).toBe("recovered");
+      expect(map.get("back")).toBe("fatigued");
+      expect(map.get("biceps")).toBeUndefined();
+    });
+  });
+
+  describe("computeTemplateReadiness", () => {
+    it("returns null for empty muscles array", () => {
+      const map = buildRecoveryMap([]);
+      expect(computeTemplateReadiness([], map)).toBeNull();
+    });
+
+    it("returns 1.0 when all muscles are recovered", () => {
+      const map = buildRecoveryMap([
+        makeRecovery("chest", "recovered"),
+        makeRecovery("triceps", "recovered"),
+      ]);
+      expect(computeTemplateReadiness(["chest", "triceps"], map)).toBe(1.0);
+    });
+
+    it("returns 0.0 when all muscles are fatigued", () => {
+      const map = buildRecoveryMap([
+        makeRecovery("quads", "fatigued"),
+        makeRecovery("hamstrings", "fatigued"),
+      ]);
+      expect(computeTemplateReadiness(["quads", "hamstrings"], map)).toBe(0.0);
+    });
+
+    it("returns 0.5 when all muscles are partial", () => {
+      const map = buildRecoveryMap([
+        makeRecovery("chest", "partial"),
+        makeRecovery("back", "partial"),
+      ]);
+      expect(computeTemplateReadiness(["chest", "back"], map)).toBe(0.5);
+    });
+
+    it("returns average score for mixed recovery", () => {
+      const map = buildRecoveryMap([
+        makeRecovery("chest", "recovered"),  // 1.0
+        makeRecovery("triceps", "fatigued"), // 0.0
+      ]);
+      // (1.0 + 0.0) / 2 = 0.5
+      expect(computeTemplateReadiness(["chest", "triceps"], map)).toBe(0.5);
+    });
+
+    it("uses 0.75 for muscles with no_data", () => {
+      const map = buildRecoveryMap([
+        makeRecovery("chest", "recovered"),  // 1.0
+        makeRecovery("biceps", "no_data"),   // 0.75
+      ]);
+      // (1.0 + 0.75) / 2 = 0.875
+      expect(computeTemplateReadiness(["chest", "biceps"], map)).toBe(0.875);
+    });
+
+    it("defaults to no_data (0.75) for muscles not in recovery map", () => {
+      const map = buildRecoveryMap([
+        makeRecovery("chest", "recovered"),
+      ]);
+      // forearms not in map → no_data → 0.75
+      // (1.0 + 0.75) / 2 = 0.875
+      expect(computeTemplateReadiness(["chest", "forearms"], map)).toBe(0.875);
+    });
+
+    it("handles single muscle correctly", () => {
+      const map = buildRecoveryMap([makeRecovery("chest", "recovered")]);
+      expect(computeTemplateReadiness(["chest"], map)).toBe(1.0);
+    });
+
+    it("handles three muscles with mixed status", () => {
+      const map = buildRecoveryMap([
+        makeRecovery("chest", "recovered"),    // 1.0
+        makeRecovery("shoulders", "partial"),  // 0.5
+        makeRecovery("triceps", "fatigued"),   // 0.0
+      ]);
+      // (1.0 + 0.5 + 0.0) / 3 = 0.5
+      expect(computeTemplateReadiness(["chest", "shoulders", "triceps"], map)).toBeCloseTo(0.5);
+    });
+  });
+
+  describe("getReadinessBadge", () => {
+    it("returns NO_DATA for null score", () => {
+      expect(getReadinessBadge(null)).toBe("NO_DATA");
+    });
+
+    it("returns READY for score >= 0.8", () => {
+      expect(getReadinessBadge(1.0)).toBe("READY");
+      expect(getReadinessBadge(0.8)).toBe("READY");
+      expect(getReadinessBadge(0.9)).toBe("READY");
+    });
+
+    it("returns PARTIAL for score >= 0.5 and < 0.8", () => {
+      expect(getReadinessBadge(0.5)).toBe("PARTIAL");
+      expect(getReadinessBadge(0.79)).toBe("PARTIAL");
+      expect(getReadinessBadge(0.6)).toBe("PARTIAL");
+    });
+
+    it("returns REST for score < 0.5", () => {
+      expect(getReadinessBadge(0.0)).toBe("REST");
+      expect(getReadinessBadge(0.49)).toBe("REST");
+      expect(getReadinessBadge(0.1)).toBe("REST");
+    });
+  });
+
+  describe("hasWorkoutHistory", () => {
+    it("returns false when all muscles are no_data", () => {
+      expect(hasWorkoutHistory([
+        makeRecovery("chest", "no_data"),
+        makeRecovery("back", "no_data"),
+      ])).toBe(false);
+    });
+
+    it("returns true when at least one muscle has data", () => {
+      expect(hasWorkoutHistory([
+        makeRecovery("chest", "recovered"),
+        makeRecovery("back", "no_data"),
+      ])).toBe(true);
+    });
+
+    it("returns false for empty array", () => {
+      expect(hasWorkoutHistory([])).toBe(false);
+    });
+  });
+
+  describe("computeAllTemplateReadiness", () => {
+    it("computes readiness for multiple templates", () => {
+      const templateMuscles: Record<string, MuscleGroup[]> = {
+        "tpl-1": ["chest", "triceps"],
+        "tpl-2": ["quads", "hamstrings"],
+      };
+      const recoveryStatus: MuscleRecoveryStatus[] = [
+        makeRecovery("chest", "recovered"),
+        makeRecovery("triceps", "recovered"),
+        makeRecovery("quads", "fatigued"),
+        makeRecovery("hamstrings", "fatigued"),
+      ];
+
+      const result = computeAllTemplateReadiness(templateMuscles, recoveryStatus);
+
+      expect(result["tpl-1"].badge).toBe("READY");
+      expect(result["tpl-1"].score).toBe(1.0);
+      expect(result["tpl-2"].badge).toBe("REST");
+      expect(result["tpl-2"].score).toBe(0.0);
+    });
+
+    it("handles templates with no muscles", () => {
+      const templateMuscles: Record<string, MuscleGroup[]> = {
+        "tpl-empty": [],
+      };
+      const result = computeAllTemplateReadiness(templateMuscles, []);
+
+      expect(result["tpl-empty"].badge).toBe("NO_DATA");
+      expect(result["tpl-empty"].score).toBe(0);
+    });
+
+    it("handles empty template muscles map", () => {
+      const result = computeAllTemplateReadiness({}, []);
+      expect(Object.keys(result)).toHaveLength(0);
+    });
+  });
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -12,12 +12,13 @@ import {
   getAllCompletedSessionWeeks, getRecentPRs, getRecentSessions,
   getSessionAvgRPEs, getSessionSetCounts, getTemplateExerciseCounts,
   getTemplates, getTodaySchedule, getWeekAdherence, isTodayCompleted, startSession,
-  getMuscleRecoveryStatus,
+  getMuscleRecoveryStatus, getTemplatePrimaryMuscles,
 } from "../../lib/db";
 import type { Program, WorkoutTemplate } from "../../lib/types";
 import { STARTER_TEMPLATES } from "../../lib/starter-templates";
 import { computeStreak } from "../../lib/format";
 import { FlowCard, difficultyBadge, type MetaBadge } from "../../components/FlowCard";
+import { computeAllTemplateReadiness, hasWorkoutHistory, type TemplateReadiness } from "../../lib/recovery-readiness";
 import { useFocusRefetch, bumpQueryVersion } from "../../lib/query";
 import { useToast } from "../../components/ui/bna-toast";
 import { useLayout } from "../../lib/layout";
@@ -34,14 +35,17 @@ async function loadHomeData() {
     getTemplates(), getRecentSessions(5), getActiveSession(), getAllCompletedSessionWeeks(),
     getRecentPRs(5), getPrograms(), getNextWorkout(), getTodaySchedule(), isTodayCompleted(), getWeekAdherence(),
   ]);
-  const [counts, setCounts, avgRPEs, dayCounts] = await Promise.all([
+  const [counts, setCounts, avgRPEs, dayCounts, templateMuscles] = await Promise.all([
     getTemplateExerciseCounts(tpls.map((t) => t.id)),
     getSessionSetCounts(sess.map((s) => s.id)),
     getSessionAvgRPEs(sess.map((s) => s.id)),
     getProgramDayCounts(progs.map((p) => p.id)),
+    getTemplatePrimaryMuscles(tpls.map((t) => t.id)),
   ]);
   const recoveryStatus = await getMuscleRecoveryStatus();
-  return { templates: tpls, sessions: sess, active: act, streak: computeStreak(timestamps), recentPRs: prData, programs: progs, nextWorkout: nw, todaySchedule: sched, todayDone: done, adherence: adh, counts, setCounts, avgRPEs, dayCounts, recoveryStatus };
+  const templateReadiness = computeAllTemplateReadiness(templateMuscles, recoveryStatus);
+  const showReadiness = hasWorkoutHistory(recoveryStatus);
+  return { templates: tpls, sessions: sess, active: act, streak: computeStreak(timestamps), recentPRs: prData, programs: progs, nextWorkout: nw, todaySchedule: sched, todayDone: done, adherence: adh, counts, setCounts, avgRPEs, dayCounts, recoveryStatus, templateReadiness, showReadiness };
 }
 
 // eslint-disable-next-line complexity
@@ -73,6 +77,8 @@ export default function Workouts() {
   const todayDone = data?.todayDone ?? false;
   const adherence = useMemo(() => data?.adherence ?? [], [data?.adherence]);
   const recoveryStatus = data?.recoveryStatus ?? [];
+  const templateReadiness = data?.templateReadiness ?? {};
+  const showReadiness = data?.showReadiness ?? false;
 
   const reload = useCallback(() => queryClient.invalidateQueries({ queryKey: ["home"] }), [queryClient]);
   const starterMeta = useCallback((id: string) => STARTER_TEMPLATES.find((s) => s.id === id), []);
@@ -140,7 +146,7 @@ export default function Workouts() {
       <SegmentedControl value={segment} onValueChange={(v) => setUserSegment(v)} buttons={[{ value: "templates", label: "Templates", accessibilityLabel: "Templates tab" }, { value: "programs", label: "Programs", accessibilityLabel: "Programs tab" }]} style={styles.segmented} />
 
       {segment === "templates" ? (
-        <TemplatesList colors={colors} templates={allTemplates} counts={counts} starterMeta={starterMeta} onStart={startFromTemplate} onDelete={confirmDelete} onOptions={showTemplateOptions} onEdit={(id) => router.push(`/template/${id}`)} />
+        <TemplatesList colors={colors} templates={allTemplates} counts={counts} starterMeta={starterMeta} templateReadiness={templateReadiness} showReadiness={showReadiness} onStart={startFromTemplate} onDelete={confirmDelete} onOptions={showTemplateOptions} onEdit={(id) => router.push(`/template/${id}`)} />
       ) : (
         <ProgramsList colors={colors} programs={allPrograms} dayCounts={dayCounts} onPress={(id) => router.push(`/program/${id}`)} onDelete={confirmDeleteProgram} onOptions={showProgramOptions} />
       )}
@@ -152,9 +158,10 @@ export default function Workouts() {
 
 /* ── Inline sub-components ── */
 
-function TemplatesList({ colors, templates, counts, starterMeta, onStart, onDelete, onOptions, onEdit }: {
+function TemplatesList({ colors, templates, counts, starterMeta, templateReadiness, showReadiness, onStart, onDelete, onOptions, onEdit }: {
   colors: ReturnType<typeof useThemeColors>; templates: WorkoutTemplate[]; counts: Record<string, number>;
   starterMeta: (id: string) => (typeof STARTER_TEMPLATES)[number] | undefined;
+  templateReadiness: Record<string, TemplateReadiness>; showReadiness: boolean;
   onStart: (t: WorkoutTemplate) => void; onDelete: (t: WorkoutTemplate) => void; onOptions: (t: WorkoutTemplate) => void; onEdit: (id: string) => void;
 }) {
   const router = useRouter();
@@ -179,12 +186,14 @@ function TemplatesList({ colors, templates, counts, starterMeta, onStart, onDele
           if (isStarter) metaBadges.push({ icon: "star-outline", label: "Starter" });
           const badges: { label: string; type: "active" | "starter" | "recommended" }[] = [];
           if (meta?.recommended) badges.push({ label: "RECOMMENDED", type: "recommended" });
+          const readiness = !isStarter && showReadiness ? (templateReadiness[item.id]?.badge ?? null) : null;
+          const displayName = meta?.name || item.name;
           return (
-            <FlowCard key={item.id} name={meta?.name || item.name} onPress={() => onStart(item)} onLongPress={!isStarter ? () => onDelete(item) : undefined}
-              accessibilityLabel={`${isStarter ? "Starter template" : "Start workout from template"}: ${meta?.name || item.name}, ${counts[item.id] ?? 0} exercises`}
-              accessibilityHint={isStarter ? "Double-tap to start workout" : undefined} badges={badges} meta={metaBadges}
+            <FlowCard key={item.id} name={displayName} onPress={() => onStart(item)} onLongPress={!isStarter ? () => onDelete(item) : undefined}
+              accessibilityLabel={`${isStarter ? "Starter template" : "Start workout from template"}: ${displayName}, ${counts[item.id] ?? 0} exercises`}
+              accessibilityHint={isStarter ? "Double-tap to start workout" : undefined} badges={badges} readiness={readiness} meta={metaBadges}
               action={isStarter
-                ? <Pressable onPress={() => onOptions(item)} accessibilityLabel={`Options for ${meta?.name || item.name}`} hitSlop={8} style={{ padding: 8 }}><MaterialCommunityIcons name="dots-vertical" size={20} color={colors.onSurfaceVariant} /></Pressable>
+                ? <Pressable onPress={() => onOptions(item)} accessibilityLabel={`Options for ${displayName}`} hitSlop={8} style={{ padding: 8 }}><MaterialCommunityIcons name="dots-vertical" size={20} color={colors.onSurfaceVariant} /></Pressable>
                 : <Pressable onPress={() => onEdit(item.id)} accessibilityLabel={`Edit template ${item.name}`} hitSlop={8} style={{ padding: 8 }}><MaterialCommunityIcons name="pencil" size={20} color={colors.onSurfaceVariant} /></Pressable>
               } />
           );

--- a/components/FlowCard.tsx
+++ b/components/FlowCard.tsx
@@ -8,6 +8,7 @@ import type { Difficulty } from "../lib/types";
 import { DIFFICULTY_LABELS } from "../lib/types";
 import type { ReadinessBadge } from "../lib/recovery-readiness";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
 const DIFFICULTY_COLORS: Record<Difficulty, { bg: string; fg: string }> = {
   beginner: { bg: "#D1FAE5", fg: "#065F46" },
@@ -51,7 +52,7 @@ export function FlowCard({
   accessibilityHint,
 }: Props) {
   const colors = useThemeColors();
-  const isDark = colors.background === "#0D1117";
+  const isDark = useColorScheme() === "dark";
 
   const body = (
     <>

--- a/components/FlowCard.tsx
+++ b/components/FlowCard.tsx
@@ -6,12 +6,19 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { flowCardStyle } from "./ui/FlowContainer";
 import type { Difficulty } from "../lib/types";
 import { DIFFICULTY_LABELS } from "../lib/types";
+import type { ReadinessBadge } from "../lib/recovery-readiness";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
 const DIFFICULTY_COLORS: Record<Difficulty, { bg: string; fg: string }> = {
   beginner: { bg: "#D1FAE5", fg: "#065F46" },
   intermediate: { bg: "#FEF3C7", fg: "#92400E" },
   advanced: { bg: "#FEE2E2", fg: "#991B1B" },
+};
+
+const READINESS_COLORS: Record<Exclude<ReadinessBadge, "NO_DATA">, { lightBg: string; lightFg: string; darkBg: string; darkFg: string }> = {
+  READY: { lightBg: "#D1FAE5", lightFg: "#065F46", darkBg: "#064E3B", darkFg: "#A7F3D0" },
+  PARTIAL: { lightBg: "#FEF3C7", lightFg: "#92400E", darkBg: "#5C3D00", darkFg: "#FDE68A" },
+  REST: { lightBg: "#FEE2E2", lightFg: "#991B1B", darkBg: "#7F1D1D", darkFg: "#FECACA" },
 };
 
 export type MetaBadge = {
@@ -26,6 +33,7 @@ type Props = {
   onLongPress?: () => void;
   accessibilityLabel: string;
   badges?: { label: string; type: "active" | "starter" | "recommended" }[];
+  readiness?: ReadinessBadge | null;
   meta: MetaBadge[];
   action: React.ReactNode;
   accessibilityHint?: string;
@@ -37,11 +45,13 @@ export function FlowCard({
   onLongPress,
   accessibilityLabel,
   badges,
+  readiness,
   meta,
   action,
   accessibilityHint,
 }: Props) {
   const colors = useThemeColors();
+  const isDark = colors.background === "#0D1117";
 
   const body = (
     <>
@@ -76,6 +86,19 @@ export function FlowCard({
             </View>
           );
         })}
+        {readiness && readiness !== "NO_DATA" && (() => {
+          const rc = READINESS_COLORS[readiness];
+          const bg = isDark ? rc.darkBg : rc.lightBg;
+          const fg = isDark ? rc.darkFg : rc.lightFg;
+          return (
+            <View
+              style={[styles.badge, { backgroundColor: bg }]}
+              accessibilityLabel={`Recovery status: ${readiness.toLowerCase()}`}
+            >
+              <Text variant="caption" style={[styles.badgeText, { color: fg }]}>{readiness}</Text>
+            </View>
+          );
+        })()}
       </View>
       <View style={styles.metaRow}>
         {meta.map((m, i) => {

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -27,6 +27,7 @@ export {
   updateTemplateExercise,
   getTemplateExerciseCount,
   getTemplateExerciseCounts,
+  getTemplatePrimaryMuscles,
   createExerciseLink,
   unlinkExerciseGroup,
   addToExerciseLink,

--- a/lib/db/templates.ts
+++ b/lib/db/templates.ts
@@ -1,4 +1,4 @@
-import type { WorkoutTemplate, TemplateExercise } from "../types";
+import type { WorkoutTemplate, TemplateExercise, MuscleGroup } from "../types";
 import { uuid } from "../uuid";
 import { query, queryOne, execute, getDatabase } from "./helpers";
 import { mapRow } from "./exercises";
@@ -436,6 +436,41 @@ export async function unlinkSingleExercise(
       );
     }
   });
+}
+
+/**
+ * Get the unique primary muscles for each template, grouped by template ID.
+ * Excludes deleted exercises and the "full_body" pseudo-muscle.
+ */
+export async function getTemplatePrimaryMuscles(
+  templateIds: string[]
+): Promise<Record<string, MuscleGroup[]>> {
+  if (templateIds.length === 0) return {};
+  const placeholders = templateIds.map(() => "?").join(",");
+  const rows = await query<{ template_id: string; primary_muscles: string }>(
+    `SELECT te.template_id, e.primary_muscles
+     FROM template_exercises te
+     JOIN exercises e ON te.exercise_id = e.id
+     WHERE te.template_id IN (${placeholders})
+       AND e.deleted_at IS NULL
+       AND e.primary_muscles IS NOT NULL`,
+    templateIds
+  );
+
+  const result: Record<string, Set<MuscleGroup>> = {};
+  for (const row of rows) {
+    if (!result[row.template_id]) result[row.template_id] = new Set();
+    const muscles: MuscleGroup[] = JSON.parse(row.primary_muscles);
+    for (const m of muscles) {
+      if (m !== "full_body") result[row.template_id].add(m);
+    }
+  }
+
+  const out: Record<string, MuscleGroup[]> = {};
+  for (const [id, set] of Object.entries(result)) {
+    out[id] = Array.from(set);
+  }
+  return out;
 }
 
 export async function updateLinkLabel(

--- a/lib/recovery-readiness.ts
+++ b/lib/recovery-readiness.ts
@@ -1,0 +1,107 @@
+/**
+ * Recovery Readiness — pure functions for computing template readiness
+ * based on muscle recovery status.
+ *
+ * Scoring model:
+ * - recovered = 1.0
+ * - partial   = 0.5
+ * - fatigued  = 0.0
+ * - no_data   = 0.75  (assume ready if no workout history for that muscle)
+ *
+ * Badge thresholds:
+ * - >= 0.8 → READY (green)
+ * - >= 0.5 → PARTIAL (amber)
+ * - <  0.5 → REST (red)
+ * - no muscles / no data → NO_DATA
+ */
+
+import type { MuscleGroup } from "./types";
+import type { MuscleRecoveryStatus, RecoveryStatus } from "./db/recovery";
+
+export type ReadinessBadge = "READY" | "PARTIAL" | "REST" | "NO_DATA";
+
+export type TemplateReadiness = {
+  templateId: string;
+  score: number;
+  badge: ReadinessBadge;
+};
+
+const STATUS_SCORES: Record<RecoveryStatus, number> = {
+  recovered: 1.0,
+  partial: 0.5,
+  fatigued: 0.0,
+  no_data: 0.75,
+};
+
+/**
+ * Compute readiness score for a single template.
+ * Returns score between 0 and 1, or null if no muscles to evaluate.
+ */
+export function computeTemplateReadiness(
+  primaryMuscles: MuscleGroup[],
+  recoveryByMuscle: Map<MuscleGroup, RecoveryStatus>
+): number | null {
+  if (primaryMuscles.length === 0) return null;
+
+  let totalScore = 0;
+  for (const muscle of primaryMuscles) {
+    const status = recoveryByMuscle.get(muscle) ?? "no_data";
+    totalScore += STATUS_SCORES[status];
+  }
+  return totalScore / primaryMuscles.length;
+}
+
+/**
+ * Map a readiness score to a badge.
+ */
+export function getReadinessBadge(score: number | null): ReadinessBadge {
+  if (score === null) return "NO_DATA";
+  if (score >= 0.8) return "READY";
+  if (score >= 0.5) return "PARTIAL";
+  return "REST";
+}
+
+/**
+ * Build a muscle → recovery status lookup map from the recovery status array.
+ */
+export function buildRecoveryMap(
+  recoveryStatus: MuscleRecoveryStatus[]
+): Map<MuscleGroup, RecoveryStatus> {
+  const map = new Map<MuscleGroup, RecoveryStatus>();
+  for (const rs of recoveryStatus) {
+    map.set(rs.muscle, rs.status);
+  }
+  return map;
+}
+
+/**
+ * Check if the user has any workout history (i.e. any muscle is not "no_data").
+ * If all muscles are no_data, we should hide badges entirely.
+ */
+export function hasWorkoutHistory(
+  recoveryStatus: MuscleRecoveryStatus[]
+): boolean {
+  return recoveryStatus.some((rs) => rs.status !== "no_data");
+}
+
+/**
+ * Compute readiness for multiple templates at once.
+ */
+export function computeAllTemplateReadiness(
+  templateMuscles: Record<string, MuscleGroup[]>,
+  recoveryStatus: MuscleRecoveryStatus[]
+): Record<string, TemplateReadiness> {
+  const recoveryMap = buildRecoveryMap(recoveryStatus);
+  const result: Record<string, TemplateReadiness> = {};
+
+  for (const [templateId, muscles] of Object.entries(templateMuscles)) {
+    const score = computeTemplateReadiness(muscles, recoveryMap);
+    result[templateId] = {
+      templateId,
+      score: score ?? 0,
+      badge: getReadinessBadge(score),
+    };
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Add recovery readiness badges (READY / PARTIAL / REST) to workout template cards on the Workouts tab. Computed by cross-referencing each template's exercises' primary muscles with `getMuscleRecoveryStatus()`.

## Changes

- **New `lib/recovery-readiness.ts`** — Pure functions: `computeTemplateReadiness()`, `getReadinessBadge()`, `computeAllTemplateReadiness()`, `hasWorkoutHistory()`
- **New `getTemplatePrimaryMuscles()`** batch query in `lib/db/templates.ts` — returns primary muscles grouped by template ID
- **Updated `components/FlowCard.tsx`** — Added optional `readiness` prop with color-coded badge (green/amber/red) supporting light and dark themes
- **Updated `app/(tabs)/index.tsx`** — Integrated readiness computation into `loadHomeData()` and passes to `TemplatesList`
- **Updated acceptance test mocks** — Added `getTemplatePrimaryMuscles` mock to 3 acceptance test files

### Scoring Model
- `recovered` = 1.0, `partial` = 0.5, `fatigued` = 0.0, `no_data` = 0.75 (assume ready if no history)
- Badge: ≥0.8 → READY, ≥0.5 → PARTIAL, <0.5 → REST

### Key Decisions
- Badges hidden entirely for new users with no workout history
- Starter templates excluded from readiness badges (per TL)
- Text labels on badges alongside color for accessibility
- Separate `readiness` prop on FlowCard (per TL, not badge type union)
- **NO template sorting** — badges only (sorting deferred to Phase 55.1 per QD)

## Testing

- 20 new unit tests in `__tests__/lib/recovery-readiness.test.ts` — all passing
- All 1905 existing tests pass (122 suites)
- `npx tsc --noEmit` — zero errors
- `npx eslint . --ext .ts,.tsx --quiet` — zero errors
- lint-staged hook passes

## Issue

Resolves BLD-385