### PR TITLE
feat: exercise reorder in active workout session (Phase 62)

### DIFF
--- a/__tests__/acceptance/session-add-exercise.acceptance.test.tsx
+++ b/__tests__/acceptance/session-add-exercise.acceptance.test.tsx
@@ -32,6 +32,7 @@ jest.mock('../../lib/db', () => ({
   getTemplateExerciseCount: jest.fn().mockResolvedValue(0),
   getTemplateExerciseCounts: jest.fn().mockResolvedValue({}),
   addExerciseToTemplate: jest.fn().mockResolvedValue(undefined),
+  updateExercisePositions: jest.fn().mockResolvedValue(undefined),
 }))
 
 jest.mock('../../lib/programs', () => ({

--- a/__tests__/acceptance/supersets.test.tsx
+++ b/__tests__/acceptance/supersets.test.tsx
@@ -44,6 +44,7 @@ jest.mock('../../lib/db', () => ({
   getAllExercises: jest.fn().mockResolvedValue([]),
   swapExerciseInSession: jest.fn().mockResolvedValue([]),
   undoSwapInSession: jest.fn().mockResolvedValue(undefined),
+  updateExercisePositions: jest.fn().mockResolvedValue(undefined),
 }))
 
 jest.mock('../../lib/programs', () => ({

--- a/__tests__/acceptance/workout-session.acceptance.test.tsx
+++ b/__tests__/acceptance/workout-session.acceptance.test.tsx
@@ -43,6 +43,7 @@ jest.mock('../../lib/db', () => ({
   getAllExercises: jest.fn().mockResolvedValue([]),
   swapExerciseInSession: jest.fn().mockResolvedValue([]),
   undoSwapInSession: jest.fn().mockResolvedValue(undefined),
+  updateExercisePositions: jest.fn().mockResolvedValue(undefined),
 }))
 
 jest.mock('../../lib/programs', () => ({
@@ -326,7 +327,7 @@ describe('Workout Session Acceptance', () => {
     fireEvent.press(addBtn)
 
     await waitFor(() => {
-      expect(mockDb.addSet).toHaveBeenCalledWith('sess-add', 'ex-1', 4, null, null, null, null)
+      expect(mockDb.addSet).toHaveBeenCalledWith('sess-add', 'ex-1', 4, null, null, null, null, undefined, undefined, 0)
     })
   })
 

--- a/__tests__/components/duration-sets.test.tsx
+++ b/__tests__/components/duration-sets.test.tsx
@@ -80,6 +80,7 @@ function makeSet(overrides: Partial<SetWithMeta> = {}): SetWithMeta {
     swapped_from_exercise_id: null,
     set_type: "normal",
     duration_seconds: null,
+    exercise_position: 0,
     ...overrides,
   };
 }

--- a/__tests__/helpers/factories.ts
+++ b/__tests__/helpers/factories.ts
@@ -142,6 +142,7 @@ export function createSet(overrides: Partial<WorkoutSet> = {}): WorkoutSet {
     swapped_from_exercise_id: null,
     set_type: 'normal',
     duration_seconds: null,
+    exercise_position: 0,
     ...overrides,
   }
 }

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -15,8 +15,7 @@ import { Stack, useLocalSearchParams } from "expo-router";
 import { activateKeepAwakeAsync } from "expo-keep-awake";
 import BottomSheet, { BottomSheetBackdrop } from "@gorhom/bottom-sheet";
 import { setEnabled as setAudioEnabled } from "../../lib/audio";
-import { getAppSetting } from "../../lib/db";
-import { addWarmupSets } from "../../lib/db";
+import { getAppSetting, addWarmupSets } from "../../lib/db";
 import { generateWarmupSets } from "../../lib/warmup";
 import * as Haptics from "expo-haptics";
 import { useLayout } from "../../lib/layout";
@@ -95,7 +94,8 @@ export default function ActiveSession() {
     elapsed, exerciseNotesOpen, exerciseNotesDraft, halfStep, nextHint, hintTimer,
     handleUpdate, handleCheck, handleAddSet, handleModeChange, handleRPE,
     handleHalfStep, handleHalfStepClear, handleHalfStepOpen, handleDelete,
-    handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes, finish, cancel,
+    handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes,
+    handleMoveUp, handleMoveDown, finish, cancel,
   } = useSessionActions({
     id, groups, setGroups, modes, setModes, updateGroupSet, startRest, startRestWithDuration, session, showToast, showError, triggerPR,
   });
@@ -164,7 +164,8 @@ export default function ActiveSession() {
         warmupSets,
         group?.link_id,
         group?.sets[0]?.training_mode,
-        group?.sets[0]?.tempo
+        group?.sets[0]?.tempo,
+        group?.exercise_position ?? 0
       );
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       await load();
@@ -204,6 +205,8 @@ export default function ActiveSession() {
       onShowDetail={handleShowDetail}
       onSwap={handleSwapOpen}
       onDeleteExercise={handleDeleteExercise}
+      onMoveUp={handleMoveUp}
+      onMoveDown={handleMoveDown}
       timerActiveExerciseId={timerExerciseId}
       timerActiveSetIndex={timerSetIndex}
       timerIsRunning={timerIsRunning}
@@ -211,7 +214,7 @@ export default function ActiveSession() {
       onTimerStart={handleTimerStart}
       onTimerStop={handleTimerStop}
     />
-  ), [step, unit, suggestions, modes, exerciseNotesOpen, exerciseNotesDraft, halfStep, linkIds, groups, palette, handleUpdate, handleCheck, handleDelete, handleAddSet, handleAddWarmups, handleModeChange, handleRPE, handleHalfStep, handleHalfStepClear, handleHalfStepOpen, handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes, handleCycleSetType, handleLongPressSetType, handleShowDetail, handleSwapOpen, handleDeleteExercise, timerExerciseId, timerSetIndex, timerIsRunning, timerDisplaySeconds, handleTimerStart, handleTimerStop]);
+  ), [step, unit, suggestions, modes, exerciseNotesOpen, exerciseNotesDraft, halfStep, linkIds, groups, palette, handleUpdate, handleCheck, handleDelete, handleAddSet, handleAddWarmups, handleModeChange, handleRPE, handleHalfStep, handleHalfStepClear, handleHalfStepOpen, handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes, handleCycleSetType, handleLongPressSetType, handleShowDetail, handleSwapOpen, handleDeleteExercise, handleMoveUp, handleMoveDown, timerExerciseId, timerSetIndex, timerIsRunning, timerDisplaySeconds, handleTimerStart, handleTimerStop]);
 
   const listHeader = useMemo(() => (
     <SessionListHeader nextHint={nextHint} colors={colors} />
@@ -261,6 +264,7 @@ export default function ActiveSession() {
         data={groups}
         renderItem={renderExerciseGroup}
         keyExtractor={(item) => item.exercise_id}
+        extraData={groups}
         contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: 48 }}
         keyboardShouldPersistTaps="handled"
         ListHeaderComponent={listHeader}
@@ -330,19 +334,7 @@ export default function ActiveSession() {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  center: {
-    flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  detailHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingHorizontal: 16,
-    paddingTop: 16,
-    paddingBottom: 8,
-  },
+  container: { flex: 1 },
+  center: { flex: 1, alignItems: "center", justifyContent: "center" },
+  detailHeader: { flexDirection: "row", alignItems: "center", paddingHorizontal: 16, paddingTop: 16, paddingBottom: 8 },
 });

--- a/components/session/ExerciseGroupCard.tsx
+++ b/components/session/ExerciseGroupCard.tsx
@@ -45,6 +45,8 @@ export type GroupCardProps = {
   onShowDetail: (exerciseId: string) => void;
   onSwap: (exerciseId: string) => void;
   onDeleteExercise: (exerciseId: string) => void;
+  onMoveUp?: (exerciseId: string) => void;
+  onMoveDown?: (exerciseId: string) => void;
   // Timer
   timerActiveExerciseId?: string | null;
   timerActiveSetIndex?: number | null;
@@ -61,6 +63,7 @@ export const ExerciseGroupCard = memo(function ExerciseGroupCard({
   onRPE, onHalfStep, onHalfStepClear,
   onHalfStepOpen, onExerciseNotes, onExerciseNotesDraftChange, onToggleExerciseNotes, onCycleSetType, onLongPressSetType,
   onShowDetail, onSwap, onDeleteExercise,
+  onMoveUp, onMoveDown,
   timerActiveExerciseId, timerActiveSetIndex, timerIsRunning, timerDisplaySeconds,
   onTimerStart, onTimerStop,
 }: GroupCardProps) {
@@ -78,6 +81,13 @@ export const ExerciseGroupCard = memo(function ExerciseGroupCard({
   const groupColor = groupColorIdx >= 0 ? palette[groupColorIdx % palette.length] : undefined;
 
   const suggestion = suggestions[group.exercise_id];
+
+  // Reorder: only for non-superset exercises, ≥2 reorderable groups
+  const reorderableGroups = groups.filter((g) => !g.link_id);
+  const reorderIdx = group.link_id ? -1 : reorderableGroups.findIndex((g) => g.exercise_id === group.exercise_id);
+  const showMoveButtons = !group.link_id && reorderableGroups.length >= 2;
+  const isFirstReorderable = reorderIdx === 0;
+  const isLastReorderable = reorderIdx === reorderableGroups.length - 1;
 
   const hasExistingWarmups = group.sets.some((s) => s.set_type === "warmup");
   const hasWorkingWeight = suggestion != null && suggestion.weight > 0;
@@ -196,6 +206,11 @@ export const ExerciseGroupCard = memo(function ExerciseGroupCard({
           onShowDetail={onShowDetail}
           onSwap={onSwap}
           onDeleteExercise={onDeleteExercise}
+          onMoveUp={onMoveUp}
+          onMoveDown={onMoveDown}
+          isFirst={isFirstReorderable}
+          isLast={isLastReorderable}
+          showMoveButtons={showMoveButtons}
         />
         {layout.atLeastMedium ? (
           <View style={styles.groupWideRow}>
@@ -271,16 +286,6 @@ const styles = StyleSheet.create({
     gap: 8,
     flexWrap: "wrap",
   },
-  divider: {
-    marginTop: 8,
-    marginBottom: 12,
-  },
-  linkGroupHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingHorizontal: 8,
-    paddingVertical: 6,
-    marginBottom: 4,
-    borderRadius: 4,
-  },
+  divider: { marginTop: 8, marginBottom: 12 },
+  linkGroupHeader: { flexDirection: "row", alignItems: "center", paddingHorizontal: 8, paddingVertical: 6, marginBottom: 4, borderRadius: 4 },
 });

--- a/components/session/GroupCardHeader.tsx
+++ b/components/session/GroupCardHeader.tsx
@@ -23,9 +23,14 @@ export type GroupCardHeaderProps = {
   onShowDetail: (exerciseId: string) => void;
   onSwap: (exerciseId: string) => void;
   onDeleteExercise: (exerciseId: string) => void;
+  onMoveUp?: (exerciseId: string) => void;
+  onMoveDown?: (exerciseId: string) => void;
+  isFirst?: boolean;
+  isLast?: boolean;
+  showMoveButtons?: boolean;
 };
 
-export function GroupCardHeader({ group, modes, exerciseNotesOpen, exerciseNotesDraft, firstSet, onModeChange, onExerciseNotes, onExerciseNotesDraftChange, onToggleExerciseNotes, onShowDetail, onSwap, onDeleteExercise }: GroupCardHeaderProps) {
+export function GroupCardHeader({ group, modes, exerciseNotesOpen, exerciseNotesDraft, firstSet, onModeChange, onExerciseNotes, onExerciseNotesDraftChange, onToggleExerciseNotes, onShowDetail, onSwap, onDeleteExercise, onMoveUp, onMoveDown, isFirst, isLast, showMoveButtons }: GroupCardHeaderProps) {
   const colors = useThemeColors();
   const notesValue = exerciseNotesDraft ?? firstSet?.notes ?? "";
   const eid = group.exercise_id;
@@ -38,6 +43,32 @@ export function GroupCardHeader({ group, modes, exerciseNotesOpen, exerciseNotes
             <Text variant="title" style={[styles.groupTitle, { color: colors.primary }]}>{group.name}</Text>
           </Pressable>
           <View style={styles.headerActions}>
+            {showMoveButtons && (
+              <>
+                <Pressable
+                  onPress={() => onMoveUp?.(eid)}
+                  disabled={isFirst}
+                  accessibilityLabel={`Move ${group.name} up`}
+                  accessibilityRole="button"
+                  accessibilityState={{ disabled: isFirst }}
+                  hitSlop={4}
+                  style={[styles.moveBtn, isFirst && styles.moveBtnDisabled]}
+                >
+                  <MaterialCommunityIcons name="chevron-up" size={28} color={isFirst ? colors.outlineVariant : colors.onSurfaceVariant} />
+                </Pressable>
+                <Pressable
+                  onPress={() => onMoveDown?.(eid)}
+                  disabled={isLast}
+                  accessibilityLabel={`Move ${group.name} down`}
+                  accessibilityRole="button"
+                  accessibilityState={{ disabled: isLast }}
+                  hitSlop={4}
+                  style={[styles.moveBtn, isLast && styles.moveBtnDisabled]}
+                >
+                  <MaterialCommunityIcons name="chevron-down" size={28} color={isLast ? colors.outlineVariant : colors.onSurfaceVariant} />
+                </Pressable>
+              </>
+            )}
             <Pressable onPress={() => onSwap(eid)} accessibilityLabel={`Swap ${group.name}`} hitSlop={8} style={styles.iconBtn}>
               <MaterialCommunityIcons name="swap-horizontal" size={24} color={colors.onSurfaceVariant} />
             </Pressable>
@@ -70,5 +101,7 @@ const styles = StyleSheet.create({
   headerActions: { flexDirection: "row", alignItems: "center" },
   groupTitle: { fontWeight: "700" },
   iconBtn: { padding: 8 },
+  moveBtn: { width: 56, height: 56, alignItems: "center", justifyContent: "center" },
+  moveBtnDisabled: { opacity: 0.4 },
   detailsBtn: { marginLeft: -24, marginRight: -8 },
 });

--- a/components/session/types.ts
+++ b/components/session/types.ts
@@ -17,6 +17,7 @@ export type ExerciseGroup = {
   is_bodyweight: boolean;
   trackingMode: "reps" | "duration";
   equipment: Equipment;
+  exercise_position: number;
 };
 
 export const RPE_CHIPS = [6, 7, 8, 9, 10] as const;

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -18,6 +18,7 @@ import {
   getSessionSets,
   updateSetDuration,
   checkSetPR,
+  updateExercisePositions,
 } from "../lib/db";
 import { bumpQueryVersion } from "../lib/query";
 import {
@@ -171,7 +172,7 @@ export function useSessionActions({
     const num = (group?.sets.length ?? 0) + 1;
     const fallback = group?.is_voltra && group.training_modes.length > 1 ? group.training_modes[0] : null;
     const mode = modes[exerciseId] ?? fallback;
-    const newSet = await addSet(id!, exerciseId, num, null, null, mode, null);
+    const newSet = await addSet(id!, exerciseId, num, null, null, mode, null, undefined, undefined, group?.exercise_position ?? 0);
     setGroups((prev) =>
       prev.map((g) =>
         g.exercise_id === exerciseId
@@ -245,6 +246,52 @@ export function useSessionActions({
   const toggleExerciseNotes = useCallback((exerciseId: string) => {
     setExerciseNotesOpen((prev) => ({ ...prev, [exerciseId]: !prev[exerciseId] }));
   }, []);
+
+  const handleMoveExercise = useCallback(async (exerciseId: string, direction: "up" | "down") => {
+    if (!id) return;
+    // Find non-superset groups for reorder (supersets excluded)
+    const reorderableGroups = groups.filter((g) => !g.link_id);
+    const idx = reorderableGroups.findIndex((g) => g.exercise_id === exerciseId);
+    if (idx < 0) return;
+    const swapIdx = direction === "up" ? idx - 1 : idx + 1;
+    if (swapIdx < 0 || swapIdx >= reorderableGroups.length) return;
+
+    const a = reorderableGroups[idx];
+    const b = reorderableGroups[swapIdx];
+
+    // Swap positions in state
+    const newPosA = b.exercise_position;
+    const newPosB = a.exercise_position;
+
+    setGroups((prev) => {
+      const updated = prev.map((g) => {
+        if (g.exercise_id === a.exercise_id) return { ...g, exercise_position: newPosA };
+        if (g.exercise_id === b.exercise_id) return { ...g, exercise_position: newPosB };
+        return g;
+      });
+      return updated.sort((x, y) => x.exercise_position - y.exercise_position);
+    });
+
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+
+    AccessibilityInfo.announceForAccessibility(
+      `${a.name} moved to position ${direction === "up" ? idx : idx + 2}`
+    );
+
+    // Persist position swap
+    await updateExercisePositions(id, [
+      { exerciseId: a.exercise_id, position: newPosA },
+      { exerciseId: b.exercise_id, position: newPosB },
+    ]);
+  }, [id, groups]);
+
+  const handleMoveUp = useCallback((exerciseId: string) => {
+    handleMoveExercise(exerciseId, "up");
+  }, [handleMoveExercise]);
+
+  const handleMoveDown = useCallback((exerciseId: string) => {
+    handleMoveExercise(exerciseId, "down");
+  }, [handleMoveExercise]);
 
   const finish = () => {
     confirmAction(
@@ -342,6 +389,8 @@ export function useSessionActions({
     handleExerciseNotes,
     handleExerciseNotesDraftChange,
     toggleExerciseNotes,
+    handleMoveUp,
+    handleMoveDown,
     finish,
     cancel,
   };

--- a/hooks/useSessionData.ts
+++ b/hooks/useSessionData.ts
@@ -15,6 +15,7 @@ import {
   getPreviousSetsBatch,
   getExercisesByIds,
   updateSetsBatch,
+  updateExercisePositions,
 } from "../lib/db";
 import type { WorkoutSession, TrainingMode, Exercise } from "../lib/types";
 import type { SetWithMeta, ExerciseGroup } from "../components/session/types";
@@ -118,6 +119,7 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
           is_bodyweight: ex ? ex.equipment === "bodyweight" : false,
           trackingMode: parsed.includes("isometric" as TrainingMode) ? "duration" : "reps",
           equipment: ex?.equipment ?? "other",
+          exercise_position: s.exercise_position ?? 0,
         });
       }
       const prev = prevCache[s.exercise_id]?.find(
@@ -145,7 +147,21 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
         previous: prevDisplay,
       });
     }
-    setGroups([...map.values()]);
+    const groupList = [...map.values()];
+
+    // Auto-assign positions for pre-migration sessions (all positions = 0)
+    const allZero = groupList.every((g) => g.exercise_position === 0);
+    if (allZero && groupList.length > 1) {
+      const positionUpdates: { exerciseId: string; position: number }[] = [];
+      groupList.forEach((g, i) => {
+        g.exercise_position = i + 1;
+        positionUpdates.push({ exerciseId: g.exercise_id, position: i + 1 });
+      });
+      // Fire-and-forget: persist auto-assigned positions
+      updateExercisePositions(id, positionUpdates).catch(() => {});
+    }
+
+    setGroups(groupList);
 
     const entries: [string, Suggestion | null][] = exerciseIds.map((eid) => {
       try {
@@ -188,6 +204,7 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
                 setNumber: i,
                 linkId: te.link_id ?? null,
                 round: te.link_id ? i : null,
+                exercisePosition: te.position,
               });
             }
           }

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -100,6 +100,7 @@ export {
   swapExerciseInSession,
   undoSwapInSession,
   getSourceSessionSets,
+  updateExercisePositions,
 } from "./sessions";
 export type { ExerciseSession, ExerciseRecords, SourceSessionSet } from "./sessions";
 export type { E1RMTrendRow } from "./sessions";

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -1,5 +1,5 @@
 import * as SQLite from "expo-sqlite";
-import { createCoreTables, createExtensionTables } from "./tables";
+import { createCoreTables, createExtensionTables, addColumnIfMissing } from "./tables";
 import { createScheduleAndIndexes } from "./table-migrations";
 
 async function addPerformanceIndexes(database: SQLite.SQLiteDatabase): Promise<void> {
@@ -19,4 +19,6 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   await createScheduleAndIndexes(database);
   await createExtensionTables(database);
   await addPerformanceIndexes(database);
+  // Phase 62: exercise reorder support
+  await addColumnIfMissing(database, "workout_sets", "exercise_position", "INTEGER DEFAULT 0");
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -88,6 +88,7 @@ export const workoutSets = sqliteTable("workout_sets", {
   swapped_from_exercise_id: text("swapped_from_exercise_id"),
   set_type: text("set_type").default("normal"),
   duration_seconds: integer("duration_seconds"),
+  exercise_position: integer("exercise_position").default(0),
 }, (table) => [
   index("idx_workout_sets_exercise").on(table.exercise_id),
   index("idx_workout_sets_session").on(table.session_id),

--- a/lib/db/session-sets.ts
+++ b/lib/db/session-sets.ts
@@ -30,6 +30,7 @@ export async function getSessionSets(
       swapped_from_exercise_id: workoutSets.swapped_from_exercise_id,
       set_type: workoutSets.set_type,
       duration_seconds: workoutSets.duration_seconds,
+      exercise_position: workoutSets.exercise_position,
       exercise_name: exercises.name,
       exercise_deleted_at: exercises.deleted_at,
       swapped_from_name: swappedExercise.name,
@@ -38,7 +39,7 @@ export async function getSessionSets(
     .leftJoin(exercises, eq(workoutSets.exercise_id, exercises.id))
     .leftJoin(swappedExercise, eq(workoutSets.swapped_from_exercise_id, swappedExercise.id))
     .where(eq(workoutSets.session_id, sessionId))
-    .orderBy(asc(workoutSets.exercise_id), asc(workoutSets.set_number))
+    .orderBy(asc(workoutSets.exercise_position), asc(workoutSets.exercise_id), asc(workoutSets.set_number))
     .all();
   return rows.map((r) => ({
     id: r.id,
@@ -58,6 +59,7 @@ export async function getSessionSets(
     swapped_from_exercise_id: r.swapped_from_exercise_id ?? null,
     set_type: (r.set_type as SetType) ?? "normal",
     duration_seconds: r.duration_seconds ?? null,
+    exercise_position: r.exercise_position ?? 0,
     exercise_name: r.exercise_name ?? undefined,
     exercise_deleted: r.exercise_deleted_at != null,
     swapped_from_name: r.swapped_from_name ?? undefined,
@@ -119,7 +121,8 @@ export async function addSet(
   trainingMode?: TrainingMode | null,
   tempo?: string | null,
   _isWarmup?: boolean,
-  setType?: SetType
+  setType?: SetType,
+  exercisePosition?: number
 ): Promise<WorkoutSet> {
   const id = uuid();
   const resolvedType: SetType = setType ?? "normal";
@@ -134,6 +137,7 @@ export async function addSet(
     training_mode: trainingMode ?? null,
     tempo: tempo ?? null,
     set_type: resolvedType,
+    exercise_position: exercisePosition ?? 0,
   });
   return {
     id,
@@ -153,6 +157,7 @@ export async function addSet(
     swapped_from_exercise_id: null,
     set_type: resolvedType,
     duration_seconds: null,
+    exercise_position: exercisePosition ?? 0,
   };
 }
 
@@ -167,6 +172,7 @@ export async function addSetsBatch(
     tempo?: string | null;
     isWarmup?: boolean;
     setType?: SetType;
+    exercisePosition?: number;
   }[]
 ): Promise<WorkoutSet[]> {
   const results: WorkoutSet[] = sets.map((s) => {
@@ -189,18 +195,19 @@ export async function addSetsBatch(
       swapped_from_exercise_id: null,
       set_type: resolvedType,
       duration_seconds: null,
+      exercise_position: s.exercisePosition ?? 0,
     };
   });
   // Use prepared statements for batch insert performance
   await withTransaction(async (db) => {
     const stmt = await db.prepareAsync(
-      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo, set_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, training_mode, tempo, set_type, exercise_position) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     try {
       for (const r of results) {
         await stmt.executeAsync([
           r.id, r.session_id, r.exercise_id, r.set_number,
-          r.link_id, r.round, r.training_mode, r.tempo, r.set_type,
+          r.link_id, r.round, r.training_mode, r.tempo, r.set_type, r.exercise_position,
         ]);
       }
     } finally {
@@ -216,10 +223,12 @@ export async function addWarmupSets(
   warmupSets: { weight: number; reps: number }[],
   linkId?: string | null,
   trainingMode?: TrainingMode | null,
-  tempo?: string | null
+  tempo?: string | null,
+  exercisePosition?: number
 ): Promise<WorkoutSet[]> {
   if (warmupSets.length === 0) return [];
   const warmupCount = warmupSets.length;
+  const pos = exercisePosition ?? 0;
 
   const results: WorkoutSet[] = warmupSets.map((ws, i) => ({
     id: uuid(),
@@ -239,6 +248,7 @@ export async function addWarmupSets(
     swapped_from_exercise_id: null,
     set_type: "warmup" as SetType,
     duration_seconds: null,
+    exercise_position: pos,
   }));
 
   await withTransaction(async (db) => {
@@ -250,13 +260,13 @@ export async function addWarmupSets(
 
     // Insert warmup sets
     const stmt = await db.prepareAsync(
-      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, link_id, round, training_mode, tempo, set_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, link_id, round, training_mode, tempo, set_type, exercise_position) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     try {
       for (const r of results) {
         await stmt.executeAsync([
           r.id, r.session_id, r.exercise_id, r.set_number,
-          r.weight, r.reps, r.link_id, r.round, r.training_mode, r.tempo, "warmup",
+          r.weight, r.reps, r.link_id, r.round, r.training_mode, r.tempo, "warmup", r.exercise_position,
         ]);
       }
     } finally {
@@ -566,4 +576,23 @@ export async function getRestSecondsForLink(
     .where(and(eq(workoutSessions.id, sessionId), eq(templateExercises.link_id, linkId)))
     .get();
   return row?.rest != null ? Number(row.rest) : 90;
+}
+
+export async function updateExercisePositions(
+  sessionId: string,
+  positions: { exerciseId: string; position: number }[]
+): Promise<void> {
+  if (positions.length === 0) return;
+  await withTransaction(async (db) => {
+    const stmt = await db.prepareAsync(
+      "UPDATE workout_sets SET exercise_position = ? WHERE session_id = ? AND exercise_id = ?"
+    );
+    try {
+      for (const p of positions) {
+        await stmt.executeAsync([p.position, sessionId, p.exerciseId]);
+      }
+    } finally {
+      await stmt.finalizeAsync();
+    }
+  });
 }

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -32,6 +32,7 @@ export {
   getRestSecondsForExercise,
   getRestSecondsForLink,
   getSourceSessionSets,
+  updateExercisePositions,
 } from "./session-sets";
 export type { SourceSessionSet } from "./session-sets";
 

--- a/lib/db/tables.ts
+++ b/lib/db/tables.ts
@@ -102,7 +102,8 @@ export async function createCoreTables(database: SQLite.SQLiteDatabase): Promise
       tempo TEXT DEFAULT NULL,
       swapped_from_exercise_id TEXT DEFAULT NULL,
       set_type TEXT DEFAULT 'normal',
-      duration_seconds INTEGER
+      duration_seconds INTEGER,
+      exercise_position INTEGER DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS food_entries (

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -224,6 +224,7 @@ export type WorkoutSet = {
   swapped_from_exercise_id: string | null;
   set_type: SetType;
   duration_seconds: number | null;
+  exercise_position: number;
 };
 
 export const TRAINING_MODE_LABELS: Record<TrainingMode, { label: string; short: string; description: string }> = {


### PR DESCRIPTION
## Summary
Add up/down move buttons to exercise group headers in active workout sessions, allowing users to reorder exercises without losing logged sets.

## Changes
- `lib/db/schema.ts`: Add `exercise_position` column to `workout_sets` table
- `lib/db/migrations.ts`: Idempotent migration using `addColumnIfMissing` PRAGMA guard
- `lib/db/tables.ts`: Add column to CREATE TABLE DDL
- `lib/db/session-sets.ts`: Update ORDER BY to 3-column sort (exercise_position, exercise_id, set_number); add `updateExercisePositions` batch function; pass exercise_position through addSet/addSetsBatch/addWarmupSets
- `hooks/useSessionActions.ts`: Add `handleMoveUp`/`handleMoveDown` callbacks with position swap, haptic feedback, and accessibility announcements
- `hooks/useSessionData.ts`: Auto-assign positions for pre-migration sessions (all positions=0); populate `exercise_position` in group state
- `components/session/GroupCardHeader.tsx`: Always-visible ↑/↓ buttons (56×56dp touch targets) with disabled states
- `components/session/ExerciseGroupCard.tsx`: Compute reorder state, hide buttons for supersets/single-exercise sessions
- `app/session/[id].tsx`: Wire callbacks, add `extraData` to FlashList for re-renders
- `lib/types.ts`, `components/session/types.ts`: Add `exercise_position` to types

## Testing
- `npx tsc --noEmit` — clean (only pre-existing drizzle-kit issue)
- `npx eslint . --ext .ts,.tsx --quiet` — 0 errors
- `npx jest` — all new test mocks added; no new test failures vs baseline
- Updated test factories and 3 acceptance test mocks for `exercise_position` field and `updateExercisePositions` function

## Edge Cases Handled
- Pre-migration sessions (all positions=0): auto-assigned on load
- Superset exercises: move buttons hidden
- Single-exercise sessions: move buttons hidden
- First/last exercise: appropriate button disabled
- Warmup sets: inherit exercise position when added

## Issue
Refs: BLD-411