### PR TITLE
feat: quick-add exercises from recent history (Phase 73, BLD-453)

### DIFF
--- a/__tests__/lib/db/exercise-history-quick-add.test.ts
+++ b/__tests__/lib/db/exercise-history-quick-add.test.ts
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Unit tests for getRecentExercises and getFrequentExercises (Phase 73 — BLD-453).
+ *
+ * Uses jest.resetModules() + globalThis cleanup to get fresh module state for each test.
+ */
+
+const mockRecentRows = [
+  {
+    id: "ex-1", name: "Barbell Bench Press", category: "chest",
+    primary_muscles: '["chest"]', secondary_muscles: '["triceps"]',
+    equipment: "barbell", instructions: "", difficulty: "intermediate",
+    is_custom: 0, deleted_at: null, mount_position: null,
+    attachment: "handle", training_modes: '["weight"]', is_voltra: 0,
+  },
+  {
+    id: "ex-2", name: "Barbell Squat", category: "legs_glutes",
+    primary_muscles: '["quads"]', secondary_muscles: '["glutes"]',
+    equipment: "barbell", instructions: "", difficulty: "intermediate",
+    is_custom: 0, deleted_at: null, mount_position: null,
+    attachment: "handle", training_modes: '["weight"]', is_voltra: 0,
+  },
+];
+
+const mockFrequentRows = [
+  {
+    id: "ex-3", name: "Deadlift", category: "back",
+    primary_muscles: '["back"]', secondary_muscles: '["hamstrings"]',
+    equipment: "barbell", instructions: "", difficulty: "advanced",
+    is_custom: 0, deleted_at: null, mount_position: null,
+    attachment: "handle", training_modes: '["weight"]', is_voltra: 0,
+  },
+  {
+    id: "ex-1", name: "Barbell Bench Press", category: "chest",
+    primary_muscles: '["chest"]', secondary_muscles: '["triceps"]',
+    equipment: "barbell", instructions: "", difficulty: "intermediate",
+    is_custom: 0, deleted_at: null, mount_position: null,
+    attachment: "handle", training_modes: '["weight"]', is_voltra: 0,
+  },
+];
+
+function mockCreateChain(result: any[]) {
+  const chain: any = {};
+  chain.select = jest.fn().mockReturnValue(chain);
+  chain.from = jest.fn().mockReturnValue(chain);
+  chain.innerJoin = jest.fn().mockReturnValue(chain);
+  chain.where = jest.fn().mockReturnValue(chain);
+  chain.groupBy = jest.fn().mockReturnValue(chain);
+  chain.orderBy = jest.fn().mockReturnValue(chain);
+  chain.limit = jest.fn().mockResolvedValue(result);
+  return chain;
+}
+
+const mockStmt = {
+  executeAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  finalizeAsync: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  getFirstAsync: jest.fn().mockResolvedValue(null),
+  runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+  prepareAsync: jest.fn().mockResolvedValue(mockStmt),
+};
+
+jest.mock("expo-sqlite", () => ({
+  openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+}));
+
+describe("Quick-Add DB queries (Phase 73)", () => {
+  let mockDrizzleDb: any;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockDrizzleDb = null;
+    // Clear the globalThis DB singleton so getDrizzle() re-initializes
+    (globalThis as any).__cablesnap_db = undefined;
+    (globalThis as any).__cablesnap_drizzle = undefined;
+    (globalThis as any).__cablesnap_init = undefined;
+
+    // Re-register mocks after resetModules clears them
+    jest.doMock("expo-sqlite", () => ({
+      openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+    }));
+  });
+
+  it("getRecentExercises returns exercises from last 7 days, maps to Exercise type, and excludes deleted", async () => {
+    jest.doMock("drizzle-orm/expo-sqlite", () => ({
+      drizzle: jest.fn(() => {
+        mockDrizzleDb = mockCreateChain(mockRecentRows);
+        return mockDrizzleDb;
+      }),
+    }));
+
+    const { getRecentExercises } = require("../../../lib/db/exercise-history");
+    const result = await getRecentExercises(7, 5);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("ex-1");
+    expect(result[0].name).toBe("Barbell Bench Press");
+    expect(result[0].primary_muscles).toEqual(["chest"]);
+    expect(result[0].is_custom).toBe(false);
+    expect(result[1].id).toBe("ex-2");
+    expect(mockDrizzleDb.innerJoin).toHaveBeenCalledTimes(2);
+    expect(mockDrizzleDb.groupBy).toHaveBeenCalled();
+    expect(mockDrizzleDb.limit).toHaveBeenCalledWith(5);
+  });
+
+  it("getFrequentExercises returns top exercises by session count, excludes deleted, over-fetches by 5", async () => {
+    jest.doMock("drizzle-orm/expo-sqlite", () => ({
+      drizzle: jest.fn(() => {
+        mockDrizzleDb = mockCreateChain(mockFrequentRows);
+        return mockDrizzleDb;
+      }),
+    }));
+
+    const { getFrequentExercises } = require("../../../lib/db/exercise-history");
+    const result = await getFrequentExercises(10);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("ex-3");
+    expect(result[0].name).toBe("Deadlift");
+    expect(result[0].primary_muscles).toEqual(["back"]);
+    expect(result[1].id).toBe("ex-1");
+    expect(mockDrizzleDb.limit).toHaveBeenCalledWith(15);
+    expect(mockDrizzleDb.innerJoin).toHaveBeenCalledTimes(2);
+    expect(mockDrizzleDb.groupBy).toHaveBeenCalled();
+  });
+});

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -1,13 +1,6 @@
 /* eslint-disable max-lines-per-function, react-hooks/exhaustive-deps */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  FlatList,
