### PR TITLE
feat: post-workout muscle coverage map on session summary (BLD-442)

### DIFF
--- a/__tests__/lib/aggregate-muscles.test.ts
+++ b/__tests__/lib/aggregate-muscles.test.ts
@@ -1,0 +1,28 @@
+import { aggregateMuscles } from "../../lib/aggregate-muscles";
+import type { MuscleGroup } from "../../lib/types";
+
+describe("aggregateMuscles", () => {
+  it("separates primary/secondary, deduplicates, and primary wins over secondary", () => {
+    // Basic separation
+    const simple = aggregateMuscles([
+      { primary_muscles: ["chest" as MuscleGroup], secondary_muscles: ["triceps" as MuscleGroup] },
+    ]);
+    expect(simple.primary).toEqual(["chest"]);
+    expect(simple.secondary).toEqual(["triceps"]);
+
+    // Empty input
+    const empty = aggregateMuscles([]);
+    expect(empty.primary).toEqual([]);
+    expect(empty.secondary).toEqual([]);
+
+    // Primary wins when muscle appears as both across exercises + deduplication
+    const multi = aggregateMuscles([
+      { primary_muscles: ["chest" as MuscleGroup, "shoulders" as MuscleGroup], secondary_muscles: ["triceps" as MuscleGroup] },
+      { primary_muscles: ["chest" as MuscleGroup], secondary_muscles: ["shoulders" as MuscleGroup, "core" as MuscleGroup] },
+    ]);
+    expect(multi.primary).toEqual(expect.arrayContaining(["chest", "shoulders"]));
+    expect(multi.primary.filter((m) => m === "chest")).toHaveLength(1);
+    expect(multi.secondary).toEqual(expect.arrayContaining(["triceps", "core"]));
+    expect(multi.secondary).not.toContain("shoulders");
+  });
+});

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -17,6 +17,7 @@ import PRsCard from "../../../components/session/summary/PRsCard";
 import WeightIncreasesCard from "../../../components/session/summary/WeightIncreasesCard";
 import ComparisonCard from "../../../components/session/summary/ComparisonCard";
 import SetsCard from "../../../components/session/summary/SetsCard";
+import MusclesWorkedCard from "../../../components/session/summary/MusclesWorkedCard";
 import SummaryFooter from "../../../components/session/summary/SummaryFooter";
 import type { ShareCardExercise, ShareCardPR } from "../../../components/ShareCard";
 import { useThemeColors } from "@/hooks/useThemeColors";
@@ -29,7 +30,7 @@ export default function Summary() {
   const { id } = useLocalSearchParams<{ id: string }>();
 
   const data = useSummaryData(id);
-  const { session, completed, grouped, prs, repPrs, increases, comparison, unit, volume, setsBreakdown, newAchievements, completedSetCount } = data;
+  const { session, completed, grouped, prs, repPrs, increases, comparison, unit, volume, setsBreakdown, newAchievements, completedSetCount, primaryMuscles, secondaryMuscles } = data;
   const actions = useSummaryActions(id);
 
   // Sync rating/notes when session loads
@@ -90,6 +91,7 @@ export default function Summary() {
     ...(allPrs.length > 0 ? [{ key: "prs" }] : []),
     ...(increases.length > 0 ? [{ key: "increases" }] : []),
     ...(comparison?.previous ? [{ key: "comparison" }] : []),
+    ...((primaryMuscles.length > 0 || secondaryMuscles.length > 0) ? [{ key: "muscles" }] : []),
     ...(grouped.length > 0 ? [{ key: "sets" }] : []),
   ] as { key: string }[];
 
@@ -125,6 +127,7 @@ export default function Summary() {
           if (item.key === "prs") return <PRsCard prs={prs} repPrs={repPrs} unit={unit} colors={colors} />;
           if (item.key === "increases") return <WeightIncreasesCard increases={increases} unit={unit} colors={colors} />;
           if (item.key === "comparison" && comparison?.previous) return <ComparisonCard comparison={comparison} colors={colors} />;
+          if (item.key === "muscles") return <MusclesWorkedCard primaryMuscles={primaryMuscles} secondaryMuscles={secondaryMuscles} colors={colors} />;
           if (item.key === "sets") return <SetsCard grouped={grouped} colors={colors} />;
           return null;
         }}

