### PR TITLE
feat: RMR override for accurate macro targets (BLD-429)

### DIFF
--- a/__tests__/components/BodyProfileCard.test.tsx
+++ b/__tests__/components/BodyProfileCard.test.tsx
@@ -95,6 +95,9 @@ jest.mock('../../lib/nutrition-calc', () => ({
     carbs: 275,
     fat: 73,
   }),
+  calculateBMR: jest.fn().mockReturnValue(1700),
+  convertToMetric: jest.fn().mockReturnValue({ weight_kg: 75, height_cm: 175 }),
+  calculateDeviationPercent: jest.fn().mockReturnValue(0),
   migrateProfile: (p: unknown) => p,
 }))
 

--- a/__tests__/lib/nutrition-calc.test.ts
+++ b/__tests__/lib/nutrition-calc.test.ts
@@ -4,6 +4,7 @@ import {
   calculateMacros,
   calculateFromProfile,
   convertToMetric,
+  calculateDeviationPercent,
   migrateProfile,
   type NutritionProfile,
 } from "../../lib/nutrition-calc";
@@ -182,6 +183,55 @@ describe("nutrition-calc", () => {
       // calories = round(2633.06) = 2633
       expect(result.calories).toBe(2633);
       expect(result.protein).toBe(165); // 75 * 2.2
+    });
+    it("uses rmr_override when provided", () => {
+      const profile: NutritionProfile = { ...baseProfile, rmr_override: 1750 };
+      const result = calculateFromProfile(profile);
+      // TDEE = 1750 * 1.55 = 2712.5, calories = round(2712.5) = 2713
+      expect(result.calories).toBe(2713);
+    });
+
+    it("ignores rmr_override when null", () => {
+      const profile: NutritionProfile = { ...baseProfile, rmr_override: null };
+      const result = calculateFromProfile(profile);
+      const baseline = calculateFromProfile(baseProfile);
+      expect(result.calories).toBe(baseline.calories);
+    });
+
+    it("ignores rmr_override when 0", () => {
+      const profile: NutritionProfile = { ...baseProfile, rmr_override: 0 };
+      const result = calculateFromProfile(profile);
+      const baseline = calculateFromProfile(baseProfile);
+      expect(result.calories).toBe(baseline.calories);
+    });
+
+    it("applies calorie floor with low rmr_override", () => {
+      const profile: NutritionProfile = {
+        ...baseProfile,
+        rmr_override: 500,
+        activityLevel: "sedentary",
+        goal: "cut",
+      };
+      const result = calculateFromProfile(profile);
+      // TDEE = 500 * 1.2 = 600, 600 - 500 = 100 → floor 1200
+      expect(result.calories).toBe(1200);
+      expect(result.belowFloor).toBe(true);
+    });
+  });
+
+  describe("calculateDeviationPercent", () => {
+    it("calculates percentage deviation accurately", () => {
+      // 2000 vs 1700 → |300/1700| * 100 = 17.65%
+      expect(calculateDeviationPercent(2000, 1700)).toBeCloseTo(17.65, 1);
+    });
+
+    it("returns 0 when estimatedBMR is 0", () => {
+      expect(calculateDeviationPercent(1750, 0)).toBe(0);
+    });
+
+    it("returns absolute deviation for values below estimate", () => {
+      // 1400 vs 1700 → |300/1700| * 100 = 17.65%
+      expect(calculateDeviationPercent(1400, 1700)).toBeCloseTo(17.65, 1);
     });
   });
 

--- a/components/BodyProfileForm.tsx
+++ b/components/BodyProfileForm.tsx
@@ -1,11 +1,12 @@
-import React from "react";
-import { StyleSheet } from "react-native";
+import React, { useState } from "react";
+import { Pressable, StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Input } from "@/components/ui/input";
 import { SegmentedControl } from "@/components/ui/segmented-control";
 import { ActivityDropdown } from "./profile/ActivityDropdown";
 import { GOAL_LABELS, type ActivityLevel, type Goal, type Sex } from "../lib/nutrition-calc";
 import { fontSizes } from "@/constants/design-tokens";