-  KeyboardAvoidingView,
-  Platform,
-  Pressable,
-  StyleSheet,
-  View,
-} from "react-native";
+import { FlatList, KeyboardAvoidingView, Platform, Pressable, StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { useToast } from "@/components/ui/bna-toast";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";

--- a/components/ExercisePickerSheet.tsx
+++ b/components/ExercisePickerSheet.tsx
@@ -230,6 +230,7 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
         ]}
         accessibilityLabel={`Select ${exercise.name}`}
         accessibilityRole="button"
+        accessibilityState={{ disabled: false }}
       >
         <Text
           variant="body"

--- a/components/ExercisePickerSheet.tsx
+++ b/components/ExercisePickerSheet.tsx
@@ -79,6 +79,10 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
           const recentIds = new Set(recent.map((e) => e.id));
           setFrequentExercises(frequent.filter((e) => !recentIds.has(e.id)).slice(0, 10));
         })
+        .catch(() => {
+          // Recent/frequent failed — still show full exercise list
+          getAllExercises().then(setExercises).catch(() => {});
+        })
         .finally(() => setLoading(false));
 
       translateY.value = withSpring(SNAP_MID, SPRING_CONFIG);

--- a/components/ExercisePickerSheet.tsx
+++ b/components/ExercisePickerSheet.tsx
@@ -30,6 +30,7 @@ import {
 } from "../lib/types";
 import { duration as durationTokens, elevation } from "../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { useToast } from "@/components/ui/bna-toast";
 import { fontSizes } from "@/constants/design-tokens";
 
 type Props = {
@@ -44,6 +45,7 @@ const COMPACT_ITEM_HEIGHT = 48;
 
 export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Props) {
   const colors = useThemeColors();
+  const { error: showError } = useToast();
   const { height: SCREEN_H } = useWindowDimensions();
   const SNAP_MID = SCREEN_H * 0.45;
   const SNAP_TOP = SCREEN_H * 0.06;
@@ -80,7 +82,7 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
           setFrequentExercises(frequent.filter((e) => !recentIds.has(e.id)).slice(0, 10));
         })
         .catch(() => {
-          // Recent/frequent failed — still show full exercise list
+          showError("Couldn't load recent exercises");
           getAllExercises().then(setExercises).catch(() => {});
         })
         .finally(() => setLoading(false));
@@ -93,7 +95,7 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
         runOnJS(setMounted)(false);
       });
     }
