### PR TITLE
feat: per-muscle volume landmarks with customization (BLD-431)

### DIFF
--- a/__tests__/acceptance/muscle-volume.test.tsx
+++ b/__tests__/acceptance/muscle-volume.test.tsx
@@ -13,6 +13,11 @@ jest.mock('../../lib/db', () => ({
   getMuscleVolumeTrend: (...a: unknown[]) => mockGetMuscleVolumeTrend(...a),
 }))
 
+jest.mock('../../lib/db/settings', () => ({
+  getAppSetting: jest.fn().mockResolvedValue(null),
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+}))
+
 jest.mock('expo-router', () => {
   const RealReact = require('react')
   return {
@@ -100,10 +105,10 @@ describe('MuscleVolumeSegment — Rendering', () => {
   })
 
   it('shows weekly set counts for each muscle group', async () => {
-    const { findByLabelText } = renderScreen(<MuscleVolumeSegment />)
-    expect(await findByLabelText('Chest: 15 sets')).toBeTruthy()
-    expect(await findByLabelText('Back: 18 sets')).toBeTruthy()
-    expect(await findByLabelText('Shoulders: 12 sets')).toBeTruthy()
+    const { findAllByLabelText } = renderScreen(<MuscleVolumeSegment />)
+    expect((await findAllByLabelText(/Chest: 15 sets/)).length).toBeGreaterThan(0)
+    expect((await findAllByLabelText(/Back: 18 sets/)).length).toBeGreaterThan(0)
+    expect((await findAllByLabelText(/Shoulders: 12 sets/)).length).toBeGreaterThan(0)
   })
 
   it('shows exercise count in list row a11y labels', async () => {
@@ -112,9 +117,10 @@ describe('MuscleVolumeSegment — Rendering', () => {
     expect(await findByLabelText('Back: 18 sets from 4 exercises')).toBeTruthy()
   })
 
-  it('shows MEV landmark label', async () => {
+  it('shows MEV landmark value when muscle is selected', async () => {
     const { findByText } = renderScreen(<MuscleVolumeSegment />)
-    expect(await findByText('MEV')).toBeTruthy()
+    // First muscle (chest) is auto-selected, MEV label shows for selected muscle
+    expect(await findByText(/MEV: \d+/)).toBeTruthy()
   })
 })
 
@@ -151,7 +157,7 @@ describe('MuscleVolumeSegment — Week Navigation', () => {
 describe('MuscleVolumeSegment — Muscle Selection', () => {
   it('selecting a muscle group loads its trend', async () => {
     const { findByLabelText } = renderScreen(<MuscleVolumeSegment />)
-    const backRow = await findByLabelText('Back: 18 sets')
+    const backRow = await findByLabelText('Back: 18 sets from 4 exercises')
     fireEvent.press(backRow)
 
     await waitFor(() => {
@@ -167,7 +173,7 @@ describe('MuscleVolumeSegment — Muscle Selection', () => {
 
   it('changes trend title when different muscle is selected', async () => {
     const { findByLabelText, findByText } = renderScreen(<MuscleVolumeSegment />)
-    const backRow = await findByLabelText('Back: 18 sets')
+    const backRow = await findByLabelText('Back: 18 sets from 4 exercises')
     fireEvent.press(backRow)
 
     await waitFor(async () => {

--- a/__tests__/lib/volume-landmarks.test.ts
+++ b/__tests__/lib/volume-landmarks.test.ts
@@ -1,0 +1,110 @@
+import {
+  DEFAULT_LANDMARKS,
+  mergeWithDefaults,
+  parseCustomLandmarks,
+  getVolumeStatus,
+  getVolumeStatusLabel,
+} from '../../lib/volume-landmarks'
+import type { VolumeLandmarks } from '../../lib/volume-landmarks'
+
+describe('volume-landmarks — defaults', () => {
+  it('provides landmarks for all 14 muscle groups', () => {
+    const keys = Object.keys(DEFAULT_LANDMARKS)
+    expect(keys).toHaveLength(14)
+    expect(keys).toContain('chest')
+    expect(keys).toContain('full_body')
+  })
+
+  it('all defaults have MEV < MRV', () => {
+    for (const lm of Object.values(DEFAULT_LANDMARKS)) {
+      expect(lm.mev).toBeLessThan(lm.mrv)
+    }
+  })
+})
+
+describe('volume-landmarks — mergeWithDefaults', () => {
+  it('returns defaults when custom is null', () => {
+    const result = mergeWithDefaults(null)
+    expect(result).toEqual(DEFAULT_LANDMARKS)
+  })
+
+  it('overrides specific muscle when custom provided', () => {
+    const custom: Partial<Record<string, VolumeLandmarks>> = {
+      chest: { mev: 12, mrv: 24 },
+    }
+    const result = mergeWithDefaults(custom)
+    expect(result.chest).toEqual({ mev: 12, mrv: 24 })
+    expect(result.back).toEqual(DEFAULT_LANDMARKS.back)
+  })
+
+  it('ignores unknown keys in custom', () => {
+    const custom = { nonexistent_muscle: { mev: 5, mrv: 10 } }
+    const result = mergeWithDefaults(custom)
+    expect(result).toEqual(DEFAULT_LANDMARKS)
+    expect((result as Record<string, unknown>)['nonexistent_muscle']).toBeUndefined()
+  })
+})
+
+describe('volume-landmarks — parseCustomLandmarks', () => {
+  it('returns null for null input', () => {
+    expect(parseCustomLandmarks(null)).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(parseCustomLandmarks('')).toBeNull()
+  })
+
+  it('returns null for malformed JSON', () => {
+    expect(parseCustomLandmarks('{{invalid')).toBeNull()
+  })
+
+  it('returns null for array JSON', () => {
+    expect(parseCustomLandmarks('[1,2,3]')).toBeNull()
+  })
+
+  it('returns null for primitive JSON', () => {
+    expect(parseCustomLandmarks('"hello"')).toBeNull()
+  })
+
+  it('parses valid JSON object', () => {
+    const input = JSON.stringify({ chest: { mev: 12, mrv: 24 } })
+    const result = parseCustomLandmarks(input)
+    expect(result).toEqual({ chest: { mev: 12, mrv: 24 } })
+  })
+})
+
+describe('volume-landmarks — getVolumeStatus', () => {
+  const lm: VolumeLandmarks = { mev: 10, mrv: 20 }
+
+  it.each([
+    [0, 'below_mev'],
+    [5, 'below_mev'],
+    [9, 'below_mev'],
+    [10, 'optimal'],
+    [15, 'optimal'],
+    [20, 'optimal'],
+    [21, 'above_mrv'],
+    [50, 'above_mrv'],
+  ] as const)('classifies %d sets as %s', (sets, expected) => {
+    expect(getVolumeStatus(sets, lm)).toBe(expected)
+  })
+})
+
+describe('volume-landmarks — getVolumeStatusLabel', () => {
+  it('maps statuses to human-readable labels', () => {
+    expect(getVolumeStatusLabel('below_mev')).toBe('below MEV')
+    expect(getVolumeStatusLabel('optimal')).toBe('in optimal range')
+    expect(getVolumeStatusLabel('above_mrv')).toBe('above MRV')
+  })
+})
+
+describe('volume-landmarks — maxSets dynamic calculation', () => {
+  it('maxSets uses max MRV, not flat 20', () => {
+    const merged = mergeWithDefaults(null)
+    const allMrvValues = Object.values(merged).map((l) => l.mrv)
+    const maxMrv = Math.max(...allMrvValues)
+    // back and lats have MRV=25, so maxSets floor should be 25
+    expect(maxMrv).toBe(25)
+    expect(maxMrv).toBeGreaterThan(20)
+  })
+})

--- a/__tests__/lib/volume-landmarks.test.ts
+++ b/__tests__/lib/volume-landmarks.test.ts
@@ -98,6 +98,20 @@ describe('volume-landmarks — getVolumeStatusLabel', () => {
   })
 })
 
+describe('volume-landmarks — stepper constraints', () => {
+  it('allows MEV = MRV (narrow zone)', () => {
+    const lm: VolumeLandmarks = { mev: 12, mrv: 12 }
+    expect(getVolumeStatus(12, lm)).toBe('optimal')
+    expect(getVolumeStatus(11, lm)).toBe('below_mev')
+    expect(getVolumeStatus(13, lm)).toBe('above_mrv')
+  })
+
+  it('getVolumeStatus handles MEV=0 correctly', () => {
+    const lm: VolumeLandmarks = { mev: 0, mrv: 10 }
+    expect(getVolumeStatus(0, lm)).toBe('optimal')
+  })
+})
+
 describe('volume-landmarks — maxSets dynamic calculation', () => {
   it('maxSets uses max MRV, not flat 20', () => {
     const merged = mergeWithDefaults(null)

--- a/components/MuscleVolumeSegment.tsx
+++ b/components/MuscleVolumeSegment.tsx
@@ -1,17 +1,19 @@
-import React from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { Pressable, StyleSheet, View, FlatList } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
-import { ChevronLeft, ChevronRight } from "lucide-react-native";
+import { ChevronLeft, ChevronRight, SlidersHorizontal } from "lucide-react-native";
 import { MUSCLE_LABELS } from "../lib/types";
 import { useLayout } from "../lib/layout";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useMuscleVolume } from "@/hooks/useMuscleVolume";
 import type { VolumeRow } from "@/hooks/useMuscleVolume";
+import { getVolumeStatus } from "../lib/volume-landmarks";
 import VolumeBarChart from "./muscle-volume/VolumeBarChart";
 import VolumeTrendChart from "./muscle-volume/VolumeTrendChart";
+import VolumeLandmarksSheet from "./muscle-volume/VolumeLandmarksSheet";
 
 const MuscleRow = React.memo(function MuscleRow({
   item,
@@ -64,7 +66,36 @@ export default function MuscleVolumeSegment() {
   const {
     offset, setOffset, data, trend, selected, selectMuscle,
     loading, error, load, monday, maxSets, hasEnoughTrend, reduced, formatRange,
+    landmarks, saveLandmark, resetLandmark, resetAllLandmarks,
   } = useMuscleVolume();
+  const [sheetVisible, setSheetVisible] = useState(false);
+
+  const volumeSummary = useMemo(() => {
+    if (data.length === 0) return null;
+    let underMev = 0;
+    let overMrv = 0;
+    for (const row of data) {
+      const status = getVolumeStatus(row.sets, landmarks[row.muscle]);
+      if (status === "below_mev") underMev++;
+      if (status === "above_mrv") overMrv++;
+    }
+    if (underMev === 0 && overMrv === 0) return null;
+    const parts: string[] = [];
+    if (underMev > 0) parts.push(`${underMev} muscle${underMev > 1 ? "s" : ""} under MEV`);
+    if (overMrv > 0) parts.push(`${overMrv} muscle${overMrv > 1 ? "s" : ""} over MRV`);
+    return parts.join(" · ");
+  }, [data, landmarks]);
+
+  const handleSummaryPress = useCallback(() => {
+    // Find first muscle outside optimal and select it
+    for (const row of data) {
+      const status = getVolumeStatus(row.sets, landmarks[row.muscle]);
+      if (status !== "optimal") {
+        selectMuscle(row.muscle);
+        return;
+      }
+    }
+  }, [data, landmarks, selectMuscle]);
 
   const chartWidth = layout.atLeastMedium
     ? (layout.width - 96) / 2 - 32
@@ -149,13 +180,42 @@ export default function MuscleVolumeSegment() {
           {/* Volume Bars + Trend flow side by side on tablet */}
           <View style={layout.atLeastMedium ? styles.flowRow : undefined}>
           <Card style={StyleSheet.flatten([styles.card, layout.atLeastMedium && styles.flowCard, { backgroundColor: colors.surface }])}>
+            <View style={styles.chartHeader}>
+              <View style={{ flex: 1 }} />
+              <Button
+                variant="ghost"
+                size="sm"
+                onPress={() => setSheetVisible(true)}
+                accessibilityLabel="Customize volume targets"
+                style={styles.customizeBtn}
+              >
+                <SlidersHorizontal size={16} color={colors.onSurfaceVariant} />
+                <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 4 }}>
+                  Customize
+                </Text>
+              </Button>
+            </View>
             <VolumeBarChart
               data={data}
               selected={selected}
               maxSets={maxSets}
               onSelect={selectMuscle}
               colors={colors}
+              landmarks={landmarks}
             />
+            {volumeSummary && (
+              <Pressable
+                onPress={handleSummaryPress}
+                style={styles.summaryRow}
+                accessibilityRole="button"
+                accessibilityLabel={volumeSummary}
+                accessibilityHint="Tap to highlight relevant muscles"
+              >
+                <Text variant="caption" style={{ color: colors.tertiary, textAlign: "center" }}>
+                  {volumeSummary}
+                </Text>
+              </Pressable>
+            )}
           </Card>
 
           <Card style={StyleSheet.flatten([styles.card, layout.atLeastMedium && styles.flowCard, { backgroundColor: colors.surface }])}>
@@ -196,6 +256,14 @@ export default function MuscleVolumeSegment() {
           </Card>
         </>
       )}
+      <VolumeLandmarksSheet
+        visible={sheetVisible}
+        onClose={() => setSheetVisible(false)}
+        landmarks={landmarks}
+        onSave={saveLandmark}
+        onReset={resetLandmark}
+        onResetAll={resetAllLandmarks}
+      />
     </View>
   );
 }
@@ -236,5 +304,19 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     borderBottomWidth: StyleSheet.hairlineWidth,
     minHeight: 48,
+  },
+  chartHeader: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    paddingHorizontal: 12,
+    paddingTop: 8,
+  },
+  customizeBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  summaryRow: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
   },
 });

--- a/components/muscle-volume/VolumeBarChart.tsx
+++ b/components/muscle-volume/VolumeBarChart.tsx
@@ -7,9 +7,8 @@ import type { MuscleGroup } from "../../lib/types";
 import { MUSCLE_LABELS } from "../../lib/types";
 import type { VolumeRow } from "../../hooks/useMuscleVolume";
 import type { ThemeColors } from "@/hooks/useThemeColors";
-
-const MEV = 10;
-const MRV = 20;
+import type { VolumeLandmarks } from "../../lib/volume-landmarks";
+import { getVolumeStatus, getVolumeStatusLabel } from "../../lib/volume-landmarks";
 
 type Props = {
   data: VolumeRow[];
@@ -17,41 +16,44 @@ type Props = {
   maxSets: number;
   onSelect: (muscle: MuscleGroup) => void;
   colors: ThemeColors;
+  landmarks: Record<MuscleGroup, VolumeLandmarks>;
 };
 
-export default function VolumeBarChart({ data, selected, maxSets, onSelect, colors }: Props) {
-  const mevPos = (MEV / maxSets) * 100;
-  const mrvPos = (MRV / maxSets) * 100;
+function getBarColor(
+  sets: number,
+  lm: VolumeLandmarks,
+  colors: ThemeColors,
+  active: boolean
+): string {
+  const status = getVolumeStatus(sets, lm);
+  const opacity = active ? "" : "99";
+  switch (status) {
+    case "below_mev":
+      return colors.surfaceVariant;
+    case "optimal":
+      return colors.primary + opacity;
+    case "above_mrv":
+      return colors.tertiary + opacity;
+  }
+}
 
+export default function VolumeBarChart({
+  data, selected, maxSets, onSelect, colors, landmarks,
+}: Props) {
   return (
     <CardContent>
       <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
         Sets per Muscle Group
       </Text>
       <View style={styles.bars}>
-        {/* Landmark labels */}
-        <View style={styles.landmarks}>
-          {mevPos < 95 && (
-            <View style={[styles.landmark, { left: `${mevPos}%` }]}>
-              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-                MEV
-              </Text>
-              <View style={[styles.dottedLine, { borderColor: colors.outlineVariant }]} />
-            </View>
-          )}
-          {mrvPos < 95 && (
-            <View style={[styles.landmark, { left: `${mrvPos}%` }]}>
-              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-                MRV
-              </Text>
-              <View style={[styles.dottedLine, { borderColor: colors.outlineVariant }]} />
-            </View>
-          )}
-        </View>
-
         {data.map((item) => {
           const pct = (item.sets / maxSets) * 100;
           const active = item.muscle === selected;
+          const lm = landmarks[item.muscle];
+          const status = getVolumeStatus(item.sets, lm);
+          const statusLabel = getVolumeStatusLabel(status);
+          const barColor = getBarColor(item.sets, lm, colors, active);
+
           return (
             <Pressable
               key={item.muscle}
@@ -61,7 +63,7 @@ export default function VolumeBarChart({ data, selected, maxSets, onSelect, colo
                 active && { backgroundColor: colors.primary + "18" },
               ]}
               accessibilityRole="button"
-              accessibilityLabel={`${MUSCLE_LABELS[item.muscle]}: ${item.sets} sets`}
+              accessibilityLabel={`${MUSCLE_LABELS[item.muscle]}: ${item.sets} sets, ${statusLabel}`}
               accessibilityHint="Double tap to see weekly trend"
               accessibilityState={{ selected: active }}
             >
@@ -78,10 +80,11 @@ export default function VolumeBarChart({ data, selected, maxSets, onSelect, colo
                     styles.barFill,
                     {
                       width: `${pct}%`,
-                      backgroundColor: active
-                        ? colors.primary
-                        : colors.primary + "99",
+                      backgroundColor: barColor,
                       borderRadius: 4,
+                      borderStyle: status === "below_mev" ? "dashed" : "solid",
+                      borderWidth: status === "below_mev" ? 1.5 : 0,
+                      borderColor: status === "below_mev" ? colors.onSurfaceVariant : undefined,
                     },
                   ]}
                 />
@@ -95,6 +98,18 @@ export default function VolumeBarChart({ data, selected, maxSets, onSelect, colo
             </Pressable>
           );
         })}
+
+        {/* Show MEV/MRV text labels when a muscle is selected */}
+        {selected && landmarks[selected] && (
+          <View style={styles.landmarkTextRow}>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+              MEV: {landmarks[selected].mev}
+            </Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 12 }}>
+              MRV: {landmarks[selected].mrv}
+            </Text>
+          </View>
+        )}
       </View>
     </CardContent>
   );
@@ -103,26 +118,6 @@ export default function VolumeBarChart({ data, selected, maxSets, onSelect, colo
 const styles = StyleSheet.create({
   bars: {
     position: "relative",
-  },
-  landmarks: {
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    left: 72,
-    right: 36,
-  },
-  landmark: {
-    position: "absolute",
-    top: -4,
-    bottom: 0,
-    alignItems: "center",
-    width: 1,
-  },
-  dottedLine: {
-    flex: 1,
-    width: 0,
-    borderLeftWidth: 1,
-    borderStyle: "dashed",
   },
   barRow: {
     flexDirection: "row",
@@ -144,5 +139,11 @@ const styles = StyleSheet.create({
   },
   barFill: {
     height: "100%",
+  },
+  landmarkTextRow: {
+    flexDirection: "row",
+    paddingHorizontal: 4,
+    paddingTop: 4,
+    paddingLeft: 76,
   },
 });

--- a/components/muscle-volume/VolumeLandmarksSheet.tsx
+++ b/components/muscle-volume/VolumeLandmarksSheet.tsx
@@ -119,7 +119,7 @@ export default function VolumeLandmarksSheet({
       setPending((prev) => {
         const next = new Map(prev);
         const current = next.get(muscle) ?? landmarks[muscle];
-        const newMev = Math.max(MIN_MEV, Math.min(current.mrv - 1, current.mev + delta, MAX_SETS));
+        const newMev = Math.max(MIN_MEV, Math.min(current.mrv, current.mev + delta, MAX_SETS));
         next.set(muscle, { ...current, mev: newMev });
         return next;
       });
@@ -133,7 +133,7 @@ export default function VolumeLandmarksSheet({
       setPending((prev) => {
         const next = new Map(prev);
         const current = next.get(muscle) ?? landmarks[muscle];
-        const newMrv = Math.max(Math.max(MIN_MRV, current.mev + 1), Math.min(current.mrv + delta, MAX_SETS));
+        const newMrv = Math.max(Math.max(MIN_MRV, current.mev), Math.min(current.mrv + delta, MAX_SETS));
         next.set(muscle, { ...current, mrv: newMrv });
         return next;
       });

--- a/components/muscle-volume/VolumeLandmarksSheet.tsx
+++ b/components/muscle-volume/VolumeLandmarksSheet.tsx
@@ -218,7 +218,7 @@ export default function VolumeLandmarksSheet({
                   onDecrement={() => handleMevChange(muscle, -1)}
                   onIncrement={() => handleMevChange(muscle, 1)}
                   min={MIN_MEV}
-                  max={Math.min(lm.mrv - 1, MAX_SETS)}
+                  max={Math.min(lm.mrv, MAX_SETS)}
                   colors={colors}
                 />
                 <NumericStepper
@@ -226,7 +226,7 @@ export default function VolumeLandmarksSheet({
                   value={lm.mrv}
                   onDecrement={() => handleMrvChange(muscle, -1)}
                   onIncrement={() => handleMrvChange(muscle, 1)}
-                  min={Math.max(MIN_MRV, lm.mev + 1)}
+                  min={Math.max(MIN_MRV, lm.mev)}
                   max={MAX_SETS}
                   colors={colors}
                 />

--- a/components/muscle-volume/VolumeLandmarksSheet.tsx
+++ b/components/muscle-volume/VolumeLandmarksSheet.tsx
@@ -1,0 +1,276 @@
+/* eslint-disable max-lines-per-function */
+import React, { useCallback, useState } from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { MUSCLE_LABELS } from "../../lib/types";
+import type { MuscleGroup } from "../../lib/types";
+import type { VolumeLandmarks } from "../../lib/volume-landmarks";
+import { DEFAULT_LANDMARKS } from "../../lib/volume-landmarks";
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  landmarks: Record<MuscleGroup, VolumeLandmarks>;
+  onSave: (muscle: MuscleGroup, value: VolumeLandmarks) => void;
+  onReset: (muscle: MuscleGroup) => void;
+  onResetAll: () => void;
+};
+
+const MUSCLE_KEYS = Object.keys(MUSCLE_LABELS) as MuscleGroup[];
+const MIN_MEV = 0;
+const MIN_MRV = 1;
+const MAX_SETS = 50;
+
+function NumericStepper({
+  label,
+  value,
+  onIncrement,
+  onDecrement,
+  min,
+  max,
+  colors,
+}: {
+  label: string;
+  value: number;
+  onIncrement: () => void;
+  onDecrement: () => void;
+  min: number;
+  max: number;
+  colors: ReturnType<typeof useThemeColors>;
+}) {
+  return (
+    <View style={stepperStyles.container}>
+      <Text variant="caption" style={{ color: colors.onSurfaceVariant, width: 36 }}>
+        {label}
+      </Text>
+      <Button
+        variant="secondary"
+        size="sm"
+        onPress={onDecrement}
+        disabled={value <= min}
+        accessibilityLabel={`Decrease ${label}`}
+        style={stepperStyles.btn}
+      >
+        <Text>−</Text>
+      </Button>
+      <Text
+        variant="body"
+        style={{ color: colors.onSurface, width: 32, textAlign: "center", fontWeight: "600" }}
+        accessibilityLabel={`${label}: ${value}`}
+      >
+        {value}
+      </Text>
+      <Button
+        variant="secondary"
+        size="sm"
+        onPress={onIncrement}
+        disabled={value >= max}
+        accessibilityLabel={`Increase ${label}`}
+        style={stepperStyles.btn}
+      >
+        <Text>+</Text>
+      </Button>
+    </View>
+  );
+}
+
+const stepperStyles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  btn: {
+    minWidth: 40,
+    minHeight: 40,
+  },
+});
+
+export default function VolumeLandmarksSheet({
+  visible,
+  onClose,
+  landmarks,
+  onSave,
+  onReset,
+  onResetAll,
+}: Props) {
+  const colors = useThemeColors();
+  const [expanded, setExpanded] = useState<MuscleGroup | null>(null);
+  const [pending, setPending] = useState<Map<MuscleGroup, VolumeLandmarks>>(new Map());
+
+  const handleClose = useCallback(() => {
+    for (const [muscle, value] of pending.entries()) {
+      onSave(muscle, value);
+    }
+    setPending(new Map());
+    setExpanded(null);
+    onClose();
+  }, [onClose, onSave, pending]);
+
+  const handleToggle = useCallback((muscle: MuscleGroup) => {
+    setExpanded((prev) => (prev === muscle ? null : muscle));
+  }, []);
+
+  const handleMevChange = useCallback(
+    (muscle: MuscleGroup, delta: number) => {
+      setPending((prev) => {
+        const next = new Map(prev);
+        const current = next.get(muscle) ?? landmarks[muscle];
+        const newMev = Math.max(MIN_MEV, Math.min(current.mrv - 1, current.mev + delta, MAX_SETS));
+        next.set(muscle, { ...current, mev: newMev });
+        return next;
+      });
+      setExpanded(muscle);
+    },
+    [landmarks]
+  );
+
+  const handleMrvChange = useCallback(
+    (muscle: MuscleGroup, delta: number) => {
+      setPending((prev) => {
+        const next = new Map(prev);
+        const current = next.get(muscle) ?? landmarks[muscle];
+        const newMrv = Math.max(Math.max(MIN_MRV, current.mev + 1), Math.min(current.mrv + delta, MAX_SETS));
+        next.set(muscle, { ...current, mrv: newMrv });
+        return next;
+      });
+      setExpanded(muscle);
+    },
+    [landmarks]
+  );
+
+  const handleResetMuscle = useCallback(
+    (muscle: MuscleGroup) => {
+      setPending((prev) => {
+        const next = new Map(prev);
+        next.delete(muscle);
+        return next;
+      });
+      onReset(muscle);
+      setExpanded(muscle);
+    },
+    [onReset]
+  );
+
+  const handleResetAll = useCallback(() => {
+    setPending(new Map());
+    onResetAll();
+    setExpanded(null);
+  }, [onResetAll]);
+
+  return (
+    <BottomSheet
+      isVisible={visible}
+      onClose={handleClose}
+      title="Customize Volume Targets"
+      snapPoints={[0.6, 0.9]}
+    >
+      <Button
+        variant="secondary"
+        size="sm"
+        onPress={handleResetAll}
+        accessibilityLabel="Reset all volume targets to defaults"
+        style={{ marginBottom: 12, alignSelf: "flex-start" }}
+      >
+        <Text>Reset All to Defaults</Text>
+      </Button>
+
+      {MUSCLE_KEYS.map((muscle) => {
+        const lm = pending.get(muscle) ?? landmarks[muscle];
+        const isDefault =
+          lm.mev === DEFAULT_LANDMARKS[muscle].mev &&
+          lm.mrv === DEFAULT_LANDMARKS[muscle].mrv;
+        const isExpanded = expanded === muscle;
+
+        return (
+          <View key={muscle}>
+            <Pressable
+              onPress={() => handleToggle(muscle)}
+              style={[
+                styles.muscleRow,
+                { borderBottomColor: colors.outlineVariant },
+                isExpanded && { backgroundColor: colors.primary + "10" },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`${MUSCLE_LABELS[muscle]}: MEV ${lm.mev}, MRV ${lm.mrv}${isDefault ? "" : " (customized)"}`}
+              accessibilityState={{ expanded: isExpanded }}
+            >
+              <Text variant="body" style={{ color: colors.onSurface, flex: 1 }}>
+                {MUSCLE_LABELS[muscle]}
+              </Text>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                MEV {lm.mev} / MRV {lm.mrv}
+                {!isDefault ? " ✎" : ""}
+              </Text>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}>
+                {isExpanded ? "▼" : "›"}
+              </Text>
+            </Pressable>
+
+            {isExpanded && (
+              <View style={[styles.expandedArea, { backgroundColor: colors.surface }]}>
+                <NumericStepper
+                  label="MEV"
+                  value={lm.mev}
+                  onDecrement={() => handleMevChange(muscle, -1)}
+                  onIncrement={() => handleMevChange(muscle, 1)}
+                  min={MIN_MEV}
+                  max={Math.min(lm.mrv - 1, MAX_SETS)}
+                  colors={colors}
+                />
+                <NumericStepper
+                  label="MRV"
+                  value={lm.mrv}
+                  onDecrement={() => handleMrvChange(muscle, -1)}
+                  onIncrement={() => handleMrvChange(muscle, 1)}
+                  min={Math.max(MIN_MRV, lm.mev + 1)}
+                  max={MAX_SETS}
+                  colors={colors}
+                />
+                {!isDefault && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onPress={() => handleResetMuscle(muscle)}
+                    accessibilityLabel={`Reset ${MUSCLE_LABELS[muscle]} to default`}
+                    style={{ marginTop: 4 }}
+                  >
+                    <Text>Reset</Text>
+                  </Button>
+                )}
+                {lm.mev === lm.mrv && (
+                  <Text variant="caption" style={{ color: colors.tertiary, marginTop: 4 }}>
+                    Your optimal zone is very narrow
+                  </Text>
+                )}
+              </View>
+            )}
+          </View>
+        );
+      })}
+
+      <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 12, textAlign: "center" }}>
+        Based on RP hypertrophy guidelines
+      </Text>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  muscleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    minHeight: 48,
+  },
+  expandedArea: {
+    padding: 12,
+    paddingLeft: 16,
+    gap: 8,
+  },
+});

--- a/hooks/useMuscleVolume.ts
+++ b/hooks/useMuscleVolume.ts
@@ -3,12 +3,19 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { AccessibilityInfo } from "react-native";
 import { useFocusEffect } from "expo-router";
 import { getMuscleVolumeForWeek, getMuscleVolumeTrend } from "../lib/db";
+import { getAppSetting, setAppSetting } from "../lib/db/settings";
 import type { MuscleGroup } from "../lib/types";
+import type { VolumeLandmarks } from "../lib/volume-landmarks";
+import {
+  DEFAULT_LANDMARKS,
+  VOLUME_LANDMARKS_SETTING_KEY,
+  mergeWithDefaults,
+  parseCustomLandmarks,
+} from "../lib/volume-landmarks";
 
 export type VolumeRow = { muscle: MuscleGroup; sets: number; exercises: number };
 export type TrendRow = { week: string; sets: number };
 
-const MRV = 20;
 const TREND_WEEKS = 8;
 
 function mondayOfWeek(offset: number): Date {
@@ -38,13 +45,25 @@ export function useMuscleVolume() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reduced, setReduced] = useState(false);
+  const [landmarks, setLandmarks] = useState<Record<MuscleGroup, VolumeLandmarks>>(
+    { ...DEFAULT_LANDMARKS }
+  );
 
   const monday = useMemo(() => mondayOfWeek(offset), [offset]);
+
+  const loadLandmarks = useCallback(async () => {
+    const raw = await getAppSetting(VOLUME_LANDMARKS_SETTING_KEY);
+    const custom = parseCustomLandmarks(raw);
+    const merged = mergeWithDefaults(custom);
+    setLandmarks(merged);
+    return merged;
+  }, []);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
+      await loadLandmarks();
       const rows = await getMuscleVolumeForWeek(monday.getTime());
       setData(rows);
       if (rows.length > 0) {
@@ -66,7 +85,7 @@ export function useMuscleVolume() {
     } finally {
       setLoading(false);
     }
-  }, [monday]);
+  }, [monday, loadLandmarks]);
 
   useFocusEffect(
     useCallback(() => {
@@ -86,15 +105,46 @@ export function useMuscleVolume() {
     }
   }, []);
 
-  const maxSets = useMemo(
-    () => Math.max(...data.map((d) => d.sets), MRV),
-    [data]
-  );
+  const maxSets = useMemo(() => {
+    const allMrvValues = Object.values(landmarks).map((l) => l.mrv);
+    return Math.max(...data.map((d) => d.sets), ...allMrvValues);
+  }, [data, landmarks]);
 
   const hasEnoughTrend = useMemo(
     () => trend.filter((t) => t.sets > 0).length >= 2,
     [trend]
   );
+
+  const saveLandmark = useCallback(
+    async (muscle: MuscleGroup, value: VolumeLandmarks) => {
+      const raw = await getAppSetting(VOLUME_LANDMARKS_SETTING_KEY);
+      const custom = parseCustomLandmarks(raw) ?? {};
+      custom[muscle] = value;
+      await setAppSetting(VOLUME_LANDMARKS_SETTING_KEY, JSON.stringify(custom));
+      setLandmarks((prev) => ({ ...prev, [muscle]: value }));
+    },
+    []
+  );
+
+  const resetLandmark = useCallback(
+    async (muscle: MuscleGroup) => {
+      const raw = await getAppSetting(VOLUME_LANDMARKS_SETTING_KEY);
+      const custom = parseCustomLandmarks(raw) ?? {};
+      delete custom[muscle];
+      if (Object.keys(custom).length === 0) {
+        await setAppSetting(VOLUME_LANDMARKS_SETTING_KEY, "{}");
+      } else {
+        await setAppSetting(VOLUME_LANDMARKS_SETTING_KEY, JSON.stringify(custom));
+      }
+      setLandmarks((prev) => ({ ...prev, [muscle]: DEFAULT_LANDMARKS[muscle] }));
+    },
+    []
+  );
+
+  const resetAllLandmarks = useCallback(async () => {
+    await setAppSetting(VOLUME_LANDMARKS_SETTING_KEY, "{}");
+    setLandmarks({ ...DEFAULT_LANDMARKS });
+  }, []);
 
   return {
     offset,
@@ -111,5 +161,9 @@ export function useMuscleVolume() {
     hasEnoughTrend,
     reduced,
     formatRange,
+    landmarks,
+    saveLandmark,
+    resetLandmark,
+    resetAllLandmarks,
   };
 }

--- a/lib/volume-landmarks.ts
+++ b/lib/volume-landmarks.ts
@@ -1,0 +1,85 @@
+/**
+ * Evidence-based per-muscle volume landmarks (MEV / MRV).
+ * Sources: Dr. Mike Israetel / Renaissance Periodization hypertrophy guidelines, rounded.
+ */
+import type { MuscleGroup } from "./types";
+
+export type VolumeLandmarks = { mev: number; mrv: number };
+
+export const DEFAULT_LANDMARKS: Record<MuscleGroup, VolumeLandmarks> = {
+  chest:      { mev: 10, mrv: 22 },
+  back:       { mev: 10, mrv: 25 },
+  shoulders:  { mev: 8,  mrv: 22 },
+  biceps:     { mev: 8,  mrv: 22 },
+  triceps:    { mev: 6,  mrv: 18 },
+  quads:      { mev: 8,  mrv: 20 },
+  hamstrings: { mev: 6,  mrv: 16 },
+  glutes:     { mev: 4,  mrv: 16 },
+  calves:     { mev: 8,  mrv: 16 },
+  core:       { mev: 6,  mrv: 16 },
+  forearms:   { mev: 4,  mrv: 14 },
+  traps:      { mev: 6,  mrv: 18 },
+  lats:       { mev: 10, mrv: 25 },
+  full_body:  { mev: 10, mrv: 20 },
+};
+
+export const VOLUME_LANDMARKS_SETTING_KEY = "volume_landmarks_custom";
+
+/**
+ * Merge user overrides with defaults. Unknown keys silently ignored.
+ */
+export function mergeWithDefaults(
+  custom: Partial<Record<string, VolumeLandmarks>> | null
+): Record<MuscleGroup, VolumeLandmarks> {
+  if (!custom) return { ...DEFAULT_LANDMARKS };
+  const merged = { ...DEFAULT_LANDMARKS };
+  for (const key of Object.keys(custom)) {
+    if (key in merged) {
+      merged[key as MuscleGroup] = custom[key]!;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Safely parse stored custom landmarks. Returns null on malformed JSON.
+ */
+export function parseCustomLandmarks(
+  raw: string | null
+): Partial<Record<string, VolumeLandmarks>> | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Determine volume status for a muscle based on its set count and landmarks.
+ */
+export type VolumeStatus = "below_mev" | "optimal" | "above_mrv";
+
+export function getVolumeStatus(
+  sets: number,
+  landmarks: VolumeLandmarks
+): VolumeStatus {
+  if (sets < landmarks.mev) return "below_mev";
+  if (sets > landmarks.mrv) return "above_mrv";
+  return "optimal";
+}
+
+export function getVolumeStatusLabel(status: VolumeStatus): string {
+  switch (status) {
+    case "below_mev":
+      return "below MEV";
+    case "optimal":
+      return "in optimal range";
+    case "above_mrv":
+      return "above MRV";
+  }
+}


### PR DESCRIPTION
## Summary

Replace hardcoded MEV=10/MRV=20 with evidence-based per-muscle volume landmarks. Add color-coded bars, a customization bottom sheet, and a volume status summary line.

## Changes

- **`lib/volume-landmarks.ts`** (new): Default landmarks for 14 muscle groups, merge/parse utilities, status classification
- **`hooks/useMuscleVolume.ts`**: Remove hardcoded MRV=20, load custom landmarks from app_settings, dynamic maxSets calculation, add save/reset functions
- **`components/muscle-volume/VolumeBarChart.tsx`**: Color-coded bars (surfaceVariant+dashed below MEV, primary optimal, amber above MRV), MEV/MRV text labels on tap, removed global landmark lines
- **`components/muscle-volume/VolumeLandmarksSheet.tsx`** (new): Accordion bottom sheet for per-muscle MEV/MRV editing with numeric steppers, Reset, and validation
- **`components/MuscleVolumeSegment.tsx`**: Customize button, landmarks prop passing, volume status summary line
- **`__tests__/lib/volume-landmarks.test.ts`** (new): 21 tests for landmarks logic
- **`__tests__/acceptance/muscle-volume.test.tsx`**: Updated existing tests for new a11y labels

## Testing

- 36 tests pass (15 existing + 21 new)
- TypeScript: zero errors
- ESLint: zero warnings
- Test budget: 1716/1800 (84 remaining)

## Issue

Resolves BLD-431