+import { useThemeColors } from "@/hooks/useThemeColors";
 
 const SEX_BUTTONS = [
   { value: "male", label: "Male", accessibilityLabel: "Male" },
@@ -29,12 +30,18 @@ type Props = {
   activityMenuVisible: boolean; setActivityMenuVisible: (v: boolean) => void;
   handleFieldBlur: (field: string, value: string) => void;
   handleSegmentChange: (field: "sex" | "activityLevel" | "goal", value: string) => void;
+  rmrOverride: string;
+  handleRmrChange: (v: string) => void;
+  clearRmrOverride: () => void;
+  rmrDeviationInfo: { deviation: number; estimated: number } | null;
 };
 
 type SegButton = { value: string; label: string; accessibilityLabel: string };
 
 export function BodyProfileForm(props: Props) {
   const { colors, handleFieldBlur, handleSegmentChange } = props;
+  const themeColors = useThemeColors();
+  const [tooltipVisible, setTooltipVisible] = useState(false);
 
   return (
     <>
@@ -79,6 +86,68 @@ export function BodyProfileForm(props: Props) {
         value={props.goal} onValueChange={(v) => handleSegmentChange("goal", v)}
         buttons={GOAL_BUTTONS as unknown as SegButton[]} style={styles.segmented}
       />
+
+      {/* RMR Override — optional advanced field */}
+      <View style={styles.rmrContainer}>
+        <View style={styles.rmrLabelRow}>
+          <Text variant="caption" style={[styles.fieldLabel, { color: colors.onSurface, fontWeight: "600", marginBottom: 0 }]}>
+            Measured RMR (optional)
+          </Text>
+          <Pressable
+            onPress={() => setTooltipVisible(!tooltipVisible)}
+            hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+            accessibilityLabel="Help: What is Measured RMR"
+            accessibilityRole="button"
+            style={styles.tooltipButton}
+          >
+            <Text variant="caption" style={{ color: themeColors.primary, fontSize: fontSizes.sm }}>ⓘ</Text>
+          </Pressable>
+        </View>
+
+        {tooltipVisible && (
+          <Text
+            variant="caption"
+            style={[styles.tooltipText, { color: themeColors.onSurfaceVariant, backgroundColor: themeColors.surfaceVariant }]}
+          >
+            Enter your Resting Metabolic Rate from a clinical metabolic test (indirect calorimetry). Do not use smart scale or fitness tracker estimates — they&apos;re often less accurate than our built-in formula. Leave blank to use automatic calculation.
+          </Text>
+        )}
+
+        <View style={styles.rmrInputRow}>
+          <Input
+            value={props.rmrOverride}
+            onChangeText={props.handleRmrChange}
+            keyboardType="numeric"
+            variant="outline"
+            containerStyle={styles.rmrInput}
+            placeholder="e.g. 1750"
+            accessibilityLabel="Measured resting metabolic rate in kilocalories per day"
+            accessibilityHint="Optional: enter your clinically measured RMR for more accurate calorie targets"
+          />
+          <Text variant="caption" style={[styles.rmrSuffix, { color: themeColors.onSurfaceVariant }]}>kcal/day</Text>
+          {props.rmrOverride ? (
+            <Pressable
+              onPress={props.clearRmrOverride}
+              hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+              accessibilityLabel="Clear measured RMR value"
+              accessibilityRole="button"
+              style={styles.clearButton}
+            >
+              <Text variant="caption" style={{ color: themeColors.onSurfaceVariant, fontSize: fontSizes.base }}>×</Text>
+            </Pressable>
+          ) : null}
+        </View>
+
+        {props.rmrDeviationInfo && (
+          <Text
+            variant="caption"
+            accessibilityLiveRegion="polite"
+            style={[styles.deviationWarning, { color: themeColors.tertiary }]}
+          >
+            This value is {props.rmrDeviationInfo.deviation}% different from the estimated {props.rmrDeviationInfo.estimated} kcal. Double-check it&apos;s from a clinical metabolic test.
+          </Text>
+        )}
+      </View>
     </>
   );
 }
@@ -87,4 +156,13 @@ const styles = StyleSheet.create({
   input: { marginBottom: 4 },
   fieldLabel: { marginTop: 16, marginBottom: 8, fontSize: fontSizes.sm },
   segmented: { marginBottom: 8 },
+  rmrContainer: { marginTop: 16 },
+  rmrLabelRow: { flexDirection: "row", alignItems: "center", marginBottom: 8 },
+  tooltipButton: { marginLeft: 6, minWidth: 48, minHeight: 48, alignItems: "center", justifyContent: "center" },
+  tooltipText: { fontSize: fontSizes.xs, padding: 10, borderRadius: 6, marginBottom: 8, lineHeight: 18 },
+  rmrInputRow: { flexDirection: "row", alignItems: "center" },
+  rmrInput: { flex: 1, marginBottom: 0 },
+  rmrSuffix: { marginLeft: 8, fontSize: fontSizes.sm },
+  clearButton: { marginLeft: 8, minWidth: 48, minHeight: 48, alignItems: "center", justifyContent: "center" },
+  deviationWarning: { fontSize: fontSizes.xs, marginTop: 6, lineHeight: 18 },
 });

--- a/hooks/useBodyProfile.ts
+++ b/hooks/useBodyProfile.ts
@@ -5,6 +5,9 @@ import { getBodySettings, getLatestBodyWeight, updateBodySex } from "../lib/db/b
 import { useToast } from "@/components/ui/bna-toast";
 import {
   calculateFromProfile,
+  calculateBMR,
+  convertToMetric,
+  calculateDeviationPercent,
   migrateProfile,
   type ActivityLevel,
   type Goal,
@@ -41,6 +44,7 @@ export function useBodyProfile() {
   const [heightUnit, setHeightUnit] = useState<"cm" | "in">("cm");
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [activityMenuVisible, setActivityMenuVisible] = useState(false);
+  const [rmrOverride, setRmrOverride] = useState("");
   const toast = useToast();
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMounted = useRef(true);
@@ -73,6 +77,9 @@ export function useBodyProfile() {
         setHeight(String(profile.height));
         setActivityLevel(profile.activityLevel);
         setGoal(profile.goal);
+        if (profile.rmr_override != null && profile.rmr_override > 0) {
+          setRmrOverride(String(profile.rmr_override));
+        }
         initialSnapshot.current = JSON.stringify(profile);
       } else if (latestWeight) {
         setWeight(String(latestWeight.weight));
@@ -92,12 +99,14 @@ export function useBodyProfile() {
   async function saveProfile(
     birthYearVal: string, weightVal: string, heightVal: string,
     sexVal: Sex, actVal: ActivityLevel, goalVal: Goal,
+    rmrVal?: string,
   ) {
     if (validateField("birthYear", birthYearVal) || validateField("weight", weightVal) || validateField("height", heightVal)) {
       return;
     }
 
     try {
+      const rmrNum = rmrVal ? parseFloat(rmrVal) : null;
       const profile: NutritionProfile = {
         birthYear: parseInt(birthYearVal, 10),
         weight: parseFloat(weightVal),
@@ -107,6 +116,7 @@ export function useBodyProfile() {
         goal: goalVal,
         weightUnit,
         heightUnit,
+        ...(rmrNum != null && rmrNum > 0 ? { rmr_override: rmrNum } : {}),
       };
 
       const profileJson = JSON.stringify(profile);
@@ -125,10 +135,11 @@ export function useBodyProfile() {
   function debouncedSave(
     birthYearVal: string, weightVal: string, heightVal: string,
     sexVal: Sex, actVal: ActivityLevel, goalVal: Goal,
+    rmrVal?: string,
   ) {
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => {
-      saveProfile(birthYearVal, weightVal, heightVal, sexVal, actVal, goalVal);
+      saveProfile(birthYearVal, weightVal, heightVal, sexVal, actVal, goalVal, rmrVal);
     }, 300);
   }
 
@@ -139,7 +150,7 @@ export function useBodyProfile() {
       if (err) next[field] = err; else delete next[field];
       return next;
     });
-    if (!err) saveProfile(birthYear, weight, height, sex, activityLevel, goal);
+    if (!err) saveProfile(birthYear, weight, height, sex, activityLevel, goal, rmrOverride);
   }
 
   function handleSegmentChange(field: "sex" | "activityLevel" | "goal", value: string) {
@@ -151,8 +162,35 @@ export function useBodyProfile() {
     else if (field === "activityLevel") { newAct = value as ActivityLevel; setActivityLevel(newAct); }
     else if (field === "goal") { newGoal = value as Goal; setGoal(newGoal); }
 
-    debouncedSave(birthYear, weight, height, newSex, newAct, newGoal);
+    debouncedSave(birthYear, weight, height, newSex, newAct, newGoal, rmrOverride);
   }
+
+  function handleRmrChange(value: string) {
+    setRmrOverride(value);
+    debouncedSave(birthYear, weight, height, sex, activityLevel, goal, value);
+  }
+
+  function clearRmrOverride() {
+    setRmrOverride("");
+    debouncedSave(birthYear, weight, height, sex, activityLevel, goal, "");
+  }
+
+  // Compute deviation info for the UI
+  const rmrDeviationInfo = (() => {
+    const rmrNum = parseFloat(rmrOverride);
+    if (!rmrOverride || isNaN(rmrNum) || rmrNum <= 0) return null;
+
+    const weightNum = parseFloat(weight);
+    const heightNum = parseFloat(height);
+    const birthYearNum = parseInt(birthYear, 10);
+    if (!weight || isNaN(weightNum) || !height || isNaN(heightNum) || !birthYear || isNaN(birthYearNum)) return null;
+
+    const { weight_kg, height_cm } = convertToMetric(weightNum, weightUnit, heightNum, heightUnit);
+    const age = new Date().getFullYear() - birthYearNum;
+    const estimatedBMR = calculateBMR(weight_kg, height_cm, age, sex);
+    const deviation = calculateDeviationPercent(rmrNum, estimatedBMR);
+    return deviation > 20 ? { deviation: Math.round(deviation), estimated: Math.round(estimatedBMR) } : null;
+  })();
 
   return {
     cardState, loadProfile,
@@ -160,5 +198,6 @@ export function useBodyProfile() {
     sex, activityLevel, goal, weightUnit, heightUnit,
     errors, activityMenuVisible, setActivityMenuVisible,
     handleFieldBlur, handleSegmentChange,
+    rmrOverride, handleRmrChange, clearRmrOverride, rmrDeviationInfo,
   };
 }

--- a/lib/nutrition-calc.ts
+++ b/lib/nutrition-calc.ts
@@ -30,6 +30,7 @@ export interface NutritionProfile {
   goal: Goal;
   weightUnit: "kg" | "lb";
   heightUnit: "cm" | "in";
+  rmr_override?: number | null;
 }
 
 const ACTIVITY_MULTIPLIERS: Record<ActivityLevel, number> = {
@@ -95,6 +96,14 @@ export function calculateMacros(
 }
 
 /**
+ * Calculate absolute percentage deviation between a user-provided RMR and the formula estimate.
+ */
+export function calculateDeviationPercent(inputRMR: number, estimatedBMR: number): number {
+  if (estimatedBMR === 0) return 0;
+  return Math.abs(((inputRMR - estimatedBMR) / estimatedBMR) * 100);
+}
+
+/**
  * Parse a raw profile object into a typed NutritionProfile.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- handles raw JSON input
@@ -111,7 +120,8 @@ export function calculateFromProfile(profile: NutritionProfile): MacroTargets & 
   );
 
   const age = new Date().getFullYear() - profile.birthYear;
-  const bmr = calculateBMR(weight_kg, height_cm, age, profile.sex);
+  const useOverride = profile.rmr_override != null && profile.rmr_override > 0;
+  const bmr = useOverride ? profile.rmr_override! : calculateBMR(weight_kg, height_cm, age, profile.sex);
   const tdee = calculateTDEE(bmr, profile.activityLevel);
   const rawCalories = tdee + GOAL_ADJUSTMENTS[profile.goal];
   const belowFloor = rawCalories < CALORIE_FLOOR;


### PR DESCRIPTION
## Summary

Add optional Measured RMR input to the body profile so users with clinical metabolic testing can get accurate calorie/macro targets instead of relying on the Mifflin-St Jeor estimate.

## Changes

- **lib/nutrition-calc.ts**: Add `rmr_override` field to `NutritionProfile`, `calculateDeviationPercent()` helper, and override logic in `calculateFromProfile()`
- **hooks/useBodyProfile.ts**: Manage RMR state, compute deviation info for UI warning, pass through save pipeline
- **components/BodyProfileForm.tsx**: Add RMR numeric input with help tooltip (ⓘ), clear button (×), and inline >20% deviation warning
- **Accessibility**: `accessibilityLabel` on input/buttons, `accessibilityLiveRegion="polite"` on warning, 48dp tap targets via hitSlop
- **Tests**: 7 new tests covering override logic, null/0 fallback, calorie floor interaction, deviation calculation

## Testing

- `npx tsc --noEmit` — passes
- `npx jest __tests__/lib/nutrition-calc.test.ts` — 30/30 pass (7 new)
- `npx jest __tests__/components/BodyProfileCard.test.tsx` — 2/2 pass
- `npx eslint` — zero warnings

## Issue

Resolves BLD-429