### PR TITLE
fix: body profile save dirty-check + minimal toast animation (BLD-389)

### DIFF
--- a/__tests__/components/BodyProfileCard.test.tsx
+++ b/__tests__/components/BodyProfileCard.test.tsx
@@ -1,0 +1,138 @@
+jest.setTimeout(10000)
+
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  useLocalSearchParams: () => ({}),
+  usePathname: () => '/test',
+  useFocusEffect: jest.fn(),
+  Stack: { Screen: () => null },
+  Redirect: () => null,
+}))
+
+jest.mock('@react-navigation/native', () => {
+  const RealReact = require('react')
+  return {
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({
+  useLayout: () => ({ wide: false, width: 375, scale: 1.0, horizontalPadding: 16 }),
+}))
+
+const mockSetAppSetting = jest.fn().mockResolvedValue(undefined)
+
+const SAVED_PROFILE = JSON.stringify({
+  birthYear: 1990,
+  weight: 75,
+  height: 175,
+  sex: 'male',
+  activityLevel: 'moderately_active',
+  goal: 'maintain',
+  weightUnit: 'kg',
+  heightUnit: 'cm',
+})
+
+const mockGetAppSetting = jest.fn().mockImplementation((key: string) => {
+  if (key === 'nutrition_profile') return Promise.resolve(SAVED_PROFILE)
+  return Promise.resolve(null)
+})
+
+jest.mock('../../lib/db', () => ({
+  getAppSetting: (...args: unknown[]) => mockGetAppSetting(...args),
+  setAppSetting: (...args: unknown[]) => mockSetAppSetting(...args),
+  updateMacroTargets: jest.fn().mockResolvedValue(undefined),
+  getBodySettings: jest.fn().mockResolvedValue({
+    weight_unit: 'kg',
+    measurement_unit: 'cm',
+    weight_goal: null,
+    body_fat_goal: null,
+  }),
+}))
+
+jest.mock('../../lib/db/body', () => ({
+  getBodySettings: jest.fn().mockResolvedValue({
+    weight_unit: 'kg',
+    measurement_unit: 'cm',
+    weight_goal: null,
+    body_fat_goal: null,
+  }),
+  getLatestBodyWeight: jest.fn().mockResolvedValue(null),
+}))
+
+jest.mock('../../lib/nutrition-calc', () => ({
+  ACTIVITY_LABELS: {
+    sedentary: 'Sedentary (little exercise)',
+    lightly_active: 'Lightly active',
+    moderately_active: 'Moderately active',
+    very_active: 'Very active',
+    extra_active: 'Extra active',
+  },
+  GOAL_LABELS: { cut: 'Cut', maintain: 'Maintain', bulk: 'Bulk' },
+  calculateFromProfile: jest.fn().mockReturnValue({
+    calories: 2200,
+    protein: 150,
+    carbs: 275,
+    fat: 73,
+  }),
+  migrateProfile: (p: unknown) => p,
+}))
+
+import BodyProfileCard from '../../components/BodyProfileCard'
+
+describe('BodyProfileCard dirty-check', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAppSetting.mockImplementation((key: string) => {
+      if (key === 'nutrition_profile') return Promise.resolve(SAVED_PROFILE)
+      return Promise.resolve(null)
+    })
+  })
+
+  it('does not save when segment tapped to same value', async () => {
+    const { findByLabelText } = renderScreen(<BodyProfileCard />)
+
+    // Wait for profile to load
+    const maleSegment = await findByLabelText('Male')
+    // Tap the already-selected "Male" segment
+    fireEvent.press(maleSegment)
+
+    // Wait a tick for debounced save
+    await new Promise((r) => setTimeout(r, 500))
+
+    // setAppSetting should NOT be called with nutrition_profile
+    const profileSaveCalls = mockSetAppSetting.mock.calls.filter(
+      (c: unknown[]) => c[0] === 'nutrition_profile'
+    )
+    expect(profileSaveCalls).toHaveLength(0)
+  })
+
+  it('saves when a value actually changes', async () => {
+    const { findByLabelText } = renderScreen(<BodyProfileCard />)
+
+    // Wait for profile to load
+    await findByLabelText('Male')
+
+    // Change sex to Female
+    const femaleSegment = await findByLabelText('Female')
+    fireEvent.press(femaleSegment)
+
+    // Wait for debounced save
+    await waitFor(() => {
+      const profileSaveCalls = mockSetAppSetting.mock.calls.filter(
+        (c: unknown[]) => c[0] === 'nutrition_profile'
+      )
+      expect(profileSaveCalls.length).toBeGreaterThanOrEqual(1)
+    })
+  })
+})

