### PR TITLE
fix: patch VirtualizedList to render all items in tests (BLD-426)

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,23 @@
 // We rely on moduleNameMapper in jest.config.js to intercept
 // react-native-reanimated and react-native-worklets before they load native code.
 
+// Patch VirtualizedList to render all items in tests (no virtualization).
+// FlashList rendered everything; FlatList virtualizes by default (initialNumToRender=10),
+// breaking findByText assertions for items beyond the first 10.
+jest.mock(
+  '@react-native/virtualized-lists/Lists/VirtualizedListProps',
+  () => {
+    const actual = jest.requireActual(
+      '@react-native/virtualized-lists/Lists/VirtualizedListProps'
+    );
+    return {
+      ...actual,
+      initialNumToRenderOrDefault: (n) => n ?? 200,
+      maxToRenderPerBatchOrDefault: (n) => n ?? 200,
+    };
+  }
+);
+
 // Mock react-native-safe-area-context for tests (was previously provided by PaperProvider)
 jest.mock('react-native-safe-area-context', () => {
   const insets = { top: 0, bottom: 0, left: 0, right: 0 };


### PR DESCRIPTION
## Summary

Fix the 4 test regressions introduced by the FlashList→FlatList migration (PR #252). FlatList virtualizes by default (`initialNumToRender=10`), causing `findByText` assertions to fail for items beyond the first 10. FlashList rendered all items, so tests relied on this behavior.

## Changes

- `jest.setup.js`: Mock `initialNumToRenderOrDefault` and `maxToRenderPerBatchOrDefault` from `@react-native/virtualized-lists` to return 200 instead of 10, ensuring all list items render in tests.

## Testing

- `npx tsc --noEmit` — passes (0 errors)
- `npx jest` — 46 failed, 1752 passed (matches pre-BLD-426 baseline exactly; 0 new regressions)
- Specifically verified: `voltra-exercises.test.tsx`, `exercise.test.tsx`, `body-progress.acceptance.test.tsx`, `phase43-1rm-features.acceptance.test.tsx` — all previously-failing tests now pass

## Issue

Follow-up fix for BLD-426 (QD revert)