### PR TITLE
fix: replace FlashList with FlatList in template screens (BLD-419)

### DIFF
--- a/app/program/pick-template.tsx
+++ b/app/program/pick-template.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  FlatList,
   Pressable,
   StyleSheet,
   View,
 } from "react-native";
-import { FlashList } from "@shopify/flash-list";
 import { SearchBar } from "@/components/ui/searchbar";
 import { Text } from "@/components/ui/text";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
@@ -97,7 +97,7 @@ export default function PickTemplate() {
           style={[styles.search, { backgroundColor: colors.surface }]}
           accessibilityLabel="Search templates"
         />
-        <FlashList
+        <FlatList
           data={filtered}
           renderItem={renderItem}
           keyExtractor={(item) => item.id}

--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -1,6 +1,5 @@
 import { useCallback } from "react";
-import { StyleSheet, View } from "react-native";
-import { FlashList } from "@shopify/flash-list";
+import { FlatList, StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { Chip } from "@/components/ui/chip";
@@ -91,7 +90,7 @@ export default function EditTemplate() {
           </View>
         )}
 
-        <FlashList
+        <FlatList
           data={exercises}
           renderItem={renderItem}
           keyExtractor={(item) => item.id}

--- a/app/template/create.tsx
+++ b/app/template/create.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useState } from "react";
 import {
   Alert,
+  FlatList,
   Pressable,
   StyleSheet,
   TouchableOpacity,
   View,
 } from "react-native";
-import { FlashList } from "@shopify/flash-list";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
@@ -191,7 +191,7 @@ export default function CreateTemplate() {
                 Exercises ({exercises.length})
               </Text>
             </View>
-            <FlashList
+            <FlatList
               data={exercises}
               renderItem={renderItem}
               keyExtractor={(item) => item.id}


### PR DESCRIPTION
## Summary
Fix template exercises appearing empty on certain Android devices (Samsung Z Fold6) by replacing FlashList with FlatList in all template-related screens.

## Root Cause Analysis
**This is NOT database corruption.** FlashList v2 has layout measurement issues that cause lists to render empty — the data exists in the database but FlashList fails to calculate proper dimensions, resulting in zero-height rendering.

This was already identified and fixed for the weekly schedule modal in BLD-413 (commit aa52195). That fix was incomplete — it only fixed `components/program/WeeklySchedule.tsx` but left three other template screens using FlashList.

## Changes
- `app/template/[id].tsx`: FlashList → FlatList (template editor exercise list)
- `app/template/create.tsx`: FlashList → FlatList (template creation exercise list)
- `app/program/pick-template.tsx`: FlashList → FlatList (template picker list)

## Why FlatList over FlashList
FlashList v2 auto-measures items, but this measurement can fail on:
- Foldable devices (changing screen dimensions)
- Modal/sheet contexts
- Certain Android layouts

FlatList is the reliable fallback for these use cases. The lists in template screens are typically small (5-15 items), so FlashList's virtualization benefits don't apply.

## Testing
- `npx tsc -- ✅ clean (only pre-existing BLD-420 WIP errors from untracked files)noEmit` 
- `npx jest --testPathPattern=template` — ✅ same pass/fail as main (4 pre-existing failures)
- `npx eslint` — ✅ clean

## Issue
Resolves BLD-419 (GH #244)