### PR TITLE
feat: inline plate loading guide in workout session

### DIFF
--- a/__tests__/components/duration-sets.test.tsx
+++ b/__tests__/components/duration-sets.test.tsx
@@ -91,6 +91,7 @@ function makeProps(overrides: Partial<SetRowProps> = {}): SetRowProps {
     unit: "kg",
     halfStep: null,
     trackingMode: "reps",
+    equipment: "barbell",
     onUpdate: jest.fn(),
     onCheck: jest.fn(),
     onDelete: jest.fn(),

--- a/__tests__/components/plate-hint.test.tsx
+++ b/__tests__/components/plate-hint.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { PlateHint } from "../../components/session/PlateHint";
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({ onSurfaceVariant: "#666" }),
+}));
+
+describe("PlateHint", () => {
+  it("renders plate breakdown for barbell, hides for non-barbell, shows remainder, respects units", () => {
+    // Barbell with weight > bar: shows plate hint
+    const { queryByText, rerender } = render(
+      <PlateHint weight={102.5} unit="kg" equipment="barbell" />,
+    );
+    expect(queryByText(/Per side: 25 \+ 15 \+ 1\.25/)).toBeTruthy();
+
+    // Non-barbell: no hint
+    rerender(<PlateHint weight={102.5} unit="kg" equipment="dumbbell" />);
+    expect(queryByText(/Per side/)).toBeNull();
+
+    // Bodyweight: no hint
+    rerender(<PlateHint weight={80} unit="kg" equipment="bodyweight" />);
+    expect(queryByText(/Per side/)).toBeNull();
+
+    // Weight <= bar weight: no hint
+    rerender(<PlateHint weight={20} unit="kg" equipment="barbell" />);
+    expect(queryByText(/Per side/)).toBeNull();
+
+    // Weight = 0: no hint
+    rerender(<PlateHint weight={0} unit="kg" equipment="barbell" />);
+    expect(queryByText(/Per side/)).toBeNull();
+
+    // Null weight: no hint
+    rerender(<PlateHint weight={null} unit="kg" equipment="barbell" />);
+    expect(queryByText(/Per side/)).toBeNull();
+
+    // Remainder (91.3kg): shows ≈
+    rerender(<PlateHint weight={91.3} unit="kg" equipment="barbell" />);
+    expect(queryByText(/≈/)).toBeTruthy();
+    expect(queryByText(/Per side/)).toBeTruthy();
+
+    // lb units: 135lb with 45lb bar → per side = 45
+    rerender(<PlateHint weight={135} unit="lb" equipment="barbell" />);
+    expect(queryByText(/Per side: 45/)).toBeTruthy();
+
+    // lb units: 225lb → per side = 90 → 55 + 35
+    rerender(<PlateHint weight={225} unit="lb" equipment="barbell" />);
+    expect(queryByText(/Per side: 55 \+ 35/)).toBeTruthy();
+
+    // Accessibility label exists
+    rerender(<PlateHint weight={60} unit="kg" equipment="barbell" />);
+    const text = queryByText(/Per side: 20/);
+    expect(text).toBeTruthy();
+    expect(text?.props.accessibilityLabel).toMatch(/kilograms/);
+  });
+});

