### PR TITLE
fix: replace fixed width with flexShrink on day labels (BLD-427)

### DIFF
--- a/components/program/WeeklySchedule.tsx
+++ b/components/program/WeeklySchedule.tsx
@@ -199,7 +199,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   dayLabel: {
-    width: 44,
+    minWidth: 44,
+    flexShrink: 0,
     fontWeight: "600",
   },
   dayInfo: {


### PR DESCRIPTION
## Summary
Day labels in WeeklySchedule used `width: 44` which truncated text on Samsung Z Fold6 with accessibility font sizes. Same pattern as BLD-421 (Input label truncation).

## Changes
- `components/program/WeeklySchedule.tsx`: Replace `width: 44` → `minWidth: 44` + `flexShrink: 0` on `dayLabel` style

## Root Cause
Fixed width constraint clips text when device font scaling exceeds expected bounds (common on foldable devices with accessibility settings).

## Testing
- `npx tsc --noEmit` — clean
- ESLint (lint-staged) — clean
- Visual: day labels (Mon, Tue, etc.) now expand naturally while maintaining minimum alignment width

## Issue
Refs: BLD-427