### PR TITLE
feat: estimated workout duration on template cards (BLD-438)

### DIFF
--- a/components/home/TemplatesList.tsx
+++ b/components/home/TemplatesList.tsx
@@ -27,6 +27,37 @@ type Props = {
   onEdit: (id: string) => void;
 };
 
+function buildMetaBadges(
+  meta: (typeof STARTER_TEMPLATES)[number] | undefined,
+  counts: Record<string, number>,
+  durationEstimates: Record<string, number | null>,
+  itemId: string
+): MetaBadge[] {
+  if (meta) {
+    return [difficultyBadge(meta.difficulty), { icon: "clock-outline", label: meta.duration }, { icon: "dumbbell", label: `${meta.exercises.length} exercises` }];
+  }
+  const badges: MetaBadge[] = [];
+  const est = durationEstimates[itemId];
+  if (est != null) badges.push({ icon: "clock-outline", label: formatDurationEstimate(est) });
+  badges.push({ icon: "dumbbell", label: `${counts[itemId] ?? 0} exercises` });
+  return badges;
+}
+
+function buildMenuItems(
+  isStarter: boolean,
+  item: WorkoutTemplate,
+  onOptions: (t: WorkoutTemplate) => void,
+  onEdit: (id: string) => void,
+  onDelete: (t: WorkoutTemplate) => void
+): FlowCardMenuItem[] {
+  if (isStarter) return [{ label: "Duplicate", icon: "content-copy", onPress: () => onOptions(item) }];
+  return [
+    { label: "Edit", icon: "pencil", onPress: () => onEdit(item.id) },
+    { label: "Duplicate", icon: "content-copy", onPress: () => onOptions(item) },
+    { label: "Delete", icon: "trash-can-outline", onPress: () => onDelete(item), destructive: true },
+  ];
+}
+
 export function TemplatesList({ colors, templates, counts, durationEstimates, starterMeta, templateReadiness, showReadiness, onStart, onDelete, onOptions, onEdit }: Props) {
   const router = useRouter();
   return (
@@ -46,25 +77,14 @@ export function TemplatesList({ colors, templates, counts, durationEstimates, st
         <View style={styles.flowList}>
           {templates.map((item) => {
             const meta = starterMeta(item.id);
-            const isStarter = !!meta || item.is_starter;
-            const metaBadges: MetaBadge[] = meta ? [difficultyBadge(meta.difficulty), { icon: "clock-outline", label: meta.duration }, { icon: "dumbbell", label: `${meta.exercises.length} exercises` }] : [];
-            if (!meta) {
-              const est = durationEstimates[item.id];
-              if (est != null) metaBadges.push({ icon: "clock-outline", label: formatDurationEstimate(est) });
-              metaBadges.push({ icon: "dumbbell", label: `${counts[item.id] ?? 0} exercises` });
-            }
+            const isStarter = !!meta || !!item.is_starter;
+            const metaBadges = buildMetaBadges(meta, counts, durationEstimates, item.id);
             if (isStarter) metaBadges.push({ icon: "star-outline", label: "Starter" });
             const badges: { label: string; type: "active" | "starter" | "recommended" }[] = [];
             if (meta?.recommended) badges.push({ label: "RECOMMENDED", type: "recommended" });
             const readiness = !isStarter && showReadiness ? (templateReadiness[item.id]?.badge ?? null) : null;
             const displayName = meta?.name || item.name;
-            const menuItems: FlowCardMenuItem[] = isStarter
-              ? [{ label: "Duplicate", icon: "content-copy", onPress: () => onOptions(item) }]
-              : [
-                  { label: "Edit", icon: "pencil", onPress: () => onEdit(item.id) },
-                  { label: "Duplicate", icon: "content-copy", onPress: () => onOptions(item) },
-                  { label: "Delete", icon: "trash-can-outline", onPress: () => onDelete(item), destructive: true },
-                ];
+            const menuItems = buildMenuItems(isStarter, item, onOptions, onEdit, onDelete);
             const durationEst = !meta ? durationEstimates[item.id] : null;
             const spokenDuration = durationEst != null ? `, ${formatSpokenDuration(durationEst)}` : "";
             return (


### PR DESCRIPTION
## Summary

Add estimated workout duration badges to user-created template cards on the home screen. The estimate is the median duration of the user's last 5 completed sessions for that template, displayed as "~45m" with a clock icon.

## Changes

- **lib/db/sessions.ts**: New `getTemplateDurationEstimates()` — batched SQL query using ROW_NUMBER() window function to fetch last 5 sessions per template, with JS-side median computation
- **lib/format.ts**: New `formatDurationEstimate()` ("~45m") and `formatSpokenDuration()` ("approximately 45 minutes") helpers
- **components/home/loadHomeData.ts**: Wire duration estimates into home data loading with try/catch fallback
- **components/home/TemplatesList.tsx**: Display clock badge before exercise count for non-starter templates; extract helpers to reduce complexity; update accessibilityLabel with spoken duration
- **app/(tabs)/index.tsx**: Pass durationEstimates prop to TemplatesList

## Testing

- 13 unit tests for format helpers (edge cases: 0s, boundaries, hours+minutes, very long)
- 8 unit tests for DB query (empty, single, median computation, batch verification, SQL filters)
- tsc passes, lint passes, all tests pass

## Issue

Resolves BLD-438