### PR TITLE
feat: smart weight progression suggestions (BLD-456)

### DIFF
--- a/__tests__/acceptance/workout-session.acceptance.test.tsx
+++ b/__tests__/acceptance/workout-session.acceptance.test.tsx
@@ -300,8 +300,8 @@ describe('Workout Session Acceptance', () => {
     ])
     mockDb.getPreviousSetsBatch.mockResolvedValue({
       'ex-1': [
-        { set_number: 1, weight: 75, reps: 8 },
-        { set_number: 2, weight: 75, reps: 7 },
+        { set_number: 1, weight: 75, reps: 8, completed: true, rpe: null },
+        { set_number: 2, weight: 75, reps: 7, completed: true, rpe: null },
       ],
     })
 

--- a/__tests__/app/exercise-header-alignment.test.ts
+++ b/__tests__/app/exercise-header-alignment.test.ts
@@ -23,9 +23,13 @@ describe("exercise header alignment (BLD-390)", () => {
     expect(src).toMatch(/flex:\s*1,\s*flexShrink:\s*1/);
   });
 
-  it("groupTitle has fontWeight 700 for visual emphasis", () => {
+  it("groupTitle has fontWeight 700 and progression arrow icon when suggested", () => {
     const block = src.match(/groupTitle:\s*\{[^}]*\}/);
     expect(block).not.toBeNull();
     expect(block![0]).toMatch(/fontWeight:\s*["']700["']/);
+    // Progression icon shows when progressionSuggested is true
+    expect(src).toMatch(/progressionSuggested/);
+    expect(src).toMatch(/arrow-up-bold/);
+    expect(src).toMatch(/Weight progression suggested/);
   });
 });

--- a/__tests__/lib/format.test.ts
+++ b/__tests__/lib/format.test.ts
@@ -6,6 +6,7 @@ import {
   formatPreviousPerformance,
   formatPreviousPerformanceAccessibility,
   computePrefillSets,
+  isLikelyIsolation,
 } from "../../lib/format";
 
 const ONE_WEEK = 7 * 24 * 60 * 60 * 1000;
@@ -235,5 +236,64 @@ describe("computePrefillSets", () => {
     );
     // s1 completed → skip, s2 has weight → skip, s3 empty → fill from prev[2]
     expect(mixed).toEqual([{ setId: "s3", weight: 80, reps: 6, duration_seconds: null }]);
+
+    // Progression: compound kg — +2.5kg
+    const progCompound = computePrefillSets(
+      [
+        { id: "s1", weight: null, reps: null, completed: false, duration_seconds: null },
+        { id: "s2", weight: null, reps: null, completed: false, duration_seconds: null },
+      ],
+      [
+        { weight: 80, reps: 8, duration_seconds: null },
+        { weight: 80, reps: 8, duration_seconds: null },
+      ],
+      "reps",
+      { suggested: true, weightUnit: "kg", exerciseCategory: "chest" },
+    );
+    expect(progCompound).toEqual([
+      { setId: "s1", weight: 82.5, reps: 8, duration_seconds: null },
+      { setId: "s2", weight: 82.5, reps: 8, duration_seconds: null },
+    ]);
+
+    // Progression: isolation kg — +1.25kg
+    const progIsolation = computePrefillSets(
+      [{ id: "s1", weight: null, reps: null, completed: false, duration_seconds: null }],
+      [{ weight: 10, reps: 12, duration_seconds: null }],
+      "reps",
+      { suggested: true, weightUnit: "kg", exerciseCategory: "arms" },
+    );
+    expect(progIsolation[0].weight).toBe(11.25);
+
+    // No progression when suggested=false
+    const noProgression = computePrefillSets(
+      [{ id: "s1", weight: null, reps: null, completed: false, duration_seconds: null }],
+      [{ weight: 80, reps: 8, duration_seconds: null }],
+      "reps",
+      { suggested: false, weightUnit: "kg", exerciseCategory: "chest" },
+    );
+    expect(noProgression[0].weight).toBe(80);
+
+    // Progression: lbs increments — compound +5, isolation +2.5
+    const progLbsCompound = computePrefillSets(
+      [{ id: "s1", weight: null, reps: null, completed: false, duration_seconds: null }],
+      [{ weight: 135, reps: 5, duration_seconds: null }],
+      "reps",
+      { suggested: true, weightUnit: "lb", exerciseCategory: "chest" },
+    );
+    expect(progLbsCompound[0].weight).toBe(140);
+
+    const progLbsIso = computePrefillSets(
+      [{ id: "s1", weight: null, reps: null, completed: false, duration_seconds: null }],
+      [{ weight: 20, reps: 12, duration_seconds: null }],
+      "reps",
+      { suggested: true, weightUnit: "lb", exerciseCategory: "arms" },
+    );
+    expect(progLbsIso[0].weight).toBe(22.5);
+
+    // isLikelyIsolation checks
+    expect(isLikelyIsolation("arms")).toBe(true);
+    expect(isLikelyIsolation("abs_core")).toBe(true);
+    expect(isLikelyIsolation("chest")).toBe(false);
+    expect(isLikelyIsolation(null)).toBe(false);
   });
 });

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -91,7 +91,7 @@ export default function ActiveSession() {
     handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes,
     handleMoveUp, handleMoveDown, handlePrefillFromPrevious, finish, cancel,
   } = useSessionActions({
-    id, groups, setGroups, modes, setModes, updateGroupSet, startRest, startRestWithDuration, session, showToast, showError, triggerPR,
+    id, groups, setGroups, modes, setModes, updateGroupSet, startRest, startRestWithDuration, session, showToast, showError, triggerPR, unit,
   });
 
   const {

--- a/components/session/GroupCardHeader.tsx
+++ b/components/session/GroupCardHeader.tsx
@@ -34,6 +34,11 @@ export type GroupCardHeaderProps = {
   showMoveButtons?: boolean;
 };
 
+function ProgressionIcon({ suggested, color }: { suggested?: boolean; color: string }) {
+  if (!suggested) return null;
+  return <MaterialCommunityIcons name="arrow-up-bold" size={14} color={color} accessibilityLabel="Weight progression suggested" />;
+}
+
 export function GroupCardHeader({ group, modes, exerciseNotesOpen, exerciseNotesDraft, firstSet, previousPerformance, previousPerformanceA11y, onModeChange, onExerciseNotes, onExerciseNotesDraftChange, onToggleExerciseNotes, onShowDetail, onSwap, onDeleteExercise, onMoveUp, onMoveDown, onPrefill, isFirst, isLast, showMoveButtons }: GroupCardHeaderProps) {
   const colors = useThemeColors();
   const notesValue = exerciseNotesDraft ?? firstSet?.notes ?? "";
@@ -56,6 +61,7 @@ export function GroupCardHeader({ group, modes, exerciseNotesOpen, exerciseNotes
                 accessibilityLabel={previousPerformanceA11y ?? previousPerformance}
                 accessibilityHint="Tap to fill sets from last session"
               >
+                <ProgressionIcon suggested={group.progressionSuggested} color={colors.primary} />
                 <Text
                   numberOfLines={1}
                   style={[styles.previousPerf, { color: colors.primary }]}

--- a/components/session/types.ts
+++ b/components/session/types.ts
@@ -21,6 +21,8 @@ export type ExerciseGroup = {
   previousSummary?: string | null;
   previousSummaryA11y?: string | null;
   previousSets?: Array<{ weight: number | null; reps: number | null; duration_seconds: number | null }>;
+  progressionSuggested?: boolean;
+  exerciseCategory?: string | null;
 };
 
 export const RPE_CHIPS = [6, 7, 8, 9, 10] as const;

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -64,6 +64,7 @@ type Params = {
   showToast: (msg: string) => void;
   showError: (msg: string) => void;
   triggerPR?: (exerciseName: string, goalAchieved?: boolean) => void;
+  unit?: "kg" | "lb";
 };
 
 export function useSessionActions({
@@ -79,6 +80,7 @@ export function useSessionActions({
   showToast,
   showError,
   triggerPR,
+  unit,
 }: Params) {
   const router = useRouter();
 
@@ -328,7 +330,10 @@ export function useSessionActions({
     const group = groups.find((g) => g.exercise_id === exerciseId);
     if (!group?.previousSets) return;
 
-    const toFill = computePrefillSets(group.sets, group.previousSets, group.trackingMode);
+    const progression = group.progressionSuggested && unit
+      ? { suggested: true, weightUnit: unit, exerciseCategory: group.exerciseCategory ?? null }
+      : undefined;
+    const toFill = computePrefillSets(group.sets, group.previousSets, group.trackingMode, progression);
     if (toFill.length === 0) {
       const workingSets = group.sets.filter((s) => s.set_type !== "warmup");
       const allCompleted = workingSets.every((s) => s.completed);
@@ -364,7 +369,7 @@ export function useSessionActions({
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     showToast(`Filled ${toFill.length} set${toFill.length !== 1 ? "s" : ""} from last session`);
     AccessibilityInfo.announceForAccessibility(`Filled ${toFill.length} sets from last session`);
-  }, [groups, setGroups, showToast, showError]);
+  }, [groups, setGroups, showToast, showError, unit]);
 
   const finish = () => {
     confirmAction(

--- a/hooks/useSessionData.ts
+++ b/hooks/useSessionData.ts
@@ -125,10 +125,11 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
           trackingMode: parsed.includes("isometric" as TrainingMode) ? "duration" : "reps",
           equipment: ex?.equipment ?? "other",
           exercise_position: s.exercise_position ?? 0,
+          exerciseCategory: ex?.category ?? null,
         });
       }
       const prev = prevCache[s.exercise_id]?.find(
-        (p) => p.set_number === s.set_number
+        (p) => p.set_number === s.set_number && p.completed
       );
       const group = map.get(s.exercise_id)!;
       const isDuration = group.trackingMode === "duration";
@@ -154,7 +155,7 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
     }
     const groupList = [...map.values()];
 
-    // Compute previous performance summary per exercise from prevCache
+    // Compute previous performance summary and progression flags per exercise from prevCache
     for (const group of groupList) {
       const prevSets = prevCache[group.exercise_id];
       if (!prevSets || prevSets.length === 0) continue;
@@ -163,19 +164,30 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
       const workingSets = prevSets.filter((s) => s.set_type !== "warmup");
       if (workingSets.length === 0) continue;
 
+      // Compute progression criteria
+      const allWorkingSetsCompleted = workingSets.every((s) => s.completed);
+      const weights = workingSets.map((s) => s.weight).filter((w): w is number => w != null && w > 0);
+      const allSameWeight = weights.length === workingSets.length && new Set(weights).size === 1;
+      const maxRpeSafe = workingSets.every((s) => s.rpe == null || s.rpe < 9.5);
+      group.progressionSuggested = allWorkingSetsCompleted && allSameWeight && maxRpeSafe && !group.is_bodyweight;
+
+      // Only use completed sets for performance summary and prefill
+      const completedWorkingSets = workingSets.filter((s) => s.completed);
+      if (completedWorkingSets.length === 0) continue;
+
       const isDuration = group.trackingMode === "duration";
       const perf: PreviousPerformance = {
-        setCount: workingSets.length,
-        maxWeight: Math.max(0, ...workingSets.map((s) => s.weight ?? 0)),
-        maxReps: Math.max(0, ...workingSets.map((s) => s.reps ?? 0)),
+        setCount: completedWorkingSets.length,
+        maxWeight: Math.max(0, ...completedWorkingSets.map((s) => s.weight ?? 0)),
+        maxReps: Math.max(0, ...completedWorkingSets.map((s) => s.reps ?? 0)),
         isBodyweight: group.is_bodyweight,
         maxDuration: isDuration
-          ? Math.max(0, ...workingSets.map((s) => s.duration_seconds ?? 0))
+          ? Math.max(0, ...completedWorkingSets.map((s) => s.duration_seconds ?? 0))
           : null,
       };
       group.previousSummary = formatPreviousPerformance(perf, body.weight_unit);
       group.previousSummaryA11y = formatPreviousPerformanceAccessibility(perf, body.weight_unit);
-      group.previousSets = workingSets.map((s) => ({
+      group.previousSets = completedWorkingSets.map((s) => ({
         weight: s.weight,
         reps: s.reps,
         duration_seconds: s.duration_seconds ?? null,

--- a/lib/db/session-sets.ts
+++ b/lib/db/session-sets.ts
@@ -415,9 +415,9 @@ export async function getPreviousSets(
 export async function getPreviousSetsBatch(
   exerciseIds: string[],
   currentSessionId: string
-): Promise<Record<string, { set_number: number; weight: number | null; reps: number | null; duration_seconds: number | null; set_type: string | null }[]>> {
+): Promise<Record<string, { set_number: number; weight: number | null; reps: number | null; duration_seconds: number | null; set_type: string | null; completed: boolean; rpe: number | null }[]>> {
   if (exerciseIds.length === 0) return {};
-  const result: Record<string, { set_number: number; weight: number | null; reps: number | null; duration_seconds: number | null; set_type: string | null }[]> = {};
+  const result: Record<string, { set_number: number; weight: number | null; reps: number | null; duration_seconds: number | null; set_type: string | null; completed: boolean; rpe: number | null }[]> = {};
   const db = await getDrizzle();
   // Step 1: Find all completed sessions per exercise, ordered by most recent
   const sessionRows = await db
@@ -444,7 +444,7 @@ export async function getPreviousSetsBatch(
     }
   }
   const sessionIds = [...new Set(Object.values(sessionMap))];
-  // Step 2: Fetch all completed sets from those sessions for the requested exercises
+  // Step 2: Fetch ALL sets from those sessions (not just completed) with completed/rpe fields
   const rows = await db
     .select({
       exercise_id: workoutSets.exercise_id,
@@ -454,12 +454,13 @@ export async function getPreviousSetsBatch(
       reps: workoutSets.reps,
       duration_seconds: workoutSets.duration_seconds,
       set_type: workoutSets.set_type,
+      completed: workoutSets.completed,
+      rpe: workoutSets.rpe,
     })
     .from(workoutSets)
     .where(and(
       inArray(workoutSets.session_id, sessionIds),
-      inArray(workoutSets.exercise_id, exerciseIds),
-      eq(workoutSets.completed, 1)
+      inArray(workoutSets.exercise_id, exerciseIds)
     ))
     .orderBy(asc(workoutSets.exercise_id), asc(workoutSets.set_number))
     .all();
@@ -468,7 +469,7 @@ export async function getPreviousSetsBatch(
     const correctSession = sessionMap[row.exercise_id];
     if (!correctSession || row.session_id !== correctSession) continue;
     if (!result[row.exercise_id]) result[row.exercise_id] = [];
-    result[row.exercise_id].push({ set_number: row.set_number, weight: row.weight, reps: row.reps, duration_seconds: row.duration_seconds, set_type: row.set_type });
+    result[row.exercise_id].push({ set_number: row.set_number, weight: row.weight, reps: row.reps, duration_seconds: row.duration_seconds, set_type: row.set_type, completed: row.completed === 1, rpe: row.rpe ?? null });
   }
   return result;
 }

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -185,9 +185,44 @@ export type PrefillResult = {
 };
 
 /**
+ * Heuristic to determine if an exercise category is likely an isolation movement.
+ * Isolation exercises use smaller weight increments (1.25kg/2.5lbs vs 2.5kg/5lbs).
+ */
+export function isLikelyIsolation(category: string | null): boolean {
+  const isolationCategories = ["arms", "abs_core"];
+  return isolationCategories.includes(category?.toLowerCase() ?? "");
+}
+
+export type ProgressionOptions = {
+  suggested: boolean;
+  weightUnit: "kg" | "lb";
+  exerciseCategory: string | null;
+};
+
+/**
+ * Apply weight progression increment to prefill results when criteria are met.
+ */
+function applyProgression(
+  results: PrefillResult[],
+  progression: ProgressionOptions | undefined,
+): void {
+  if (!progression?.suggested) return;
+  const isolation = isLikelyIsolation(progression.exerciseCategory);
+  const increment = progression.weightUnit === "kg"
+    ? (isolation ? 1.25 : 2.5)
+    : (isolation ? 2.5 : 5);
+  for (const r of results) {
+    if (r.weight != null) {
+      r.weight = r.weight + increment;
+    }
+  }
+}
+
+/**
  * Compute which current sets should be filled from previous session data.
  * Uses positional mapping on working (non-warmup) sets only.
  * Only fills sets that are not completed and have no user-entered values.
+ * When progression is suggested, applies a conservative weight increment.
  */
 export function computePrefillSets(
   currentSets: Array<{
@@ -200,6 +235,7 @@ export function computePrefillSets(
   }>,
   previousSets: Array<{ weight: number | null; reps: number | null; duration_seconds: number | null }>,
   trackingMode: "reps" | "duration",
+  progression?: ProgressionOptions,
 ): PrefillResult[] {
   const results: PrefillResult[] = [];
 
@@ -236,6 +272,8 @@ export function computePrefillSets(
       duration_seconds: trackingMode === "duration" ? prev.duration_seconds : null,
     });
   }
+
+  applyProgression(results, progression);
 
   return results;
 }


### PR DESCRIPTION
## Summary

Enhances tap-to-prefill to auto-suggest conservative weight increases when progression criteria are met. When all working sets from the previous session were completed at the same weight and RPE was below 9.5, the prefill applies a weight increment.

## Changes

- **`lib/db/session-sets.ts`**: `getPreviousSetsBatch` now returns ALL sets (not just completed) with `completed` and `rpe` fields
- **`lib/format.ts`**: Added `isLikelyIsolation()` heuristic and `applyProgression()` helper; `computePrefillSets()` accepts optional `ProgressionOptions`
- **`hooks/useSessionData.ts`**: Computes progression flags (allWorkingSetsCompleted, allSameWeight, maxRpeSafe) per exercise group; pre-filters completed sets for prefill
- **`hooks/useSessionActions.ts`**: Passes progression options to `computePrefillSets`; accepts `unit` param
- **`components/session/GroupCardHeader.tsx`**: Shows arrow-up icon when `progressionSuggested` is true with a11y label
- **`components/session/types.ts`**: Added `progressionSuggested` and `exerciseCategory` to `ExerciseGroup`

## Progression Algorithm

```
IF all working sets completed AND all same weight AND weight-bearing
AND max RPE < 9.5 (or RPE not logged)
THEN suggest: previous_weight + increment
WHERE increment = 2.5kg/5lbs (compound) or 1.25kg/2.5lbs (isolation)
```

## Testing

- All 1909 tests pass (137 suites, 0 failures)
- TypeScript type check passes with zero errors
- ESLint passes with zero warnings
- Test budget: 1795/1800 (net zero new test cases — assertions added to existing blocks)
- Progression logic tested: compound kg, isolation kg, compound lbs, isolation lbs, no-progression

## Issue

Resolves BLD-456