### PR TITLE
fix: replace FlashList with FlatList in program detail (BLD-422)

### DIFF
--- a/__tests__/app/program-flatlist-migration.test.ts
+++ b/__tests__/app/program-flatlist-migration.test.ts
@@ -1,0 +1,41 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Structural test for BLD-422: Program detail FlashList → FlatList migration.
+ * FlashList v2 has layout measurement issues on foldable devices (Samsung Z Fold6),
+ * causing empty renders. FlatList is the reliable replacement for small lists.
+ */
+
+const programDetailPath = path.resolve(__dirname, "../../app/program/[id].tsx");
+const src = fs.readFileSync(programDetailPath, "utf-8");
+
+describe("program detail FlashList migration (BLD-422)", () => {
+  it("does not import FlashList", () => {
+    expect(src).not.toMatch(/@shopify\/flash-list/);
+  });
+
+  it("imports FlatList from react-native", () => {
+    expect(src).toMatch(/import\s*\{[^}]*FlatList[^}]*\}\s*from\s*["']react-native["']/);
+  });
+
+  it("uses FlatList component (not FlashList)", () => {
+    expect(src).toMatch(/<FlatList[\s\n]/);
+    expect(src).not.toMatch(/<FlashList[\s\n]/);
+  });
+
+  it("renders dayName text without explicit numberOfLines truncation", () => {
+    // dayName text in the card should not be artificially truncated
+    const dayNameUsages = src.match(/dayName\(item\)/g);
+    expect(dayNameUsages).not.toBeNull();
+    // Verify no numberOfLines={1} on the Text containing dayName
+    const dayTextMatch = src.match(/Day \{index \+ 1\}:.*dayName/);
+    expect(dayTextMatch).not.toBeNull();
+    // The surrounding Text should not have numberOfLines
+    const textBlock = src.substring(
+      src.indexOf("Day {index + 1}") - 100,
+      src.indexOf("Day {index + 1}") + 100
+    );
+    expect(textBlock).not.toMatch(/numberOfLines/);
+  });
+});

--- a/app/program/[id].tsx
+++ b/app/program/[id].tsx
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines-per-function, complexity */
 import { useCallback } from "react";
-import { StyleSheet, TouchableOpacity, View } from "react-native";
-import { FlashList } from "@shopify/flash-list";
+import { FlatList, StyleSheet, TouchableOpacity, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Chip } from "@/components/ui/chip";
@@ -10,7 +9,6 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useFocusEffect } from "expo-router";
 import { useLayout } from "../../lib/layout";
-import type { ProgramDay } from "../../lib/types";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useProgramDetail, dayName } from "@/hooks/useProgramDetail";
 import { WeeklySchedule } from "@/components/program/WeeklySchedule";
@@ -52,7 +50,7 @@ export default function ProgramDetail() {
   return (
     <>
       <Stack.Screen options={{ title: program.name }} />
-      <FlashList
+      <FlatList
         style={StyleSheet.flatten([styles.container, { backgroundColor: colors.background }])}
         contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: 48 }}
         data={days}
@@ -152,7 +150,7 @@ export default function ProgramDetail() {
             </View>
           </>
         }
-        renderItem={({ item, index }: { item: ProgramDay; index: number }) => (
+        renderItem={({ item, index }) => (
           <Card
             style={StyleSheet.flatten([
               styles.card,


### PR DESCRIPTION
## Summary

Replace FlashList with FlatList in the program detail view (`app/program/[id].tsx`) to fix empty rendering on Samsung Z Fold6 foldable devices and weekday text truncation.

## Changes

- Replaced `FlashList` import from `@shopify/flash-list` with `FlatList` from `react-native`
- Removed unused `ProgramDay` type import (FlatList infers types from data prop)
- Added structural regression test to prevent FlashList re-introduction

## Root Cause

FlashList v2's auto-measurement produces zero-height renders on foldable devices where screen dimensions change dynamically. This caused:
- GH #239: Template picker shows no templates
- GH #240: Weekday text truncated in program day list

FlatList is the reliable choice for lists with <20 items (program days typically 3-7).

## Testing

- All 14 existing program acceptance tests pass
- New structural test validates FlashList removal
- TypeScript compilation clean (`tsc --noEmit`)
- ESLint passes with zero warnings

## Issue

Resolves BLD-422, fixes GH #239, GH #240