### PR TITLE
feat: per-exercise strength goals (BLD-433)

### DIFF
--- a/__tests__/lib/db/strength-goals.test.ts
+++ b/__tests__/lib/db/strength-goals.test.ts
@@ -139,6 +139,16 @@ describe("createGoal", () => {
 
     expect(r1.id).not.toBe(r2.id);
   });
+
+  it("throws when an active goal already exists for the exercise", async () => {
+    await createGoal({ exerciseId: "ex-1", targetWeight: 100 });
+
+    // Simulate that getGoalForExercise now finds the first goal
+    mockDrizzleGetResult = { id: "mock-id", exercise_id: "ex-1", target_weight: 100, achieved_at: null };
+
+    await expect(createGoal({ exerciseId: "ex-1", targetWeight: 120 }))
+      .rejects.toThrow("An active goal already exists for this exercise");
+  });
 });
 
 describe("getGoalForExercise", () => {

--- a/__tests__/lib/db/strength-goals.test.ts
+++ b/__tests__/lib/db/strength-goals.test.ts
@@ -1,0 +1,287 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Unit tests for strength goals CRUD (Phase 66 — BLD-433).
+ * Tests: createGoal, getGoalForExercise, getActiveGoals, updateGoal,
+ *        achieveGoal, deleteGoal, getCompletedGoals, getCurrentBestWeight/Reps.
+ */
+
+const mockStmt = {
+  executeAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  finalizeAsync: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  getFirstAsync: jest.fn().mockResolvedValue(null),
+  runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+  prepareAsync: jest.fn().mockResolvedValue(mockStmt),
+};
+
+jest.mock("expo-sqlite", () => ({
+  openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+}));
+
+let mockDrizzleGetResult: any = undefined;
+let mockDrizzleAllResult: any[] = [];
+let mockUpdateSet: any = null;
+let mockDeleteCalled = false;
+
+jest.mock("drizzle-orm/expo-sqlite", () => ({
+  drizzle: jest.fn(() => ({
+    select: jest.fn(() => {
+      const chain: any = {
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        get: jest.fn(() => mockDrizzleGetResult),
+        all: jest.fn(() => mockDrizzleAllResult),
+        then: (r: any) => Promise.resolve(mockDrizzleAllResult).then(r),
+      };
+      return chain;
+    }),
+    insert: jest.fn(() => {
+      const c: any = {
+        values: jest.fn().mockReturnThis(),
+        then: (r: any) => Promise.resolve().then(r),
+      };
+      return c;
+    }),
+    update: jest.fn(() => {
+      const c: any = {
+        set: jest.fn((s: any) => {
+          mockUpdateSet = s;
+          return c;
+        }),
+        where: jest.fn().mockReturnThis(),
+        then: (r: any) => Promise.resolve().then(r),
+      };
+      return c;
+    }),
+    delete: jest.fn(() => {
+      mockDeleteCalled = true;
+      const c: any = {
+        where: jest.fn().mockReturnThis(),
+        then: (r: any) => Promise.resolve().then(r),
+      };
+      return c;
+    }),
+  })),
+}));
+
+import {
+  createGoal,
+  getGoalForExercise,
+  getActiveGoals,
+  updateGoal,
+  achieveGoal,
+  deleteGoal,
+  getCompletedGoals,
+  getCurrentBestWeight,
+  getCurrentBestReps,
+} from "../../../lib/db/strength-goals";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDrizzleGetResult = undefined;
+  mockDrizzleAllResult = [];
+  mockUpdateSet = null;
+  mockDeleteCalled = false;
+  mockDb.getAllAsync.mockResolvedValue([]);
+  mockDb.getFirstAsync.mockResolvedValue(null);
+});
+
+describe("createGoal", () => {
+  it("creates a weight goal with correct fields", async () => {
+    const result = await createGoal({
+      exerciseId: "ex-1",
+      targetWeight: 100,
+      targetReps: null,
+      deadline: "2026-06-01",
+    });
+
+    expect(result.exercise_id).toBe("ex-1");
+    expect(result.target_weight).toBe(100);
+    expect(result.target_reps).toBeNull();
+    expect(result.deadline).toBe("2026-06-01");
+    expect(result.achieved_at).toBeNull();
+    expect(result.id).toBeTruthy();
+    expect(result.created_at).toBeTruthy();
+    expect(result.updated_at).toBeTruthy();
+  });
+
+  it("creates a bodyweight (reps) goal", async () => {
+    const result = await createGoal({
+      exerciseId: "ex-2",
+      targetReps: 20,
+    });
+
+    expect(result.exercise_id).toBe("ex-2");
+    expect(result.target_weight).toBeNull();
+    expect(result.target_reps).toBe(20);
+    expect(result.deadline).toBeNull();
+  });
+
+  it("defaults optional fields to null", async () => {
+    const result = await createGoal({ exerciseId: "ex-3" });
+
+    expect(result.target_weight).toBeNull();
+    expect(result.target_reps).toBeNull();
+    expect(result.deadline).toBeNull();
+    expect(result.achieved_at).toBeNull();
+  });
+
+  it("generates a unique ID for each goal", async () => {
+    const r1 = await createGoal({ exerciseId: "ex-1", targetWeight: 50 });
+    const r2 = await createGoal({ exerciseId: "ex-2", targetWeight: 60 });
+
+    expect(r1.id).not.toBe(r2.id);
+  });
+});
+
+describe("getGoalForExercise", () => {
+  it("returns the goal when one exists", async () => {
+    const mockGoal = {
+      id: "g-1",
+      exercise_id: "ex-1",
+      target_weight: 100,
+      target_reps: null,
+      deadline: null,
+      achieved_at: null,
+      created_at: "2026-04-20T00:00:00Z",
+      updated_at: "2026-04-20T00:00:00Z",
+    };
+    mockDrizzleGetResult = mockGoal;
+
+    const result = await getGoalForExercise("ex-1");
+    expect(result).toEqual(mockGoal);
+  });
+
+  it("returns null when no active goal exists", async () => {
+    mockDrizzleGetResult = undefined;
+
+    const result = await getGoalForExercise("ex-nonexistent");
+    expect(result).toBeNull();
+  });
+});
+
+describe("getActiveGoals", () => {
+  it("returns all active (non-achieved) goals", async () => {
+    const goals = [
+      { id: "g-1", exercise_id: "ex-1", achieved_at: null },
+      { id: "g-2", exercise_id: "ex-2", achieved_at: null },
+    ];
+    mockDrizzleAllResult = goals;
+
+    const result = await getActiveGoals();
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("g-1");
+  });
+
+  it("returns empty array when no active goals", async () => {
+    mockDrizzleAllResult = [];
+
+    const result = await getActiveGoals();
+    expect(result).toEqual([]);
+  });
+});
+
+describe("updateGoal", () => {
+  it("updates target weight", async () => {
+    await updateGoal("g-1", { targetWeight: 120 });
+    expect(mockUpdateSet).toHaveProperty("target_weight", 120);
+    expect(mockUpdateSet).toHaveProperty("updated_at");
+  });
+
+  it("updates target reps", async () => {
+    await updateGoal("g-1", { targetReps: 25 });
+    expect(mockUpdateSet).toHaveProperty("target_reps", 25);
+  });
+
+  it("updates deadline", async () => {
+    await updateGoal("g-1", { deadline: "2026-12-01" });
+    expect(mockUpdateSet).toHaveProperty("deadline", "2026-12-01");
+  });
+
+  it("clears deadline when set to null", async () => {
+    await updateGoal("g-1", { deadline: null });
+    expect(mockUpdateSet).toHaveProperty("deadline", null);
+  });
+
+  it("only updates provided fields plus updated_at", async () => {
+    await updateGoal("g-1", { targetWeight: 150 });
+    expect(mockUpdateSet).not.toHaveProperty("target_reps");
+    expect(mockUpdateSet).not.toHaveProperty("deadline");
+    expect(mockUpdateSet).toHaveProperty("updated_at");
+  });
+});
+
+describe("achieveGoal", () => {
+  it("sets achieved_at and updated_at timestamps", async () => {
+    await achieveGoal("g-1");
+    expect(mockUpdateSet).toHaveProperty("achieved_at");
+    expect(mockUpdateSet).toHaveProperty("updated_at");
+    expect(mockUpdateSet.achieved_at).toBeTruthy();
+  });
+});
+
+describe("deleteGoal", () => {
+  it("deletes the goal", async () => {
+    await deleteGoal("g-1");
+    expect(mockDeleteCalled).toBe(true);
+  });
+});
+
+describe("getCompletedGoals", () => {
+  it("returns goals with achieved_at set", async () => {
+    const completed = [
+      { id: "g-1", exercise_id: "ex-1", achieved_at: "2026-04-15T00:00:00Z" },
+    ];
+    mockDrizzleAllResult = completed;
+
+    const result = await getCompletedGoals();
+    expect(result).toHaveLength(1);
+    expect(result[0].achieved_at).toBeTruthy();
+  });
+});
+
+describe("getCurrentBestWeight", () => {
+  it("returns the max weight from completed workout sets", async () => {
+    mockDb.getAllAsync.mockResolvedValue([{ best: 95.5 }]);
+
+    const result = await getCurrentBestWeight("ex-1");
+    expect(result).toBe(95.5);
+  });
+
+  it("returns null when no completed sets exist", async () => {
+    mockDb.getAllAsync.mockResolvedValue([{ best: null }]);
+
+    const result = await getCurrentBestWeight("ex-no-history");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when query returns empty", async () => {
+    mockDb.getAllAsync.mockResolvedValue([]);
+
+    const result = await getCurrentBestWeight("ex-empty");
+    expect(result).toBeNull();
+  });
+});
+
+describe("getCurrentBestReps", () => {
+  it("returns the max reps from completed workout sets", async () => {
+    mockDb.getAllAsync.mockResolvedValue([{ best: 15 }]);
+
+    const result = await getCurrentBestReps("ex-pullups");
+    expect(result).toBe(15);
+  });
+
+  it("returns null when no completed sets exist", async () => {
+    mockDb.getAllAsync.mockResolvedValue([{ best: null }]);
+
+    const result = await getCurrentBestReps("ex-no-data");
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/lib/insights.test.ts
+++ b/__tests__/lib/insights.test.ts
@@ -4,6 +4,7 @@ import {
   type InsightData,
   type E1RMTrendRow,
   type WeeklyVolumeRow,
+  type GoalInsightRow,
 } from "../../lib/insights";
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -28,7 +29,55 @@ describe("generateInsight", () => {
     expect(generateInsight(makeData())).toBeNull();
   });
 
-  describe("strength trend (highest priority)", () => {
+  describe("goal progress (highest priority)", () => {
+    const goals: GoalInsightRow[] = [
+      { exercise_id: "e1", exercise_name: "Bench Press", progressPct: 85 },
+      { exercise_id: "e2", exercise_name: "Squat", progressPct: 60 },
+    ];
+
+    it("picks the goal with the highest progress", () => {
+      const result = generateInsight(makeData({ goalInsights: goals }));
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe("goal_progress");
+      expect(result!.title).toContain("85%");
+      expect(result!.title).toContain("Bench Press");
+      expect(result!.icon).toBe("bullseye-arrow");
+      expect(result!.exerciseId).toBe("e1");
+    });
+
+    it("includes accessibility label", () => {
+      const result = generateInsight(makeData({ goalInsights: goals }));
+      expect(result!.accessibilityLabel).toContain("Training insight:");
+      expect(result!.accessibilityLabel).toContain("Tap to view details");
+    });
+
+    it("returns null when all goals have 0% progress", () => {
+      const zeroGoals: GoalInsightRow[] = [
+        { exercise_id: "e1", exercise_name: "Bench Press", progressPct: 0 },
+      ];
+      const result = generateInsight(makeData({ goalInsights: zeroGoals }));
+      // Should fall through to null (or other insight types)
+      expect(result === null || result.type !== "goal_progress").toBe(true);
+    });
+
+    it("returns null when goalInsights is empty", () => {
+      const result = generateInsight(makeData({ goalInsights: [] }));
+      expect(result).toBeNull();
+    });
+
+    it("takes priority over strength, volume, and consistency", () => {
+      const trends: E1RMTrendRow[] = [
+        { exercise_id: "e1", name: "Squat", current_e1rm: 200, previous_e1rm: 100 },
+      ];
+      const result = generateInsight(makeData({
+        goalInsights: goals,
+        e1rmTrends: trends,
+      }));
+      expect(result!.type).toBe("goal_progress");
+    });
+  });
+
+  describe("strength trend (second priority)", () => {
     const trends: E1RMTrendRow[] = [
       { exercise_id: "e1", name: "Bench Press", current_e1rm: 105, previous_e1rm: 100 },
       { exercise_id: "e2", name: "Squat", current_e1rm: 150, previous_e1rm: 140 },

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -64,7 +64,7 @@ export default function Workouts() {
     <ScrollView style={[styles.container, { backgroundColor: colors.background }]} contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: tabBarHeight + 16 }}>
       <StatsRow colors={colors} streak={data?.streak ?? 0} weekDone={weekDone} scheduled={scheduled} prCount={(data?.recentPRs ?? []).length} />
       {insight && !insightDismissed && (
-        <InsightCard colors={colors} insight={insight} onPress={() => { if (insight.type === "strength" && insight.exerciseId) router.push(`/exercise/${insight.exerciseId}`); }} onDismiss={() => setInsightDismissed(true)} />
+        <InsightCard colors={colors} insight={insight} onPress={() => { if ((insight.type === "strength" || insight.type === "goal_progress") && insight.exerciseId) router.push(`/exercise/${insight.exerciseId}`); }} onDismiss={() => setInsightDismissed(true)} />
       )}
       <HomeBanners colors={colors} active={data?.active ?? null} todaySchedule={todaySchedule} todayDone={data?.todayDone ?? false} adherence={adherence} nextWorkout={nextWorkout} onResumeSession={(id) => router.push(`/session/${id}`)} onStartFromSchedule={startFromSchedule} onStartNextWorkout={startNextWorkout} />
       <AdherenceBar colors={colors} adherence={adherence} />

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -35,10 +35,36 @@ import ExerciseRecordsCard from "@/components/exercise/ExerciseRecordsCard";
 import ExerciseChartCard from "@/components/exercise/ExerciseChartCard";
 import StrengthLevelBadge from "@/components/exercise/StrengthLevelBadge";
 import { useStrengthLevel } from "@/hooks/useStrengthLevel";
+import { useStrengthGoal } from "@/hooks/useStrengthGoals";
+import { useBottomSheet } from "@/components/ui/bottom-sheet";
+import GoalProgressCard from "@/components/exercise/GoalProgressCard";
+import GoalSetForm from "@/components/exercise/GoalSetForm";
 import { fontSizes } from "@/constants/design-tokens";
 
 function formatDateLong(ts: number): string {
   return new Intl.DateTimeFormat(undefined, { year: "numeric", month: "short", day: "numeric" }).format(new Date(ts));
+}
+
+function GoalSection({ goalState, colors, bw, unit, onOpenSheet }: {
+  goalState: ReturnType<typeof useStrengthGoal>; colors: ReturnType<typeof useThemeColors>;
+  bw: boolean; unit: "kg" | "lb"; onOpenSheet: () => void;
+}) {
+  if (goalState.isLoading) return null;
+  if (goalState.goal) {
+    return (
+      <GoalProgressCard
+        colors={colors} goal={goalState.goal} currentBest={goalState.currentBest}
+        progressPct={goalState.progressPct} isBodyweight={bw} unit={unit}
+        onEdit={onOpenSheet}
+        onDelete={() => goalState.goal && goalState.deleteGoal(goalState.goal.id)}
+      />
+    );
+  }
+  return (
+    <Button variant="outline" onPress={onOpenSheet} label="Set Goal"
+      style={{ alignSelf: "flex-start", marginTop: 8, marginBottom: 8 }}
+      accessibilityLabel="Set a strength goal for this exercise" />
+  );
 }
 
 export default function ExerciseDetail() {
@@ -51,6 +77,8 @@ export default function ExerciseDetail() {
   const { toast: showToast } = useToast();
   const d = useExerciseDetail(id);
   const strengthLevel = useStrengthLevel(d.exercise?.name, d.records?.est_1rm ?? null, d.unit);
+  const goalSheet = useBottomSheet();
+  const goalState = useStrengthGoal(id, d.bw);
 
   const edit = useCallback(() => { if (id) router.push(`/exercise/edit/${id}`); }, [id, router]);
   const remove = useCallback(async () => {
@@ -113,6 +141,9 @@ export default function ExerciseDetail() {
             {steps.map((step, i) => <Text key={i} variant="body" style={[styles.step, { color: colors.onSurface }]}>{step}</Text>)}</View>)}
         </>
       )}
+
+      {/* Goal Progress Card — above Records/Chart for discoverability */}
+      <GoalSection goalState={goalState} colors={colors} bw={d.bw} unit={d.unit} onOpenSheet={goalSheet.open} />
 
       <FlowContainer gap={16}>
         <ExerciseRecordsCard colors={colors} records={d.records} recordsLoading={d.recordsLoading} recordsError={d.recordsError}
@@ -187,6 +218,18 @@ export default function ExerciseDetail() {
         keyExtractor={(item) => item.session_id} renderItem={renderItem} ListHeaderComponent={renderHeader}
         ListFooterComponent={renderFooter}
         onEndReached={d.loadMore} onEndReachedThreshold={0.3} />
+      {id && (
+        <GoalSetForm
+          isVisible={goalSheet.isVisible}
+          onClose={goalSheet.close}
+          exerciseId={id}
+          isBodyweight={d.bw}
+          unit={d.unit}
+          existingGoal={goalState.goal}
+          onCreate={goalState.createGoal}
+          onUpdate={goalState.updateGoal}
+        />
+      )}
     </>
   );
 }

--- a/components/exercise/GoalProgressCard.tsx
+++ b/components/exercise/GoalProgressCard.tsx
@@ -1,0 +1,205 @@
+import React from "react";
+import { Alert, StyleSheet, TouchableOpacity, View } from "react-native";
+import { Card, CardContent } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { toDisplay } from "@/lib/units";
+import { radii, fontSizes, spacing } from "@/constants/design-tokens";
+import type { ThemeColors } from "@/hooks/useThemeColors";
+import type { StrengthGoalRow } from "@/lib/db";
+
+type Props = {
+  colors: ThemeColors;
+  goal: StrengthGoalRow;
+  currentBest: number | null;
+  progressPct: number;
+  isBodyweight: boolean;
+  unit: "kg" | "lb";
+  onEdit: () => void;
+  onDelete: () => void;
+  style?: object;
+};
+
+function AchievedCard({ colors, goal, targetDisplay, unitLabel, style }: {
+  colors: ThemeColors; goal: StrengthGoalRow; targetDisplay: number; unitLabel: string; style?: object;
+}) {
+  const achievedDate = goal.achieved_at
+    ? new Date(goal.achieved_at).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })
+    : "";
+  return (
+    <Card style={[styles.card, style, { backgroundColor: colors.surface }]}>
+      <CardContent style={styles.cardContent}>
+        <View style={styles.header}>
+          <View style={styles.titleRow}>
+            <Text style={{ color: colors.onSurface, fontSize: fontSizes.base, fontWeight: "600" }}>
+              ✅ Achieved on {achievedDate}
+            </Text>
+          </View>
+        </View>
+        <Text style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm, marginTop: spacing.xs }}>
+          Target: {targetDisplay} {unitLabel}
+        </Text>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function GoalProgressCard({
+  colors, goal, currentBest, progressPct, isBodyweight, unit,
+  onEdit, onDelete, style,
+}: Props) {
+  const target = isBodyweight ? goal.target_reps : goal.target_weight;
+  const bestDisplay = isBodyweight
+    ? (currentBest ?? 0)
+    : toDisplay(currentBest ?? 0, unit);
+  const targetDisplay = isBodyweight
+    ? (target ?? 0)
+    : toDisplay(target ?? 0, unit);
+  const unitLabel = isBodyweight ? "reps" : unit;
+  const clampedPct = Math.min(progressPct, 100);
+  const isOverachieved = progressPct > 100;
+
+  if (goal.achieved_at != null) {
+    return <AchievedCard colors={colors} goal={goal} targetDisplay={targetDisplay} unitLabel={unitLabel} style={style} />;
+  }
+
+  const deadlinePassed = goal.deadline
+    ? new Date(goal.deadline) < new Date()
+    : false;
+
+  const progressLabel = `Goal progress: ${bestDisplay} of ${targetDisplay} ${unitLabel}, ${progressPct} percent`;
+
+  const confirmDelete = () => {
+    Alert.alert(
+      "Delete Goal",
+      "Are you sure you want to delete this goal?",
+      [
+        { text: "Cancel", style: "cancel" },
+        { text: "Delete", style: "destructive", onPress: onDelete },
+      ],
+    );
+  };
+
+  return (
+    <Card
+      style={[styles.card, style, { backgroundColor: colors.surface }]}
+      accessibilityLabel={progressLabel}
+    >
+      <CardContent style={styles.cardContent}>
+        <View style={styles.header}>
+          <View style={styles.titleRow}>
+            <MaterialCommunityIcons
+              name="bullseye-arrow"
+              size={20}
+              color={colors.primary}
+            />
+            <Text style={{ color: colors.onSurface, fontSize: fontSizes.base, fontWeight: "600", marginLeft: spacing.sm }}>
+              Goal
+            </Text>
+          </View>
+          <View style={styles.actions}>
+            <TouchableOpacity
+              onPress={onEdit}
+              accessibilityLabel="Edit goal"
+              accessibilityRole="button"
+              hitSlop={8}
+              style={styles.iconButton}
+            >
+              <MaterialCommunityIcons name="pencil" size={18} color={colors.onSurfaceVariant} />
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={confirmDelete}
+              accessibilityLabel="Delete goal"
+              accessibilityRole="button"
+              hitSlop={8}
+              style={styles.iconButton}
+            >
+              <MaterialCommunityIcons name="close" size={18} color={colors.onSurfaceVariant} />
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {/* Progress bar */}
+        <View
+          style={[styles.progressTrack, { backgroundColor: colors.outlineVariant }]}
+          accessibilityRole="progressbar"
+          accessibilityValue={{ min: 0, max: 100, now: clampedPct }}
+          accessibilityLabel={progressLabel}
+        >
+          <View
+            style={[
+              styles.progressFill,
+              {
+                width: `${clampedPct}%`,
+                backgroundColor: isOverachieved ? colors.tertiary : colors.primary,
+              },
+            ]}
+          />
+        </View>
+
+        {/* Stats line */}
+        <View style={styles.statsRow}>
+          <Text style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>
+            {bestDisplay} / {targetDisplay} {unitLabel} ({progressPct}%)
+          </Text>
+          {goal.deadline && (
+            <Text style={{ color: deadlinePassed ? colors.error : colors.onSurfaceVariant, fontSize: fontSizes.xs }}>
+              by {new Date(goal.deadline).toLocaleDateString(undefined, { year: "numeric", month: "short" })}
+            </Text>
+          )}
+        </View>
+
+        {isOverachieved && (
+          <Text style={{ color: colors.tertiary, fontSize: fontSizes.xs, marginTop: spacing.xxs }}>
+            You&apos;ve exceeded this goal! Consider setting a higher target.
+          </Text>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginTop: 8,
+    marginBottom: 8,
+  },
+  cardContent: {
+    padding: 16,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  actions: {
+    flexDirection: "row",
+    gap: 4,
+  },
+  iconButton: {
+    minWidth: 48,
+    minHeight: 48,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  progressTrack: {
+    height: 10,
+    borderRadius: radii.pill,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    borderRadius: radii.pill,
+  },
+  statsRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginTop: 8,
+  },
+});

--- a/components/exercise/GoalSetForm.tsx
+++ b/components/exercise/GoalSetForm.tsx
@@ -88,7 +88,8 @@ export default function GoalSetForm({
     const opts: { label: string; value: string | null }[] = [{ label: "No deadline", value: null }];
     const now = new Date();
     for (let i = 1; i <= 12; i++) {
-      const d = new Date(now.getFullYear(), now.getMonth() + i, 1);
+      // Last day of the target month (day 0 of next month = last day of current month)
+      const d = new Date(now.getFullYear(), now.getMonth() + i + 1, 0);
       const label = d.toLocaleDateString(undefined, { year: "numeric", month: "short" });
       opts.push({ label, value: d.toISOString().slice(0, 10) });
     }

--- a/components/exercise/GoalSetForm.tsx
+++ b/components/exercise/GoalSetForm.tsx
@@ -1,0 +1,161 @@
+import React, { useCallback, useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { useToast } from "@/components/ui/bna-toast";
+import { toDisplay, toKg } from "@/lib/units";
+import { fontSizes, spacing } from "@/constants/design-tokens";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { StrengthGoalRow, CreateGoalInput, UpdateGoalInput } from "@/lib/db";
+import NumericStepper from "./NumericStepper";
+
+type Props = {
+  isVisible: boolean;
+  onClose: () => void;
+  exerciseId: string;
+  isBodyweight: boolean;
+  unit: "kg" | "lb";
+  existingGoal?: StrengthGoalRow | null;
+  onCreate: (input: CreateGoalInput) => Promise<void>;
+  onUpdate: (goalId: string, updates: UpdateGoalInput) => Promise<void>;
+};
+
+export default function GoalSetForm({
+  isVisible, onClose, exerciseId, isBodyweight, unit,
+  existingGoal, onCreate, onUpdate,
+}: Props) {
+  const colors = useThemeColors();
+  const { toast } = useToast();
+  const isEditing = existingGoal != null;
+
+  const getInitialValue = () => {
+    if (!existingGoal) return isBodyweight ? 10 : (unit === "lb" ? 135 : 60);
+    if (isBodyweight) return existingGoal.target_reps ?? 10;
+    return toDisplay(existingGoal.target_weight ?? 60, unit);
+  };
+
+  const [targetValue, setTargetValue] = useState(getInitialValue);
+  const [deadline, setDeadline] = useState<string | null>(existingGoal?.deadline ?? null);
+  const [saving, setSaving] = useState(false);
+
+  // Reset state when the sheet opens with new data
+  React.useEffect(() => {
+    if (isVisible) {
+      setTargetValue(getInitialValue());
+      setDeadline(existingGoal?.deadline ?? null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isVisible, existingGoal?.id]);
+
+  const minValue = isBodyweight ? 1 : (unit === "lb" ? 1 : 0.5);
+  const step = isBodyweight ? 1 : (unit === "lb" ? 5 : 2.5);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    try {
+      if (isEditing && existingGoal) {
+        const updates: UpdateGoalInput = { deadline };
+        if (isBodyweight) {
+          updates.targetReps = targetValue;
+          updates.targetWeight = null;
+        } else {
+          updates.targetWeight = toKg(targetValue, unit);
+          updates.targetReps = null;
+        }
+        await onUpdate(existingGoal.id, updates);
+      } else {
+        const input: CreateGoalInput = {
+          exerciseId,
+          deadline,
+        };
+        if (isBodyweight) {
+          input.targetReps = targetValue;
+        } else {
+          input.targetWeight = toKg(targetValue, unit);
+        }
+        await onCreate(input);
+      }
+      onClose();
+    } catch {
+      toast({ description: "Failed to save goal. Please try again." });
+    } finally {
+      setSaving(false);
+    }
+  }, [isEditing, existingGoal, exerciseId, isBodyweight, targetValue, deadline, unit, onCreate, onUpdate, onClose, toast]);
+
+  const deadlineOptions = React.useMemo(() => {
+    const opts: { label: string; value: string | null }[] = [{ label: "No deadline", value: null }];
+    const now = new Date();
+    for (let i = 1; i <= 12; i++) {
+      const d = new Date(now.getFullYear(), now.getMonth() + i, 1);
+      const label = d.toLocaleDateString(undefined, { year: "numeric", month: "short" });
+      opts.push({ label, value: d.toISOString().slice(0, 10) });
+    }
+    return opts;
+  }, []);
+
+  return (
+    <BottomSheet
+      isVisible={isVisible}
+      onClose={onClose}
+      title={isEditing ? "Edit Goal" : "Set Goal"}
+      snapPoints={[0.45]}
+    >
+      <View style={styles.container}>
+        <Text style={{ color: colors.onSurface, fontSize: fontSizes.base, fontWeight: "600", marginBottom: spacing.sm }}>
+          Target {isBodyweight ? "Reps" : `Weight (${unit})`}
+        </Text>
+
+        <NumericStepper
+          value={targetValue}
+          onValueChange={setTargetValue}
+          min={minValue}
+          step={step}
+          unit={isBodyweight ? "reps" : unit}
+        />
+
+        <Text style={{ color: colors.onSurface, fontSize: fontSizes.base, fontWeight: "600", marginTop: spacing.lg, marginBottom: spacing.sm }}>
+          Deadline (optional)
+        </Text>
+
+        <View style={styles.deadlineRow}>
+          {deadlineOptions.slice(0, 5).map((opt) => (
+            <Button
+              key={opt.value ?? "none"}
+              variant={deadline === opt.value ? "default" : "outline"}
+              onPress={() => setDeadline(opt.value)}
+              label={opt.label}
+              style={styles.deadlineButton}
+            />
+          ))}
+        </View>
+
+        <Button
+          variant="default"
+          onPress={handleSave}
+          label={saving ? "Saving..." : (isEditing ? "Update Goal" : "Save Goal")}
+          disabled={saving || targetValue < minValue}
+          style={styles.saveButton}
+        />
+      </View>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingVertical: 8,
+  },
+  deadlineRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  deadlineButton: {
+    marginBottom: 4,
+  },
+  saveButton: {
+    marginTop: 24,
+  },
+});

--- a/components/exercise/NumericStepper.tsx
+++ b/components/exercise/NumericStepper.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+
+type Props = {
+  value: number;
+  onValueChange: (v: number) => void;
+  min: number;
+  step: number;
+  unit: string;
+  max?: number;
+};
+
+export default function NumericStepper({ value, onValueChange, min, step, unit, max = 9999 }: Props) {
+  const colors = useThemeColors();
+
+  const decrement = () => {
+    const next = Math.round((value - step) * 10) / 10;
+    if (next >= min) onValueChange(next);
+  };
+
+  const increment = () => {
+    const next = Math.round((value + step) * 10) / 10;
+    if (next <= max) onValueChange(next);
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button
+        variant="secondary"
+        onPress={decrement}
+        disabled={value <= min}
+        accessibilityLabel={`Decrease by ${step}`}
+        style={styles.btn}
+      >
+        <Text>−</Text>
+      </Button>
+      <Text
+        variant="title"
+        style={{ color: colors.onSurface, minWidth: 80, textAlign: "center", fontWeight: "700" }}
+        accessibilityLabel={`${value} ${unit}`}
+      >
+        {value} {unit}
+      </Text>
+      <Button
+        variant="secondary"
+        onPress={increment}
+        disabled={value >= max}
+        accessibilityLabel={`Increase by ${step}`}
+        style={styles.btn}
+      >
+        <Text>+</Text>
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 12,
+    paddingVertical: 8,
+  },
+  btn: {
+    minWidth: 48,
+    minHeight: 48,
+  },
+});

--- a/components/home/InsightCard.tsx
+++ b/components/home/InsightCard.tsx
@@ -1,9 +1,17 @@
 import { Pressable, StyleSheet } from "react-native";
 import Ionicons from "@expo/vector-icons/Ionicons";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Text } from "@/components/ui/text";
 import type { ThemeColors } from "@/hooks/useThemeColors";
 import type { Insight } from "@/lib/insights";
 import { fontSizes } from "@/constants/design-tokens";
+
+const IONICON_MAP: Record<string, string> = {
+  "trending-up": "trending-up",
+  "bar-chart": "bar-chart",
+  "star": "star",
+  "heart": "heart",
+};
 
 type Props = {
   colors: ThemeColors;
@@ -13,6 +21,8 @@ type Props = {
 };
 
 export default function InsightCard({ colors, insight, onPress, onDismiss }: Props) {
+  const isMCI = insight.icon === "bullseye-arrow";
+
   return (
     <Pressable
       style={[styles.card, { backgroundColor: colors.surface }]}
@@ -20,13 +30,23 @@ export default function InsightCard({ colors, insight, onPress, onDismiss }: Pro
       accessibilityRole="button"
       accessibilityLabel={insight.accessibilityLabel}
     >
-      <Ionicons
-        name={insight.icon}
-        size={20}
-        color={colors.primary}
-        accessibilityElementsHidden={true}
-        importantForAccessibility="no"
-      />
+      {isMCI ? (
+        <MaterialCommunityIcons
+          name="bullseye-arrow"
+          size={20}
+          color={colors.primary}
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no"
+        />
+      ) : (
+        <Ionicons
+          name={IONICON_MAP[insight.icon] as keyof typeof Ionicons.glyphMap ?? "trending-up"}
+          size={20}
+          color={colors.primary}
+          accessibilityElementsHidden={true}
+          importantForAccessibility="no"
+        />
+      )}
       <Text
         variant="body"
         style={[styles.title, { color: colors.onSurface }]}

--- a/components/home/loadHomeData.ts
+++ b/components/home/loadHomeData.ts
@@ -8,7 +8,9 @@ import {
 } from "../../lib/db";
 import { computeStreak } from "../../lib/format";
 import { computeAllTemplateReadiness, hasWorkoutHistory } from "../../lib/recovery-readiness";
-import { generateInsight } from "../../lib/insights";
+import { generateInsight, type GoalInsightRow } from "../../lib/insights";
+import { getActiveGoals, getCurrentBestWeight, getCurrentBestReps } from "../../lib/db";
+import { getExerciseById } from "../../lib/db";
 
 export async function loadHomeData() {
   const [tpls, sess, act, timestamps, prData, progs, nw, sched, done, adh] = await Promise.all([
@@ -28,6 +30,32 @@ export async function loadHomeData() {
   const recoveryStatus = await getMuscleRecoveryStatus();
   const templateReadiness = computeAllTemplateReadiness(templateMuscles, recoveryStatus);
   const showReadiness = hasWorkoutHistory(recoveryStatus);
-  const insight = generateInsight({ totalSessions, timestamps, e1rmTrends, weeklyVolume });
+
+  // Load goal insights (degrade gracefully if no goals)
+  const goalInsights = await loadGoalInsights();
+
+  const insight = generateInsight({ totalSessions, timestamps, e1rmTrends, weeklyVolume, goalInsights });
   return { templates: tpls, sessions: sess, active: act, streak: computeStreak(timestamps), recentPRs: prData, programs: progs, nextWorkout: nw, todaySchedule: sched, todayDone: done, adherence: adh, counts, setCounts, avgRPEs, dayCounts, recoveryStatus, templateReadiness, showReadiness, insight };
+}
+
+async function loadGoalInsights(): Promise<GoalInsightRow[]> {
+  try {
+    const activeGoals = await getActiveGoals();
+    const results: GoalInsightRow[] = [];
+    for (const goal of activeGoals.slice(0, 3)) {
+      const exercise = await getExerciseById(goal.exercise_id);
+      if (!exercise) continue;
+      const isBodyweight = goal.target_reps != null && goal.target_weight == null;
+      const best = isBodyweight
+        ? await getCurrentBestReps(goal.exercise_id)
+        : await getCurrentBestWeight(goal.exercise_id);
+      const target = isBodyweight ? (goal.target_reps ?? 0) : (goal.target_weight ?? 0);
+      const pct = target > 0 && best != null ? Math.round((best / target) * 100) : 0;
+      results.push({ exercise_id: goal.exercise_id, exercise_name: exercise.name, progressPct: pct });
+    }
+    return results;
+  } catch {
+    // Goals not available (e.g. first launch before migration)
+    return [];
+  }
 }

--- a/components/progress/ActiveGoalsCard.tsx
+++ b/components/progress/ActiveGoalsCard.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { useRouter } from "expo-router";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { useActiveGoals } from "@/hooks/useStrengthGoals";
+import { getCurrentBestWeight, getCurrentBestReps, type StrengthGoalRow } from "@/lib/db";
+import { getExerciseById } from "@/lib/db";
+import { useFocusEffect } from "expo-router";
+import { useCallback, useState } from "react";
+import { radii, fontSizes, spacing } from "@/constants/design-tokens";
+
+type GoalSummary = {
+  goal: StrengthGoalRow;
+  exerciseName: string;
+  progressPct: number;
+};
+
+export default function ActiveGoalsCard() {
+  const colors = useThemeColors();
+  const router = useRouter();
+  const { goals, isLoading } = useActiveGoals();
+  const [summaries, setSummaries] = useState<GoalSummary[]>([]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (goals.length === 0) {
+        setSummaries([]);
+        return;
+      }
+      (async () => {
+        const results: GoalSummary[] = [];
+        // Only show first 3
+        for (const goal of goals.slice(0, 3)) {
+          try {
+            const exercise = await getExerciseById(goal.exercise_id);
+            if (!exercise) continue;
+            const isBodyweight = goal.target_reps != null && goal.target_weight == null;
+            const best = isBodyweight
+              ? await getCurrentBestReps(goal.exercise_id)
+              : await getCurrentBestWeight(goal.exercise_id);
+            const target = isBodyweight ? (goal.target_reps ?? 0) : (goal.target_weight ?? 0);
+            const pct = target > 0 && best != null ? Math.round((best / target) * 100) : 0;
+            results.push({
+              goal,
+              exerciseName: exercise.name,
+              progressPct: pct,
+            });
+          } catch {
+            // skip if exercise deleted
+          }
+        }
+        setSummaries(results);
+      })();
+    }, [goals]),
+  );
+
+  if (isLoading || summaries.length === 0) return null;
+
+  return (
+    <View style={[styles.card, { backgroundColor: colors.surface }]}>
+      <View style={styles.header}>
+        <MaterialCommunityIcons name="bullseye-arrow" size={18} color={colors.primary} />
+        <Text variant="subtitle" style={{ color: colors.onSurface, marginLeft: spacing.sm }}>
+          Active Goals
+        </Text>
+      </View>
+      {summaries.map((s) => (
+        <Pressable
+          key={s.goal.id}
+          onPress={() => router.push(`/exercise/${s.goal.exercise_id}`)}
+          accessibilityLabel={`${s.exerciseName} goal: ${s.progressPct} percent complete`}
+          accessibilityRole="button"
+          style={styles.goalRow}
+        >
+          <View style={{ flex: 1 }}>
+            <Text style={{ color: colors.onSurface, fontSize: fontSizes.sm }} numberOfLines={1}>
+              {s.exerciseName}
+            </Text>
+            <View style={[styles.miniTrack, { backgroundColor: colors.outlineVariant }]}>
+              <View
+                style={[
+                  styles.miniFill,
+                  {
+                    width: `${Math.min(s.progressPct, 100)}%`,
+                    backgroundColor: s.progressPct > 100 ? colors.tertiary : colors.primary,
+                  },
+                ]}
+              />
+            </View>
+          </View>
+          <Text style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.xs, marginLeft: spacing.sm }}>
+            {s.progressPct}%
+          </Text>
+        </Pressable>
+      ))}
+      {goals.length > 3 && (
+        <Text style={{ color: colors.primary, fontSize: fontSizes.xs, marginTop: spacing.xs, textAlign: "center" }}>
+          +{goals.length - 3} more
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+    padding: 18,
+    marginBottom: 16,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  goalRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 6,
+  },
+  miniTrack: {
+    height: 6,
+    borderRadius: radii.pill,
+    overflow: "hidden",
+    marginTop: 4,
+  },
+  miniFill: {
+    height: "100%",
+    borderRadius: radii.pill,
+  },
+});

--- a/components/progress/WorkoutSegment.tsx
+++ b/components/progress/WorkoutSegment.tsx
@@ -21,6 +21,7 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { WorkoutChartCard, PRCard, SessionsCard } from "./WorkoutCards";
 import CalendarView from "./CalendarView";
 import StrengthLevelsCard from "./StrengthLevelsCard";
+import ActiveGoalsCard from "./ActiveGoalsCard";
 import { fontSizes } from "@/constants/design-tokens";
 
 let cachedWeekStart: number | null = null;
@@ -215,6 +216,7 @@ export default function WorkoutSegment() {
               <PRCard prs={prs} style={wideCard} />
               <SessionsCard sessions={sessions} style={wideCard} />
             </View>
+            <ActiveGoalsCard />
             <StrengthLevelsCard />
           </>
         ) : (
@@ -226,6 +228,7 @@ export default function WorkoutSegment() {
             {volCard}
             <PRCard prs={prs} />
             <SessionsCard sessions={sessions} />
+            <ActiveGoalsCard />
             <StrengthLevelsCard />
           </>
         )

--- a/components/session/PRCelebration.tsx
+++ b/components/session/PRCelebration.tsx
@@ -158,12 +158,12 @@ export function PRCelebration({ celebration }: PRCelebrationProps) {
           {particles}
         </View>
       )}
-      <Animated.View style={[styles.badge, { backgroundColor: colors.primary }, badgeStyle]}>
+      <Animated.View style={[styles.badge, { backgroundColor: colors.primary, shadowColor: colors.shadow }, badgeStyle]}>
         <Text style={styles.badgeEmoji}>🏆</Text>
         <Text style={[styles.badgeText, { color: colors.onPrimary }]}>NEW PR!</Text>
       </Animated.View>
       {celebration.goalAchieved && (
-        <Animated.View style={[styles.goalBadge, { backgroundColor: colors.tertiary }, badgeStyle]}>
+        <Animated.View style={[styles.goalBadge, { backgroundColor: colors.tertiary, shadowColor: colors.shadow }, badgeStyle]}>
           <MaterialCommunityIcons name="bullseye-arrow" size={20} color={colors.onPrimary} />
           <Text style={[styles.badgeText, { color: colors.onPrimary }]}>GOAL ACHIEVED!</Text>
         </Animated.View>
@@ -200,7 +200,6 @@ const styles = StyleSheet.create({
     borderRadius: 24,
     gap: 8,
     elevation: 8,
-    shadowColor: "#000", // shadow colors are theme-independent per platform conventions
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
@@ -214,7 +213,6 @@ const styles = StyleSheet.create({
     gap: 6,
     marginTop: 8,
     elevation: 6,
-    shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.25,
     shadowRadius: 6,

--- a/components/session/PRCelebration.tsx
+++ b/components/session/PRCelebration.tsx
@@ -12,6 +12,7 @@ import Animated, {
   cancelAnimation,
   Easing,
 } from "react-native-reanimated";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import type { PRCelebrationState } from "@/hooks/usePRCelebration";
 import { fontSizes } from "@/constants/design-tokens";
@@ -161,6 +162,12 @@ export function PRCelebration({ celebration }: PRCelebrationProps) {
         <Text style={styles.badgeEmoji}>🏆</Text>
         <Text style={[styles.badgeText, { color: colors.onPrimary }]}>NEW PR!</Text>
       </Animated.View>
+      {celebration.goalAchieved && (
+        <Animated.View style={[styles.goalBadge, { backgroundColor: colors.tertiary }, badgeStyle]}>
+          <MaterialCommunityIcons name="bullseye-arrow" size={20} color={colors.onPrimary} />
+          <Text style={[styles.badgeText, { color: colors.onPrimary }]}>GOAL ACHIEVED!</Text>
+        </Animated.View>
+      )}
     </View>
   );
 }
@@ -197,6 +204,20 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.3,
     shadowRadius: 8,
+  },
+  goalBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    gap: 6,
+    marginTop: 8,
+    elevation: 6,
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 6,
   },
   badgeEmoji: {
     fontSize: fontSizes.xxl,

--- a/hooks/usePRCelebration.ts
+++ b/hooks/usePRCelebration.ts
@@ -7,6 +7,7 @@ export type PRCelebrationState = {
   visible: boolean;
   exerciseName: string;
   showConfetti: boolean;
+  goalAchieved: boolean;
 };
 
 export function usePRCelebration() {
@@ -14,24 +15,27 @@ export function usePRCelebration() {
     visible: false,
     exerciseName: "",
     showConfetti: false,
+    goalAchieved: false,
   });
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reducedMotion = useReducedMotion();
 
   const triggerPR = useCallback(
-    (exerciseName: string) => {
+    (exerciseName: string, goalAchieved = false) => {
       // Clear any existing timer
       if (timerRef.current) clearTimeout(timerRef.current);
 
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-      AccessibilityInfo.announceForAccessibility(
-        `New personal record for ${exerciseName}`
-      );
+      const announcement = goalAchieved
+        ? `Goal achieved! New personal record for ${exerciseName}`
+        : `New personal record for ${exerciseName}`;
+      AccessibilityInfo.announceForAccessibility(announcement);
 
       setCelebration({
         visible: true,
         exerciseName,
         showConfetti: !reducedMotion,
+        goalAchieved,
       });
 
       timerRef.current = setTimeout(() => {

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -19,6 +19,9 @@ import {
   updateSetDuration,
   checkSetPR,
   updateExercisePositions,
+  getGoalForExercise,
+  achieveGoal,
+  getCurrentBestWeight,
 } from "../lib/db";
 import { bumpQueryVersion } from "../lib/query";
 import {
@@ -30,6 +33,23 @@ import type { TrainingMode } from "../lib/types";
 import { formatTime } from "../lib/format";
 import { confirmAction } from "../lib/confirm";
 import type { SetWithMeta, ExerciseGroup } from "../components/session/types";
+
+/** Check if completing a set achieves a strength goal. Non-throwing. */
+async function checkGoalAchievement(exerciseId: string): Promise<boolean> {
+  try {
+    const goal = await getGoalForExercise(exerciseId);
+    if (goal?.target_weight != null) {
+      const best = await getCurrentBestWeight(exerciseId);
+      if (best != null && best >= goal.target_weight) {
+        await achieveGoal(goal.id);
+        return true;
+      }
+    }
+  } catch {
+    // Goal check must never block PR celebration
+  }
+  return false;
+}
 
 type Params = {
   id: string | undefined;
@@ -43,7 +63,7 @@ type Params = {
   session: { started_at: number; name: string } | null;
   showToast: (msg: string) => void;
   showError: (msg: string) => void;
-  triggerPR?: (exerciseName: string) => void;
+  triggerPR?: (exerciseName: string, goalAchieved?: boolean) => void;
 };
 
 export function useSessionActions({
@@ -138,7 +158,8 @@ export function useSessionActions({
           const isPR = await checkSetPR(set.exercise_id, set.weight, id);
           if (isPR) {
             const group = groups.find((g) => g.exercise_id === set.exercise_id);
-            triggerPR(group?.name ?? "exercise");
+            const goalAchieved = await checkGoalAchievement(set.exercise_id);
+            triggerPR(group?.name ?? "exercise", goalAchieved);
             updateGroupSet(set.id, { is_pr: true });
           }
         } catch {

--- a/hooks/useStrengthGoals.ts
+++ b/hooks/useStrengthGoals.ts
@@ -1,0 +1,131 @@
+import { useCallback, useState } from "react";
+import { useFocusEffect } from "expo-router";
+import {
+  getGoalForExercise,
+  getActiveGoals,
+  createGoal,
+  updateGoal,
+  achieveGoal,
+  deleteGoal,
+  getCurrentBestWeight,
+  getCurrentBestReps,
+  type StrengthGoalRow,
+  type CreateGoalInput,
+  type UpdateGoalInput,
+} from "@/lib/db";
+
+export type GoalWithProgress = {
+  goal: StrengthGoalRow;
+  currentBest: number | null;
+  progressPct: number;
+  isBodyweight: boolean;
+};
+
+export function useStrengthGoal(exerciseId: string | undefined, isBodyweight: boolean) {
+  const [goal, setGoal] = useState<StrengthGoalRow | null>(null);
+  const [currentBest, setCurrentBest] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    if (!exerciseId) {
+      setGoal(null);
+      setCurrentBest(null);
+      setIsLoading(false);
+      return;
+    }
+    try {
+      const [g, best] = await Promise.all([
+        getGoalForExercise(exerciseId),
+        isBodyweight ? getCurrentBestReps(exerciseId) : getCurrentBestWeight(exerciseId),
+      ]);
+      setGoal(g);
+      setCurrentBest(best);
+    } catch {
+      setGoal(null);
+      setCurrentBest(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [exerciseId, isBodyweight]);
+
+  useFocusEffect(
+    useCallback(() => {
+      setIsLoading(true);
+      reload();
+    }, [reload]),
+  );
+
+  const target = goal
+    ? (isBodyweight ? goal.target_reps : goal.target_weight) ?? 0
+    : 0;
+  const progressPct = target > 0 && currentBest != null
+    ? Math.round((currentBest / target) * 100)
+    : 0;
+
+  const handleCreate = useCallback(
+    async (input: CreateGoalInput) => {
+      await createGoal(input);
+      await reload();
+    },
+    [reload],
+  );
+
+  const handleUpdate = useCallback(
+    async (goalId: string, updates: UpdateGoalInput) => {
+      await updateGoal(goalId, updates);
+      await reload();
+    },
+    [reload],
+  );
+
+  const handleAchieve = useCallback(
+    async (goalId: string) => {
+      await achieveGoal(goalId);
+      await reload();
+    },
+    [reload],
+  );
+
+  const handleDelete = useCallback(
+    async (goalId: string) => {
+      await deleteGoal(goalId);
+      await reload();
+    },
+    [reload],
+  );
+
+  return {
+    goal,
+    currentBest,
+    progressPct,
+    isLoading,
+    reload,
+    createGoal: handleCreate,
+    updateGoal: handleUpdate,
+    achieveGoal: handleAchieve,
+    deleteGoal: handleDelete,
+  };
+}
+
+export function useActiveGoals() {
+  const [goals, setGoals] = useState<StrengthGoalRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useFocusEffect(
+    useCallback(() => {
+      setIsLoading(true);
+      (async () => {
+        try {
+          const g = await getActiveGoals();
+          setGoals(g);
+        } catch {
+          setGoals([]);
+        } finally {
+          setIsLoading(false);
+        }
+      })();
+    }, []),
+  );
+
+  return { goals, isLoading };
+}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -285,3 +285,16 @@ export type { MuscleRecoveryStatus, RecoveryStatus } from "./recovery";
 
 export { getStrengthOverview } from "./strength-overview";
 export type { StrengthOverviewRow } from "./strength-overview";
+
+export {
+  getActiveGoals,
+  getGoalForExercise,
+  createGoal,
+  updateGoal,
+  achieveGoal,
+  deleteGoal,
+  getCompletedGoals,
+  getCurrentBestWeight,
+  getCurrentBestReps,
+} from "./strength-goals";
+export type { StrengthGoalRow, CreateGoalInput, UpdateGoalInput } from "./strength-goals";

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -21,4 +21,29 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   await addPerformanceIndexes(database);
   // Phase 62: exercise reorder support
   await addColumnIfMissing(database, "workout_sets", "exercise_position", "INTEGER DEFAULT 0");
+
+  // Phase 66: strength goals table
+  await database.execAsync(`
+    CREATE TABLE IF NOT EXISTS strength_goals (
+      id TEXT PRIMARY KEY,
+      exercise_id TEXT NOT NULL,
+      target_weight REAL,
+      target_reps INTEGER,
+      deadline TEXT,
+      achieved_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (exercise_id) REFERENCES exercises(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_strength_goals_exercise ON strength_goals(exercise_id);
+    CREATE INDEX IF NOT EXISTS idx_strength_goals_active ON strength_goals(achieved_at);
+  `);
+  // Partial unique index for one-active-goal-per-exercise constraint
+  try {
+    await database.execAsync(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_strength_goals_one_active ON strength_goals(exercise_id) WHERE achieved_at IS NULL`
+    );
+  } catch {
+    // SQLite on some platforms doesn't support partial indexes — constraint enforced at app level
+  }
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -318,6 +318,22 @@ export const healthConnectSyncLog = sqliteTable("health_connect_sync_log", {
   index("idx_hc_sync_log_status").on(table.status),
 ]);
 
+// ─── Strength Goals ─────────────────────────────────────────────────────────
+
+export const strengthGoals = sqliteTable("strength_goals", {
+  id: text("id").primaryKey(),
+  exercise_id: text("exercise_id").notNull(),
+  target_weight: real("target_weight"),
+  target_reps: integer("target_reps"),
+  deadline: text("deadline"),
+  achieved_at: text("achieved_at"),
+  created_at: text("created_at").notNull(),
+  updated_at: text("updated_at").notNull(),
+}, (table) => [
+  index("idx_strength_goals_exercise").on(table.exercise_id),
+  index("idx_strength_goals_active").on(table.achieved_at),
+]);
+
 // ─── Inferred Select Types ─────────────────────────────────────────────────
 // Use these instead of manually-defined Row types.
 
@@ -346,3 +362,4 @@ export type AchievementEarnedRow = typeof achievementsEarned.$inferSelect;
 export type StravaConnectionRow = typeof stravaConnection.$inferSelect;
 export type StravaSyncLogRow = typeof stravaSyncLog.$inferSelect;
 export type HealthConnectSyncLogRow = typeof healthConnectSyncLog.$inferSelect;
+export type StrengthGoalRow = typeof strengthGoals.$inferSelect;

--- a/lib/db/strength-goals.ts
+++ b/lib/db/strength-goals.ts
@@ -1,0 +1,120 @@
+import { eq, and, isNull, isNotNull, desc } from "drizzle-orm";
+import { uuid } from "../uuid";
+import { getDrizzle, query } from "./helpers";
+import { strengthGoals } from "./schema";
+import type { StrengthGoalRow } from "./schema";
+
+export type { StrengthGoalRow };
+
+export type CreateGoalInput = {
+  exerciseId: string;
+  targetWeight?: number | null;
+  targetReps?: number | null;
+  deadline?: string | null;
+};
+
+export type UpdateGoalInput = {
+  targetWeight?: number | null;
+  targetReps?: number | null;
+  deadline?: string | null;
+};
+
+export async function getActiveGoals(): Promise<StrengthGoalRow[]> {
+  const db = await getDrizzle();
+  return db
+    .select()
+    .from(strengthGoals)
+    .where(isNull(strengthGoals.achieved_at))
+    .orderBy(desc(strengthGoals.created_at));
+}
+
+export async function getGoalForExercise(
+  exerciseId: string,
+): Promise<StrengthGoalRow | null> {
+  const db = await getDrizzle();
+  const row = await db
+    .select()
+    .from(strengthGoals)
+    .where(
+      and(
+        eq(strengthGoals.exercise_id, exerciseId),
+        isNull(strengthGoals.achieved_at),
+      ),
+    )
+    .get();
+  return row ?? null;
+}
+
+export async function createGoal(input: CreateGoalInput): Promise<StrengthGoalRow> {
+  const db = await getDrizzle();
+  const id = uuid();
+  const now = new Date().toISOString();
+  const row: StrengthGoalRow = {
+    id,
+    exercise_id: input.exerciseId,
+    target_weight: input.targetWeight ?? null,
+    target_reps: input.targetReps ?? null,
+    deadline: input.deadline ?? null,
+    achieved_at: null,
+    created_at: now,
+    updated_at: now,
+  };
+  await db.insert(strengthGoals).values(row);
+  return row;
+}
+
+export async function updateGoal(
+  goalId: string,
+  updates: UpdateGoalInput,
+): Promise<void> {
+  const db = await getDrizzle();
+  const now = new Date().toISOString();
+  const set: Record<string, unknown> = { updated_at: now };
+  if (updates.targetWeight !== undefined) set.target_weight = updates.targetWeight;
+  if (updates.targetReps !== undefined) set.target_reps = updates.targetReps;
+  if (updates.deadline !== undefined) set.deadline = updates.deadline;
+  await db.update(strengthGoals).set(set).where(eq(strengthGoals.id, goalId));
+}
+
+export async function achieveGoal(goalId: string): Promise<void> {
+  const db = await getDrizzle();
+  const now = new Date().toISOString();
+  await db
+    .update(strengthGoals)
+    .set({ achieved_at: now, updated_at: now })
+    .where(eq(strengthGoals.id, goalId));
+}
+
+export async function deleteGoal(goalId: string): Promise<void> {
+  const db = await getDrizzle();
+  await db.delete(strengthGoals).where(eq(strengthGoals.id, goalId));
+}
+
+export async function getCompletedGoals(): Promise<StrengthGoalRow[]> {
+  const db = await getDrizzle();
+  return db
+    .select()
+    .from(strengthGoals)
+    .where(isNotNull(strengthGoals.achieved_at))
+    .orderBy(desc(strengthGoals.achieved_at));
+}
+
+type CurrentBestRow = { best: number | null };
+
+/** Compute current best weight for an exercise from completed workout sets. */
+export async function getCurrentBestWeight(exerciseId: string): Promise<number | null> {
+  const rows = await query<CurrentBestRow>(
+    `SELECT MAX(weight) as best FROM workout_sets WHERE exercise_id = ? AND completed = 1 AND weight IS NOT NULL`,
+    [exerciseId],
+  );
+  return rows[0]?.best ?? null;
+}
+
+/** Compute current best reps for a bodyweight exercise from completed workout sets. */
+export async function getCurrentBestReps(exerciseId: string): Promise<number | null> {
+  const rows = await query<CurrentBestRow>(
+    `SELECT MAX(reps) as best FROM workout_sets WHERE exercise_id = ? AND completed = 1 AND reps IS NOT NULL`,
+    [exerciseId],
+  );
+  return rows[0]?.best ?? null;
+}

--- a/lib/db/strength-goals.ts
+++ b/lib/db/strength-goals.ts
@@ -46,6 +46,11 @@ export async function getGoalForExercise(
 }
 
 export async function createGoal(input: CreateGoalInput): Promise<StrengthGoalRow> {
+  // App-level guard: one active goal per exercise (backup for partial unique index)
+  const existing = await getGoalForExercise(input.exerciseId);
+  if (existing) {
+    throw new Error("An active goal already exists for this exercise");
+  }
   const db = await getDrizzle();
   const id = uuid();
   const now = new Date().toISOString();

--- a/lib/db/tables.ts
+++ b/lib/db/tables.ts
@@ -10,7 +10,7 @@ const VALID_TABLES = new Set([
   "interaction_log", "progress_photos", "achievements_earned",
   "strava_connection", "strava_sync_log", "health_connect_sync_log",
   "meal_templates", "meal_template_items", "app_settings",
-  "program_schedule",
+  "program_schedule", "strength_goals",
 ]);
 
 function assertValidTable(table: string): void {
@@ -277,6 +277,22 @@ export async function createExtensionTables(database: SQLite.SQLiteDatabase): Pr
       UNIQUE(session_id)
     );
     CREATE INDEX IF NOT EXISTS idx_hc_sync_log_status ON health_connect_sync_log(status);
+
+    CREATE TABLE IF NOT EXISTS strength_goals (
+      id TEXT PRIMARY KEY,
+      exercise_id TEXT NOT NULL,
+      target_weight REAL,
+      target_reps INTEGER,
+      deadline TEXT,
+      achieved_at TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (exercise_id) REFERENCES exercises(id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_strength_goals_exercise ON strength_goals(exercise_id);
+    CREATE INDEX IF NOT EXISTS idx_strength_goals_active ON strength_goals(achieved_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_strength_goals_one_active
+      ON strength_goals(exercise_id) WHERE achieved_at IS NULL;
 
     CREATE TABLE IF NOT EXISTS meal_templates (
       id TEXT PRIMARY KEY, name TEXT NOT NULL, meal TEXT NOT NULL,

--- a/lib/insights.ts
+++ b/lib/insights.ts
@@ -3,12 +3,12 @@
  * Each generator returns Insight | null. The prioritizer picks the top one.
  */
 
-export type InsightType = "strength" | "volume" | "consistency" | "returning";
+export type InsightType = "strength" | "volume" | "consistency" | "returning" | "goal_progress";
 
 export type Insight = {
   type: InsightType;
   title: string;
-  icon: "trending-up" | "bar-chart" | "star" | "heart";
+  icon: "trending-up" | "bar-chart" | "star" | "heart" | "bullseye-arrow";
   /** exercise ID for strength trend navigation */
   exerciseId?: string;
   accessibilityLabel: string;
@@ -26,11 +26,18 @@ export type WeeklyVolumeRow = {
   volume: number;
 };
 
+export type GoalInsightRow = {
+  exercise_id: string;
+  exercise_name: string;
+  progressPct: number;
+};
+
 export type InsightData = {
   totalSessions: number;
   timestamps: number[];
   e1rmTrends: E1RMTrendRow[];
   weeklyVolume: WeeklyVolumeRow[];
+  goalInsights?: GoalInsightRow[];
 };
 
 /**
@@ -42,12 +49,36 @@ export function generateInsight(data: InsightData): Insight | null {
   if (data.totalSessions < 5) return null;
 
   return (
+    generateGoalInsight(data.goalInsights) ??
     generateStrengthInsight(data.e1rmTrends) ??
     generateVolumeInsight(data.weeklyVolume) ??
     generateConsistencyInsight(data.timestamps) ??
     generateReturningInsight(data.timestamps) ??
     null
   );
+}
+
+function generateGoalInsight(goals?: GoalInsightRow[]): Insight | null {
+  if (!goals || goals.length === 0) return null;
+
+  // Pick the goal with the highest progress
+  let best: GoalInsightRow | null = null;
+  for (const g of goals) {
+    if (g.progressPct > 0 && (!best || g.progressPct > best.progressPct)) {
+      best = g;
+    }
+  }
+
+  if (!best || best.progressPct <= 0) return null;
+
+  const title = `You're ${best.progressPct}% of the way to your ${best.exercise_name} goal!`;
+  return {
+    type: "goal_progress",
+    title,
+    icon: "bullseye-arrow",
+    exerciseId: best.exercise_id,
+    accessibilityLabel: `Training insight: ${title}. Tap to view details.`,
+  };
 }
 
 function generateStrengthInsight(trends: E1RMTrendRow[]): Insight | null {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cablesnap",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cablesnap",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",


### PR DESCRIPTION
## Summary

Add a personal strength goal system: users set target weight/reps per exercise, see a progress bar on exercise detail, get enhanced PR celebration on goal achievement, and see active goals on Progress tab + home insights.

## Changes

### New Files (6)
- `lib/db/strength-goals.ts` — CRUD operations + getCurrentBestWeight/Reps
- `hooks/useStrengthGoals.ts` — React hooks with focus-refetch and isLoading
- `components/exercise/GoalProgressCard.tsx` — Progress bar with edit/delete, full a11y
- `components/exercise/GoalSetForm.tsx` — Bottom sheet with weight/reps stepper + deadline
- `components/exercise/NumericStepper.tsx` — Reusable ±/+ numeric input
- `components/progress/ActiveGoalsCard.tsx` — Compact goals summary (up to 3)

### Modified Files (8)
- `lib/db/schema.ts` — Drizzle schema for strength_goals table
- `lib/db/tables.ts` — Migration + partial unique index
- `app/exercise/[id].tsx` — GoalSection above Records/Chart
- `hooks/usePRCelebration.ts` — Extended with goalAchieved flag
- `components/session/PRCelebration.tsx` — 'GOAL ACHIEVED!' badge
- `components/progress/WorkoutSegment.tsx` — ActiveGoalsCard integration
- `lib/insights.ts` — goal_progress insight type (highest priority)
- `components/home/loadHomeData.ts` — Goal insights with graceful degradation

### Tests (26 new)
- `__tests__/lib/db/strength-goals.test.ts` — 21 tests for CRUD, edge cases
- `__tests__/lib/insights.test.ts` — 5 new tests for goal_progress insights

## Testing

- tsc: zero errors
- eslint: zero warnings
- 26 new tests all passing
- Test budget: 1744/1800 (56 remaining)

## Issue

Resolves BLD-433