### PR TITLE
fix: exercise detail bottom content overlap (BLD-425)

### DIFF
--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -168,9 +168,10 @@ export default function ExerciseDetail() {
         </View>
       ) : undefined }} />
       <FlashList style={{ flex: 1, backgroundColor: colors.background }}
+        contentContainerStyle={{ paddingBottom: 100 }}
         data={d.historyLoading || d.historyError || d.history.length === 0 ? [] : d.history}
         keyExtractor={(item) => item.session_id} renderItem={renderItem} ListHeaderComponent={renderHeader}
-        ListFooterComponent={renderFooter} ListFooterComponentStyle={{ paddingBottom: 100 }}
+        ListFooterComponent={renderFooter}
         onEndReached={d.loadMore} onEndReachedThreshold={0.3} />
     </>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cablesnap",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cablesnap",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
@@ -12658,9 +12658,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12680,9 +12677,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12704,9 +12698,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12726,9 +12717,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,


### PR DESCRIPTION
## Summary

Exercise detail view content (instructions, charts, session history) was hidden behind the bottom tab bar. The `ListFooterComponentStyle={{ paddingBottom: 100 }}` only applied when the footer component rendered content — when `renderFooter` returned `null` (no history data), the padding was lost.

## Changes

- Replaced `ListFooterComponentStyle={{ paddingBottom: 100 }}` with `contentContainerStyle={{ paddingBottom: 100 }}` on the FlashList
- `contentContainerStyle` always applies regardless of footer content, ensuring reliable bottom spacing

## Audit — Other Detail Views

Other detail views already use `contentContainerStyle` with `paddingBottom`:
- `app/session/detail/[id].tsx` — `paddingBottom: 48`
- `app/program/[id].tsx` — `paddingBottom: 48`
- `app/session/summary/[id].tsx` — `paddingBottom: 48`
- `app/history.tsx` — `paddingBottom: 40`

These values (40-48) may be insufficient for devices with larger tab bars but are not part of this fix scope.

## Testing

- TypeScript typecheck passes (`tsc --noEmit`)
- ESLint passes (lint-staged)
- Related tests pass (7/7)
- Test budget: 1680/1800 (no change)

## Issue

Resolves BLD-425