-  }, [visible, mounted, translateY, backdropOpacity, SCREEN_H, SNAP_MID]);
+  }, [visible, mounted, translateY, backdropOpacity, SCREEN_H, SNAP_MID, showError]);
 
   const dismiss = useCallback(() => {
     translateY.value = withTiming(SCREEN_H, { duration: durationTokens.fast });

--- a/components/ExercisePickerSheet.tsx
+++ b/components/ExercisePickerSheet.tsx
@@ -21,6 +21,7 @@ import { Chip } from "@/components/ui/chip";
 import { SearchBar } from "@/components/ui/searchbar";
 import { X } from "lucide-react-native";
 import { getAllExercises } from "../lib/db";
+import { getRecentExercises, getFrequentExercises } from "../lib/db/exercise-history";
 import {
   CATEGORIES,
   CATEGORY_LABELS,
@@ -39,6 +40,7 @@ type Props = {
 
 const SPRING_CONFIG = { damping: 20, stiffness: 200, mass: 0.8 };
 const ITEM_HEIGHT = 64;
+const COMPACT_ITEM_HEIGHT = 48;
 
 export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Props) {
   const colors = useThemeColors();
@@ -48,6 +50,8 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
   const DISMISS_THRESHOLD = SCREEN_H * 0.75;
 
   const [exercises, setExercises] = useState<Exercise[]>([]);
+  const [recentExercises, setRecentExercises] = useState<Exercise[]>([]);
+  const [frequentExercises, setFrequentExercises] = useState<Exercise[]>([]);
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<Set<Category>>(new Set());
   const [loading, setLoading] = useState(true);
@@ -63,8 +67,18 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
       setQuery("");
       setSelected(new Set());
       setLoading(true);
-      getAllExercises()
-        .then(setExercises)
+      Promise.all([
+        getAllExercises(),
+        getRecentExercises(7, 5),
+        getFrequentExercises(10),
+      ])
+        .then(([all, recent, frequent]) => {
+          setExercises(all);
+          setRecentExercises(recent);
+          // Deduplicate: remove exercises already in recent
+          const recentIds = new Set(recent.map((e) => e.id));
+          setFrequentExercises(frequent.filter((e) => !recentIds.has(e.id)).slice(0, 10));
+        })
         .finally(() => setLoading(false));
 
       translateY.value = withSpring(SNAP_MID, SPRING_CONFIG);
@@ -127,6 +141,20 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
     });
   }, [exercises, query, selected]);
 
+  const showQuickAdd = !query;
+
+  const filteredRecent = useMemo(() => {
+    if (!showQuickAdd) return [];
+    if (selected.size === 0) return recentExercises;
+    return recentExercises.filter((ex) => selected.has(ex.category));
+  }, [showQuickAdd, recentExercises, selected]);
+
+  const filteredFrequent = useMemo(() => {
+    if (!showQuickAdd) return [];
+    if (selected.size === 0) return frequentExercises;
+    return frequentExercises.filter((ex) => selected.has(ex.category));
+  }, [showQuickAdd, frequentExercises, selected]);
+
   const toggle = useCallback((cat: Category) => {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -186,6 +214,71 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
     ),
     [colors, handlePick],
   );
+
+  const renderCompactItem = useCallback(
+    (exercise: Exercise) => (
+      <Pressable
+        key={exercise.id}
+        onPress={() => handlePick(exercise)}
+        style={({ pressed }) => [
+          styles.compactItem,
+          {
+            backgroundColor: colors.surface,
+            borderBottomColor: colors.outlineVariant,
+          },
+          pressed && { opacity: 0.7 },
+        ]}
+        accessibilityLabel={`Select ${exercise.name}`}
+        accessibilityRole="button"
+      >
+        <Text
+          variant="body"
+          numberOfLines={1}
+          style={{ color: colors.onSurface }}
+        >
+          {exercise.name}
+        </Text>
+      </Pressable>
+    ),
+    [colors, handlePick],
+  );
+
+  const listHeader = useMemo(() => {
+    if (!showQuickAdd) return null;
+    const hasRecent = filteredRecent.length > 0;
+    const hasFrequent = filteredFrequent.length > 0;
+    if (!hasRecent && !hasFrequent) return null;
+
+    return (
+      <View>
+        {hasRecent && (
+          <>
+            <Text
+              variant="caption"
+              style={[styles.sectionHeader, { color: colors.onSurfaceVariant }]}
+              accessibilityRole="header"
+            >
+              RECENT
+            </Text>
+            {filteredRecent.map(renderCompactItem)}
+          </>
+        )}
+        {hasFrequent && (
+          <>
+            <Text
+              variant="caption"
+              style={[styles.sectionHeader, { color: colors.onSurfaceVariant }]}
+              accessibilityRole="header"
+            >
+              FREQUENTLY USED
+            </Text>
+            {filteredFrequent.map(renderCompactItem)}
+          </>
+        )}
+        <View style={[styles.quickAddDivider, { backgroundColor: colors.outlineVariant }]} />
+      </View>
+    );
+  }, [showQuickAdd, filteredRecent, filteredFrequent, colors, renderCompactItem]);
 
   if (!mounted) return null;
 
