### PR TITLE
fix: restore all missing column migrations for upgrading users (BLD-461)

### DIFF
--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -1,5 +1,5 @@
 import * as SQLite from "expo-sqlite";
-import { createCoreTables, createExtensionTables, addColumnIfMissing } from "./tables";
+import { createCoreTables, createExtensionTables, addColumnIfMissing, hasColumn } from "./tables";
 import { createScheduleAndIndexes } from "./table-migrations";
 
 async function addPerformanceIndexes(database: SQLite.SQLiteDatabase): Promise<void> {
@@ -19,8 +19,61 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   await createScheduleAndIndexes(database);
   await createExtensionTables(database);
   await addPerformanceIndexes(database);
-  // Phase 62: exercise reorder support
+  // ── Column migrations for users upgrading from older database versions ──
+  // These were removed in 4b0add8 under "0 users" assumption; restored for BLD-461.
+  // addColumnIfMissing is idempotent — safe to run on fresh and upgraded databases.
+
+  // exercises table
+  await addColumnIfMissing(database, "exercises", "deleted_at", "INTEGER DEFAULT NULL");
+  await addColumnIfMissing(database, "exercises", "mount_position", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "exercises", "attachment", "TEXT DEFAULT 'handle'");
+  await addColumnIfMissing(database, "exercises", "training_modes", `TEXT DEFAULT '["weight"]'`);
+  await addColumnIfMissing(database, "exercises", "is_voltra", "INTEGER DEFAULT 0");
+
+  // workout_templates table
+  await addColumnIfMissing(database, "workout_templates", "is_starter", "INTEGER DEFAULT 0");
+
+  // programs table
+  await addColumnIfMissing(database, "programs", "is_starter", "INTEGER DEFAULT 0");
+
+  // template_exercises table
+  await addColumnIfMissing(database, "template_exercises", "link_id", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "template_exercises", "link_label", "TEXT DEFAULT ''");
+  await addColumnIfMissing(database, "template_exercises", "target_duration_seconds", "INTEGER");
+  await addColumnIfMissing(database, "template_exercises", "training_mode", "TEXT DEFAULT NULL");
+
+  // workout_sessions table
+  await addColumnIfMissing(database, "workout_sessions", "program_day_id", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sessions", "rating", "INTEGER DEFAULT NULL");
+
+  // workout_sets table
+  await addColumnIfMissing(database, "workout_sets", "rpe", "REAL DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sets", "notes", "TEXT DEFAULT ''");
+  await addColumnIfMissing(database, "workout_sets", "link_id", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sets", "round", "INTEGER DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sets", "training_mode", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sets", "tempo", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sets", "swapped_from_exercise_id", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sets", "duration_seconds", "INTEGER");
   await addColumnIfMissing(database, "workout_sets", "exercise_position", "INTEGER DEFAULT 0");
+
+  // workout_sets.set_type migration (replaces deprecated is_warmup column)
+  if (!(await hasColumn(database, "workout_sets", "set_type"))) {
+    await database.execAsync(
+      "ALTER TABLE workout_sets ADD COLUMN set_type TEXT DEFAULT 'normal'"
+    );
+    if (await hasColumn(database, "workout_sets", "is_warmup")) {
+      await database.execAsync(
+        "UPDATE workout_sets SET set_type = 'warmup' WHERE is_warmup = 1"
+      );
+      await database.execAsync(
+        "UPDATE workout_sets SET set_type = 'normal' WHERE is_warmup = 0 OR is_warmup IS NULL"
+      );
+    }
+  }
+
+  // body_settings table
+  await addColumnIfMissing(database, "body_settings", "sex", "TEXT NOT NULL DEFAULT 'male'");
 
   // Phase 66: strength goals table
   await database.execAsync(`


### PR DESCRIPTION
## Summary
Restores all column migrations that were removed in commit 4b0add8 under the assumption of zero existing users. Users upgrading from older database versions crash because `seedStarters()` attempts INSERT with columns that don't exist (e.g. `template_exercises.training_mode`), causing `cannot rollback - no transaction is active`.

## Root Cause
Commit 4b0add8 removed ALL `addColumnIfMissing` calls from both `migrations.ts` and `table-migrations.ts`, folding them into `CREATE TABLE IF NOT EXISTS` DDL. For existing databases, `CREATE TABLE IF NOT EXISTS` is a no-op, so columns added after the initial table creation are never created.

## Changes
- `lib/db/migrations.ts`: Restore all 23 missing column migrations across 7 tables:
  - `exercises`: deleted_at, mount_position, attachment, training_modes, is_voltra
  - `workout_templates`: is_starter
  - `programs`: is_starter
  - `template_exercises`: link_id, link_label, target_duration_seconds, training_mode
  - `workout_sessions`: program_day_id, rating
  - `workout_sets`: rpe, notes, link_id, round, training_mode, tempo, swapped_from_exercise_id, duration_seconds, exercise_position, set_type
  - `body_settings`: sex
- Add safety guard for `set_type` migration: checks for `is_warmup` column before referencing it

## Testing
- `npx tsc --noEmit` — clean
- `npx jest --no-coverage` — 1974 passed, 134 suites
- All migrations are idempotent (`addColumnIfMissing` checks column existence first)
- Zero new test cases (test budget: 1699/1800)

## Issue
Fixes BLD-461, BLD-462