### PR TITLE
feat: Strength Standards & Strength Level Classification (Phase 63)

### DIFF
--- a/__tests__/lib/strength-standards.test.ts
+++ b/__tests__/lib/strength-standards.test.ts
@@ -1,0 +1,106 @@
+import {
+  getStrengthLevel,
+  matchExercise,
+  hasStandards,
+  getStandardExerciseKeys,
+  LEVELS,
+} from "../../lib/strength-standards";
+
+describe("strength-standards", () => {
+  describe("matchExercise + hasStandards", () => {
+    it("matches standard names case-insensitively and with prefixes", () => {
+      expect(matchExercise("Bench Press")).toBe("bench press");
+      expect(matchExercise("SQUAT")).toBe("squat");
+      expect(matchExercise("deadlift")).toBe("deadlift");
+      expect(matchExercise("Overhead Press")).toBe("overhead press");
+      expect(matchExercise("Barbell Row")).toBe("barbell row");
+      expect(matchExercise("Barbell Bench Press")).toBe("bench press");
+      expect(matchExercise("Back Squat")).toBe("squat");
+      expect(matchExercise("Conventional Deadlift")).toBe("deadlift");
+      expect(matchExercise("Standing Overhead Press")).toBe("overhead press");
+      expect(matchExercise("  bench press  ")).toBe("bench press");
+    });
+
+    it("returns null for non-standard exercises and hasStandards agrees", () => {
+      expect(matchExercise("Cable Fly")).toBeNull();
+      expect(matchExercise("Bicep Curl")).toBeNull();
+      expect(matchExercise("")).toBeNull();
+      expect(hasStandards("Cable Fly")).toBe(false);
+      expect(hasStandards("Bench Press")).toBe(true);
+      expect(hasStandards("Barbell Squat")).toBe(true);
+    });
+  });
+
+  describe("getStandardExerciseKeys + LEVELS", () => {
+    it("returns all 5 keys and levels in correct order", () => {
+      const keys = getStandardExerciseKeys();
+      expect(keys).toHaveLength(5);
+      expect(keys).toContain("bench press");
+      expect(keys).toContain("squat");
+      expect(keys).toContain("deadlift");
+      expect(keys).toContain("overhead press");
+      expect(keys).toContain("barbell row");
+      expect(LEVELS).toEqual(["beginner", "novice", "intermediate", "advanced", "elite"]);
+    });
+  });
+
+  describe("getStrengthLevel", () => {
+    it("returns Intermediate for male 80kg BW / 80kg bench (ratio 1.0)", () => {
+      const result = getStrengthLevel("Bench Press", "male", 80, 80);
+      expect(result).not.toBeNull();
+      expect(result!.level).toBe("intermediate");
+      expect(result!.nextLevel).toBe("advanced");
+      expect(result!.nextThresholdKg).toBe(100);
+    });
+
+    it("returns Intermediate for female 60kg BW / 45kg bench (ratio 0.75)", () => {
+      const result = getStrengthLevel("Bench Press", "female", 60, 45);
+      expect(result).not.toBeNull();
+      expect(result!.level).toBe("intermediate");
+      expect(result!.nextLevel).toBe("advanced");
+      expect(result!.nextThresholdKg).toBe(60);
+    });
+
+    it("returns Elite with no next level for top-tier lifts", () => {
+      const result = getStrengthLevel("Squat", "male", 80, 200);
+      expect(result).not.toBeNull();
+      expect(result!.level).toBe("elite");
+      expect(result!.nextLevel).toBeNull();
+      expect(result!.nextThresholdKg).toBeNull();
+    });
+
+    it("returns Beginner when ratio is below beginner threshold", () => {
+      const result = getStrengthLevel("Bench Press", "male", 80, 30);
+      expect(result).not.toBeNull();
+      expect(result!.level).toBe("beginner");
+      expect(result!.nextLevel).toBe("novice");
+    });
+
+    it("treats threshold as inclusive (at threshold = achieved)", () => {
+      const r1 = getStrengthLevel("Bench Press", "male", 80, 80);
+      expect(r1!.level).toBe("intermediate");
+      const r2 = getStrengthLevel("Bench Press", "male", 80, 60);
+      expect(r2!.level).toBe("novice");
+    });
+
+    it("returns null for invalid inputs and non-standard exercises", () => {
+      expect(getStrengthLevel("Cable Fly", "male", 80, 50)).toBeNull();
+      expect(getStrengthLevel("Bench Press", "male", 0, 80)).toBeNull();
+      expect(getStrengthLevel("Bench Press", "male", 80, 0)).toBeNull();
+      expect(getStrengthLevel("Bench Press", "male", -5, 80)).toBeNull();
+      expect(getStrengthLevel("Bench Press", "male", 80, -10)).toBeNull();
+    });
+
+    it("works for all supported exercises (male and female)", () => {
+      const exercises = ["Bench Press", "Squat", "Deadlift", "Overhead Press", "Barbell Row"];
+      for (const ex of exercises) {
+        const m = getStrengthLevel(ex, "male", 80, 80);
+        expect(m).not.toBeNull();
+        expect(LEVELS).toContain(m!.level);
+        const f = getStrengthLevel(ex, "female", 60, 45);
+        expect(f).not.toBeNull();
+        expect(LEVELS).toContain(f!.level);
+      }
+    });
+  });
+});

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -33,6 +33,8 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { useExerciseDetail, MAX_ITEMS } from "@/hooks/useExerciseDetail";
 import ExerciseRecordsCard from "@/components/exercise/ExerciseRecordsCard";
 import ExerciseChartCard from "@/components/exercise/ExerciseChartCard";