@@ -257,12 +350,8 @@ export default function ExercisePickerSheet({ visible, onDismiss, onPick }: Prop
           data={filtered}
           renderItem={renderItem}
           keyExtractor={(item) => item.id}
-          getItemLayout={(_data, index) => ({
-            length: ITEM_HEIGHT,
-            offset: ITEM_HEIGHT * index,
-            index,
-          })}
           style={styles.list}
+          ListHeaderComponent={listHeader}
           ListEmptyComponent={
             loading ? null : (
               <View style={styles.empty}>
@@ -350,5 +439,23 @@ const styles = StyleSheet.create({
   empty: {
     alignItems: "center",
     paddingTop: 48,
+  },
+  sectionHeader: {
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 4,
+  },
+  compactItem: {
+    paddingHorizontal: 16,
+    minHeight: COMPACT_ITEM_HEIGHT,
+    justifyContent: "center",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  quickAddDivider: {
+    height: StyleSheet.hairlineWidth,
+    marginTop: 8,
+    marginBottom: 4,
   },
 });

--- a/components/MuscleVolumeSegment.tsx
+++ b/components/MuscleVolumeSegment.tsx
@@ -269,54 +269,14 @@ export default function MuscleVolumeSegment() {
 }
 
 const styles = StyleSheet.create({
-  center: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 32,
-  },
-  weekRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: 8,
-    paddingHorizontal: 4,
-  },
-  chevron: {
-    minWidth: 48,
-    minHeight: 48,
-  },
-  card: {
-    marginHorizontal: 16,
-    marginBottom: 12,
-  },
-  flowRow: {
-    flexDirection: "row",
-    gap: 12,
-  },
-  flowCard: {
-    flex: 1,
-  },
-
-  row: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: 10,
-    paddingHorizontal: 8,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    minHeight: 48,
-  },
-  chartHeader: {
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    paddingHorizontal: 12,
-    paddingTop: 8,
-  },
-  customizeBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  summaryRow: {
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-  },
+  center: { flex: 1, justifyContent: "center", alignItems: "center", padding: 32 },
+  weekRow: { flexDirection: "row", alignItems: "center", marginBottom: 8, paddingHorizontal: 4 },
+  chevron: { minWidth: 48, minHeight: 48 },
+  card: { marginHorizontal: 16, marginBottom: 12 },
+  flowRow: { flexDirection: "row", gap: 12 },
+  flowCard: { flex: 1 },
+  row: { flexDirection: "row", alignItems: "center", paddingVertical: 10, paddingHorizontal: 8, borderBottomWidth: StyleSheet.hairlineWidth, minHeight: 48 },
+  chartHeader: { flexDirection: "row", justifyContent: "flex-end", paddingHorizontal: 12, paddingTop: 8 },
+  customizeBtn: { flexDirection: "row", alignItems: "center" },
+  summaryRow: { paddingVertical: 8, paddingHorizontal: 16 },
 });

--- a/lib/db/exercise-history.ts
+++ b/lib/db/exercise-history.ts
@@ -1,6 +1,8 @@
-import { eq, ne, and, sql, desc, asc, isNotNull, inArray, max, sum, count } from "drizzle-orm";
+import { eq, ne, and, sql, desc, asc, isNotNull, isNull, inArray, max, sum, count } from "drizzle-orm";
 import { query, queryOne, getDrizzle } from "./helpers";
-import { workoutSets, workoutSessions } from "./schema";
+import { workoutSets, workoutSessions, exercises } from "./schema";
+import { mapRow } from "./exercises";
+import type { Exercise } from "../types";
 
 export type ExerciseSession = {
   session_id: string;
@@ -403,4 +405,90 @@ export async function getBestSet(
 
   if (rows.length === 0) return null;
   return { weight: rows[0].weight!, reps: rows[0].reps! };
+}
+
+/**
+ * Recent exercises: distinct exercises used in the last `days` days,
+ * ordered by most-recent session, limited to `limit` results.
+ */
+export async function getRecentExercises(
+  days: number = 7,
+  limit: number = 5,
+): Promise<Exercise[]> {
+  const db = await getDrizzle();
+  const cutoff = Date.now() - days * 86_400_000;
+  const rows = await db
+    .select({
+      id: exercises.id,
+      name: exercises.name,
+      category: exercises.category,
+      primary_muscles: exercises.primary_muscles,
+      secondary_muscles: exercises.secondary_muscles,
+      equipment: exercises.equipment,
+      instructions: exercises.instructions,
+      difficulty: exercises.difficulty,
+      is_custom: exercises.is_custom,
+      deleted_at: exercises.deleted_at,
+      mount_position: exercises.mount_position,
+      attachment: exercises.attachment,
+      training_modes: exercises.training_modes,
+      is_voltra: exercises.is_voltra,
+    })
+    .from(workoutSets)
+    .innerJoin(workoutSessions, eq(workoutSets.session_id, workoutSessions.id))
+    .innerJoin(exercises, eq(workoutSets.exercise_id, exercises.id))
+    .where(
+      and(
+        sql`${workoutSessions.started_at} > ${cutoff}`,
+        eq(workoutSets.completed, 1),
+        isNull(exercises.deleted_at),
+      )
+    )
+    .groupBy(exercises.id)
+    .orderBy(desc(max(workoutSessions.started_at)))
+    .limit(limit);
+
+  return (rows as unknown[]).map((r) => mapRow(r as Parameters<typeof mapRow>[0]));
+}
+
+/**
+ * Frequent exercises: top exercises by number of distinct sessions,
+ * over-fetches by `recentLimit` to allow JS deduplication with recent results.
+ */
+export async function getFrequentExercises(
+  limit: number = 10,
+  recentLimit: number = 5,
+): Promise<Exercise[]> {
+  const db = await getDrizzle();
+  const rows = await db
+    .select({
+      id: exercises.id,
+      name: exercises.name,
+      category: exercises.category,
+      primary_muscles: exercises.primary_muscles,
+      secondary_muscles: exercises.secondary_muscles,
+      equipment: exercises.equipment,
+      instructions: exercises.instructions,
+      difficulty: exercises.difficulty,
+      is_custom: exercises.is_custom,
+      deleted_at: exercises.deleted_at,
+      mount_position: exercises.mount_position,
+      attachment: exercises.attachment,
+      training_modes: exercises.training_modes,
+      is_voltra: exercises.is_voltra,
+    })
+    .from(workoutSets)
+    .innerJoin(workoutSessions, eq(workoutSets.session_id, workoutSessions.id))
+    .innerJoin(exercises, eq(workoutSets.exercise_id, exercises.id))
+    .where(
+      and(
+        eq(workoutSets.completed, 1),
+        isNull(exercises.deleted_at),
+      )
+    )
+    .groupBy(exercises.id)
+    .orderBy(desc(sql`COUNT(DISTINCT ${workoutSessions.id})`))
+    .limit(limit + recentLimit);
+
+  return (rows as unknown[]).map((r) => mapRow(r as Parameters<typeof mapRow>[0]));
 }


### PR DESCRIPTION
## Summary

Add Recent and Frequently Used exercise sections at the top of ExercisePickerSheet for one-tap access to commonly used exercises.

## Changes

- **`lib/db/exercise-history.ts`**: Add `getRecentExercises()` (last 7 days, max 5) and `getFrequentExercises()` (top 10 all-time) Drizzle ORM queries
- **`components/ExercisePickerSheet.tsx`**: Add Recent/Frequent sections via `ListHeaderComponent` on existing FlatList
  - Compact rows (name only, 48dp min height) for quick-add items
  - Section headers with `accessibilityRole='header'`
  - Subtle `outlineVariant` divider between Frequent and All Exercises
  - Sections hide when search query entered
  - Category filter applies to Recent/Frequent sections too
  - JS deduplication removes exercises in Recent from Frequent list
- **`__tests__/lib/db/exercise-history-quick-add.test.ts`**: 2 DB unit tests for new queries

## Testing

- TypeScript: `tsc --noEmit` passes with 0 errors
- ESLint: 0 warnings (lint-staged verified)
- DB tests: 2/2 passing
- Full suite: no new test failures (64 pre-existing failures tracked by BLD-454)

## Issue

Resolves BLD-453