--- a/components/BodyProfileCard.tsx
+++ b/components/BodyProfileCard.tsx
@@ -60,6 +60,7 @@ export default function BodyProfileCard() {
   const toast = useToast();
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMounted = useRef(true);
+  const initialSnapshot = useRef<string | null>(null);
 
   useEffect(() => {
     return () => {
@@ -90,6 +91,7 @@ export default function BodyProfileCard() {
         setSex(profile.sex);
         setActivityLevel(profile.activityLevel);
         setGoal(profile.goal);
+        initialSnapshot.current = JSON.stringify(profile);
       } else if (latestWeight) {
         setWeight(String(latestWeight.weight));
       }
@@ -143,9 +145,14 @@ export default function BodyProfileCard() {
         weightUnit,
         heightUnit,
       };
+
+      const profileJson = JSON.stringify(profile);
+      if (profileJson === initialSnapshot.current) return;
+
       await setAppSetting("nutrition_profile", JSON.stringify(profile));
       const result = calculateFromProfile(profile);
       await updateMacroTargets(result.calories, result.protein, result.carbs, result.fat);
+      initialSnapshot.current = profileJson;
       if (isMounted.current) toast.success("Profile saved");
     } catch {
       if (isMounted.current) toast.error("Could not save profile");

--- a/components/ui/bna-toast.tsx
+++ b/components/ui/bna-toast.tsx
@@ -25,8 +25,6 @@ import Animated, {
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
-  withDelay,
-  withSpring,
   withTiming,
 } from 'react-native-reanimated';
 
@@ -50,17 +48,10 @@ interface ToastProps extends ToastData {
 }
 
 const { width: screenWidth } = Dimensions.get('window');
-const DYNAMIC_ISLAND_HEIGHT = 37;
-const EXPANDED_HEIGHT = 85;
+const TOAST_HEIGHT = 52;
 const TOAST_MARGIN = 8;
-const DYNAMIC_ISLAND_WIDTH = 126;
-const EXPANDED_WIDTH = screenWidth - 32;
-
-// Reanimated spring configuration
-const SPRING_CONFIG = {
-  stiffness: 120,
-  damping: 8,
-};
+const MIN_TOAST_WIDTH = 200;
+const MAX_TOAST_WIDTH = screenWidth - 64;
 
 export function Toast({
   id,
@@ -71,48 +62,22 @@ export function Toast({
   index,
   action,
 }: ToastProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-
   // Reanimated shared values
-  const translateY = useSharedValue(-100);
+  const translateY = useSharedValue(-20);
   const translateX = useSharedValue(0);
   const opacity = useSharedValue(0);
-  const scale = useSharedValue(0.8);
-  const width = useSharedValue(DYNAMIC_ISLAND_WIDTH);
-  const height = useSharedValue(DYNAMIC_ISLAND_HEIGHT);
-  const borderRadius = useSharedValue(18.5);
-  const contentOpacity = useSharedValue(0);
+  const scale = useSharedValue(0.85);
 
   // Dynamic Island colors (dark theme optimized)
   const backgroundColor = '#1C1C1E'; // iOS Dynamic Island background
   const mutedTextColor = '#8E8E93'; // iOS secondary text color
 
   useEffect(() => {
-    const hasContentToShow = Boolean(title || description || action);
-
-    if (hasContentToShow) {
-      // If there's content, start directly with expanded state
-      width.value = EXPANDED_WIDTH;
-      height.value = EXPANDED_HEIGHT;
-      borderRadius.value = 20;
-      setIsExpanded(true);
-
-      // Animate in expanded toast
-      translateY.value = withSpring(0, SPRING_CONFIG);
-      opacity.value = withTiming(1, { duration: 300 });
-      scale.value = withSpring(1, SPRING_CONFIG);
-      // CORRECTED LINE: Use withDelay to wrap withTiming
-      contentOpacity.value = withDelay(100, withTiming(1, { duration: 300 }));
-    } else {
-      // If no content, show compact Dynamic Island with icon only
-      setIsExpanded(false);
-
-      // Animate in compact toast
-      translateY.value = withSpring(0, SPRING_CONFIG);
-      opacity.value = withTiming(1, { duration: 200 });
-      scale.value = withSpring(1, SPRING_CONFIG);
-    }
-  }, []); // This effect should only run once when the toast mounts
+    // Punch-in animation: scale 0.85→1.0 + opacity 0→1, 200ms
+    translateY.value = withTiming(0, { duration: 200 });
+    opacity.value = withTiming(1, { duration: 200 });
+    scale.value = withTiming(1, { duration: 200 });
+  }, []);
 
   const getVariantColor = () => {
     switch (variant) {
@@ -147,19 +112,18 @@ export function Toast({
   };
 
   const dismiss = useCallback(() => {
-    // This function will be called from the UI thread
     const onDismissAction = () => {
       'worklet';
       runOnJS(onDismiss)(id);
     };
 
-    translateY.value = withSpring(-100, SPRING_CONFIG);
-    opacity.value = withTiming(0, { duration: 250 }, (finished) => {
+    // Fade out, 150ms
+    opacity.value = withTiming(0, { duration: 150 }, (finished) => {
       if (finished) {
         onDismissAction();
       }
     });
-    scale.value = withSpring(0.8, SPRING_CONFIG);
+    scale.value = withTiming(0.85, { duration: 150 });
   }, [id, onDismiss]);
 
   const panGesture = Gesture.Pan()
@@ -173,7 +137,6 @@ export function Toast({
         Math.abs(translationX) > screenWidth * 0.25 ||
         Math.abs(velocityX) > 800
       ) {
-        // Dismiss action to be called from the UI thread
         const onDismissAction = () => {
           'worklet';
           runOnJS(onDismiss)(id);
@@ -182,25 +145,24 @@ export function Toast({
         // Animate out horizontally
         translateX.value = withTiming(
           translationX > 0 ? screenWidth : -screenWidth,
-          { duration: 250 }
+          { duration: 200 }
         );
-        opacity.value = withTiming(0, { duration: 250 }, (finished) => {
+        opacity.value = withTiming(0, { duration: 150 }, (finished) => {
           if (finished) {
             onDismissAction();
           }
         });
       } else {
-        // Snap back with spring animation
-        translateX.value = withSpring(0, SPRING_CONFIG);
+        // Snap back
+        translateX.value = withTiming(0, { duration: 150 });
       }
     });
 
   const getTopPosition = () => {
     const statusBarHeight = Platform.OS === 'ios' ? 59 : 20;
-    return statusBarHeight + index * (EXPANDED_HEIGHT + TOAST_MARGIN);
+    return statusBarHeight + index * (TOAST_HEIGHT + TOAST_MARGIN);
   };
 
-  // Animated styles
   const animatedContainerStyle = useAnimatedStyle(() => ({
     opacity: opacity.value,
     transform: [
@@ -210,130 +172,101 @@ export function Toast({
     ],
   }));
 
-  const animatedIslandStyle = useAnimatedStyle(() => ({
-    width: width.value,
-    height: height.value,
-    borderRadius: borderRadius.value,
-    backgroundColor,
-    justifyContent: 'center',
-    alignItems: 'center',
-    overflow: 'hidden',
-  }));
-
-  const animatedContentStyle = useAnimatedStyle(() => ({
-    opacity: contentOpacity.value,
-  }));
-
   const toastStyle: ViewStyle = {
     position: 'absolute',
     top: getTopPosition(),
     alignSelf: 'center',
     shadowColor: Colors.light.shadow,
-    shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.25,
-    shadowRadius: 20,
-    elevation: 10,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.15,
+    shadowRadius: 12,
+    elevation: 8,
     zIndex: 1000 + index,
+  };
+
+  const islandStyle: ViewStyle = {
+    minWidth: MIN_TOAST_WIDTH,
+    maxWidth: MAX_TOAST_WIDTH,
+    borderRadius: 14,
+    backgroundColor,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    overflow: 'hidden',
   };
 
   return (
     <GestureDetector gesture={panGesture}>
       <Animated.View style={[toastStyle, animatedContainerStyle]}>
-        <Animated.View style={animatedIslandStyle}>
-          {/* Compact state - just icon or indicator */}
-          {!isExpanded && (
-            <View style={{ justifyContent: 'center', alignItems: 'center' }}>
-              {getIcon()}
-            </View>
+        <View style={islandStyle}>
+          {getIcon() && (
+            <View style={{ marginRight: 10 }}>{getIcon()}</View>
           )}
 
-          {/* Expanded state - full content */}
-          {isExpanded && (
-            <Animated.View
-              style={[
-                {
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
-                  paddingHorizontal: 16,
-                  paddingVertical: 12,
-                  flexDirection: 'row',
-                  alignItems: 'center',
-                },
-                animatedContentStyle,
-              ]}
-            >
-              {getIcon() && (
-                <View style={{ marginRight: 12 }}>{getIcon()}</View>
-              )}
-
-              <View style={{ flex: 1, minWidth: 0 }}>
-                {title && (
-                  <Text
-                    variant='subtitle'
-                    style={{
-                      color: Colors.light.onToast,
-                      fontSize: 14,
-                      fontWeight: '600',
-                      marginBottom: description ? 2 : 0,
-                    }}
-                    numberOfLines={1}
-                    ellipsizeMode='tail'
-                  >
-                    {title}
-                  </Text>
-                )}
-                {description && (
-                  <Text
-                    variant='caption'
-                    style={{
-                      color: mutedTextColor,
-                      fontSize: 13,
-                      fontWeight: '400',
-                    }}
-                    numberOfLines={2}
-                    ellipsizeMode='tail'
-                  >
-                    {description}
-                  </Text>
-                )}
-              </View>
-
-              {action && (
-                <TouchableOpacity
-                  onPress={action.onPress}
-                  style={{
-                    marginLeft: 12,
-                    paddingHorizontal: 12,
-                    paddingVertical: 6,
-                    backgroundColor: getVariantColor(),
-                    borderRadius: 12,
-                  }}
-                >
-                  <Text
-                    variant='caption'
-                    style={{
-                      color: Colors.light.onToast,
-                      fontSize: 12,
-                      fontWeight: '600',
-                    }}
-                  >
-                    {action.label}
-                  </Text>
-                </TouchableOpacity>
-              )}
-
-              <TouchableOpacity
-                onPress={dismiss}
-                style={{ marginLeft: 8, padding: 4, borderRadius: 8 }}
+          <View style={{ flex: 1, minWidth: 0 }}>
+            {title && (
+              <Text
+                variant='subtitle'
+                style={{
+                  color: Colors.light.onToast,
+                  fontSize: 14,
+                  fontWeight: '600',
+                  marginBottom: description ? 2 : 0,
+                }}
+                numberOfLines={1}
+                ellipsizeMode='tail'
               >
-                <X size={14} color={mutedTextColor} />
-              </TouchableOpacity>
-            </Animated.View>
+                {title}
+              </Text>
+            )}
+            {description && (
+              <Text
+                variant='caption'
+                style={{
+                  color: mutedTextColor,
+                  fontSize: 13,
+                  fontWeight: '400',
+                }}
+                numberOfLines={2}
+                ellipsizeMode='tail'
+              >
+                {description}
+              </Text>
+            )}
+          </View>
+
+          {action && (
+            <TouchableOpacity
+              onPress={action.onPress}
+              style={{
+                marginLeft: 12,
+                paddingHorizontal: 12,
+                paddingVertical: 6,
+                backgroundColor: getVariantColor(),
+                borderRadius: 12,
+              }}
+            >
+              <Text
+                variant='caption'
+                style={{
+                  color: Colors.light.onToast,
+                  fontSize: 12,
+                  fontWeight: '600',
+                }}
+              >
+                {action.label}
+              </Text>
+            </TouchableOpacity>
           )}
-        </Animated.View>
+
+          <TouchableOpacity
+            onPress={dismiss}
+            style={{ marginLeft: 8, padding: 4, borderRadius: 8 }}
+          >
+            <X size={14} color={mutedTextColor} />
+          </TouchableOpacity>
+        </View>
       </Animated.View>
     </GestureDetector>
   );


### PR DESCRIPTION
## Summary

Fixes two UX issues reported in GitHub #219: (1) body profile saving on every interaction even when values haven't changed, and (2) toast animation being too flashy (Dynamic Island style).

## Changes

### Part 1: Save-only-on-change
- `components/BodyProfileCard.tsx`: Added `initialSnapshot` ref that captures the profile JSON after load. Before saving, compares current profile against snapshot — skips save and toast if unchanged. Updates snapshot after successful save.

### Part 2: Toast styling
- `components/ui/bna-toast.tsx`: Replaced Dynamic Island expansion animation with minimal centered design:
  - Fixed-size toast with auto-width (min 200px, max screenWidth-64)
  - Quick scale 0.85→1.0 + opacity punch-in (200ms), no spring bounce
  - Fade-out exit (150ms)
  - Removed unused `withSpring`/`withDelay` imports and `isExpanded` state
  - Kept swipe-to-dismiss gesture and stacking behavior

### Tests
- `__tests__/components/BodyProfileCard.test.tsx`: New test file verifying dirty-check — same-value taps don't save, changed values do save.

## Testing

- TypeScript type check: 0 errors
- 112 related tests pass (settings, body, toast, profile)
- 2 new BodyProfileCard dirty-check tests pass

Fixes #219
Resolves BLD-389