+import StrengthLevelBadge from "@/components/exercise/StrengthLevelBadge";
+import { useStrengthLevel } from "@/hooks/useStrengthLevel";
 import { fontSizes } from "@/constants/design-tokens";
 
 function formatDateLong(ts: number): string {
@@ -48,6 +50,7 @@ export default function ExerciseDetail() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const { toast: showToast } = useToast();
   const d = useExerciseDetail(id);
+  const strengthLevel = useStrengthLevel(d.exercise?.name, d.records?.est_1rm ?? null, d.unit);
 
   const edit = useCallback(() => { if (id) router.push(`/exercise/edit/${id}`); }, [id, router]);
   const remove = useCallback(async () => {
@@ -120,6 +123,17 @@ export default function ExerciseDetail() {
           chartLoading={d.chartLoading} chartError={d.chartError} exerciseId={id} exerciseName={exercise.name} loadChart={d.loadChart}
           style={layout.atLeastMedium ? { ...flowCardStyle, maxWidth: 560 } : undefined} />
       </FlowContainer>
+
+      {strengthLevel && (
+        <StrengthLevelBadge
+          colors={colors}
+          level={strengthLevel.level}
+          nextLevel={strengthLevel.nextLevel}
+          nextThresholdKg={strengthLevel.nextThresholdKg}
+          unit={d.unit}
+          style={{ marginTop: 8 }}
+        />
+      )}
 
       <Text variant="title" style={{ color: colors.onSurface, marginTop: 8, marginBottom: 8 }}>Session History</Text>
       {d.historyLoading ? <ActivityIndicator style={styles.loader} /> : d.historyError ? (

--- a/components/exercise/StrengthLevelBadge.tsx
+++ b/components/exercise/StrengthLevelBadge.tsx
@@ -1,0 +1,85 @@
+import { StyleSheet, useColorScheme, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { STRENGTH_LEVEL_COLORS } from "@/constants/theme";
+import { toDisplay } from "@/lib/units";
+import { fontSizes } from "@/constants/design-tokens";
+import type { StrengthLevel } from "@/lib/strength-standards";
+import type { ThemeColors } from "@/hooks/useThemeColors";
+
+type Props = {
+  colors: ThemeColors;
+  level: StrengthLevel;
+  nextLevel: StrengthLevel | null;
+  nextThresholdKg: number | null;
+  unit: "kg" | "lb";
+  style?: object;
+};
+
+const LEVEL_LABELS: Record<StrengthLevel, string> = {
+  beginner: "Beginner",
+  novice: "Novice",
+  intermediate: "Intermediate",
+  advanced: "Advanced",
+  elite: "Elite",
+};
+
+export default function StrengthLevelBadge({
+  colors,
+  level,
+  nextLevel,
+  nextThresholdKg,
+  unit,
+  style,
+}: Props) {
+  const scheme = useColorScheme();
+  const palette = scheme === "dark" ? STRENGTH_LEVEL_COLORS.dark : STRENGTH_LEVEL_COLORS.light;
+  const badgeColor = palette[level];
+
+  const nextText = nextLevel && nextThresholdKg != null
+    ? `${LEVEL_LABELS[nextLevel]} at ${toDisplay(nextThresholdKg, unit)} ${unit}`
+    : null;
+
+  const a11yLabel = nextText
+    ? `Strength level: ${LEVEL_LABELS[level]}. Next level ${nextText}.`
+    : `Strength level: ${LEVEL_LABELS[level]}.`;
+
+  return (
+    <View style={[styles.container, style]} accessibilityLabel={a11yLabel}>
+      <View style={[styles.badge, { backgroundColor: badgeColor.bg }]}>
+        <Text style={[styles.levelText, { color: badgeColor.text }]}>
+          {LEVEL_LABELS[level]}
+        </Text>
+      </View>
+      {nextText && (
+        <Text
+          variant="caption"
+          style={[styles.nextHint, { color: colors.onSurfaceVariant }]}
+        >
+          Next: {nextText}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginTop: 8,
+  },
+  badge: {
+    borderRadius: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+  },
+  levelText: {
+    fontSize: fontSizes.sm,
+    fontWeight: "600",
+  },
+  nextHint: {
+    fontSize: fontSizes.xs,
+    flexShrink: 1,
+  },
+});

--- a/components/progress/StrengthLevelsCard.tsx
+++ b/components/progress/StrengthLevelsCard.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useState } from "react";
+import { StyleSheet, useColorScheme, View } from "react-native";
+import { useFocusEffect } from "expo-router";
+import { Card, CardContent } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
+import { getStrengthOverview } from "@/lib/db";
+import { getBodySettings, getLatestBodyWeight } from "@/lib/db/body";
+import { getStrengthLevel, matchExercise, type StrengthLevel, type StrengthResult } from "@/lib/strength-standards";
+import { toKg, toDisplay } from "@/lib/units";
+import { STRENGTH_LEVEL_COLORS } from "@/constants/theme";
+import { fontSizes } from "@/constants/design-tokens";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { Sex } from "@/lib/nutrition-calc";
+
+type LevelRow = StrengthResult & {
+  name: string;
+  e1rmKg: number;
+};
+
+const LEVEL_LABELS: Record<StrengthLevel, string> = {
+  beginner: "Beginner",
+  novice: "Novice",
+  intermediate: "Intermediate",
+  advanced: "Advanced",
+  elite: "Elite",
+};
+
+export default function StrengthLevelsCard({ style }: { style?: object }) {
+  const colors = useThemeColors();
+  const scheme = useColorScheme();
+  const palette = scheme === "dark" ? STRENGTH_LEVEL_COLORS.dark : STRENGTH_LEVEL_COLORS.light;
+  const [rows, setRows] = useState<LevelRow[]>([]);
+
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        try {
+          const [settings, latestBW, overview] = await Promise.all([
+            getBodySettings(),
+            getLatestBodyWeight(),
+            getStrengthOverview(),
+          ]);
+
+          if (!latestBW || latestBW.weight <= 0) { setRows([]); return; }
+          const gender = settings.sex as Sex;
+          if (gender !== "male" && gender !== "female") { setRows([]); return; }
+          const weightUnit = settings.weight_unit as "kg" | "lb";
+          const bodyWeightKg = toKg(latestBW.weight, weightUnit);
+
+          const levels: LevelRow[] = [];
+          for (const row of overview) {
+            if (!matchExercise(row.name)) continue;
+            const e1rmKg = toKg(row.est_1rm, weightUnit);
+            const result = getStrengthLevel(row.name, gender, bodyWeightKg, e1rmKg);
+            if (result) {
+              levels.push({ ...result, name: row.name, e1rmKg });
+            }
+          }
+
+          setRows(levels);
+        } catch {
+          setRows([]);
+        }
+      })();
+    }, []),
+  );
+
+  if (rows.length === 0) return null;
+
+  return (
+    <Card style={style}>
+      <CardContent>
+        <Text variant="title" style={[styles.title, { color: colors.onSurface }]}>
+          Strength Levels
+        </Text>
+        {rows.map((row) => {
+          const badgeColor = palette[row.level];
+          const nextHint = row.nextLevel && row.nextThresholdKg != null
+            ? `→ ${LEVEL_LABELS[row.nextLevel]} at ${Math.round(row.e1rmKg > 0 ? toDisplay(row.nextThresholdKg, "kg") : 0)} kg`
+            : null;
+          const a11yLabel = `${row.name}: ${LEVEL_LABELS[row.level]}${nextHint ? `. ${nextHint}` : ""}`;
+
+          return (
+            <View key={row.name} style={styles.row} accessibilityLabel={a11yLabel}>
+              <Text
+                variant="body"
+                style={[styles.exerciseName, { color: colors.onSurface }]}
+                numberOfLines={1}
+              >
+                {row.name}
+              </Text>
+              <View style={[styles.badge, { backgroundColor: badgeColor.bg }]}>
+                <Text style={[styles.badgeText, { color: badgeColor.text }]}>
+                  {LEVEL_LABELS[row.level]}
+                </Text>
+              </View>
+            </View>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  title: {
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 6,
+  },
+  exerciseName: {
+    flex: 1,
+    marginRight: 8,
+    fontSize: fontSizes.sm,
+  },
+  badge: {
+    borderRadius: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+  },
+  badgeText: {
+    fontSize: fontSizes.xs,
+    fontWeight: "600",
+  },
+});

--- a/components/progress/WorkoutSegment.tsx
+++ b/components/progress/WorkoutSegment.tsx
@@ -20,6 +20,7 @@ import WeeklySummary from "../../components/WeeklySummary";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { WorkoutChartCard, PRCard, SessionsCard } from "./WorkoutCards";
 import CalendarView from "./CalendarView";
+import StrengthLevelsCard from "./StrengthLevelsCard";
 import { fontSizes } from "@/constants/design-tokens";
 
 let cachedWeekStart: number | null = null;
@@ -214,6 +215,7 @@ export default function WorkoutSegment() {
               <PRCard prs={prs} style={wideCard} />
               <SessionsCard sessions={sessions} style={wideCard} />
             </View>
+            <StrengthLevelsCard />
           </>
         ) : (
           <>
@@ -224,6 +226,7 @@ export default function WorkoutSegment() {
             {volCard}
             <PRCard prs={prs} />
             <SessionsCard sessions={sessions} />
+            <StrengthLevelsCard />
           </>
         )
       }

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -120,6 +120,25 @@ export function difficultyText(level: string): string {
 // Fixed colors for the camera viewfinder — must contrast against a live
 // camera feed, not the app theme.
 
+// ─── Strength Level Colors ──────────────────────────────────────────
+
+export const STRENGTH_LEVEL_COLORS = {
+  light: {
+    beginner:     { bg: "#E0E0E0", text: "#424242" },
+    novice:       { bg: "#BBDEFB", text: "#0D47A1" },
+    intermediate: { bg: "#C8E6C9", text: "#1B5E20" },
+    advanced:     { bg: "#FFE0B2", text: "#E65100" },
+    elite:        { bg: "#F8BBD0", text: "#880E4F" },
+  } as Record<string, { bg: string; text: string }>,
+  dark: {
+    beginner:     { bg: "#616161", text: "#E0E0E0" },
+    novice:       { bg: "#1565C0", text: "#E3F2FD" },
+    intermediate: { bg: "#2E7D32", text: "#E8F5E9" },
+    advanced:     { bg: "#E65100", text: "#FFF3E0" },
+    elite:        { bg: "#AD1457", text: "#FCE4EC" },
+  } as Record<string, { bg: string; text: string }>,
+};
+
 export const CAMERA_OVERLAY = {
   background: "#000000",
   text: "#ffffff",

--- a/hooks/useStrengthLevel.ts
+++ b/hooks/useStrengthLevel.ts
@@ -1,0 +1,71 @@
+import { useCallback, useState } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import { getBodySettings, getLatestBodyWeight } from "../lib/db/body";
+import { getStrengthLevel, type StrengthResult } from "../lib/strength-standards";
+import { toKg } from "../lib/units";
+import type { Sex } from "../lib/nutrition-calc";
+
+export type StrengthLevelData = StrengthResult & {
+  bodyWeightKg: number;
+  e1rmKg: number;
+  gender: Sex;
+};
+
+/**
+ * Computes the strength level for a given exercise, combining e1RM with
+ * the user's latest body weight and gender from settings.
+ *
+ * Returns null when any required data is missing (no body weight, no e1RM,
+ * exercise not in standards table, or gender not set).
+ */
+export function useStrengthLevel(
+  exerciseName: string | undefined,
+  e1rm: number | null,
+  unit: "kg" | "lb",
+): StrengthLevelData | null {
+  const [result, setResult] = useState<StrengthLevelData | null>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!exerciseName || e1rm == null || e1rm <= 0) {
+        setResult(null);
+        return;
+      }
+
+      (async () => {
+        try {
+          const [settings, latestBW] = await Promise.all([
+            getBodySettings(),
+            getLatestBodyWeight(),
+          ]);
+
+          if (!latestBW || latestBW.weight <= 0) {
+            setResult(null);
+            return;
+          }
+
+          const gender = settings.sex as Sex;
+          if (gender !== "male" && gender !== "female") {
+            setResult(null);
+            return;
+          }
+
+          const bodyWeightKg = toKg(latestBW.weight, settings.weight_unit as "kg" | "lb");
+          const e1rmKg = toKg(e1rm, unit);
+
+          const level = getStrengthLevel(exerciseName, gender, bodyWeightKg, e1rmKg);
+          if (!level) {
+            setResult(null);
+            return;
+          }
+
+          setResult({ ...level, bodyWeightKg, e1rmKg, gender });
+        } catch {
+          setResult(null);
+        }
+      })();
+    }, [exerciseName, e1rm, unit]),
+  );
+
+  return result;
+}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -282,3 +282,6 @@ export type {
 
 export { getMuscleRecoveryStatus, RECOVERY_HOURS } from "./recovery";
 export type { MuscleRecoveryStatus, RecoveryStatus } from "./recovery";
+
+export { getStrengthOverview } from "./strength-overview";
+export type { StrengthOverviewRow } from "./strength-overview";

--- a/lib/db/strength-overview.ts
+++ b/lib/db/strength-overview.ts
@@ -1,0 +1,32 @@
+import { query } from "./helpers";
+
+export type StrengthOverviewRow = {
+  exercise_id: string;
+  name: string;
+  est_1rm: number;
+};
+
+/**
+ * Get the best e1RM for all exercises that have at least one completed weighted set.
+ * Used by the progress screen strength levels card.
+ */
+export async function getStrengthOverview(): Promise<StrengthOverviewRow[]> {
+  return query<StrengthOverviewRow>(
+    `SELECT
+       ws.exercise_id,
+       e.name,
+       MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS est_1rm
+     FROM workout_sets ws
+     JOIN workout_sessions wss ON ws.session_id = wss.id
+     JOIN exercises e ON ws.exercise_id = e.id
+     WHERE ws.completed = 1
+       AND ws.set_type != 'warmup'
+       AND ws.weight > 0
+       AND ws.reps > 0
+       AND ws.reps <= 12
+       AND wss.completed_at IS NOT NULL
+       AND e.deleted_at IS NULL
+     GROUP BY ws.exercise_id
+     ORDER BY est_1rm DESC`,
+  );
+}

--- a/lib/strength-standards.ts
+++ b/lib/strength-standards.ts
@@ -1,0 +1,114 @@
+// Strength level classification for compound lifts.
+// Levels are based on e1RM as a multiplier of body weight, split by gender.
+
+export type StrengthLevel = "beginner" | "novice" | "intermediate" | "advanced" | "elite";
+
+export type StrengthThresholds = {
+  beginner: number;
+  novice: number;
+  intermediate: number;
+  advanced: number;
+  elite: number;
+};
+
+export type StrengthResult = {
+  level: StrengthLevel;
+  nextLevel: StrengthLevel | null;
+  nextThresholdKg: number | null;
+};
+
+const LEVELS: StrengthLevel[] = ["beginner", "novice", "intermediate", "advanced", "elite"];
+
+// BW multipliers for each exercise × gender
+const STANDARDS: Record<string, Record<"male" | "female", StrengthThresholds>> = {
+  "bench press": {
+    male:   { beginner: 0.50, novice: 0.75, intermediate: 1.00, advanced: 1.25, elite: 1.50 },
+    female: { beginner: 0.25, novice: 0.50, intermediate: 0.75, advanced: 1.00, elite: 1.25 },
+  },
+  "squat": {
+    male:   { beginner: 0.75, novice: 1.00, intermediate: 1.50, advanced: 2.00, elite: 2.50 },
+    female: { beginner: 0.50, novice: 0.75, intermediate: 1.25, advanced: 1.75, elite: 2.25 },
+  },
+  "deadlift": {
+    male:   { beginner: 1.00, novice: 1.25, intermediate: 1.75, advanced: 2.25, elite: 3.00 },
+    female: { beginner: 0.50, novice: 1.00, intermediate: 1.50, advanced: 2.00, elite: 2.50 },
+  },
+  "overhead press": {
+    male:   { beginner: 0.35, novice: 0.55, intermediate: 0.75, advanced: 1.00, elite: 1.25 },
+    female: { beginner: 0.20, novice: 0.35, intermediate: 0.50, advanced: 0.75, elite: 1.00 },
+  },
+  "barbell row": {
+    male:   { beginner: 0.50, novice: 0.75, intermediate: 1.00, advanced: 1.25, elite: 1.50 },
+    female: { beginner: 0.25, novice: 0.50, intermediate: 0.75, advanced: 1.00, elite: 1.25 },
+  },
+};
+
+// Sorted longest-first so "barbell bench press" matches "bench press" not "press"
+const STANDARD_KEYS = Object.keys(STANDARDS).sort((a, b) => b.length - a.length);
+
+/**
+ * Match a freeform exercise name to a standards key.
+ * Normalizes by lowercasing and checking if the name contains a standard key.
+ */
+export function matchExercise(name: string): string | null {
+  const normalized = name.toLowerCase().trim();
+  for (const key of STANDARD_KEYS) {
+    if (normalized.includes(key)) return key;
+  }
+  return null;
+}
+
+/**
+ * Determine the user's strength level for a given exercise.
+ *
+ * @param exerciseName - Freeform exercise name (e.g. "Barbell Bench Press")
+ * @param gender - "male" or "female"
+ * @param bodyWeightKg - User's body weight in kg
+ * @param e1rmKg - Estimated 1RM in kg
+ * @returns StrengthResult with current level and next target, or null if no standard exists
+ */
+export function getStrengthLevel(
+  exerciseName: string,
+  gender: "male" | "female",
+  bodyWeightKg: number,
+  e1rmKg: number,
+): StrengthResult | null {
+  if (bodyWeightKg <= 0 || e1rmKg <= 0) return null;
+
+  const key = matchExercise(exerciseName);
+  if (!key) return null;
+
+  const thresholds = STANDARDS[key]?.[gender];
+  if (!thresholds) return null;
+
+  const ratio = e1rmKg / bodyWeightKg;
+
+  // Walk levels top-down: first threshold the ratio meets or exceeds is the level
+  let level: StrengthLevel = "beginner";
+  for (let i = LEVELS.length - 1; i >= 0; i--) {
+    if (ratio >= thresholds[LEVELS[i]]) {
+      level = LEVELS[i];
+      break;
+    }
+  }
+
+  const levelIdx = LEVELS.indexOf(level);
+  const nextLevel = levelIdx < LEVELS.length - 1 ? LEVELS[levelIdx + 1] : null;
+  const nextThresholdKg = nextLevel
+    ? Math.round(thresholds[nextLevel] * bodyWeightKg * 10) / 10
+    : null;
+
+  return { level, nextLevel, nextThresholdKg };
+}
+
+/** Check if an exercise has strength standards data. */
+export function hasStandards(exerciseName: string): boolean {
+  return matchExercise(exerciseName) !== null;
+}
+
+/** Get all standard exercise keys. */
+export function getStandardExerciseKeys(): string[] {
+  return Object.keys(STANDARDS);
+}
+
+export { LEVELS };


### PR DESCRIPTION
## Summary
Add strength level classification (Beginner → Novice → Intermediate → Advanced → Elite) for compound lifts based on user's e1RM relative to body weight and gender.

## Changes
- `lib/strength-standards.ts`: Pure TS module with BW multiplier standards for Big 5 lifts + lookup functions
- `hooks/useStrengthLevel.ts`: Hook combining e1RM + body weight + gender settings
- `lib/db/strength-overview.ts`: DB query for best e1RM across all exercises
- `components/exercise/StrengthLevelBadge.tsx`: Compact badge with level + next target hint
- `components/progress/StrengthLevelsCard.tsx`: Overview card showing levels across all compound lifts
- `constants/theme.ts`: Added `STRENGTH_LEVEL_COLORS` for light/dark themes
- `lib/db/index.ts`: Re-export `getStrengthOverview`
- `app/exercise/[id].tsx`: Integrated StrengthLevelBadge below records card
- `components/progress/WorkoutSegment.tsx`: Integrated StrengthLevelsCard after sessions card
- `__tests__/lib/strength-standards.test.ts`: 10 tests covering all edge cases

## Testing
- `npx tsc --noEmit` — clean ✅
- `npx jest --testPathPattern=strength` — 10/10 passing ✅
- Lint (lint-staged) — clean ✅

## Issue
Refs: BLD-420