--- a/components/session/summary/MusclesWorkedCard.tsx
+++ b/components/session/summary/MusclesWorkedCard.tsx
@@ -1,0 +1,66 @@
+import { StyleSheet, View } from "react-native";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { Card, CardContent } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
+import { MuscleMap } from "@/components/MuscleMap";
+import { MUSCLE_LABELS } from "@/lib/types";
+import type { MuscleGroup } from "@/lib/types";
+import type { ThemeColors } from "@/hooks/useThemeColors";
+import { useProfileGender } from "@/lib/useProfileGender";
+import ErrorBoundary from "@/components/ErrorBoundary";
+
+type Props = {
+  primaryMuscles: MuscleGroup[];
+  secondaryMuscles: MuscleGroup[];
+  colors: ThemeColors;
+};
+
+function MusclesWorkedCardInner({ primaryMuscles, secondaryMuscles, colors }: Props) {
+  const gender = useProfileGender();
+
+  const allMuscles = [...primaryMuscles, ...secondaryMuscles];
+  const muscleNames = allMuscles
+    .filter((m) => m !== "full_body")
+    .map((m) => MUSCLE_LABELS[m])
+    .join(", ");
+
+  return (
+    <Card
+      style={StyleSheet.flatten([styles.section, { backgroundColor: colors.surface }])}
+      accessibilityLabel={`Muscles worked: ${muscleNames}`}
+    >
+      <CardContent>
+        <View style={styles.sectionHeader}>
+          <MaterialCommunityIcons name="human-handsup" size={20} color={colors.primary} />
+          <Text
+            variant="title"
+            style={{ color: colors.onSurface, marginLeft: 8, fontWeight: "700" }}
+          >
+            Muscles Worked
+          </Text>
+        </View>
+        <View style={styles.mapContainer}>
+          <MuscleMap
+            primary={primaryMuscles}
+            secondary={secondaryMuscles}
+            gender={gender}
+          />
+        </View>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function MusclesWorkedCard(props: Props) {
+  return (
+    <ErrorBoundary>
+      <MusclesWorkedCardInner {...props} />
+    </ErrorBoundary>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: { marginBottom: 16 },
+  sectionHeader: { flexDirection: "row", alignItems: "center", marginBottom: 12 },
+  mapContainer: { maxHeight: 200 },
+});

--- a/hooks/useSummaryData.ts
+++ b/hooks/useSummaryData.ts
@@ -11,13 +11,15 @@ import {
   getSessionSetCount,
   getSessionSets,
   getSessionWeightIncreases,
+  getExercisesByIds,
   buildAchievementContext,
   getEarnedAchievementIds,
   saveEarnedAchievements,
 } from "../lib/db";
 import { evaluateAchievements } from "../lib/achievements";
 import type { AchievementDef } from "../lib/achievements";
-import type { WorkoutSession, WorkoutSet } from "../lib/types";
+import type { WorkoutSession, WorkoutSet, MuscleGroup } from "../lib/types";
+import { aggregateMuscles } from "../lib/aggregate-muscles";
 
 type PR = { exercise_id: string; name: string; weight: number; previous_max: number };
 type RepPR = { exercise_id: string; name: string; reps: number; previous_max: number };
@@ -41,6 +43,8 @@ export function useSummaryData(id: string | undefined) {
   const [unit, setUnit] = useState<"kg" | "lb">("kg");
   const [newAchievements, setNewAchievements] = useState<AchievementDef[]>([]);
   const [completedSetCount, setCompletedSetCount] = useState(0);
+  const [primaryMuscles, setPrimaryMuscles] = useState<MuscleGroup[]>([]);
+  const [secondaryMuscles, setSecondaryMuscles] = useState<MuscleGroup[]>([]);
 
   useEffect(() => {
     if (!id) return;
@@ -71,6 +75,17 @@ export function useSummaryData(id: string | undefined) {
         (inc) => !prData.some((pr) => pr.exercise_id === inc.exercise_id)
       ));
       setComparison(compData);
+
+      // Aggregate muscles from completed exercises
+      const completedSets = setsData.filter((s) => s.completed);
+      const exerciseIds = [...new Set(completedSets.map((s) => s.exercise_id))];
+      if (exerciseIds.length > 0) {
+        const exerciseMap = await getExercisesByIds(exerciseIds);
+        const exerciseList = Object.values(exerciseMap);
+        const { primary, secondary } = aggregateMuscles(exerciseList);
+        setPrimaryMuscles(primary);
+        setSecondaryMuscles(secondary);
+      }
 
       try {
         const [ctx, alreadyEarnedIds] = await Promise.all([
@@ -140,5 +155,6 @@ export function useSummaryData(id: string | undefined) {
     prs, repPrs, durationPrs, increases, comparison,
     unit, volume, setsBreakdown,
     newAchievements, completedSetCount,
+    primaryMuscles, secondaryMuscles,
   };
 }

--- a/lib/aggregate-muscles.ts
+++ b/lib/aggregate-muscles.ts
@@ -1,0 +1,23 @@
+import type { MuscleGroup } from "./types";
+
+/**
+ * Aggregate primary/secondary muscles from a set of exercises.
+ * If a muscle appears as primary in ANY exercise, it's primary overall.
+ * Otherwise if it's secondary in any, it stays secondary.
+ */
+export function aggregateMuscles(
+  exercises: { primary_muscles: MuscleGroup[]; secondary_muscles: MuscleGroup[] }[],
+): { primary: MuscleGroup[]; secondary: MuscleGroup[] } {
+  const primarySet = new Set<MuscleGroup>();
+  const secondarySet = new Set<MuscleGroup>();
+
+  for (const ex of exercises) {
+    for (const m of ex.primary_muscles) primarySet.add(m);
+    for (const m of ex.secondary_muscles) secondarySet.add(m);
+  }
+
+  // Primary wins over secondary
+  for (const m of primarySet) secondarySet.delete(m);
+
+  return { primary: [...primarySet], secondary: [...secondarySet] };
+}


### PR DESCRIPTION
## Summary

Adds a MusclesWorkedCard to the session summary screen showing a body map highlighting muscles trained during the workout. Primary muscles at high intensity, secondary at lower intensity. Front and back body views side-by-side.

## Changes

- **`lib/aggregate-muscles.ts`** — Pure function aggregating primary/secondary muscles from exercises. Primary wins over secondary when a muscle appears in both roles.
- **`components/session/summary/MusclesWorkedCard.tsx`** — New component rendering MuscleMap with error boundary, surface background, and accessibility label.
- **`hooks/useSummaryData.ts`** — Fetches exercise data and aggregates muscles for the session.
- **`app/session/summary/[id].tsx`** — Integrates MusclesWorkedCard after comparison card, before sets card. Hidden when no exercises have muscle data.

## Testing

- 1 consolidated unit test covering: primary/secondary separation, primary-wins-over-secondary, empty input, deduplication
- TypeScript passes with zero errors
- ESLint passes with zero warnings

## Issue

Resolves BLD-442