### PR TITLE
fix: remove fixed width and truncation from Input labels

### DIFF
--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -178,8 +178,6 @@ export const Input = forwardRef<TextInput, InputProps>(
                     {label && (
                       <Text
                         variant='caption'
-                        numberOfLines={1}
-                        ellipsizeMode='tail'
                         style={[
                           {
                             color: error ? danger : muted,
@@ -222,10 +220,10 @@ export const Input = forwardRef<TextInput, InputProps>(
                 gap: 8,
               }}
             >
-              {/* Left section - Icon + Label (fixed width to simulate grid column) */}
+              {/* Left section - Icon + Label */}
               <View
                 style={{
-                  width: label ? 120 : 'auto',
+                  flexShrink: 0,
                   flexDirection: 'row',
                   alignItems: 'center',
                   gap: 8,
@@ -238,8 +236,6 @@ export const Input = forwardRef<TextInput, InputProps>(
                 {label && (
                   <Text
                     variant='caption'
-                    numberOfLines={1}
-                    ellipsizeMode='tail'
                     style={[
                       {
                         color: error ? danger : muted,
@@ -488,8 +484,6 @@ export const GroupedInputItem = forwardRef<TextInput, GroupedInputItemProps>(
                     {label && (
                       <Text
                         variant='caption'
-                        numberOfLines={1}
-                        ellipsizeMode='tail'
                         style={[
                           {
                             color: error ? danger : muted,
@@ -546,7 +540,7 @@ export const GroupedInputItem = forwardRef<TextInput, GroupedInputItemProps>(
               {/* Icon & Label */}
               <View
                 style={{
-                  width: label ? 120 : 'auto',
+                  flexShrink: 0,
                   flexDirection: 'row',
                   alignItems: 'center',
                   gap: 8,
@@ -559,8 +553,6 @@ export const GroupedInputItem = forwardRef<TextInput, GroupedInputItemProps>(
                 {label && (
                   <Text
                     variant='caption'
-                    numberOfLines={1}
-                    ellipsizeMode='tail'
                     style={[
                       {
                         color: error ? danger : muted,


### PR DESCRIPTION
## Summary
Fix input label truncation by removing the fixed `width: 120` constraint and `numberOfLines={1}` / `ellipsizeMode='tail'` from label Text components. Labels now display in full using `flexShrink: 0` for natural sizing.

## Changes
- `components/ui/input.tsx`: Fix 4 label truncation locations:
  - **Input textarea layout**: Remove `numberOfLines={1}` + `ellipsizeMode='tail'`
  - **Input row layout**: Replace `width: 120` with `flexShrink: 0`, remove truncation props
  - **GroupedInputItem textarea layout**: Remove truncation props
  - **GroupedInputItem row layout**: Replace `width: 120` with `flexShrink: 0`, remove truncation props

## Testing
- `npx tsc --noEmit` — passes (no input.tsx errors)
- `npx eslint` — passes (lint-staged verified)
- Full test suite: no new regressions (21 pre-existing failures)

## Issue
Refs: BLD-421