### PR TITLE
fix: use template literal for Errors button to prevent web text node error (BLD-387)

### DIFF
--- a/__tests__/acceptance/settings.test.tsx
+++ b/__tests__/acceptance/settings.test.tsx
@@ -435,6 +435,12 @@ describe('Settings Screen Acceptance', () => {
     })
   })
 
+  it('Error log button renders count as single text node (no View-wrapped text)', async () => {
+    const { findByText } = renderScreen(<Settings />)
+    const label = await findByText('Errors (2)')
+    expect(label).toBeTruthy()
+  })
+
   // ── Import from Strong Button ──────────────────────────────────
 
   it('Import from Strong button navigates to import screen', async () => {

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -250,7 +250,7 @@ function FeedbackCard({ colors, count, onBug, onFeature, onErrors }: {
         <View style={styles.buttonFlow}>
           <Button variant="default" icon={Bug} onPress={onBug} accessibilityLabel="Report a bug">Report Bug</Button>
           <Button variant="outline" icon={Lightbulb} onPress={onFeature} accessibilityLabel="Request a feature">Feature Request</Button>
-          <Button variant="outline" icon={List} onPress={onErrors} accessibilityLabel={`View error log, ${count} ${count === 1 ? "error" : "errors"}`}>Errors ({count})</Button>
+          <Button variant="outline" icon={List} onPress={onErrors} accessibilityLabel={`View error log, ${count} ${count === 1 ? "error" : "errors"}`}>{`Errors (${count})`}</Button>
         </View>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary

Fixes the 'Unexpected text node: ). A text node cannot be a child of a \<View\>' console error on web by converting the Errors button children from JSX interpolation to a template literal.

## Changes

- `app/(tabs)/settings.tsx`: Changed `Errors ({count})` → `{\`Errors (${count})\`}` so JSX produces a single string child instead of three separate text nodes
- `__tests__/acceptance/settings.test.tsx`: Added test verifying the button renders with the expected text

## Root Cause

JSX `Errors ({count})` creates 3 child nodes: `'Errors ('`, `count` (number), `')'`. The Button component's non-string branch renders children inside a \<View\>, but React Native Web requires all text inside \<Text\> components.

## Testing

- All 29 settings acceptance tests pass
- TypeScript type check passes with zero errors

Fixes #217
Resolves BLD-387