### PR TITLE
fix: exercise header alignment on medium screens (BLD-390)

### DIFF
--- a/__tests__/app/exercise-header-alignment.test.ts
+++ b/__tests__/app/exercise-header-alignment.test.ts
@@ -1,0 +1,68 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Structural tests for BLD-390: Exercise header alignment fix (GitHub #220).
+ * Verifies that the non-compact groupHeader does NOT use flexWrap: "wrap",
+ * which caused elements to break onto separate lines on medium-width screens.
+ */
+
+const src = fs.readFileSync(
+  path.resolve(__dirname, "../../components/session/GroupCardHeader.tsx"),
+  "utf-8"
+);
+
+describe("exercise header alignment (BLD-390)", () => {
+  describe("groupHeader style", () => {
+    it("does NOT use flexWrap wrap (causes misalignment on medium screens)", () => {
+      const block = src.match(/groupHeader:\s*\{[^}]*\}/);
+      expect(block).not.toBeNull();
+      expect(block![0]).not.toMatch(/flexWrap/);
+    });
+
+    it("uses flexDirection row for horizontal layout", () => {
+      const block = src.match(/groupHeader:\s*\{[^}]*\}/);
+      expect(block).not.toBeNull();
+      expect(block![0]).toMatch(/flexDirection:\s*["']row["']/);
+    });
+
+    it("uses alignItems center for vertical centering", () => {
+      const block = src.match(/groupHeader:\s*\{[^}]*\}/);
+      expect(block).not.toBeNull();
+      expect(block![0]).toMatch(/alignItems:\s*["']center["']/);
+    });
+  });
+
+  describe("groupTitle style", () => {
+    it("has flex: 1 so it fills remaining space and shrinks for buttons", () => {
+      const block = src.match(/groupTitle:\s*\{[^}]*\}/);
+      expect(block).not.toBeNull();
+      expect(block![0]).toMatch(/flex:\s*1/);
+    });
+
+    it("has minWidth to prevent title from disappearing", () => {
+      const block = src.match(/groupTitle:\s*\{[^}]*\}/);
+      expect(block).not.toBeNull();
+      expect(block![0]).toMatch(/minWidth:\s*\d+/);
+    });
+  });
+
+  describe("non-compact layout", () => {
+    it("title Pressable has flex: 1 to take remaining width", () => {
+      // The non-compact branch wraps the title in a Pressable with flex: 1
+      const nonCompactBlock = src.match(
+        /View style=\{styles\.groupHeader\}[\s\S]*?<\/View>/
+      );
+      expect(nonCompactBlock).not.toBeNull();
+      expect(nonCompactBlock![0]).toMatch(/style=\{\{\s*flex:\s*1\s*\}\}/);
+    });
+
+    it("title Text uses numberOfLines for truncation", () => {
+      expect(src).toMatch(/numberOfLines=\{[12]\}/);
+    });
+
+    it("title Text uses ellipsizeMode tail", () => {
+      expect(src).toMatch(/ellipsizeMode="tail"/);
+    });
+  });
+});

--- a/components/session/GroupCardHeader.tsx
+++ b/components/session/GroupCardHeader.tsx
@@ -193,7 +193,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 12,
     marginBottom: 8,
-    flexWrap: "wrap",
   },
   groupTitle: {
     fontWeight: "700",


### PR DESCRIPTION
## Summary

Fixes exercise header elements wrapping to different lines on medium-width screens (e.g. Z Fold6 unfolded at ~619dp). The exercise name, Details button, swap icon, and notes icon now stay on a single horizontal row.

## Changes

- Removed `flexWrap: 'wrap'` from `groupHeader` style in `GroupCardHeader.tsx`
- The title Pressable (`flex: 1`) fills remaining space while icon buttons stay fixed-width
- Long exercise names truncate with ellipsis via existing `numberOfLines` + `ellipsizeMode`

## Testing

- Added 8 structural tests in `exercise-header-alignment.test.ts` verifying:
  - `groupHeader` does NOT use `flexWrap`
  - Layout uses `flexDirection: row` + `alignItems: center`
  - Title has `flex: 1` and `minWidth` for graceful truncation
  - Text uses `numberOfLines` + `ellipsizeMode: tail`
- `tsc --noEmit` passes (zero errors)
- ESLint passes (zero errors)

## Issue

Resolves BLD-390 / GitHub #220