### PR TITLE
test: fix conflicting BLD-203 test after BLD-390 flexWrap removal

### DIFF
--- a/__tests__/app/workout-header-overflow.test.ts
+++ b/__tests__/app/workout-header-overflow.test.ts
@@ -6,12 +6,11 @@ const sessionSrc = [
   fs.readFileSync(path.resolve(__dirname, "../../components/session/GroupCardHeader.tsx"), "utf-8"),
 ].join("\n");
 
-describe("Workout session exercise header overflow fix (BLD-203)", () => {
-  it("groupHeader uses flexWrap: wrap", () => {
-    expect(sessionSrc).toContain('flexWrap: "wrap"');
+describe("Workout session exercise header overflow fix (BLD-203, updated BLD-390)", () => {
+  it("groupHeader does NOT use flexWrap (removed in BLD-390 to fix alignment)", () => {
     const headerMatch = sessionSrc.match(/groupHeader:\s*\{[^}]+\}/s);
     expect(headerMatch).not.toBeNull();
-    expect(headerMatch![0]).toContain('flexWrap: "wrap"');
+    expect(headerMatch![0]).not.toContain("flexWrap");
   });
 
   it("groupTitle has minWidth to prevent overflow", () => {


### PR DESCRIPTION
## Summary

Fixes the test failure caused by the BLD-203 test (`workout-header-overflow.test.ts`) asserting `flexWrap: 'wrap'` is present, which conflicts with BLD-390's intentional removal of that property.

## Changes

- Updated `__tests__/app/workout-header-overflow.test.ts` to assert `flexWrap` is NOT present in `groupHeader` (matching the BLD-390 design decision)

## Testing

- Both `workout-header-overflow.test.ts` (6 tests) and `exercise-header-alignment.test.ts` (8 tests) pass
- No contradicting assertions

## Issue

Resolves BLD-390 (revert fix)