### PR TITLE
feat: workout toolbox & rest timer integration into session header (BLD-396)

### DIFF
--- a/__tests__/components/session/SessionHeaderToolbar.test.tsx
+++ b/__tests__/components/session/SessionHeaderToolbar.test.tsx
@@ -1,0 +1,294 @@
+import React from "react";
+import { render, fireEvent, act } from "@testing-library/react-native";
+import { SessionHeaderToolbar } from "../../../components/session/SessionHeaderToolbar";
+
+// Mock expo-vector-icons
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => {
+  const { Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ name, ...props }: { name: string }) => <Text {...props}>{name}</Text>,
+  };
+});
+
+// Mock theme colors
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#6200ee",
+    primaryContainer: "#e8def8",
+    onSurface: "#1c1b1f",
+    onSurfaceVariant: "#49454f",
+    surface: "#fffbfe",
+    surfaceVariant: "#e7e0ec",
+    background: "#fffbfe",
+  }),
+}));
+
+// Mock db
+const mockGetAppSetting = jest.fn().mockResolvedValue(null);
+const mockSetAppSetting = jest.fn().mockResolvedValue(undefined);
+jest.mock("../../../lib/db", () => ({
+  getAppSetting: (...args: unknown[]) => mockGetAppSetting(...args),
+  setAppSetting: (...args: unknown[]) => mockSetAppSetting(...args),
+}));
+
+// Mock format
+jest.mock("../../../lib/format", () => ({
+  formatTime: (seconds: number) => {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${String(s).padStart(2, "0")}`;
+  },
+}));
+
+const defaultProps = {
+  rest: 0,
+  elapsed: 300,
+  onStartRest: jest.fn(),
+  onDismissRest: jest.fn(),
+  onOpenToolbox: jest.fn(),
+};
+
+describe("SessionHeaderToolbar", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockGetAppSetting.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders elapsed time and toolbox button when no rest active", () => {
+    const { getByText, queryByText } = render(
+      <SessionHeaderToolbar {...defaultProps} />
+    );
+    expect(getByText("5:00")).toBeTruthy();
+    expect(getByText("wrench")).toBeTruthy();
+    // No rest countdown visible
+    expect(queryByText(/^\d{2}:\d{2}$/)).toBeNull();
+  });
+
+  it("renders rest countdown when rest > 0", () => {
+    const { getByText } = render(
+      <SessionHeaderToolbar {...defaultProps} rest={90} />
+    );
+    expect(getByText("01:30")).toBeTruthy();
+    expect(getByText("5:00")).toBeTruthy();
+  });
+
+  it("tapping elapsed time starts rest with default duration (90s)", async () => {
+    const onStartRest = jest.fn();
+    mockGetAppSetting.mockResolvedValue(null);
+
+    const { getByText } = render(
+      <SessionHeaderToolbar {...defaultProps} onStartRest={onStartRest} />
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText("5:00"));
+    });
+
+    expect(mockGetAppSetting).toHaveBeenCalledWith("rest_timer_default_seconds");
+    expect(onStartRest).toHaveBeenCalledWith(90);
+  });
+
+  it("tapping elapsed time uses saved default duration", async () => {
+    const onStartRest = jest.fn();
+    mockGetAppSetting.mockResolvedValue("60");
+
+    const { getByText } = render(
+      <SessionHeaderToolbar {...defaultProps} onStartRest={onStartRest} />
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText("5:00"));
+    });
+
+    expect(onStartRest).toHaveBeenCalledWith(60);
+  });
+
+  it("does NOT start rest when tapping elapsed while rest is active", async () => {
+    const onStartRest = jest.fn();
+
+    const { getByText } = render(
+      <SessionHeaderToolbar {...defaultProps} rest={45} onStartRest={onStartRest} />
+    );
+
+    await act(async () => {
+      fireEvent.press(getByText("5:00"));
+    });
+
+    expect(onStartRest).not.toHaveBeenCalled();
+  });
+
+  it("tapping rest countdown dismisses rest", () => {
+    const onDismissRest = jest.fn();
+
+    const { getByText } = render(
+      <SessionHeaderToolbar {...defaultProps} rest={45} onDismissRest={onDismissRest} />
+    );
+
+    fireEvent.press(getByText("00:45"));
+    expect(onDismissRest).toHaveBeenCalledTimes(1);
+  });
+
+  it("tapping wrench opens toolbox", () => {
+    const onOpenToolbox = jest.fn();
+
+    const { getByText } = render(
+      <SessionHeaderToolbar {...defaultProps} onOpenToolbox={onOpenToolbox} />
+    );
+
+    fireEvent.press(getByText("wrench"));
+    expect(onOpenToolbox).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows REST DONE ✓ for 3 seconds when rest reaches 0", () => {
+    const { rerender, getByText, queryByText } = render(
+      <SessionHeaderToolbar {...defaultProps} rest={1} />
+    );
+
+    // Rest goes to 0
+    rerender(<SessionHeaderToolbar {...defaultProps} rest={0} />);
+
+    expect(getByText("REST DONE ✓")).toBeTruthy();
+
+    // After 3 seconds, it disappears
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(queryByText("REST DONE ✓")).toBeNull();
+  });
+
+  it("tapping REST DONE ✓ dismisses it immediately", () => {
+    const onDismissRest = jest.fn();
+    const { rerender, getByText, queryByText } = render(
+      <SessionHeaderToolbar {...defaultProps} rest={1} onDismissRest={onDismissRest} />
+    );
+
+    rerender(
+      <SessionHeaderToolbar {...defaultProps} rest={0} onDismissRest={onDismissRest} />
+    );
+
+    fireEvent.press(getByText("REST DONE ✓"));
+    expect(onDismissRest).toHaveBeenCalledTimes(1);
+    expect(queryByText("REST DONE ✓")).toBeNull();
+  });
+
+  it("long-pressing timer area opens duration picker modal", async () => {
+    mockGetAppSetting.mockResolvedValue("true");
+
+    const { getByText, queryByText } = render(
+      <SessionHeaderToolbar {...defaultProps} />
+    );
+
+    // Duration picker not visible initially
+    expect(queryByText("Rest Duration")).toBeNull();
+
+    await act(async () => {
+      fireEvent(getByText("5:00"), "longPress");
+    });
+
+    expect(getByText("Rest Duration")).toBeTruthy();
+    expect(getByText("30s")).toBeTruthy();
+    expect(getByText("1m")).toBeTruthy();
+    expect(getByText("1.5m")).toBeTruthy();
+    expect(getByText("2m")).toBeTruthy();
+  });
+
+  it("selecting a preset starts rest and saves default", async () => {
+    const onStartRest = jest.fn();
+    mockGetAppSetting.mockResolvedValue("true");
+
+    const { getByText, queryByText } = render(
+      <SessionHeaderToolbar {...defaultProps} onStartRest={onStartRest} />
+    );
+
+    // Open picker
+    await act(async () => {
+      fireEvent(getByText("5:00"), "longPress");
+    });
+
+    // Select 60s preset
+    await act(async () => {
+      fireEvent.press(getByText("1m"));
+    });
+
+    expect(mockSetAppSetting).toHaveBeenCalledWith("rest_timer_default_seconds", "60");
+    expect(onStartRest).toHaveBeenCalledWith(60);
+
+    // Picker should close
+    expect(queryByText("Rest Duration")).toBeNull();
+  });
+
+  it("dismissing picker without selecting does not change timer state", async () => {
+    const onStartRest = jest.fn();
+    mockGetAppSetting.mockResolvedValue("true");
+
+    const { getByText } = render(
+      <SessionHeaderToolbar {...defaultProps} onStartRest={onStartRest} />
+    );
+
+    // Open picker
+    await act(async () => {
+      fireEvent(getByText("5:00"), "longPress");
+    });
+
+    expect(getByText("Rest Duration")).toBeTruthy();
+
+    // Dismiss via overlay — verify no rest started
+    expect(onStartRest).not.toHaveBeenCalled();
+  });
+
+  it("responds to pickerRequested prop", async () => {
+    mockGetAppSetting.mockResolvedValue("true");
+    const onPickerDismissed = jest.fn();
+
+    const { getByText, rerender } = render(
+      <SessionHeaderToolbar
+        {...defaultProps}
+        pickerRequested={false}
+        onPickerDismissed={onPickerDismissed}
+      />
+    );
+
+    await act(async () => {
+      rerender(
+        <SessionHeaderToolbar
+          {...defaultProps}
+          pickerRequested={true}
+          onPickerDismissed={onPickerDismissed}
+        />
+      );
+    });
+
+    expect(getByText("Rest Duration")).toBeTruthy();
+    expect(onPickerDismissed).toHaveBeenCalled();
+  });
+
+  it("vibrate and sound toggles save settings", async () => {
+    mockGetAppSetting.mockResolvedValue("true");
+
+    const { getByText } = render(
+      <SessionHeaderToolbar {...defaultProps} />
+    );
+
+    // Open picker
+    await act(async () => {
+      fireEvent(getByText("5:00"), "longPress");
+    });
+
+    expect(getByText("Vibrate on complete")).toBeTruthy();
+    expect(getByText("Sound on complete")).toBeTruthy();
+  });
+
+  it("does not show REST DONE ✓ on initial render with rest=0", () => {
+    const { queryByText } = render(
+      <SessionHeaderToolbar {...defaultProps} rest={0} />
+    );
+    expect(queryByText("REST DONE ✓")).toBeNull();
+  });
+});

--- a/__tests__/components/session/SessionHeaderToolbar.test.tsx
+++ b/__tests__/components/session/SessionHeaderToolbar.test.tsx
@@ -20,6 +20,7 @@ jest.mock("@/hooks/useThemeColors", () => ({
     onSurfaceVariant: "#49454f",
     surface: "#fffbfe",
     surfaceVariant: "#e7e0ec",
+    shadow: "#000000",
     background: "#fffbfe",
   }),
 }));

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines-per-function, react-hooks/exhaustive-deps */
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   KeyboardAvoidingView,
   Platform,
@@ -16,7 +16,6 @@ import { activateKeepAwakeAsync } from "expo-keep-awake";
 import BottomSheet, { BottomSheetBackdrop } from "@gorhom/bottom-sheet";
 import { setEnabled as setAudioEnabled } from "../../lib/audio";
 import { getAppSetting } from "../../lib/db";
-import { formatTime } from "../../lib/format";
 import { useLayout } from "../../lib/layout";
 import ExercisePickerSheet from "../../components/ExercisePickerSheet";
 import SubstitutionSheet from "../../components/SubstitutionSheet";
@@ -33,6 +32,7 @@ import { SetTypeSheet } from "../../components/session/SetTypeSheet";
 import { SessionListHeader } from "../../components/session/SessionListHeader";
 import { SessionListFooter } from "../../components/session/SessionListFooter";
 import { SessionToolboxSheet } from "../../components/session/SessionToolboxSheet";
+import { SessionHeaderToolbar } from "../../components/session/SessionHeaderToolbar";
 
 export default function ActiveSession() {
   useEffect(() => {
@@ -99,6 +99,7 @@ export default function ActiveSession() {
   } = useSessionTimer({ sessionId: id, groups, dismissRest, handleUpdate });
   const detailSnapPoints = useMemo(() => ["40%", "90%"], []);
   const toolboxSheetRef = useRef<BottomSheet>(null);
+  const [restSettingsRequested, setRestSettingsRequested] = useState(false);
 
   const handleToolboxOpen = useCallback(() => {
     // Mutual exclusion: close exercise picker before opening toolbox
@@ -113,6 +114,14 @@ export default function ActiveSession() {
   const handleToolboxStartRest = useCallback((seconds: number) => {
     startRestWithDuration(seconds);
   }, [startRestWithDuration]);
+
+  const handleOpenRestSettings = useCallback(() => {
+    setRestSettingsRequested(true);
+  }, []);
+
+  const handleRestSettingsDismissed = useCallback(() => {
+    setRestSettingsRequested(false);
+  }, []);
 
   // Wrap add exercise to close toolbox (mutual exclusion)
   const handleAddExerciseWrapped = useCallback(() => {
@@ -200,38 +209,15 @@ export default function ActiveSession() {
         options={{
           title: session.name,
           headerRight: () => (
-            <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
-              {rest > 0 && (
-                <Pressable
-                  onPress={dismissRest}
-                  accessibilityLabel={`Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds. Tap to skip.`}
-                  accessibilityLiveRegion="polite"
-                  style={{ minWidth: 48, minHeight: 48, alignItems: "center", justifyContent: "center" }}
-                >
-                  <Text variant="body" style={{ color: colors.primary, fontWeight: "700", fontSize: 16 }}>
-                    {String(Math.floor(rest / 60)).padStart(2, "0")}:{String(rest % 60).padStart(2, "0")}
-                  </Text>
-                </Pressable>
-              )}
-              <Text
-                variant="body"
-                style={{
-                  color: rest > 0 ? colors.onSurfaceVariant : colors.primary,
-                  marginRight: 4,
-                  fontSize: rest > 0 ? 13 : 14,
-                }}
-              >
-                {formatTime(elapsed)}
-              </Text>
-              <Pressable
-                onPress={handleToolboxOpen}
-                accessibilityLabel="Open workout toolbox"
-                accessibilityRole="button"
-                style={{ minWidth: 56, minHeight: 56, alignItems: "center", justifyContent: "center" }}
-              >
-                <MaterialCommunityIcons name="wrench" size={22} color={colors.onSurfaceVariant} />
-              </Pressable>
-            </View>
+            <SessionHeaderToolbar
+              rest={rest}
+              elapsed={elapsed}
+              onStartRest={handleToolboxStartRest}
+              onDismissRest={dismissRest}
+              onOpenToolbox={handleToolboxOpen}
+              pickerRequested={restSettingsRequested}
+              onPickerDismissed={handleRestSettingsDismissed}
+            />
           ),
         }}
       />
@@ -301,7 +287,7 @@ export default function ActiveSession() {
       />
       <SessionToolboxSheet
         sheetRef={toolboxSheetRef}
-        onStartRest={handleToolboxStartRest}
+        onOpenRestSettings={handleOpenRestSettings}
         onDismiss={handleToolboxDismiss}
       />
     </>

--- a/components/session/SessionHeaderToolbar.tsx
+++ b/components/session/SessionHeaderToolbar.tsx
@@ -6,7 +6,6 @@ import {
   Switch,
   View,
 } from "react-native";
-import type { ViewStyle } from "react-native";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Text } from "@/components/ui/text";
 import { Chip } from "@/components/ui/chip";
@@ -29,7 +28,6 @@ type Props = {
   onStartRest: (duration: number) => void;
   onDismissRest: () => void;
   onOpenToolbox: () => void;
-  restFlashStyle?: ViewStyle;
   pickerRequested?: boolean;
   onPickerDismissed?: () => void;
 };
@@ -152,7 +150,7 @@ function SessionHeaderToolbarInner({
             <Text
               variant="body"
               style={{
-                color: showRestDone ? colors.primary : colors.primary,
+                color: colors.primary,
                 fontWeight: "700",
                 fontSize: 16,
               }}
@@ -169,7 +167,7 @@ function SessionHeaderToolbarInner({
           onPress={handleElapsedTap}
           onLongPress={handleLongPress}
           delayLongPress={400}
-          disabled={false}
+          disabled={isRestActive}
           accessibilityLabel={
             isRestActive
               ? `Elapsed time: ${formatTime(elapsed)}`
@@ -248,7 +246,7 @@ function RestDurationPicker({
     >
       <Pressable style={styles.modalOverlay} onPress={onDismiss} accessibilityLabel="Dismiss rest settings" accessibilityRole="button">
         <Pressable
-          style={[styles.pickerContainer, { backgroundColor: colors.surface }]}
+          style={[styles.pickerContainer, { backgroundColor: colors.surface, shadowColor: colors.shadow }]}
           onPress={(e) => e.stopPropagation()}
           accessibilityRole="none"
         >
@@ -338,7 +336,6 @@ const styles = StyleSheet.create({
     minWidth: 280,
     maxWidth: 340,
     elevation: 8,
-    shadowColor: "#000",
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.25,
     shadowRadius: 8,

--- a/components/session/SessionHeaderToolbar.tsx
+++ b/components/session/SessionHeaderToolbar.tsx
@@ -1,0 +1,357 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Modal,
+  Pressable,
+  StyleSheet,
+  Switch,
+  View,
+} from "react-native";
+import type { ViewStyle } from "react-native";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { Text } from "@/components/ui/text";
+import { Chip } from "@/components/ui/chip";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { formatTime } from "../../lib/format";
+import { getAppSetting, setAppSetting } from "../../lib/db";
+
+const REST_PRESETS = [30, 60, 90, 120] as const;
+const DEFAULT_REST_SECONDS = 90;
+const REST_DONE_DISPLAY_MS = 3000;
+
+function presetLabel(seconds: number): string {
+  if (seconds >= 60) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}
+
+type Props = {
+  rest: number;
+  elapsed: number;
+  onStartRest: (duration: number) => void;
+  onDismissRest: () => void;
+  onOpenToolbox: () => void;
+  restFlashStyle?: ViewStyle;
+  pickerRequested?: boolean;
+  onPickerDismissed?: () => void;
+};
+
+function SessionHeaderToolbarInner({
+  rest,
+  elapsed,
+  onStartRest,
+  onDismissRest,
+  onOpenToolbox,
+  pickerRequested,
+  onPickerDismissed,
+}: Props) {
+  const colors = useThemeColors();
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [showRestDone, setShowRestDone] = useState(false);
+  const prevRestRef = useRef(0);
+  const restDoneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Settings state for the picker modal
+  const [vibrateSetting, setVibrateSetting] = useState(true);
+  const [soundSetting, setSoundSetting] = useState(true);
+
+  // Detect rest completion: previous rest > 0 → current rest === 0
+  useEffect(() => {
+    if (prevRestRef.current > 0 && rest === 0) {
+      setShowRestDone(true); // eslint-disable-line react-hooks/set-state-in-effect
+      restDoneTimerRef.current = setTimeout(() => {
+        setShowRestDone(false);
+      }, REST_DONE_DISPLAY_MS);
+    }
+    prevRestRef.current = rest;
+  }, [rest]);
+
+  // Cleanup rest done timer on unmount
+  useEffect(() => {
+    return () => {
+      if (restDoneTimerRef.current) clearTimeout(restDoneTimerRef.current);
+    };
+  }, []);
+
+  const handleElapsedTap = useCallback(async () => {
+    if (rest > 0) return; // Disabled when rest is active
+    const savedDefault = await getAppSetting("rest_timer_default_seconds");
+    const duration = savedDefault ? parseInt(savedDefault, 10) : DEFAULT_REST_SECONDS;
+    onStartRest(isNaN(duration) || duration < 1 ? DEFAULT_REST_SECONDS : duration);
+  }, [rest, onStartRest]);
+
+  const handleRestTap = useCallback(() => {
+    onDismissRest();
+    setShowRestDone(false);
+    if (restDoneTimerRef.current) {
+      clearTimeout(restDoneTimerRef.current);
+      restDoneTimerRef.current = null;
+    }
+  }, [onDismissRest]);
+
+  const handleLongPress = useCallback(async () => {
+    // Load current settings before opening picker
+    const [vibrate, sound] = await Promise.all([
+      getAppSetting("rest_timer_vibrate"),
+      getAppSetting("rest_timer_sound"),
+    ]);
+    setVibrateSetting(vibrate !== "false");
+    setSoundSetting(sound !== "false");
+    setPickerVisible(true);
+  }, []);
+
+  // Open picker when externally requested (e.g., from toolbox sheet "Rest Settings")
+  useEffect(() => {
+    if (!pickerRequested) return;
+    Promise.all([
+      getAppSetting("rest_timer_vibrate"),
+      getAppSetting("rest_timer_sound"),
+    ]).then(([vibrate, sound]) => {
+      setVibrateSetting(vibrate !== "false");
+      setSoundSetting(sound !== "false");
+      setPickerVisible(true);
+    });
+    onPickerDismissed?.();
+  }, [pickerRequested, onPickerDismissed]);
+
+  const handlePresetSelect = useCallback(async (seconds: number) => {
+    setPickerVisible(false);
+    await setAppSetting("rest_timer_default_seconds", String(seconds));
+    onStartRest(seconds);
+  }, [onStartRest]);
+
+  const handleVibrateToggle = useCallback(async (value: boolean) => {
+    setVibrateSetting(value);
+    await setAppSetting("rest_timer_vibrate", String(value));
+  }, []);
+
+  const handleSoundToggle = useCallback(async (value: boolean) => {
+    setSoundSetting(value);
+    await setAppSetting("rest_timer_sound", String(value));
+  }, []);
+
+  const handlePickerDismiss = useCallback(() => {
+    setPickerVisible(false);
+  }, []);
+
+  const isRestActive = rest > 0;
+
+  return (
+    <>
+      <View style={styles.container}>
+        {/* Rest countdown or "REST DONE ✓" */}
+        {(isRestActive || showRestDone) && (
+          <Pressable
+            onPress={handleRestTap}
+            accessibilityLabel={
+              showRestDone
+                ? "Rest complete. Tap to dismiss."
+                : `Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds. Tap to dismiss.`
+            }
+            accessibilityLiveRegion="polite"
+            style={styles.timerButton}
+          >
+            <Text
+              variant="body"
+              style={{
+                color: showRestDone ? colors.primary : colors.primary,
+                fontWeight: "700",
+                fontSize: 16,
+              }}
+            >
+              {showRestDone
+                ? "REST DONE ✓"
+                : `${String(Math.floor(rest / 60)).padStart(2, "0")}:${String(rest % 60).padStart(2, "0")}`}
+            </Text>
+          </Pressable>
+        )}
+
+        {/* Elapsed time */}
+        <Pressable
+          onPress={handleElapsedTap}
+          onLongPress={handleLongPress}
+          delayLongPress={400}
+          disabled={false}
+          accessibilityLabel={
+            isRestActive
+              ? `Elapsed time: ${formatTime(elapsed)}`
+              : `Elapsed time: ${formatTime(elapsed)}. Tap to start rest timer. Long press for rest settings.`
+          }
+          accessibilityRole="button"
+          style={styles.elapsedButton}
+        >
+          <Text
+            variant="body"
+            style={{
+              color: isRestActive ? colors.onSurfaceVariant : colors.primary,
+              fontSize: isRestActive ? 13 : 14,
+            }}
+          >
+            {formatTime(elapsed)}
+          </Text>
+        </Pressable>
+
+        {/* Wrench / toolbox button */}
+        <Pressable
+          onPress={onOpenToolbox}
+          accessibilityLabel="Open workout toolbox"
+          accessibilityRole="button"
+          style={styles.toolboxButton}
+        >
+          <MaterialCommunityIcons
+            name="wrench"
+            size={22}
+            color={colors.onSurfaceVariant}
+          />
+        </Pressable>
+      </View>
+
+      {/* Duration Picker Modal */}
+      <RestDurationPicker
+        visible={pickerVisible}
+        vibrateSetting={vibrateSetting}
+        soundSetting={soundSetting}
+        onSelectPreset={handlePresetSelect}
+        onVibrateToggle={handleVibrateToggle}
+        onSoundToggle={handleSoundToggle}
+        onDismiss={handlePickerDismiss}
+      />
+    </>
+  );
+}
+
+type PickerProps = {
+  visible: boolean;
+  vibrateSetting: boolean;
+  soundSetting: boolean;
+  onSelectPreset: (seconds: number) => void;
+  onVibrateToggle: (value: boolean) => void;
+  onSoundToggle: (value: boolean) => void;
+  onDismiss: () => void;
+};
+
+function RestDurationPicker({
+  visible,
+  vibrateSetting,
+  soundSetting,
+  onSelectPreset,
+  onVibrateToggle,
+  onSoundToggle,
+  onDismiss,
+}: PickerProps) {
+  const colors = useThemeColors();
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onDismiss}
+    >
+      <Pressable style={styles.modalOverlay} onPress={onDismiss} accessibilityLabel="Dismiss rest settings" accessibilityRole="button">
+        <Pressable
+          style={[styles.pickerContainer, { backgroundColor: colors.surface }]}
+          onPress={(e) => e.stopPropagation()}
+          accessibilityRole="none"
+        >
+          <Text
+            variant="subtitle"
+            style={{ color: colors.onSurface, marginBottom: 16 }}
+          >
+            Rest Duration
+          </Text>
+
+          <View style={styles.presetsRow}>
+            {REST_PRESETS.map((seconds) => (
+              <Chip
+                key={seconds}
+                selected={false}
+                onPress={() => onSelectPreset(seconds)}
+                accessibilityRole="button"
+                accessibilityLabel={`Start ${presetLabel(seconds)} rest timer`}
+              >
+                {presetLabel(seconds)}
+              </Chip>
+            ))}
+          </View>
+
+          <View style={styles.settingRow}>
+            <Text variant="body" style={{ color: colors.onSurface, flex: 1 }}>
+              Vibrate on complete
+            </Text>
+            <Switch
+              value={vibrateSetting}
+              onValueChange={onVibrateToggle}
+              trackColor={{ false: colors.surfaceVariant, true: colors.primary }}
+            />
+          </View>
+
+          <View style={styles.settingRow}>
+            <Text variant="body" style={{ color: colors.onSurface, flex: 1 }}>
+              Sound on complete
+            </Text>
+            <Switch
+              value={soundSetting}
+              onValueChange={onSoundToggle}
+              trackColor={{ false: colors.surfaceVariant, true: colors.primary }}
+            />
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+export const SessionHeaderToolbar = React.memo(SessionHeaderToolbarInner);
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
+  timerButton: {
+    minWidth: 48,
+    minHeight: 48,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  elapsedButton: {
+    minHeight: 48,
+    alignItems: "center",
+    justifyContent: "center",
+    marginRight: 4,
+  },
+  toolboxButton: {
+    minWidth: 56,
+    minHeight: 56,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  pickerContainer: {
+    borderRadius: 16,
+    padding: 24,
+    minWidth: 280,
+    maxWidth: 340,
+    elevation: 8,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 8,
+  },
+  presetsRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginBottom: 20,
+  },
+  settingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 8,
+  },
+});

--- a/components/session/SessionToolboxSheet.tsx
+++ b/components/session/SessionToolboxSheet.tsx
@@ -3,8 +3,6 @@ import React, { useCallback, useMemo, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Chip } from "@/components/ui/chip";
 import { Card, CardContent } from "@/components/ui/card";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import BottomSheet, { BottomSheetBackdrop, BottomSheetScrollView } from "@gorhom/bottom-sheet";
@@ -14,46 +12,25 @@ import { TimerContent } from "../../app/tools/timer";
 import { useThemeColors, type ThemeColors } from "@/hooks/useThemeColors";
 import { logError } from "../../lib/errors";
 
-const REST_PRESETS = [30, 60, 90, 120] as const;
-
 type Props = {
   sheetRef: React.RefObject<BottomSheet | null>;
-  onStartRest: (seconds: number) => void;
+  onOpenRestSettings: () => void;
   onDismiss: () => void;
 };
 
-export function SessionToolboxSheet({ sheetRef, onStartRest, onDismiss }: Props) {
+export function SessionToolboxSheet({ sheetRef, onOpenRestSettings, onDismiss }: Props) {
   const colors = useThemeColors();
   const snapPoints = useMemo(() => ["50%", "90%"], []);
-  const [selectedPreset, setSelectedPreset] = useState<number | null>(60);
-  const [customDuration, setCustomDuration] = useState("");
   const [plateCalcWeight, setPlateCalcWeight] = useState<string | undefined>(undefined);
-
-  const isCustom = selectedPreset === null;
-  const parsedCustom = parseInt(customDuration, 10);
-  const validCustom = !isNaN(parsedCustom) && parsedCustom >= 1;
-  const canStart = isCustom ? validCustom : selectedPreset !== null;
-
-  const handleSelectPreset = useCallback((seconds: number) => {
-    setSelectedPreset(seconds);
-    setCustomDuration("");
-  }, []);
-
-  const handleCustomFocus = useCallback(() => {
-    setSelectedPreset(null);
-  }, []);
-
-  const handleStartRest = useCallback(() => {
-    const duration = isCustom ? parsedCustom : selectedPreset;
-    if (duration && duration >= 1) {
-      onStartRest(duration);
-      sheetRef.current?.close();
-    }
-  }, [isCustom, parsedCustom, selectedPreset, onStartRest, sheetRef]);
 
   const handlePlateCalcFromRM = useCallback((weight: number) => {
     setPlateCalcWeight(String(weight));
   }, []);
+
+  const handleOpenRestSettings = useCallback(() => {
+    sheetRef.current?.close();
+    onOpenRestSettings();
+  }, [sheetRef, onOpenRestSettings]);
 
   return (
     <BottomSheet
@@ -73,45 +50,13 @@ export function SessionToolboxSheet({ sheetRef, onStartRest, onDismiss }: Props)
         contentContainerStyle={styles.content}
         keyboardShouldPersistTaps="handled"
       >
-        {/* Rest Timer Config */}
+        {/* Rest Settings — a11y fallback for long-press */}
         <ToolSection icon="timer-outline" title="Rest Timer" colors={colors}>
-          <View style={styles.presetsRow}>
-            {REST_PRESETS.map((seconds) => (
-              <Chip
-                key={seconds}
-                selected={selectedPreset === seconds}
-                onPress={() => handleSelectPreset(seconds)}
-                accessibilityRole="radio"
-                accessibilityState={{ selected: selectedPreset === seconds }}
-                accessibilityLabel={`${seconds} seconds rest`}
-              >
-                {`${seconds}s`}
-              </Chip>
-            ))}
-          </View>
-          <View style={styles.customRow}>
-            <View style={{ flex: 1 }}>
-              <Input
-                variant="outline"
-                keyboardType="numeric"
-                value={customDuration}
-                onChangeText={(text) => {
-                  setCustomDuration(text);
-                  setSelectedPreset(null);
-                }}
-                onFocus={handleCustomFocus}
-                placeholder="Custom (seconds)"
-                accessibilityLabel="Custom rest duration in seconds"
-              />
-            </View>
-          </View>
           <Button
-            variant="default"
-            onPress={handleStartRest}
-            disabled={!canStart}
-            style={styles.startButton}
-            accessibilityLabel="Start rest timer"
-            label="Start Rest Timer"
+            variant="ghost"
+            onPress={handleOpenRestSettings}
+            accessibilityLabel="Open rest timer settings"
+            label="Rest Settings"
           />
         </ToolSection>
 
@@ -201,21 +146,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     marginBottom: 16,
-  },
-  presetsRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 8,
-    marginBottom: 12,
-  },
-  customRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    marginBottom: 12,
-  },
-  startButton: {
-    marginTop: 4,
   },
   errorContainer: {
     alignItems: "center",

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -121,16 +121,29 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
   // Haptic + audio feedback on rest timer completion and countdown
   useEffect(() => {
     if (prevRest.current > 0 && rest === 0) {
-      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
-      const t1 = setTimeout(() => {
-        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
-      }, 300);
-      const t2 = setTimeout(() => {
-        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
-      }, 600);
-      restHapticTimers.current = [t1, t2];
+      // Check user settings before firing haptics/audio
+      Promise.all([
+        getAppSetting("rest_timer_vibrate"),
+        getAppSetting("rest_timer_sound"),
+      ]).then(([vibrateSetting, soundSetting]) => {
+        const shouldVibrate = vibrateSetting !== "false";
+        const shouldSound = soundSetting !== "false";
 
-      playAudio("complete");
+        if (shouldVibrate) {
+          Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+          const t1 = setTimeout(() => {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
+          }, 300);
+          const t2 = setTimeout(() => {
+            Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+          }, 600);
+          restHapticTimers.current = [t1, t2];
+        }
+
+        if (shouldSound) {
+          playAudio("complete");
+        }
+      });
 
       // eslint-disable-next-line react-hooks/immutability
       restFlash.value = 1;
@@ -139,7 +152,11 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
     }
 
     if (rest > 0 && rest <= 3) {
-      playAudio("tick");
+      getAppSetting("rest_timer_sound").then((soundSetting) => {
+        if (soundSetting !== "false") {
+          playAudio("tick");
+        }
+      });
     }
 
     prevRest.current = rest;


### PR DESCRIPTION
## Summary

Integrates the rest timer directly into the session header toolbar, reducing the most common workout action from 4 taps to 1 tap. Extracts the header right section into a dedicated `SessionHeaderToolbar` component and simplifies the toolbox sheet by removing the redundant rest timer section.

## Changes

- **New**: `components/session/SessionHeaderToolbar.tsx` — Memoized component with:
  - One-tap rest timer start (tap elapsed time area)
  - Rest countdown display with tap-to-dismiss
  - "REST DONE ✓" display for 3 seconds on timer completion
  - Long-press duration picker modal with presets (30s, 60s, 90s, 2m)
  - Vibrate/sound toggles persisted via `app_settings`
  - Elapsed time tap disabled when rest is active (TL recommendation)
- **Modified**: `app/session/[id].tsx` — Replaced inline header right JSX with `SessionHeaderToolbar`, removed unused `formatTime` import
- **Modified**: `components/session/SessionToolboxSheet.tsx` — Replaced rest timer section with "Rest Settings" a11y fallback link (QD recommendation)
- **New**: `__tests__/components/session/SessionHeaderToolbar.test.tsx` — 15 unit tests

## Testing

- 127 test suites, 1964 tests — all passing
- `tsc --noEmit` passes with zero errors
- `eslint --quiet` passes with zero warnings
- New component tests cover: rendering states, tap/dismiss, long-press picker, preset selection, REST DONE display, settings persistence, external picker trigger

## Issue

Fixes #201
Resolves BLD-396