--- a/components/session/ExerciseGroupCard.tsx
+++ b/components/session/ExerciseGroupCard.tsx
@@ -106,6 +106,7 @@ export const ExerciseGroupCard = memo(function ExerciseGroupCard({
             unit={unit}
             halfStep={halfStep}
             trackingMode={isDurationMode ? "duration" : "reps"}
+            equipment={group.equipment}
             onUpdate={onUpdate}
             onCheck={onCheck}
             onDelete={onDelete}

--- a/components/session/PlateHint.tsx
+++ b/components/session/PlateHint.tsx
@@ -1,0 +1,54 @@
+import React, { memo, useMemo } from "react";
+import { StyleSheet } from "react-native";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { solve, perSide, KG_PLATES, LB_PLATES } from "../../lib/plates";
+import type { Equipment } from "../../lib/types";
+import { fontSizes } from "@/constants/design-tokens";
+
+type Props = {
+  weight: number | null;
+  unit: "kg" | "lb";
+  equipment: Equipment;
+};
+
+export const PlateHint = memo(function PlateHint({ weight, unit, equipment }: Props) {
+  const colors = useThemeColors();
+
+  const hint = useMemo(() => {
+    if (equipment !== "barbell" || weight == null || weight <= 0) return null;
+    const barWeight = unit === "lb" ? 45 : 20;
+    if (weight <= barWeight) return null;
+    const side = perSide(weight, barWeight);
+    const result = solve(side, unit === "kg" ? KG_PLATES : LB_PLATES);
+    const plateText = result.plates.join(" + ");
+    const approx = result.remainder > 0;
+    const label = `Per side: ${plateText}`;
+    const spokenPlates = result.plates
+      .map((p) => `${p} ${unit === "kg" ? "kilograms" : "pounds"}`)
+      .join(", ");
+    const accessibilityLabel = approx
+      ? `Approximately. Plates per side: ${spokenPlates}`
+      : `Plates per side: ${spokenPlates}`;
+    return { label, approx, accessibilityLabel };
+  }, [weight, unit, equipment]);
+
+  if (!hint) return null;
+
+  return (
+    <Text
+      style={[styles.hint, { color: colors.onSurfaceVariant }]}
+      accessibilityLabel={hint.accessibilityLabel}
+    >
+      {hint.approx ? "≈ " : ""}Per side: {hint.label.replace("Per side: ", "")}
+    </Text>
+  );
+});
+
+const styles = StyleSheet.create({
+  hint: {
+    fontSize: fontSizes.xs,
+    textAlign: "center",
+    paddingHorizontal: 4,
+  },
+});

--- a/components/session/SetRow.tsx
+++ b/components/session/SetRow.tsx
@@ -8,8 +8,9 @@ import { rpeColor, rpeText } from "../../lib/rpe";
 import { radii } from "../../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { RPE_CHIPS, RPE_LABELS, type SetWithMeta } from "./types";
-import { SET_TYPE_LABELS } from "../../lib/types";
+import { SET_TYPE_LABELS, type Equipment } from "../../lib/types";
 import { fontSizes } from "@/constants/design-tokens";
+import { PlateHint } from "./PlateHint";
 
 export function formatDurationDisplay(seconds: number | null): string {
   if (seconds == null || seconds <= 0) return "0:00";
@@ -30,6 +31,7 @@ export type SetRowProps = {
   unit: "kg" | "lb";
   halfStep: { setId: string; base: number } | null;
   trackingMode: "reps" | "duration";
+  equipment: Equipment;
   onUpdate: (setId: string, field: "weight" | "reps" | "duration_seconds", val: string) => void;
   onCheck: (set: SetWithMeta) => void;
   onDelete: (setId: string) => void;
@@ -48,7 +50,7 @@ export type SetRowProps = {
 };
 
 export const SetRow = memo(function SetRow({
-  set, step, unit, halfStep, trackingMode,
+  set, step, unit, halfStep, trackingMode, equipment,
   onUpdate, onCheck, onDelete, onRPE, onHalfStep, onHalfStepClear,
   onHalfStepOpen, onCycleSetType, onLongPressSetType,
   isTimerRunning, isTimerActive, timerDisplaySeconds,
@@ -206,6 +208,8 @@ export const SetRow = memo(function SetRow({
             <MaterialCommunityIcons name="delete-outline" size={22} color={colors.error} />
           </Pressable>
         </View>
+
+      <PlateHint weight={set.weight} unit={unit} equipment={equipment} />
 
       {set.completed && (
         <View style={styles.rpeRow} accessibilityLabel="Rate of perceived exertion" accessibilityRole="radiogroup">

--- a/components/session/types.ts
+++ b/components/session/types.ts
@@ -1,4 +1,4 @@
-import type { WorkoutSet, TrainingMode } from "../../lib/types";
+import type { WorkoutSet, TrainingMode, Equipment } from "../../lib/types";
 
 export type SetWithMeta = WorkoutSet & {
   exercise_name?: string;
@@ -16,6 +16,7 @@ export type ExerciseGroup = {
   is_voltra: boolean;
   is_bodyweight: boolean;
   trackingMode: "reps" | "duration";
+  equipment: Equipment;
 };
 
 export const RPE_CHIPS = [6, 7, 8, 9, 10] as const;

--- a/hooks/useSessionData.ts
+++ b/hooks/useSessionData.ts
@@ -117,6 +117,7 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
           is_voltra: ex?.is_voltra ?? false,
           is_bodyweight: ex ? ex.equipment === "bodyweight" : false,
           trackingMode: parsed.includes("isometric" as TrainingMode) ? "duration" : "reps",
+          equipment: ex?.equipment ?? "other",
         });
       }
       const prev = prevCache[s.exercise_id]?.find(


### PR DESCRIPTION
## Summary
Add a compact 'Per side: 20 + 15 + 5 + 1.25' plate loading hint below the weight input on barbell exercise set rows during workout sessions. Eliminates mental plate math 10-15 times per workout.

## Changes
- `components/session/PlateHint.tsx`: New pure component (~50 lines) that computes and renders plate breakdown using existing `solve()`/`perSide()` from `lib/plates.ts`
- `components/session/types.ts`: Added `equipment: Equipment` field to `ExerciseGroup` type
- `hooks/useSessionData.ts`: Set `equipment` on group construction from exercise metadata
- `components/session/ExerciseGroupCard.tsx`: Pass `group.equipment` to each `SetRow`
- `components/session/SetRow.tsx`: Accept `equipment` prop, render `<PlateHint>` below weight input
- `__tests__/components/plate-hint.test.tsx`: 1 consolidated test covering barbell/non-barbell/remainder/units
- `__tests__/components/duration-sets.test.tsx`: Added required `equipment` prop to test helper

## Testing
- `npx jest --testPathPattern=plate-hint` — all assertions pass
- `npx tsc --noEmit` — clean (only pre-existing drizzle.config error)
- `npx eslint . --ext .ts,.tsx --quiet` — 0 warnings via lint-staged
- Test budget: 1759/1800 (+1 new test)

## Issue
Refs: BLD-409