### PR TITLE
feat: Live time-remaining estimate during workout (BLD-444)

### DIFF
--- a/__tests__/lib/format.test.ts
+++ b/__tests__/lib/format.test.ts
@@ -2,6 +2,7 @@ import {
   computeLongestStreak,
   withOpacity,
   mondayOf,
+  formatTimeRemaining,
 } from "../../lib/format";
 
 const ONE_WEEK = 7 * 24 * 60 * 60 * 1000;
@@ -61,19 +62,33 @@ describe("computeLongestStreak", () => {
 });
 
 describe("withOpacity", () => {
-  it("converts hex color with opacity", () => {
+  it("converts hex colors with various opacities", () => {
     expect(withOpacity("#FF0000", 0.5)).toBe("rgba(255, 0, 0, 0.5)");
-  });
-
-  it("handles full opacity", () => {
     expect(withOpacity("#00FF00", 1)).toBe("rgba(0, 255, 0, 1)");
-  });
-
-  it("handles zero opacity", () => {
     expect(withOpacity("#0000FF", 0)).toBe("rgba(0, 0, 255, 0)");
-  });
-
-  it("handles 70% opacity", () => {
     expect(withOpacity("#6750A4", 0.7)).toBe("rgba(103, 80, 164, 0.7)");
+  });
+});
+
+describe("formatTimeRemaining", () => {
+  it("returns correct remaining time text for various scenarios", () => {
+    // Normal case: 25 min remaining
+    expect(formatTimeRemaining(3000, 1500)).toBe("~25 min left");
+    // Ceil: 90 seconds remaining → ~2 min left
+    expect(formatTimeRemaining(3000, 2910)).toBe("~2 min left");
+    // Exactly 1 minute remaining
+    expect(formatTimeRemaining(3000, 2940)).toBe("~1 min left");
+    // Elapsed exceeds estimate → null
+    expect(formatTimeRemaining(3000, 3100)).toBeNull();
+    // Elapsed equals estimate → null
+    expect(formatTimeRemaining(3000, 3000)).toBeNull();
+    // Null estimate → null
+    expect(formatTimeRemaining(null, 500)).toBeNull();
+    // Zero estimate → null
+    expect(formatTimeRemaining(0, 0)).toBeNull();
+    // Negative estimate → null
+    expect(formatTimeRemaining(-100, 0)).toBeNull();
+    // Large remaining: 45 min left
+    expect(formatTimeRemaining(5400, 2700)).toBe("~45 min left");
   });
 });

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -16,6 +16,7 @@ import { activateKeepAwakeAsync } from "expo-keep-awake";
 import BottomSheet, { BottomSheetBackdrop } from "@gorhom/bottom-sheet";
 import { setEnabled as setAudioEnabled } from "../../lib/audio";
 import { getAppSetting, addWarmupSets } from "../../lib/db";
+import { getTemplateDurationEstimates } from "../../lib/db/sessions";
 import { generateWarmupSets } from "../../lib/warmup";
 import * as Haptics from "expo-haptics";
 import { useLayout } from "../../lib/layout";
@@ -107,6 +108,17 @@ export default function ActiveSession() {
   const detailSnapPoints = useMemo(() => ["40%", "90%"], []);
   const toolboxSheetRef = useRef<BottomSheet>(null);
   const [restSettingsRequested, setRestSettingsRequested] = useState(false);
+  const [estimatedDuration, setEstimatedDuration] = useState<number | null>(null);
+
+  // Fetch estimated duration from template history (Phase 70)
+  useEffect(() => {
+    if (!session?.template_id) return;
+    getTemplateDurationEstimates([session.template_id])
+      .then((estimates) => {
+        setEstimatedDuration(estimates[session.template_id!] ?? null);
+      })
+      .catch(() => {});
+  }, [session?.template_id]);
 
   const handleToolboxOpen = useCallback(() => {
     // Mutual exclusion: close exercise picker before opening toolbox
@@ -249,6 +261,7 @@ export default function ActiveSession() {
             <SessionHeaderToolbar
               rest={rest}
               elapsed={elapsed}
+              estimatedDuration={estimatedDuration}
               onStartRest={handleToolboxStartRest}
               onDismissRest={dismissRest}
               onOpenToolbox={handleToolboxOpen}

--- a/components/session/SessionHeaderToolbar.tsx
+++ b/components/session/SessionHeaderToolbar.tsx
@@ -10,7 +10,7 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { Text } from "@/components/ui/text";
 import { Chip } from "@/components/ui/chip";
 import { useThemeColors } from "@/hooks/useThemeColors";
-import { formatTime } from "../../lib/format";
+import { formatTime, formatTimeRemaining } from "../../lib/format";
 import { getAppSetting, setAppSetting } from "../../lib/db";
 import { fontSizes } from "@/constants/design-tokens";
 
@@ -26,6 +26,7 @@ function presetLabel(seconds: number): string {
 type Props = {
   rest: number;
   elapsed: number;
+  estimatedDuration?: number | null;
   onStartRest: (duration: number) => void;
   onDismissRest: () => void;
   onOpenToolbox: () => void;
@@ -36,6 +37,7 @@ type Props = {
 function SessionHeaderToolbarInner({
   rest,
   elapsed,
+  estimatedDuration,
   onStartRest,
   onDismissRest,
   onOpenToolbox,
@@ -163,16 +165,21 @@ function SessionHeaderToolbarInner({
           </Pressable>
         )}
 
-        {/* Elapsed time */}
+        {/* Elapsed time + remaining estimate */}
         <Pressable
           onPress={handleElapsedTap}
           onLongPress={handleLongPress}
           delayLongPress={400}
           disabled={isRestActive}
           accessibilityLabel={
-            isRestActive
-              ? `Elapsed time: ${formatTime(elapsed)}`
-              : `Elapsed time: ${formatTime(elapsed)}. Tap to start rest timer. Long press for rest settings.`
+            (() => {
+              const remainingText = formatTimeRemaining(estimatedDuration ?? null, elapsed);
+              const base = `Elapsed time: ${formatTime(elapsed)}`;
+              if (isRestActive) return base;
+              const suffix = ". Tap to start rest timer. Long press for rest settings.";
+              if (remainingText) return `${base}, approximately ${Math.ceil(((estimatedDuration ?? 0) - elapsed) / 60)} minutes remaining${suffix}`;
+              return `${base}${suffix}`;
+            })()
           }
           accessibilityRole="button"
           style={styles.elapsedButton}
@@ -186,6 +193,21 @@ function SessionHeaderToolbarInner({
           >
             {formatTime(elapsed)}
           </Text>
+          {(() => {
+            const remainingText = formatTimeRemaining(estimatedDuration ?? null, elapsed);
+            if (!remainingText) return null;
+            return (
+              <Text
+                variant="body"
+                style={{
+                  color: colors.onSurfaceVariant,
+                  fontSize: fontSizes.xs,
+                }}
+              >
+                {remainingText}
+              </Text>
+            );
+          })()}
         </Pressable>
 
         {/* Wrench / toolbox button */}

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -91,6 +91,18 @@ export function formatSpokenDuration(seconds: number): string {
   return `approximately ${parts.join(" ")}`;
 }
 
+export function formatTimeRemaining(
+  estimatedTotalSeconds: number | null,
+  elapsedSeconds: number
+): string | null {
+  if (estimatedTotalSeconds == null || estimatedTotalSeconds <= 0) return null;
+  const remaining = estimatedTotalSeconds - elapsedSeconds;
+  if (remaining <= 0) return null;
+  const minutes = Math.ceil(remaining / 60);
+  if (minutes <= 0) return null;
+  return `~${minutes} min left`;
+}
+
 export function hexToRgb(hex: string): string {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);


### PR DESCRIPTION
## Summary

Adds a live '~X min left' text below the elapsed time in the session header during active workouts. Uses the template's historical median duration (from Phase 67) minus elapsed time.

## Changes

- **lib/format.ts**: Added `formatTimeRemaining()` pure function
- **components/session/SessionHeaderToolbar.tsx**: Added `estimatedDuration` prop, renders remaining time below elapsed, updated accessibility label
- **app/session/[id].tsx**: Fetches template duration estimate on session load via `getTemplateDurationEstimates`
- **__tests__/lib/format.test.ts**: Added comprehensive `formatTimeRemaining` tests, consolidated `withOpacity` tests (4→1)

## Testing

- `formatTimeRemaining` unit tests cover: normal cases, ceiling behavior, elapsed exceeds estimate, null/zero/negative inputs
- TypeScript type checking passes (`tsc --noEmit`)
- ESLint passes (0 warnings)
- Test budget: 1799/1800 (net -2 from consolidation)

## Issue

Resolves BLD-444