### PR TITLE
feat: replace activity level SegmentedControl with dropdown (BLD-391)

### DIFF
--- a/__tests__/components/BodyProfileCard.test.tsx
+++ b/__tests__/components/BodyProfileCard.test.tsx
@@ -72,11 +72,18 @@ jest.mock('../../lib/db/body', () => ({
 
 jest.mock('../../lib/nutrition-calc', () => ({
   ACTIVITY_LABELS: {
-    sedentary: 'Sedentary (little exercise)',
-    lightly_active: 'Lightly active',
-    moderately_active: 'Moderately active',
-    very_active: 'Very active',
-    extra_active: 'Extra active',
+    sedentary: 'Sedentary',
+    lightly_active: 'Lightly Active',
+    moderately_active: 'Moderately Active',
+    very_active: 'Very Active',
+    extra_active: 'Extra Active',
+  },
+  ACTIVITY_DESCRIPTIONS: {
+    sedentary: 'Little or no exercise, desk job',
+    lightly_active: 'Light exercise 1–3 days/week',
+    moderately_active: 'Moderate exercise 3–5 days/week',
+    very_active: 'Hard exercise 6–7 days/week',
+    extra_active: 'Very hard exercise, physical job',
   },
   GOAL_LABELS: { cut: 'Cut', maintain: 'Maintain', bulk: 'Bulk' },
   calculateFromProfile: jest.fn().mockReturnValue({

--- a/components/BodyProfileCard.tsx
+++ b/components/BodyProfileCard.tsx
@@ -8,12 +8,12 @@ import { SegmentedControl } from "@/components/ui/segmented-control";
 import { Spinner } from "@/components/ui/spinner";
 import { useToast } from "@/components/ui/bna-toast";
 import { flowCardStyle } from "./ui/FlowContainer";
+import { ActivityDropdown } from "./profile/ActivityDropdown";
 import { useFocusEffect } from "@react-navigation/native";
 import { getAppSetting, setAppSetting, updateMacroTargets } from "../lib/db";
 import { getBodySettings, getLatestBodyWeight } from "../lib/db/body";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import {
-  ACTIVITY_LABELS,
   GOAL_LABELS,
   calculateFromProfile,
   migrateProfile,
@@ -26,14 +26,6 @@ import {
 const SEX_BUTTONS = [
   { value: "male", label: "Male", accessibilityLabel: "Male" },
   { value: "female", label: "Female", accessibilityLabel: "Female" },
-] as const;
-
-const ACTIVITY_BUTTONS = [
-  { value: "sedentary", label: ACTIVITY_LABELS.sedentary.split(" ")[0], accessibilityLabel: ACTIVITY_LABELS.sedentary },
-  { value: "lightly_active", label: ACTIVITY_LABELS.lightly_active.split(" ")[0], accessibilityLabel: ACTIVITY_LABELS.lightly_active },
-  { value: "moderately_active", label: ACTIVITY_LABELS.moderately_active.split(" ")[0], accessibilityLabel: ACTIVITY_LABELS.moderately_active },
-  { value: "very_active", label: ACTIVITY_LABELS.very_active.split(" ")[0], accessibilityLabel: ACTIVITY_LABELS.very_active },
-  { value: "extra_active", label: ACTIVITY_LABELS.extra_active.split(" ")[0], accessibilityLabel: ACTIVITY_LABELS.extra_active },
 ] as const;
 
 const GOAL_BUTTONS = [
@@ -57,6 +49,7 @@ export default function BodyProfileCard() {
   const [weightUnit, setWeightUnit] = useState<"kg" | "lb">("kg");
   const [heightUnit, setHeightUnit] = useState<"cm" | "in">("cm");
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [activityMenuVisible, setActivityMenuVisible] = useState(false);
   const toast = useToast();
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMounted = useRef(true);
@@ -290,11 +283,14 @@ export default function BodyProfileCard() {
         <Text variant="caption" style={[styles.fieldLabel, { color: colors.onSurface, fontWeight: "600" }]}>
           Activity Level
         </Text>
-        <SegmentedControl
+        <ActivityDropdown
           value={activityLevel}
-          onValueChange={(v) => handleSegmentChange("activityLevel", v)}
-          buttons={ACTIVITY_BUTTONS as unknown as Array<{ value: string; label: string; accessibilityLabel: string }>}
-          style={styles.segmented}
+          onChange={(key) => {
+            handleSegmentChange("activityLevel", key);
+            setActivityMenuVisible(false);
+          }}
+          visible={activityMenuVisible}
+          onToggle={() => setActivityMenuVisible(!activityMenuVisible)}
         />
 
         <Text variant="caption" style={[styles.fieldLabel, { color: colors.onSurface, fontWeight: "600" }]}>


### PR DESCRIPTION
## Summary

Replace the cramped 5-option SegmentedControl for activity level with a dropdown that shows full labels and descriptions. Long labels like "Moderately Active" are now fully readable.

## Changes

- Replace SegmentedControl in `BodyProfileCard.tsx` with the existing `ActivityDropdown` component
- Remove unused `ACTIVITY_BUTTONS` constant and `ACTIVITY_LABELS` import
- Add `activityMenuVisible` state for dropdown toggle control
- Update `BodyProfileCard.test.tsx` mock to include `ACTIVITY_DESCRIPTIONS` (required by ActivityDropdown)

## Testing

- All 6 tests pass (BodyProfileCard dirty-check + ActivityDropdown tests)
- TypeScript typecheck passes (1 pre-existing error in bna-toast.test.tsx, unrelated)

## Issue

Fixes #200
Resolves BLD-391