### PR TITLE
fix: resolve 5 UI/UX bugs from real device testing (BLD-413)

### DIFF
--- a/__tests__/lib/db/interaction-log.test.ts
+++ b/__tests__/lib/db/interaction-log.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 /**
- * Structural tests for BLD-292: interaction log limit expanded to 50.
+ * Structural tests for interaction log limit (reduced to 5 per GH #236).
  */
 
 const src = fs.readFileSync(
@@ -10,14 +10,13 @@ const src = fs.readFileSync(
   "utf-8"
 );
 
-describe("interaction log limits (BLD-292)", () => {
-  it("insertInteraction prunes to 50 entries", () => {
-    expect(src).toMatch(/ORDER BY timestamp DESC LIMIT 50/);
+describe("interaction log limits", () => {
+  it("insertInteraction prunes to 5 entries", () => {
+    expect(src).toMatch(/ORDER BY timestamp DESC LIMIT 5/);
   });
 
-  it("getInteractions returns up to 50 entries", () => {
-    // With Drizzle migration, getInteractions uses .limit(50) instead of raw SQL
-    expect(src).toMatch(/\.limit\(50\)/);
+  it("getInteractions returns up to 5 entries", () => {
+    expect(src).toMatch(/\.limit\(5\)/);
   });
 
   it("does NOT use time-based pruning", () => {

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -170,7 +170,7 @@ export default function ExerciseDetail() {
       <FlashList style={{ flex: 1, backgroundColor: colors.background }}
         data={d.historyLoading || d.historyError || d.history.length === 0 ? [] : d.history}
         keyExtractor={(item) => item.session_id} renderItem={renderItem} ListHeaderComponent={renderHeader}
-        ListFooterComponent={renderFooter} ListFooterComponentStyle={{ paddingBottom: 32 }}
+        ListFooterComponent={renderFooter} ListFooterComponentStyle={{ paddingBottom: 100 }}
         onEndReached={d.loadMore} onEndReachedThreshold={0.3} />
     </>
   );

--- a/components/program/WeeklySchedule.tsx
+++ b/components/program/WeeklySchedule.tsx
@@ -1,5 +1,4 @@
-import { FlashList } from "@shopify/flash-list";
-import { Modal, Pressable, StyleSheet, View } from "react-native";
+import { FlatList, Modal, Pressable, StyleSheet, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Text } from "@/components/ui/text";
@@ -115,7 +114,7 @@ export function WeeklySchedule({
                 {picker !== null ? DAYS[picker] : ""} — Pick Template
               </Text>
 
-              <FlashList
+              <FlatList
                 data={
                   picker !== null && schedEntry(picker)
                     ? [{ id: "__remove__", name: "Remove (Rest Day)" } as WorkoutTemplate, ...templates]
@@ -200,7 +199,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   dayLabel: {
-    width: 36,
+    width: 44,
     fontWeight: "600",
   },
   dayInfo: {

--- a/components/ui/bottom-sheet.tsx
+++ b/components/ui/bottom-sheet.tsx
@@ -190,8 +190,8 @@ export function BottomSheet({
       let destination: number;
 
       if (isKeyboardVisible) {
-        // Keyboard is open, move sheet up by keyboard height
-        destination = currentSnapHeight - keyboardHeight;
+        // Keyboard is open, move sheet up by keyboard height but don't push content off-screen
+        destination = Math.max(currentSnapHeight - keyboardHeight, MAX_TRANSLATE_Y);
       } else {
         // Keyboard is closed, return to original snap point
         destination = currentSnapHeight;

--- a/lib/db/settings.ts
+++ b/lib/db/settings.ts
@@ -144,7 +144,7 @@ export async function insertInteraction(
       timestamp: Date.now(),
     });
     await db.delete(interactionLog).where(
-      sql`${interactionLog.id} NOT IN (SELECT id FROM interaction_log ORDER BY timestamp DESC LIMIT 50)`
+      sql`${interactionLog.id} NOT IN (SELECT id FROM interaction_log ORDER BY timestamp DESC LIMIT 5)`
     );
   });
 }
@@ -156,7 +156,7 @@ export async function getInteractions(): Promise<
   return db.select()
     .from(interactionLog)
     .orderBy(sql`${interactionLog.timestamp} DESC`)
-    .limit(50);
+    .limit(5);
 }
 
 export async function clearInteractions(): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes 5 UI/UX bugs reported from real device testing on Samsung Z Fold6, Android 36, v0.15.2.

## Changes

### GH #235 — Add food screen invisible when keyboard active (HIGH)
- Capped bottom sheet keyboard adjustment using `MAX_TRANSLATE_Y` to prevent the sheet from being pushed above the screen edge when the keyboard opens

### GH #239 — Template picker shows no templates (HIGH)
- Replaced `FlashList` with `FlatList` in the template picker modal — FlashList has known layout measurement issues inside `Modal` components, causing it to render zero items

### GH #240 — Week day text truncated in program view (MEDIUM)
- Increased day label width from 36 to 44 in the weekly schedule component to prevent text truncation on all day abbreviations

### GH #241 — Exercise view navbar hides instructions (MEDIUM)
- Increased exercise detail list footer padding from 32 to 100 to ensure instructions are fully visible above the navigation bar

### GH #236 — Reduce diagnostic logging to last 5 interactions (LOW)
- Changed interaction log limit from 50 to 5 in both the pruning query and the retrieval query
- Updated corresponding test assertions

## Testing

- `tsc --noEmit` passes with zero errors
- ESLint passes (via lint-staged pre-commit hook)
- All test regressions verified as pre-existing (3 structural test failures exist on main)
- Updated interaction log test to match new limit

## Issue

Resolves BLD-413
Closes #235, #236, #239, #240, #241