### PR TITLE
feat: Monthly Training Report & Progress Digest (BLD-465)

### DIFF
--- a/__tests__/components/progress/MonthlyReportSegment.test.tsx
+++ b/__tests__/components/progress/MonthlyReportSegment.test.tsx
@@ -154,7 +154,7 @@ describe('Monthly Report Segment', () => {
     const utils = renderScreen(<Progress />)
     fireEvent.press(utils.getByText('Monthly'))
     await waitFor(() => {
-      expect(utils.getByText('16')).toBeTruthy()
+      expect(utils.getAllByText('16').length).toBeGreaterThan(0)
     })
     expect(utils.getByText('Bench Press')).toBeTruthy()
   })
@@ -186,7 +186,7 @@ describe('Monthly Report Segment', () => {
     const utils = renderScreen(<Progress />)
     fireEvent.press(utils.getByText('Monthly'))
     await waitFor(() => {
-      expect(utils.getByText('16')).toBeTruthy()
+      expect(utils.getAllByText('16').length).toBeGreaterThan(0)
     })
     expect(utils.queryByText('PRs This Month')).toBeNull()
   })
@@ -195,7 +195,7 @@ describe('Monthly Report Segment', () => {
     const utils = renderScreen(<Progress />)
     fireEvent.press(utils.getByText('Monthly'))
     await waitFor(() => {
-      expect(utils.getByText('16')).toBeTruthy()
+      expect(utils.getAllByText('16').length).toBeGreaterThan(0)
     })
     const prevBtn = utils.getByLabelText('Previous month')
     fireEvent.press(prevBtn)

--- a/__tests__/components/progress/MonthlyReportSegment.test.tsx
+++ b/__tests__/components/progress/MonthlyReportSegment.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react'
+import { fireEvent, waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../../helpers/render'
+import { createBodySettings, resetIds } from '../../helpers/factories'
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    useRouter: () => mockRouter,
+    useLocalSearchParams: () => ({}),
+    usePathname: () => '/test',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+    Stack: { Screen: () => null },
+    Redirect: () => null,
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../../lib/layout', () => ({
+  useLayout: () => ({
+    wide: false,
+    width: 375,
+    scale: 1.0,
+    windowClass: 'compact' as const,
+    compact: true,
+    medium: false,
+    expanded: false,
+    atLeastMedium: false,
+    horizontalPadding: 16,
+  }),
+}))
+jest.mock('../../../lib/errors', () => ({ logError: jest.fn() }))
+jest.mock('../../../lib/interactions', () => ({ log: jest.fn() }))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+jest.mock('victory-native', () => ({ CartesianChart: 'CartesianChart', Line: 'Line', Bar: 'Bar' }))
+jest.mock('../../../components/MuscleVolumeSegment', () => 'MuscleVolumeSegment')
+jest.mock('react-native-reanimated', () => {
+  const { View: RNView } = require('react-native')
+  return {
+    __esModule: true,
+    default: {
+      View: RNView,
+      Text: require('react-native').Text,
+      createAnimatedComponent: (c: unknown) => c,
+    },
+    useSharedValue: (v: number) => ({ value: v }),
+    useAnimatedStyle: () => ({}),
+    withTiming: (v: number) => v,
+    withSpring: (v: number) => v,
+    withSequence: (...args: number[]) => args[args.length - 1],
+    withDelay: (_d: number, v: number) => v,
+    useReducedMotion: () => false,
+    Easing: { bezier: () => (t: number) => t },
+  }
+})
+
+const mockSettings = createBodySettings({
+  weight_unit: 'kg',
+  measurement_unit: 'cm',
+  weight_goal: 70,
+  body_fat_goal: 15,
+})
+
+const mockMonthlyData = {
+  workouts: {
+    sessionCount: 16,
+    totalDurationSeconds: 66600,
+    totalVolume: 42350,
+    previousMonthVolume: 37500,
+    previousMonthSessionCount: 13,
+  },
+  prs: [
+    { exerciseId: 'ex1', exerciseName: 'Bench Press', weight: 100 },
+    { exerciseId: 'ex2', exerciseName: 'Squat', weight: 140 },
+  ],
+  trainingDays: 22,
+  longestStreak: 5,
+  muscleDistribution: [
+    { muscle: 'chest', sets: 18 },
+    { muscle: 'back', sets: 22 },
+  ],
+  mostImproved: { exerciseId: 'ex3', exerciseName: 'Overhead Press', percentChange: 8 },
+  body: { startWeight: 82.0, endWeight: 81.5 },
+  nutrition: { daysTracked: 26, daysOnTarget: 18 },
+}
+
+jest.mock('../../../lib/db/body', () => ({
+  getBodySettings: jest.fn().mockResolvedValue({ unit: 'kg', height_cm: 175 }),
+  getLatestBodyWeight: jest.fn().mockResolvedValue(null),
+  getPreviousBodyWeight: jest.fn().mockResolvedValue(null),
+  getBodyWeightEntries: jest.fn().mockResolvedValue([]),
+  getBodyWeightCount: jest.fn().mockResolvedValue(0),
+  getBodyWeightChartData: jest.fn().mockResolvedValue([]),
+  getLatestMeasurements: jest.fn().mockResolvedValue(null),
+  upsertBodyWeight: jest.fn().mockResolvedValue(undefined),
+  deleteBodyWeight: jest.fn().mockResolvedValue(undefined),
+  updateBodySettings: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('../../../lib/db/calendar', () => ({
+  getCalendarDays: jest.fn().mockResolvedValue([]),
+  getCalendarDayDetail: jest.fn().mockResolvedValue(null),
+  getActiveProgram: jest.fn().mockResolvedValue(null),
+}))
+jest.mock('../../../lib/db', () => ({
+  getWeeklySessionCounts: jest.fn().mockResolvedValue([]),
+  getWeeklyVolume: jest.fn().mockResolvedValue([]),
+  getPersonalRecords: jest.fn().mockResolvedValue([]),
+  getCompletedSessionsWithSetCount: jest.fn().mockResolvedValue([]),
+  getBodySettings: jest.fn().mockResolvedValue(mockSettings),
+  getLatestBodyWeight: jest.fn().mockResolvedValue(null),
+  getPreviousBodyWeight: jest.fn().mockResolvedValue(null),
+  getBodyWeightEntries: jest.fn().mockResolvedValue([]),
+  getBodyWeightCount: jest.fn().mockResolvedValue(0),
+  getBodyWeightChartData: jest.fn().mockResolvedValue([]),
+  getLatestMeasurements: jest.fn().mockResolvedValue(null),
+  upsertBodyWeight: jest.fn().mockResolvedValue(undefined),
+  deleteBodyWeight: jest.fn().mockResolvedValue(undefined),
+  updateBodySettings: jest.fn().mockResolvedValue(undefined),
+  getWeeklySummary: jest.fn().mockResolvedValue({
+    workouts: { sessionCount: 0, totalDurationSeconds: 0, totalVolume: 0, previousWeekVolume: null, previousWeekSessionCount: null, hasBodyweightOnly: false, scheduledCount: null },
+    prs: [], nutrition: null, body: null, streak: 0,
+  }),
+  getMonthlyReport: jest.fn().mockResolvedValue(mockMonthlyData),
+}))
+
+jest.mock('../../../lib/units', () => ({
+  toDisplay: (v: number) => v,
+  toKg: (v: number) => v,
+  KG_TO_LB: 2.20462,
+  LB_TO_KG: 0.453592,
+}))
+
+import Progress from '../../../app/(tabs)/progress'
+
+const mockDb = require('../../../lib/db') as Record<string, jest.Mock>
+
+describe('Monthly Report Segment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+    mockDb.getMonthlyReport.mockResolvedValue(mockMonthlyData)
+    mockDb.getBodySettings.mockResolvedValue(mockSettings)
+  })
+
+  it('renders monthly report with key stats when selecting Monthly tab', async () => {
+    const utils = renderScreen(<Progress />)
+    fireEvent.press(utils.getByText('Monthly'))
+    await waitFor(() => {
+      expect(utils.getByText('16')).toBeTruthy()
+    })
+    expect(utils.getByText('Bench Press')).toBeTruthy()
+  })
+
+  it('shows empty state when fewer than 2 sessions', async () => {
+    mockDb.getMonthlyReport.mockResolvedValue({
+      ...mockMonthlyData,
+      workouts: { ...mockMonthlyData.workouts, sessionCount: 1, totalVolume: 0, totalDurationSeconds: 0, previousMonthVolume: null, previousMonthSessionCount: null },
+      prs: [],
+      trainingDays: 1,
+      longestStreak: 1,
+      muscleDistribution: [],
+      mostImproved: null,
+      body: null,
+      nutrition: null,
+    })
+    const utils = renderScreen(<Progress />)
+    fireEvent.press(utils.getByText('Monthly'))
+    await waitFor(() => {
+      expect(utils.getByText('Just getting started!')).toBeTruthy()
+    })
+  })
+
+  it('hides PR section when no PRs in month', async () => {
+    mockDb.getMonthlyReport.mockResolvedValue({
+      ...mockMonthlyData,
+      prs: [],
+    })
+    const utils = renderScreen(<Progress />)
+    fireEvent.press(utils.getByText('Monthly'))
+    await waitFor(() => {
+      expect(utils.getByText('16')).toBeTruthy()
+    })
+    expect(utils.queryByText('PRs This Month')).toBeNull()
+  })
+
+  it('navigates between months', async () => {
+    const utils = renderScreen(<Progress />)
+    fireEvent.press(utils.getByText('Monthly'))
+    await waitFor(() => {
+      expect(utils.getByText('16')).toBeTruthy()
+    })
+    const prevBtn = utils.getByLabelText('Previous month')
+    fireEvent.press(prevBtn)
+    await waitFor(() => {
+      expect(mockDb.getMonthlyReport).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/__tests__/components/share/MonthlyShareCard.test.tsx
+++ b/__tests__/components/share/MonthlyShareCard.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('react-native-reanimated', () => {
+  const { View: RNView } = require('react-native')
+  return {
+    __esModule: true,
+    default: {
+      View: RNView,
+      Text: require('react-native').Text,
+      createAnimatedComponent: (c: unknown) => c,
+    },
+    useSharedValue: (v: number) => ({ value: v }),
+    useAnimatedStyle: () => ({}),
+    withTiming: (v: number) => v,
+    useReducedMotion: () => false,
+    Easing: { bezier: () => (t: number) => t },
+  }
+})
+
+import MonthlyShareCard from '../../../components/share/MonthlyShareCard'
+
+describe('MonthlyShareCard', () => {
+  const defaultProps = {
+    monthLabel: 'April 2026',
+    sessionCount: 16,
+    volume: '42,350',
+    unit: 'kg',
+    prCount: 3,
+    longestStreak: 5,
+  }
+
+  it('renders month label and stats', () => {
+    const { getByText } = render(<MonthlyShareCard {...defaultProps} />)
+    expect(getByText('April 2026')).toBeTruthy()
+    expect(getByText('16')).toBeTruthy()
+    expect(getByText('42,350')).toBeTruthy()
+    expect(getByText('3')).toBeTruthy()
+    expect(getByText('5d')).toBeTruthy()
+  })
+
+  it('displays CableSnap branding', () => {
+    const { getByText } = render(<MonthlyShareCard {...defaultProps} />)
+    expect(getByText('CableSnap')).toBeTruthy()
+    expect(getByText('cablesnap.app')).toBeTruthy()
+  })
+
+  it('has accessibility labels on stat blocks', () => {
+    const { getByLabelText } = render(<MonthlyShareCard {...defaultProps} />)
+    expect(getByLabelText('Workouts: 16')).toBeTruthy()
+    expect(getByLabelText('PRs: 3')).toBeTruthy()
+    expect(getByLabelText('Monthly report for April 2026')).toBeTruthy()
+  })
+})

--- a/__tests__/lib/db/monthly-report.test.ts
+++ b/__tests__/lib/db/monthly-report.test.ts
@@ -1,0 +1,179 @@
+import { computeLongestDailyStreak } from '../../../lib/format'
+
+jest.mock('../../../lib/db/helpers', () => ({
+  getDrizzle: jest.fn(),
+  query: jest.fn(),
+  queryOne: jest.fn(),
+}))
+
+const muscleResults: unknown[] = []
+
+const mockDrizzle = {
+  select: jest.fn().mockReturnThis(),
+  from: jest.fn().mockReturnThis(),
+  innerJoin: jest.fn().mockReturnThis(),
+  leftJoin: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  groupBy: jest.fn(() => {
+    const p = Promise.resolve(muscleResults) as Promise<unknown[]> & {
+      select: jest.Mock; from: jest.Mock; innerJoin: jest.Mock;
+      leftJoin: jest.Mock; where: jest.Mock; groupBy: jest.Mock;
+      orderBy: jest.Mock; limit: jest.Mock; get: jest.Mock; all: jest.Mock;
+    }
+    Object.assign(p, mockDrizzle)
+    return p
+  }),
+  orderBy: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  get: jest.fn().mockResolvedValue(null),
+  all: jest.fn().mockResolvedValue([]),
+}
+
+jest.mock('../../../lib/db/helpers', () => ({
+  getDrizzle: jest.fn().mockResolvedValue(mockDrizzle),
+  query: jest.fn().mockResolvedValue([]),
+  queryOne: jest.fn().mockResolvedValue(null),
+}))
+
+jest.mock('../../../lib/db/schema', () => ({
+  workoutSessions: { id: 'id', started_at: 'started_at', completed_at: 'completed_at', duration_seconds: 'duration_seconds' },
+  workoutSets: { id: 'id', session_id: 'session_id', exercise_id: 'exercise_id', weight: 'weight', reps: 'reps', completed: 'completed', set_type: 'set_type' },
+  exercises: { id: 'id', name: 'name', primary_muscles: 'primary_muscles' },
+  dailyLog: { id: 'id', food_entry_id: 'food_entry_id', date: 'date', servings: 'servings' },
+  foodEntries: { id: 'id', calories: 'calories' },
+  macroTargets: { calories: 'calories' },
+  bodyWeight: { id: 'id', weight: 'weight', date: 'date' },
+}))
+
+const helpers = require('../../../lib/db/helpers') as {
+  getDrizzle: jest.Mock
+  query: jest.Mock
+  queryOne: jest.Mock
+}
+
+import { getMonthlyReport } from '../../../lib/db/monthly-report'
+
+describe('Monthly Report Data Layer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    helpers.getDrizzle.mockResolvedValue(mockDrizzle)
+    helpers.query.mockResolvedValue([])
+    mockDrizzle.get.mockResolvedValue(null)
+    mockDrizzle.all.mockResolvedValue([])
+  })
+
+  test.each([
+    ['empty month returns zero session count', { count: 0, total_duration: 0 }, 0],
+    ['month with sessions returns correct count', { count: 5, total_duration: 9000 }, 5],
+  ])('%s', async (_name, sessionResult, expectedCount) => {
+    mockDrizzle.get
+      .mockResolvedValueOnce(sessionResult) // sessions
+      .mockResolvedValueOnce({ volume: 0 }) // volume
+      .mockResolvedValueOnce({ count: 0 }) // prev sessions
+      .mockResolvedValueOnce({ volume: 0 }) // prev volume
+      .mockResolvedValueOnce(null) // macro targets (nutrition)
+
+    const result = await getMonthlyReport(2026, 3) // April 2026
+    expect(result.workouts.sessionCount).toBe(expectedCount)
+    expect(result.prs).toEqual([])
+    expect(result.nutrition).toBeNull()
+  })
+
+  it('computes volume and previous month delta', async () => {
+    mockDrizzle.get
+      .mockResolvedValueOnce({ count: 4, total_duration: 7200 })
+      .mockResolvedValueOnce({ volume: 50000 })
+      .mockResolvedValueOnce({ count: 3 })
+      .mockResolvedValueOnce({ volume: 40000 })
+      .mockResolvedValueOnce(null) // macro targets
+
+    const result = await getMonthlyReport(2026, 3)
+    expect(result.workouts.totalVolume).toBe(50000)
+    expect(result.workouts.previousMonthVolume).toBe(40000)
+    expect(result.workouts.previousMonthSessionCount).toBe(3)
+  })
+
+  it('returns PRs when max weight exceeds prior', async () => {
+    mockDrizzle.get
+      .mockResolvedValueOnce({ count: 3, total_duration: 5400 })
+      .mockResolvedValueOnce({ volume: 30000 })
+      .mockResolvedValueOnce({ count: 2 })
+      .mockResolvedValueOnce({ volume: 25000 })
+      .mockResolvedValueOnce(null) // macro targets
+
+    helpers.query
+      // PRs query
+      .mockResolvedValueOnce([
+        { exercise_id: 'ex1', name: 'Bench Press', month_max: 100, prior_max: 95 },
+        { exercise_id: 'ex2', name: 'Squat', month_max: 140, prior_max: null },
+      ])
+      // Training days query
+      .mockResolvedValueOnce([{ d: '2026-04-01' }, { d: '2026-04-03' }])
+      // Most improved query
+      .mockResolvedValueOnce([])
+
+    const result = await getMonthlyReport(2026, 3)
+    expect(result.prs).toHaveLength(2)
+    expect(result.prs[0].exerciseName).toBe('Bench Press')
+    expect(result.prs[0].weight).toBe(100)
+    expect(result.trainingDays).toBe(2)
+  })
+
+  it('returns body and nutrition as null when no data', async () => {
+    mockDrizzle.get
+      .mockResolvedValueOnce({ count: 3, total_duration: 5400 })
+      .mockResolvedValueOnce({ volume: 20000 })
+      .mockResolvedValueOnce({ count: 2 })
+      .mockResolvedValueOnce({ volume: 18000 })
+      .mockResolvedValueOnce(null) // no macro targets
+
+    helpers.query
+      .mockResolvedValueOnce([]) // PRs
+      .mockResolvedValueOnce([{ d: '2026-04-01' }]) // training days
+      .mockResolvedValueOnce([]) // most improved
+
+    const result = await getMonthlyReport(2026, 3)
+    expect(result.body).toBeNull()
+    expect(result.nutrition).toBeNull()
+    expect(result.trainingDays).toBe(1)
+    expect(result.longestStreak).toBe(1)
+  })
+
+  it('computes training days and longest streak from distinct dates', async () => {
+    mockDrizzle.get
+      .mockResolvedValueOnce({ count: 5, total_duration: 9000 })
+      .mockResolvedValueOnce({ volume: 30000 })
+      .mockResolvedValueOnce({ count: 3 })
+      .mockResolvedValueOnce({ volume: 25000 })
+      .mockResolvedValueOnce(null) // no macro targets
+
+    helpers.query
+      .mockResolvedValueOnce([]) // PRs
+      .mockResolvedValueOnce([
+        { d: '2026-04-01' }, { d: '2026-04-02' }, { d: '2026-04-03' },
+        { d: '2026-04-05' }, { d: '2026-04-06' },
+      ]) // training days — streak of 3 then 2
+      .mockResolvedValueOnce([]) // most improved
+
+    const result = await getMonthlyReport(2026, 3)
+    expect(result.trainingDays).toBe(5)
+    expect(result.longestStreak).toBe(3)
+  })
+})
+
+describe('computeLongestDailyStreak', () => {
+  it('returns 0 for empty array', () => {
+    expect(computeLongestDailyStreak([])).toBe(0)
+  })
+
+  it('returns 1 for single date', () => {
+    expect(computeLongestDailyStreak(['2026-04-01'])).toBe(1)
+  })
+
+  it('computes longest consecutive run', () => {
+    expect(computeLongestDailyStreak([
+      '2026-04-01', '2026-04-02', '2026-04-03',
+      '2026-04-05', '2026-04-06',
+    ])).toBe(3)
+  })
+})

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -6,6 +6,7 @@ import MuscleVolumeSegment from "../../components/MuscleVolumeSegment";
 import WorkoutSegment from "@/components/progress/WorkoutSegment";
 import BodySegment from "@/components/progress/BodySegment";
 import NutritionSegment from "@/components/progress/NutritionSegment";
+import MonthlyReportSegment from "@/components/progress/MonthlyReportSegment";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
 export default function Progress() {
@@ -24,6 +25,7 @@ export default function Progress() {
             { value: "body", label: "Body", accessibilityLabel: "Body metrics" },
             { value: "muscles", label: "Muscles", accessibilityLabel: "Muscle volume analysis" },
             { value: "nutrition", label: "Nutrition", accessibilityLabel: "Nutrition trends" },
+            { value: "monthly", label: "Monthly", accessibilityLabel: "Monthly training report" },
           ]}
         />
       </View>
@@ -33,7 +35,9 @@ export default function Progress() {
           ? <BodySegment />
           : segment === "muscles"
             ? <MuscleVolumeSegment />
-            : <NutritionSegment />}
+            : segment === "nutrition"
+              ? <NutritionSegment />
+              : <MonthlyReportSegment />}
     </View>
   );
 }

--- a/components/FlowCardMenu.tsx
+++ b/components/FlowCardMenu.tsx
@@ -5,6 +5,7 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import type { FlowCardMenuItem } from "./FlowCard";
 import type { useThemeColors } from "@/hooks/useThemeColors";
 import { fontSizes } from "@/constants/design-tokens";
+import { Colors } from "@/theme/colors";
 
 type Props = {
   items: FlowCardMenuItem[];
@@ -61,7 +62,7 @@ const styles = StyleSheet.create({
     borderWidth: StyleSheet.hairlineWidth,
     overflow: "hidden",
     elevation: 8,
-    shadowColor: "#000",
+    shadowColor: Colors.light.shadow,
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.25,
     shadowRadius: 12,

--- a/components/progress/MonthlyReportCards.tsx
+++ b/components/progress/MonthlyReportCards.tsx
@@ -1,0 +1,399 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Card, CardContent } from "@/components/ui/card";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { spacing, fontSizes } from "@/constants/design-tokens";
+import { formatDuration } from "@/lib/format";
+import { toDisplay } from "@/lib/units";
+import { MUSCLE_LABELS } from "@/lib/types";
+import type { MonthlyReportData } from "@/lib/db";
+import { formatVolume } from "@/hooks/useMonthlyReport";
+
+// ─── Stat Pill ─────────────────────────────────────────────────────
+
+function StatValue({
+  label,
+  value,
+  delta,
+  unit,
+}: {
+  label: string;
+  value: string;
+  delta?: string | null;
+  unit?: string;
+}) {
+  const colors = useThemeColors();
+  const deltaColor = delta?.startsWith("+") ? colors.primary : delta?.startsWith("-") ? colors.error : colors.onSurfaceVariant;
+
+  return (
+    <View
+      style={styles.statItem}
+      accessibilityLabel={`${label}: ${value}${unit ? ` ${unit}` : ""}${delta ? `, ${delta} compared to last month` : ""}`}
+    >
+      <Text style={[styles.statLabel, { color: colors.onSurfaceVariant }]}>{label}</Text>
+      <Text style={[styles.statValue, { color: colors.onSurface }]}>
+        {value}{unit ? ` ${unit}` : ""}
+      </Text>
+      {delta != null && (
+        <Text style={[styles.statDelta, { color: deltaColor }]}>{delta}</Text>
+      )}
+    </View>
+  );
+}
+
+// ─── Hero Stats ────────────────────────────────────────────────────
+
+export function HeroStatsCard({
+  data,
+  unit,
+  volChange,
+  sessionDelta,
+}: {
+  data: MonthlyReportData;
+  unit: "kg" | "lb";
+  volChange: string | null;
+  sessionDelta: string | null;
+}) {
+  const { workouts } = data;
+  const vol = formatVolume(toDisplay(workouts.totalVolume, unit));
+
+  return (
+    <Card>
+      <CardContent style={styles.heroContainer}>
+        <StatValue
+          label="Workouts"
+          value={String(workouts.sessionCount)}
+          delta={sessionDelta}
+        />
+        <StatValue
+          label="Volume"
+          value={vol}
+          unit={unit}
+          delta={volChange}
+        />
+        <StatValue
+          label="Duration"
+          value={formatDuration(workouts.totalDurationSeconds)}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Consistency ───────────────────────────────────────────────────
+
+export function ConsistencyCard({
+  trainingDays,
+  longestStreak,
+  daysInMonth,
+}: {
+  trainingDays: number;
+  longestStreak: number;
+  daysInMonth: number;
+}) {
+  const colors = useThemeColors();
+
+  return (
+    <Card>
+      <CardContent>
+        <Text
+          style={[styles.sectionTitle, { color: colors.onSurface }]}
+          accessibilityRole="header"
+        >
+          Consistency
+        </Text>
+        <View style={styles.consistencyRow}>
+          <Text
+            style={[styles.consistencyValue, { color: colors.onSurface }]}
+            accessibilityLabel={`${trainingDays} out of ${daysInMonth} days trained`}
+          >
+            {trainingDays}/{daysInMonth} days trained
+          </Text>
+          <Text
+            style={[styles.consistencyValue, { color: colors.onSurface }]}
+            accessibilityLabel={`Best streak: ${longestStreak} consecutive days`}
+          >
+            Best streak: {longestStreak} {longestStreak === 1 ? "day" : "days"}
+          </Text>
+        </View>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── PRs ───────────────────────────────────────────────────────────
+
+export function PRsCard({
+  prs,
+  unit,
+}: {
+  prs: MonthlyReportData["prs"];
+  unit: "kg" | "lb";
+}) {
+  const colors = useThemeColors();
+  if (prs.length === 0) return null;
+
+  return (
+    <Card>
+      <CardContent>
+        <Text
+          style={[styles.sectionTitle, { color: colors.onSurface }]}
+          accessibilityRole="header"
+        >
+          PRs This Month
+        </Text>
+        {prs.slice(0, 5).map((pr) => (
+          <View
+            key={pr.exerciseId}
+            style={styles.prRow}
+            accessibilityLabel={`${pr.exerciseName}: ${toDisplay(pr.weight, unit)} ${unit} personal record`}
+          >
+            <Text style={[styles.prName, { color: colors.onSurface }]}>
+              {pr.exerciseName}
+            </Text>
+            <Text style={[styles.prWeight, { color: colors.primary }]}>
+              {toDisplay(pr.weight, unit)} {unit}
+            </Text>
+          </View>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Muscle Balance ────────────────────────────────────────────────
+
+export function MuscleBalanceCard({
+  distribution,
+}: {
+  distribution: MonthlyReportData["muscleDistribution"];
+}) {
+  const colors = useThemeColors();
+  if (distribution.length === 0) return null;
+
+  const maxSets = distribution[0]?.sets ?? 1;
+
+  return (
+    <Card>
+      <CardContent>
+        <Text
+          style={[styles.sectionTitle, { color: colors.onSurface }]}
+          accessibilityRole="header"
+        >
+          Sets by Muscle Group
+        </Text>
+        {distribution.slice(0, 8).map((item) => {
+          const pct = Math.round((item.sets / maxSets) * 100);
+          const label = MUSCLE_LABELS[item.muscle] ?? item.muscle;
+          return (
+            <View
+              key={item.muscle}
+              style={styles.muscleRow}
+              accessibilityLabel={`${label}: ${item.sets} sets`}
+            >
+              <Text style={[styles.muscleLabel, { color: colors.onSurface }]}>
+                {label}
+              </Text>
+              <View style={styles.barContainer}>
+                <View
+                  style={[
+                    styles.bar,
+                    { width: `${pct}%`, backgroundColor: colors.primary },
+                  ]}
+                />
+              </View>
+              <Text style={[styles.muscleSets, { color: colors.onSurfaceVariant }]}>
+                {item.sets}
+              </Text>
+            </View>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Most Improved ─────────────────────────────────────────────────
+
+export function MostImprovedCard({
+  data,
+}: {
+  data: MonthlyReportData["mostImproved"];
+}) {
+  const colors = useThemeColors();
+  if (!data) return null;
+
+  return (
+    <Card>
+      <CardContent>
+        <Text
+          style={[styles.sectionTitle, { color: colors.onSurface }]}
+          accessibilityRole="header"
+        >
+          Most Improved
+        </Text>
+        <Text
+          style={[styles.improvedText, { color: colors.onSurface }]}
+          accessibilityLabel={`${data.exerciseName}: estimated one rep max increased by ${data.percentChange} percent`}
+        >
+          {data.exerciseName}: +{data.percentChange}% e1RM
+        </Text>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Body ──────────────────────────────────────────────────────────
+
+export function BodyCard({
+  data,
+  unit,
+}: {
+  data: MonthlyReportData["body"];
+  unit: "kg" | "lb";
+}) {
+  const colors = useThemeColors();
+  if (!data || data.startWeight === null || data.endWeight === null) return null;
+
+  const start = toDisplay(data.startWeight, unit);
+  const end = toDisplay(data.endWeight, unit);
+  const delta = Math.round((end - start) * 10) / 10;
+  const sign = delta >= 0 ? "+" : "";
+  const deltaColor = delta < 0 ? colors.primary : delta > 0 ? colors.error : colors.onSurfaceVariant;
+
+  return (
+    <Card>
+      <CardContent>
+        <Text
+          style={[styles.sectionTitle, { color: colors.onSurface }]}
+          accessibilityRole="header"
+        >
+          Body Weight
+        </Text>
+        <Text
+          style={[styles.bodyText, { color: colors.onSurface }]}
+          accessibilityLabel={`Body weight changed from ${start} to ${end} ${unit}, ${sign}${delta}`}
+        >
+          {start} → {end} {unit}{" "}
+          <Text style={{ color: deltaColor }}>({sign}{delta})</Text>
+        </Text>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Nutrition ─────────────────────────────────────────────────────
+
+export function NutritionCard({
+  data,
+}: {
+  data: MonthlyReportData["nutrition"];
+}) {
+  const colors = useThemeColors();
+  if (!data) return null;
+
+  return (
+    <Card>
+      <CardContent>
+        <Text
+          style={[styles.sectionTitle, { color: colors.onSurface }]}
+          accessibilityRole="header"
+        >
+          Nutrition
+        </Text>
+        <Text
+          style={[styles.nutritionText, { color: colors.onSurface }]}
+          accessibilityLabel={`${data.daysOnTarget} out of ${data.daysTracked} tracked days on calorie target`}
+        >
+          {data.daysOnTarget}/{data.daysTracked} days on target
+        </Text>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Styles ────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  heroContainer: {
+    flexDirection: "row",
+    justifyContent: "space-around",
+  },
+  statItem: {
+    alignItems: "center",
+    gap: spacing.xxs,
+  },
+  statLabel: {
+    fontSize: fontSizes.sm,
+    fontWeight: "500",
+  },
+  statValue: {
+    fontSize: fontSizes.xl,
+    fontWeight: "700",
+  },
+  statDelta: {
+    fontSize: fontSizes.sm,
+    fontWeight: "600",
+  },
+  sectionTitle: {
+    fontSize: fontSizes.lg,
+    fontWeight: "700",
+    marginBottom: spacing.sm,
+  },
+  consistencyRow: {
+    gap: spacing.xs,
+  },
+  consistencyValue: {
+    fontSize: fontSizes.base,
+  },
+  prRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: spacing.xs,
+  },
+  prName: {
+    fontSize: fontSizes.base,
+    flex: 1,
+  },
+  prWeight: {
+    fontSize: fontSizes.base,
+    fontWeight: "700",
+  },
+  muscleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  muscleLabel: {
+    width: 80,
+    fontSize: fontSizes.sm,
+  },
+  barContainer: {
+    flex: 1,
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: "rgba(128,128,128,0.15)",
+    overflow: "hidden",
+  },
+  bar: {
+    height: "100%",
+    borderRadius: 6,
+  },
+  muscleSets: {
+    width: 30,
+    textAlign: "right",
+    fontSize: fontSizes.sm,
+  },
+  improvedText: {
+    fontSize: fontSizes.base,
+  },
+  bodyText: {
+    fontSize: fontSizes.base,
+  },
+  nutritionText: {
+    fontSize: fontSizes.base,
+  },
+});

--- a/components/progress/MonthlyReportSegment.tsx
+++ b/components/progress/MonthlyReportSegment.tsx
@@ -1,0 +1,209 @@
+import React from "react";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react-native";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { useLayout } from "@/lib/layout";
+import { spacing, fontSizes } from "@/constants/design-tokens";
+import { useMonthlyReport, formatMonthLabel } from "@/hooks/useMonthlyReport";
+import {
+  HeroStatsCard,
+  ConsistencyCard,
+  PRsCard,
+  MuscleBalanceCard,
+  MostImprovedCard,
+  BodyCard,
+  NutritionCard,
+} from "./MonthlyReportCards";
+
+export default function MonthlyReportSegment() {
+  const colors = useThemeColors();
+  const layout = useLayout();
+  const {
+    data,
+    loading,
+    error,
+    year,
+    monthIndex,
+    unit,
+    canGoBack,
+    canGoForward,
+    navigateMonth,
+    handleShare,
+    volChange,
+    sessionDelta,
+  } = useMonthlyReport();
+
+  const monthLabel = formatMonthLabel(year, monthIndex);
+  const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
+
+  // ── Loading ────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <View style={[styles.center, { paddingHorizontal: layout.horizontalPadding }]}>
+        <Text style={{ color: colors.onSurfaceVariant }}>Loading…</Text>
+      </View>
+    );
+  }
+
+  // ── Error ──────────────────────────────────────────────────────
+  if (error || !data) {
+    return (
+      <View style={[styles.center, { paddingHorizontal: layout.horizontalPadding }]}>
+        <Text style={{ color: colors.onSurfaceVariant }}>
+          Couldn{"'"}t load report
+        </Text>
+      </View>
+    );
+  }
+
+  // ── Empty state ────────────────────────────────────────────────
+  const isEmpty = data.workouts.sessionCount < 2;
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
+    >
+      {/* Month navigation */}
+      <View style={styles.navRow}>
+        <Pressable
+          onPress={() => navigateMonth(-1)}
+          disabled={!canGoBack}
+          accessibilityLabel="Previous month"
+          accessibilityRole="button"
+          style={{ opacity: canGoBack ? 1 : 0.3 }}
+        >
+          <ChevronLeft size={24} color={colors.onSurface} />
+        </Pressable>
+        <Text
+          style={[styles.monthLabel, { color: colors.onSurface }]}
+          accessibilityRole="header"
+        >
+          {monthLabel}
+        </Text>
+        <Pressable
+          onPress={() => navigateMonth(1)}
+          disabled={!canGoForward}
+          accessibilityLabel="Next month"
+          accessibilityRole="button"
+          style={{ opacity: canGoForward ? 1 : 0.3 }}
+        >
+          <ChevronRight size={24} color={colors.onSurface} />
+        </Pressable>
+      </View>
+
+      {isEmpty ? (
+        <View style={styles.emptyContainer}>
+          <MaterialCommunityIcons
+            name="dumbbell"
+            size={48}
+            color={colors.onSurfaceVariant}
+          />
+          <Text style={[styles.emptyTitle, { color: colors.onSurface }]}>
+            {data.workouts.sessionCount === 0
+              ? "No workouts this month"
+              : "Just getting started!"}
+          </Text>
+          <Text style={[styles.emptyBody, { color: colors.onSurfaceVariant }]}>
+            {data.workouts.sessionCount === 0
+              ? "Complete some workouts to see your monthly recap."
+              : "Complete a few more workouts to unlock your full monthly report."}
+          </Text>
+        </View>
+      ) : (
+        <View style={styles.cards}>
+          <HeroStatsCard
+            data={data}
+            unit={unit}
+            volChange={volChange}
+            sessionDelta={sessionDelta}
+          />
+
+          <ConsistencyCard
+            trainingDays={data.trainingDays}
+            longestStreak={data.longestStreak}
+            daysInMonth={daysInMonth}
+          />
+
+          <PRsCard prs={data.prs} unit={unit} />
+          <MuscleBalanceCard distribution={data.muscleDistribution} />
+          <MostImprovedCard data={data.mostImproved} />
+          <BodyCard data={data.body} unit={unit} />
+          <NutritionCard data={data.nutrition} />
+
+          {/* Share button */}
+          <Button
+            onPress={handleShare}
+            accessibilityLabel="Share monthly report"
+          >
+            <View style={styles.shareRow}>
+              <MaterialCommunityIcons
+                name="share-variant"
+                size={18}
+                color={colors.onPrimary ?? "#fff"}
+              />
+              <Text style={[styles.shareText, { color: colors.onPrimary ?? "#fff" }]}>
+                Share Report
+              </Text>
+            </View>
+          </Button>
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    paddingVertical: spacing.base,
+    paddingBottom: spacing.xxxl,
+  },
+  center: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  navRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: spacing.base,
+  },
+  monthLabel: {
+    fontSize: fontSizes.xl,
+    fontWeight: "700",
+  },
+  emptyContainer: {
+    alignItems: "center",
+    paddingTop: spacing.xxxl,
+    gap: spacing.md,
+  },
+  emptyTitle: {
+    fontSize: fontSizes.lg,
+    fontWeight: "700",
+  },
+  emptyBody: {
+    fontSize: fontSizes.base,
+    textAlign: "center",
+    maxWidth: 280,
+  },
+  cards: {
+    gap: spacing.md,
+  },
+  shareRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing.sm,
+  },
+  shareText: {
+    fontSize: fontSizes.base,
+    fontWeight: "600",
+  },
+});

--- a/components/progress/MonthlyReportSegment.tsx
+++ b/components/progress/MonthlyReportSegment.tsx
@@ -7,7 +7,9 @@ import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useLayout } from "@/lib/layout";
 import { spacing, fontSizes } from "@/constants/design-tokens";
-import { useMonthlyReport, formatMonthLabel } from "@/hooks/useMonthlyReport";
+import { useMonthlyReport, formatMonthLabel, formatVolume } from "@/hooks/useMonthlyReport";
+import { toDisplay } from "@/lib/units";
+import MonthlyShareCard from "@/components/share/MonthlyShareCard";
 import {
   HeroStatsCard,
   ConsistencyCard,
@@ -32,6 +34,8 @@ export default function MonthlyReportSegment() {
     canGoForward,
     navigateMonth,
     handleShare,
+    shareCardRef,
+    imageLoading,
     volChange,
     sessionDelta,
   } = useMonthlyReport();
@@ -137,19 +141,38 @@ export default function MonthlyReportSegment() {
           {/* Share button */}
           <Button
             onPress={handleShare}
+            disabled={imageLoading}
             accessibilityLabel="Share monthly report"
           >
             <View style={styles.shareRow}>
               <MaterialCommunityIcons
                 name="share-variant"
                 size={18}
-                color={colors.onPrimary ?? "#fff"}
+                color={colors.onPrimary}
               />
-              <Text style={[styles.shareText, { color: colors.onPrimary ?? "#fff" }]}>
-                Share Report
+              <Text style={[styles.shareText, { color: colors.onPrimary }]}>
+                {imageLoading ? "Generating…" : "Share Report"}
               </Text>
             </View>
           </Button>
+        </View>
+      )}
+
+      {/* Offscreen share card for image capture */}
+      {data && !isEmpty && (
+        <View
+          ref={shareCardRef}
+          collapsable={false}
+          style={styles.offscreen}
+        >
+          <MonthlyShareCard
+            monthLabel={monthLabel}
+            sessionCount={data.workouts.sessionCount}
+            volume={formatVolume(toDisplay(data.workouts.totalVolume, unit))}
+            unit={unit}
+            prCount={data.prs.length}
+            longestStreak={data.longestStreak}
+          />
         </View>
       )}
     </ScrollView>
@@ -205,5 +228,11 @@ const styles = StyleSheet.create({
   shareText: {
     fontSize: fontSizes.base,
     fontWeight: "600",
+  },
+  offscreen: {
+    position: "absolute",
+    left: -9999,
+    top: -9999,
+    opacity: 0,
   },
 });

--- a/components/share/MonthlyShareCard.tsx
+++ b/components/share/MonthlyShareCard.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { spacing, fontSizes } from "@/constants/design-tokens";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { useColorScheme } from "@/hooks/useColorScheme";
+
+export type MonthlyShareCardProps = {
+  monthLabel: string;
+  sessionCount: number;
+  volume: string;
+  unit: string;
+  prCount: number;
+  longestStreak: number;
+};
+
+const CARD_WIDTH = 1080;
+
+function StatBlock({ label, value }: { label: string; value: string }) {
+  const colors = useThemeColors();
+  return (
+    <View
+      style={shareStyles.statBlock}
+      accessibilityLabel={`${label}: ${value}`}
+    >
+      <Text style={[shareStyles.statBlockValue, { color: colors.onSurface }]}>
+        {value}
+      </Text>
+      <Text style={[shareStyles.statBlockLabel, { color: colors.onSurfaceVariant }]}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+export default function MonthlyShareCard({
+  monthLabel,
+  sessionCount,
+  volume,
+  unit,
+  prCount,
+  longestStreak,
+}: MonthlyShareCardProps) {
+  const colors = useThemeColors();
+  const isDark = useColorScheme() === "dark";
+
+  return (
+    <View
+      style={[
+        shareStyles.card,
+        {
+          width: CARD_WIDTH,
+          backgroundColor: colors.surface,
+          borderColor: isDark ? colors.outline : "transparent",
+          borderWidth: isDark ? 1 : 0,
+        },
+      ]}
+    >
+      {/* Header */}
+      <View style={shareStyles.header}>
+        <MaterialCommunityIcons
+          name="dumbbell"
+          size={32}
+          color={colors.primary}
+        />
+        <Text style={[shareStyles.brandText, { color: colors.primary }]}>
+          CableSnap
+        </Text>
+      </View>
+
+      {/* Month title */}
+      <Text
+        style={[shareStyles.monthTitle, { color: colors.onSurface }]}
+        accessibilityLabel={`Monthly report for ${monthLabel}`}
+      >
+        {monthLabel}
+      </Text>
+      <Text style={[shareStyles.subtitle, { color: colors.onSurfaceVariant }]}>
+        Monthly Training Report
+      </Text>
+
+      {/* Stats grid */}
+      <View style={shareStyles.statsGrid}>
+        <StatBlock label="Workouts" value={String(sessionCount)} />
+        <StatBlock label={`Volume (${unit})`} value={volume} />
+        <StatBlock label="PRs" value={String(prCount)} />
+        <StatBlock label="Best Streak" value={`${longestStreak}d`} />
+      </View>
+
+      {/* Footer */}
+      <View
+        style={[shareStyles.footer, { borderTopColor: colors.outlineVariant }]}
+      >
+        <Text
+          style={[shareStyles.footerText, { color: colors.onSurfaceVariant }]}
+        >
+          cablesnap.app
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const shareStyles = StyleSheet.create({
+  card: {
+    paddingVertical: spacing.xxl,
+    paddingHorizontal: spacing.xxl,
+    borderRadius: 24,
+    overflow: "hidden",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    marginBottom: spacing.xl,
+  },
+  brandText: {
+    fontSize: fontSizes.xxl,
+    fontWeight: "700",
+  },
+  monthTitle: {
+    fontSize: fontSizes.stat,
+    fontWeight: "800",
+    lineHeight: 44,
+    marginBottom: spacing.xs,
+  },
+  subtitle: {
+    fontSize: fontSizes.lg,
+    marginBottom: spacing.xl,
+  },
+  statsGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-around",
+    gap: spacing.lg,
+    marginBottom: spacing.xl,
+  },
+  statBlock: {
+    alignItems: "center",
+    minWidth: 200,
+    gap: spacing.xxs,
+  },
+  statBlockValue: {
+    fontSize: fontSizes.stat,
+    fontWeight: "800",
+  },
+  statBlockLabel: {
+    fontSize: fontSizes.lg,
+    fontWeight: "500",
+  },
+  footer: {
+    borderTopWidth: 1,
+    paddingTop: spacing.lg,
+    alignItems: "center",
+  },
+  footerText: {
+    fontSize: fontSizes.sm,
+    fontWeight: "500",
+    letterSpacing: 0.5,
+  },
+});

--- a/components/ui/toast-item.tsx
+++ b/components/ui/toast-item.tsx
@@ -43,7 +43,7 @@ export function Toast({ id, title, description, variant = 'default', onDismiss, 
 
 const styles = StyleSheet.create({
   container: { position: 'absolute', left: 32, right: 32, shadowColor: Colors.light.shadow, shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.15, shadowRadius: 12, elevation: 8 },
-  island: { borderRadius: 14, backgroundColor: '#1C1C1E', paddingHorizontal: 16, paddingVertical: 10, flexDirection: 'row', alignItems: 'center', overflow: 'hidden' },
+  island: { borderRadius: 14, backgroundColor: Colors.dark.card, paddingHorizontal: 16, paddingVertical: 10, flexDirection: 'row', alignItems: 'center', overflow: 'hidden' },
   actionBtn: { marginLeft: 12, paddingHorizontal: 12, paddingVertical: 6, borderRadius: 12 },
   dismissBtn: { marginLeft: 8, padding: 4, borderRadius: 8 },
 });

--- a/hooks/useMonthlyReport.ts
+++ b/hooks/useMonthlyReport.ts
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Share } from "react-native";
+import { View } from "react-native";
 import { useFocusEffect } from "expo-router";
+import { captureRef } from "react-native-view-shot";
+import * as Sharing from "expo-sharing";
+import * as FileSystem from "expo-file-system";
 
 import { getMonthlyReport, getBodySettings } from "@/lib/db";
 import type { MonthlyReportData } from "@/lib/db";
 import type { BodySettings } from "@/lib/types";
-import { formatDuration } from "@/lib/format";
-import { toDisplay } from "@/lib/units";
 
 // ─── Constants ─────────────────────────────────────────────────────
 
@@ -133,64 +134,27 @@ export function useMonthlyReport() {
     setMonthOffset(next);
   };
 
-  // ─── Share ─────────────────────────────────────────────────────
+  // ─── Share (image capture pipeline) ────────────────────────────
 
-  const buildShareText = (): string => {
-    if (!data) return "";
-    const { workouts, prs, trainingDays, longestStreak, body, nutrition } = data;
-    const label = formatMonthLabel(targetDate.year, targetDate.monthIndex);
-    const lines: string[] = [
-      `📊 CableSnap Monthly Report`,
-      label,
-      "",
-    ];
+  const shareCardRef = useRef<View>(null);
+  const [imageLoading, setImageLoading] = useState(false);
 
-    if (workouts.sessionCount > 0) {
-      lines.push(
-        `💪 Workouts: ${workouts.sessionCount} sessions (${formatDuration(workouts.totalDurationSeconds)} total)`
-      );
-      const volStr = `${formatVolume(toDisplay(workouts.totalVolume, unit))} ${unit}`;
-      const volChange = volumeChangePercent(workouts.totalVolume, workouts.previousMonthVolume);
-      lines.push(
-        `📈 Volume: ${volStr}${volChange ? ` (${volChange} vs last month)` : ""}`
-      );
-    }
-
-    if (trainingDays > 0) {
-      lines.push(`📅 ${trainingDays} training days · ${longestStreak} day best streak`);
-    }
-
-    if (prs.length > 0) {
-      const prParts = prs.slice(0, 3).map((pr) => {
-        const w = toDisplay(pr.weight, unit);
-        return `${pr.exerciseName} ${w}${unit}`;
-      });
-      lines.push(`🏆 PRs: ${prParts.join(", ")}`);
-    }
-
-    if (nutrition) {
-      lines.push(`🥗 Nutrition: ${nutrition.daysOnTarget}/${nutrition.daysTracked} days on target`);
-    }
-
-    if (body && body.startWeight !== null && body.endWeight !== null) {
-      const start = toDisplay(body.startWeight, unit);
-      const end = toDisplay(body.endWeight, unit);
-      const delta = Math.round((end - start) * 10) / 10;
-      const sign = delta >= 0 ? "+" : "";
-      lines.push(`⚖️ Weight: ${start} → ${end} ${unit} (${sign}${delta})`);
-    }
-
-    lines.push("", "Tracked with CableSnap");
-    return lines.join("\n");
-  };
-
-  const handleShare = async () => {
+  const handleShare = useCallback(async () => {
+    if (!shareCardRef.current) return;
+    let uri: string | null = null;
     try {
-      await Share.share({ message: buildShareText() });
+      setImageLoading(true);
+      uri = await captureRef(shareCardRef, { format: "png", quality: 1.0 });
+      await Sharing.shareAsync(uri, { mimeType: "image/png" });
     } catch {
       // Share cancelled or failed — ignore
+    } finally {
+      setImageLoading(false);
+      if (uri) {
+        FileSystem.deleteAsync(uri, { idempotent: true }).catch(() => {});
+      }
     }
-  };
+  }, []);
 
   const volChange = data
     ? volumeChangePercent(data.workouts.totalVolume, data.workouts.previousMonthVolume)
@@ -212,6 +176,8 @@ export function useMonthlyReport() {
     canGoForward,
     navigateMonth,
     handleShare,
+    shareCardRef,
+    imageLoading,
     volChange,
     sessionDelta,
   };

--- a/hooks/useMonthlyReport.ts
+++ b/hooks/useMonthlyReport.ts
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Share } from "react-native";
+import { useFocusEffect } from "expo-router";
+
+import { getMonthlyReport, getBodySettings } from "@/lib/db";
+import type { MonthlyReportData } from "@/lib/db";
+import type { BodySettings } from "@/lib/types";
+import { formatDuration } from "@/lib/format";
+import { toDisplay } from "@/lib/units";
+
+// ─── Constants ─────────────────────────────────────────────────────
+
+export const MAX_MONTHS_BACK = 12;
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+export function formatMonthLabel(year: number, monthIndex: number): string {
+  const d = new Date(year, monthIndex, 1);
+  return d.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+}
+
+export function formatVolume(vol: number): string {
+  if (vol >= 1_000_000) {
+    return `${Math.round(vol / 1000).toLocaleString()}k`;
+  }
+  return Math.round(vol).toLocaleString();
+}
+
+export function volumeChangePercent(current: number, previous: number | null): string | null {
+  if (previous === null || previous === 0) return null;
+  const pct = Math.round(((current - previous) / previous) * 100);
+  if (pct === 0) return null;
+  return pct > 0 ? `+${pct}%` : `${pct}%`;
+}
+
+export function sessionCountDelta(current: number, previous: number | null): string | null {
+  if (previous === null) return null;
+  const diff = current - previous;
+  if (diff === 0) return null;
+  return diff > 0 ? `+${diff}` : `${diff}`;
+}
+
+// ─── Hook ──────────────────────────────────────────────────────────
+
+export function useMonthlyReport() {
+  const [monthOffset, setMonthOffset] = useState(0);
+  const [data, setData] = useState<MonthlyReportData | null>(null);
+  const [settings, setSettings] = useState<BodySettings | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const cacheRef = useRef<Record<number, MonthlyReportData>>({});
+
+  const now = useMemo(() => new Date(), []);
+  const currentYear = now.getFullYear();
+  const currentMonthIndex = now.getMonth();
+
+  const targetDate = useMemo(() => {
+    const d = new Date(currentYear, currentMonthIndex + monthOffset, 1);
+    return { year: d.getFullYear(), monthIndex: d.getMonth() };
+  }, [currentYear, currentMonthIndex, monthOffset]);
+
+  const loadMonth = useCallback(
+    async (offset: number): Promise<MonthlyReportData | null> => {
+      const d = new Date(currentYear, currentMonthIndex + offset, 1);
+      try {
+        return await getMonthlyReport(d.getFullYear(), d.getMonth());
+      } catch {
+        return null;
+      }
+    },
+    [currentYear, currentMonthIndex]
+  );
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      // Always refresh current view month (don't serve stale cache)
+      const [summary, bodySettings] = await Promise.all([
+        loadMonth(monthOffset),
+        getBodySettings(),
+      ]);
+      if (summary) {
+        setData(summary);
+        cacheRef.current[monthOffset] = summary;
+      } else {
+        setError(true);
+      }
+      setSettings(bodySettings);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [monthOffset, loadMonth]);
+
+  // Preload adjacent months
+  useEffect(() => {
+    let cancelled = false;
+    const preload = async () => {
+      await new Promise((r) => setTimeout(r, 150));
+      if (cancelled) return;
+      const offsets = [monthOffset - 1, monthOffset + 1].filter(
+        (o) => o <= 0 && o >= -MAX_MONTHS_BACK && !cacheRef.current[o]
+      );
+      for (const o of offsets) {
+        if (cancelled) return;
+        const result = await loadMonth(o);
+        if (result && !cancelled) {
+          cacheRef.current[o] = result;
+        }
+      }
+    };
+    preload();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [monthOffset]);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadData();
+    }, [loadData])
+  );
+
+  const unit = settings?.weight_unit ?? "kg";
+  const canGoBack = monthOffset > -MAX_MONTHS_BACK;
+  const canGoForward = monthOffset < 0;
+
+  const navigateMonth = (dir: -1 | 1) => {
+    const next = monthOffset + dir;
+    if (next < -MAX_MONTHS_BACK || next > 0) return;
+    setMonthOffset(next);
+  };
+
+  // ─── Share ─────────────────────────────────────────────────────
+
+  const buildShareText = (): string => {
+    if (!data) return "";
+    const { workouts, prs, trainingDays, longestStreak, body, nutrition } = data;
+    const label = formatMonthLabel(targetDate.year, targetDate.monthIndex);
+    const lines: string[] = [
+      `📊 CableSnap Monthly Report`,
+      label,
+      "",
+    ];
+
+    if (workouts.sessionCount > 0) {
+      lines.push(
+        `💪 Workouts: ${workouts.sessionCount} sessions (${formatDuration(workouts.totalDurationSeconds)} total)`
+      );
+      const volStr = `${formatVolume(toDisplay(workouts.totalVolume, unit))} ${unit}`;
+      const volChange = volumeChangePercent(workouts.totalVolume, workouts.previousMonthVolume);
+      lines.push(
+        `📈 Volume: ${volStr}${volChange ? ` (${volChange} vs last month)` : ""}`
+      );
+    }
+
+    if (trainingDays > 0) {
+      lines.push(`📅 ${trainingDays} training days · ${longestStreak} day best streak`);
+    }
+
+    if (prs.length > 0) {
+      const prParts = prs.slice(0, 3).map((pr) => {
+        const w = toDisplay(pr.weight, unit);
+        return `${pr.exerciseName} ${w}${unit}`;
+      });
+      lines.push(`🏆 PRs: ${prParts.join(", ")}`);
+    }
+
+    if (nutrition) {
+      lines.push(`🥗 Nutrition: ${nutrition.daysOnTarget}/${nutrition.daysTracked} days on target`);
+    }
+
+    if (body && body.startWeight !== null && body.endWeight !== null) {
+      const start = toDisplay(body.startWeight, unit);
+      const end = toDisplay(body.endWeight, unit);
+      const delta = Math.round((end - start) * 10) / 10;
+      const sign = delta >= 0 ? "+" : "";
+      lines.push(`⚖️ Weight: ${start} → ${end} ${unit} (${sign}${delta})`);
+    }
+
+    lines.push("", "Tracked with CableSnap");
+    return lines.join("\n");
+  };
+
+  const handleShare = async () => {
+    try {
+      await Share.share({ message: buildShareText() });
+    } catch {
+      // Share cancelled or failed — ignore
+    }
+  };
+
+  const volChange = data
+    ? volumeChangePercent(data.workouts.totalVolume, data.workouts.previousMonthVolume)
+    : null;
+
+  const sessionDelta = data
+    ? sessionCountDelta(data.workouts.sessionCount, data.workouts.previousMonthSessionCount)
+    : null;
+
+  return {
+    data,
+    loading,
+    error,
+    monthOffset,
+    year: targetDate.year,
+    monthIndex: targetDate.monthIndex,
+    unit,
+    canGoBack,
+    canGoForward,
+    navigateMonth,
+    handleShare,
+    volChange,
+    sessionDelta,
+  };
+}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -224,6 +224,17 @@ export type {
   WeeklyBodySummary,
 } from "./weekly-summary";
 
+export { getMonthlyReport } from "./monthly-report";
+export type {
+  MonthlyReportData,
+  MonthlyWorkoutSummary,
+  MonthlyPR,
+  MonthlyMuscleVolume,
+  MonthlyMostImproved,
+  MonthlyBodySummary,
+  MonthlyNutritionSummary,
+} from "./monthly-report";
+
 export {
   buildAchievementContext,
   getEarnedAchievements,

--- a/lib/db/monthly-report.ts
+++ b/lib/db/monthly-report.ts
@@ -1,0 +1,466 @@
+import { getDrizzle, query } from "./helpers";
+import { sql, eq, ne, and, gte, lt, isNotNull } from "drizzle-orm";
+import { count } from "drizzle-orm";
+import { computeLongestDailyStreak, movingAvg } from "../format";
+import { NUTRITION_ON_TARGET_TOLERANCE } from "./weekly-summary";
+import type { MuscleGroup } from "../types";
+import {
+  workoutSessions,
+  workoutSets,
+  exercises,
+  dailyLog,
+  foodEntries,
+  macroTargets,
+  bodyWeight,
+} from "./schema";
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export type MonthlyWorkoutSummary = {
+  sessionCount: number;
+  totalDurationSeconds: number;
+  totalVolume: number;
+  previousMonthVolume: number | null;
+  previousMonthSessionCount: number | null;
+};
+
+export type MonthlyPR = {
+  exerciseId: string;
+  exerciseName: string;
+  weight: number;
+};
+
+export type MonthlyMuscleVolume = {
+  muscle: MuscleGroup;
+  sets: number;
+};
+
+export type MonthlyMostImproved = {
+  exerciseId: string;
+  exerciseName: string;
+  percentChange: number;
+};
+
+export type MonthlyBodySummary = {
+  startWeight: number | null;
+  endWeight: number | null;
+};
+
+export type MonthlyNutritionSummary = {
+  daysTracked: number;
+  daysOnTarget: number;
+};
+
+export type MonthlyReportData = {
+  workouts: MonthlyWorkoutSummary;
+  prs: MonthlyPR[];
+  trainingDays: number;
+  longestStreak: number;
+  muscleDistribution: MonthlyMuscleVolume[];
+  mostImproved: MonthlyMostImproved | null;
+  body: MonthlyBodySummary | null;
+  nutrition: MonthlyNutritionSummary | null;
+};
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+/** Returns ms timestamps for the first instant of monthIndex and the first instant of the following month. */
+function monthRange(year: number, monthIndex: number): { start: number; end: number } {
+  const start = new Date(year, monthIndex, 1).getTime();
+  const end = new Date(year, monthIndex + 1, 1).getTime();
+  return { start, end };
+}
+
+function prevMonthRange(year: number, monthIndex: number): { start: number; end: number } {
+  const pMonth = monthIndex === 0 ? 11 : monthIndex - 1;
+  const pYear = monthIndex === 0 ? year - 1 : year;
+  return monthRange(pYear, pMonth);
+}
+
+/** Generate YYYY-MM-DD date keys for every day in the given month. */
+function monthDateKeys(year: number, monthIndex: number): string[] {
+  const keys: string[] = [];
+  const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
+  for (let d = 1; d <= daysInMonth; d++) {
+    const mm = String(monthIndex + 1).padStart(2, "0");
+    const dd = String(d).padStart(2, "0");
+    keys.push(`${year}-${mm}-${dd}`);
+  }
+  return keys;
+}
+
+// ─── Query Functions ───────────────────────────────────────────────
+
+async function getMonthlyWorkouts(
+  year: number,
+  monthIndex: number
+): Promise<MonthlyWorkoutSummary> {
+  const { start, end } = monthRange(year, monthIndex);
+  const prev = prevMonthRange(year, monthIndex);
+  const db = await getDrizzle();
+
+  const [sessions, volume, prevSessions, prevVolume] = await Promise.all([
+    db
+      .select({
+        count: sql<number>`COUNT(*)`.as("count"),
+        total_duration: sql<number>`COALESCE(SUM(${workoutSessions.duration_seconds}), 0)`.as("total_duration"),
+      })
+      .from(workoutSessions)
+      .where(
+        and(
+          isNotNull(workoutSessions.completed_at),
+          gte(workoutSessions.started_at, start),
+          lt(workoutSessions.started_at, end),
+        )
+      )
+      .get(),
+    db
+      .select({
+        volume: sql<number>`COALESCE(SUM(${workoutSets.weight} * ${workoutSets.reps}), 0)`.as("volume"),
+      })
+      .from(workoutSets)
+      .innerJoin(workoutSessions, eq(workoutSets.session_id, workoutSessions.id))
+      .where(
+        and(
+          eq(workoutSets.completed, 1),
+          ne(workoutSets.set_type, "warmup"),
+          isNotNull(workoutSessions.completed_at),
+          gte(workoutSessions.started_at, start),
+          lt(workoutSessions.started_at, end),
+        )
+      )
+      .get(),
+    db
+      .select({
+        count: sql<number>`COUNT(*)`.as("count"),
+      })
+      .from(workoutSessions)
+      .where(
+        and(
+          isNotNull(workoutSessions.completed_at),
+          gte(workoutSessions.started_at, prev.start),
+          lt(workoutSessions.started_at, prev.end),
+        )
+      )
+      .get(),
+    db
+      .select({
+        volume: sql<number>`COALESCE(SUM(${workoutSets.weight} * ${workoutSets.reps}), 0)`.as("volume"),
+      })
+      .from(workoutSets)
+      .innerJoin(workoutSessions, eq(workoutSets.session_id, workoutSessions.id))
+      .where(
+        and(
+          eq(workoutSets.completed, 1),
+          ne(workoutSets.set_type, "warmup"),
+          isNotNull(workoutSessions.completed_at),
+          gte(workoutSessions.started_at, prev.start),
+          lt(workoutSessions.started_at, prev.end),
+        )
+      )
+      .get(),
+  ]);
+
+  return {
+    sessionCount: sessions?.count ?? 0,
+    totalDurationSeconds: sessions?.total_duration ?? 0,
+    totalVolume: volume?.volume ?? 0,
+    previousMonthVolume: prevVolume?.volume ?? null,
+    previousMonthSessionCount: prevSessions?.count ?? null,
+  };
+}
+
+async function getMonthlyPRs(
+  year: number,
+  monthIndex: number
+): Promise<MonthlyPR[]> {
+  const { start, end } = monthRange(year, monthIndex);
+
+  const rows = await query<{
+    exercise_id: string;
+    name: string;
+    month_max: number;
+    prior_max: number | null;
+  }>(
+    `SELECT
+       cur.exercise_id,
+       COALESCE(e.name, 'Deleted Exercise') AS name,
+       cur.month_max,
+       prev.prior_max
+     FROM (
+       SELECT ws.exercise_id, MAX(ws.weight) AS month_max
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1
+         AND ws.set_type != 'warmup'
+         AND ws.weight IS NOT NULL AND ws.weight > 0
+         AND wss.completed_at IS NOT NULL
+         AND wss.started_at >= ? AND wss.started_at < ?
+       GROUP BY ws.exercise_id
+     ) cur
+     LEFT JOIN (
+       SELECT ws.exercise_id, MAX(ws.weight) AS prior_max
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1
+         AND ws.set_type != 'warmup'
+         AND ws.weight IS NOT NULL AND ws.weight > 0
+         AND wss.completed_at IS NOT NULL
+         AND wss.started_at < ?
+       GROUP BY ws.exercise_id
+     ) prev ON cur.exercise_id = prev.exercise_id
+     LEFT JOIN exercises e ON cur.exercise_id = e.id
+     WHERE prev.prior_max IS NULL OR cur.month_max > prev.prior_max
+     ORDER BY cur.month_max DESC
+     LIMIT 10`,
+    [start, end, start]
+  );
+
+  return rows.map((r) => ({
+    exerciseId: r.exercise_id,
+    exerciseName: r.name,
+    weight: r.month_max,
+  }));
+}
+
+async function getMonthlyTrainingDaysAndStreak(
+  year: number,
+  monthIndex: number
+): Promise<{ trainingDays: number; longestStreak: number }> {
+  const { start, end } = monthRange(year, monthIndex);
+
+  const rows = await query<{ d: string }>(
+    `SELECT DISTINCT date(started_at / 1000, 'unixepoch', 'localtime') AS d
+     FROM workout_sessions
+     WHERE completed_at IS NOT NULL
+       AND started_at >= ? AND started_at < ?`,
+    [start, end]
+  );
+
+  const dates = rows.map((r) => r.d);
+  return {
+    trainingDays: dates.length,
+    longestStreak: computeLongestDailyStreak(dates),
+  };
+}
+
+async function getMonthlyMuscleDistribution(
+  year: number,
+  monthIndex: number
+): Promise<MonthlyMuscleVolume[]> {
+  const { start, end } = monthRange(year, monthIndex);
+  const db = await getDrizzle();
+
+  const rows = await db
+    .select({
+      exercise_id: workoutSets.exercise_id,
+      primary_muscles: exercises.primary_muscles,
+      sets: count(),
+    })
+    .from(workoutSets)
+    .innerJoin(workoutSessions, eq(workoutSets.session_id, workoutSessions.id))
+    .leftJoin(exercises, eq(workoutSets.exercise_id, exercises.id))
+    .where(
+      and(
+        isNotNull(workoutSessions.completed_at),
+        gte(workoutSessions.started_at, start),
+        lt(workoutSessions.started_at, end),
+        eq(workoutSets.completed, 1),
+        ne(workoutSets.set_type, "warmup"),
+      )
+    )
+    .groupBy(workoutSets.exercise_id);
+
+  const map = new Map<MuscleGroup, number>();
+
+  for (const row of rows) {
+    if (!row.primary_muscles) continue;
+    let muscles: MuscleGroup[];
+    try {
+      muscles = JSON.parse(row.primary_muscles);
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(muscles) || muscles.length === 0) continue;
+    for (const m of muscles) {
+      map.set(m, (map.get(m) ?? 0) + row.sets);
+    }
+  }
+
+  return Array.from(map.entries())
+    .map(([muscle, sets]) => ({ muscle, sets }))
+    .sort((a, b) => b.sets - a.sets);
+}
+
+async function getMonthlyMostImproved(
+  year: number,
+  monthIndex: number
+): Promise<MonthlyMostImproved | null> {
+  const { start, end } = monthRange(year, monthIndex);
+  const prev = prevMonthRange(year, monthIndex);
+
+  const rows = await query<{
+    exercise_id: string;
+    name: string;
+    current_e1rm: number;
+    previous_e1rm: number;
+  }>(
+    `SELECT
+       cur.exercise_id,
+       COALESCE(e.name, 'Deleted Exercise') AS name,
+       cur.e1rm AS current_e1rm,
+       prev.e1rm AS previous_e1rm
+     FROM (
+       SELECT ws.exercise_id,
+              MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm,
+              COUNT(DISTINCT wss.id) AS session_count
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1
+         AND ws.set_type != 'warmup'
+         AND ws.weight > 0
+         AND ws.reps > 0
+         AND ws.reps <= 12
+         AND wss.completed_at IS NOT NULL
+         AND wss.started_at >= ? AND wss.started_at < ?
+       GROUP BY ws.exercise_id
+       HAVING session_count >= 2
+     ) cur
+     JOIN (
+       SELECT ws.exercise_id,
+              MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1
+         AND ws.set_type != 'warmup'
+         AND ws.weight > 0
+         AND ws.reps > 0
+         AND ws.reps <= 12
+         AND wss.completed_at IS NOT NULL
+         AND wss.started_at >= ? AND wss.started_at < ?
+       GROUP BY ws.exercise_id
+     ) prev ON cur.exercise_id = prev.exercise_id
+     LEFT JOIN exercises e ON cur.exercise_id = e.id
+     WHERE cur.e1rm > prev.e1rm
+     ORDER BY (cur.e1rm - prev.e1rm) / prev.e1rm DESC
+     LIMIT 1`,
+    [start, end, prev.start, prev.end]
+  );
+
+  if (rows.length === 0) return null;
+
+  const r = rows[0];
+  const pct = Math.round(((r.current_e1rm - r.previous_e1rm) / r.previous_e1rm) * 100);
+  return {
+    exerciseId: r.exercise_id,
+    exerciseName: r.name,
+    percentChange: pct,
+  };
+}
+
+async function getMonthlyBody(
+  year: number,
+  monthIndex: number
+): Promise<MonthlyBodySummary | null> {
+  const dateKeys = monthDateKeys(year, monthIndex);
+  const startDate = dateKeys[0];
+  const endDate = dateKeys[dateKeys.length - 1];
+  const db = await getDrizzle();
+
+  const entries = await db
+    .select({ date: bodyWeight.date, weight: bodyWeight.weight })
+    .from(bodyWeight)
+    .where(
+      and(
+        gte(bodyWeight.date, startDate),
+        sql`${bodyWeight.date} <= ${endDate}`,
+      )
+    )
+    .orderBy(bodyWeight.date)
+    .all();
+
+  if (entries.length === 0) return null;
+
+  if (entries.length >= 3) {
+    const smoothed = movingAvg(entries, 3);
+    return {
+      startWeight: smoothed[0].avg,
+      endWeight: smoothed[smoothed.length - 1].avg,
+    };
+  }
+
+  return {
+    startWeight: entries[0].weight,
+    endWeight: entries[entries.length - 1].weight,
+  };
+}
+
+async function getMonthlyNutrition(
+  year: number,
+  monthIndex: number
+): Promise<MonthlyNutritionSummary | null> {
+  const dateKeys = monthDateKeys(year, monthIndex);
+  const db = await getDrizzle();
+
+  // Only report nutrition if user has set macro targets
+  const targets = await db.select().from(macroTargets).limit(1).get();
+  if (!targets) return null;
+
+  const dailyTotals = await db
+    .select({
+      date: dailyLog.date,
+      calories: sql<number>`SUM(${foodEntries.calories} * ${dailyLog.servings})`.as("calories"),
+    })
+    .from(dailyLog)
+    .innerJoin(foodEntries, eq(dailyLog.food_entry_id, foodEntries.id))
+    .where(sql`${dailyLog.date} IN (${sql.join(dateKeys.map((k) => sql`${k}`), sql`,`)})`)
+    .groupBy(dailyLog.date)
+    .all();
+
+  if (dailyTotals.length === 0) return null;
+
+  const calorieTarget = targets.calories ?? 2000;
+  const daysOnTarget = dailyTotals.filter((d) => {
+    const diff = Math.abs(d.calories - calorieTarget) / calorieTarget;
+    return diff <= NUTRITION_ON_TARGET_TOLERANCE;
+  }).length;
+
+  return {
+    daysTracked: dailyTotals.length,
+    daysOnTarget,
+  };
+}
+
+// ─── Master Function ───────────────────────────────────────────────
+
+/**
+ * Fetch all monthly report data for a given month.
+ * @param year Full year (e.g. 2026)
+ * @param monthIndex 0-based month index (0 = January, 11 = December)
+ */
+export async function getMonthlyReport(
+  year: number,
+  monthIndex: number
+): Promise<MonthlyReportData> {
+  const [workouts, prs, daysAndStreak, muscleDistribution, mostImproved, body, nutrition] =
+    await Promise.all([
+      getMonthlyWorkouts(year, monthIndex),
+      getMonthlyPRs(year, monthIndex),
+      getMonthlyTrainingDaysAndStreak(year, monthIndex),
+      getMonthlyMuscleDistribution(year, monthIndex),
+      getMonthlyMostImproved(year, monthIndex),
+      getMonthlyBody(year, monthIndex),
+      getMonthlyNutrition(year, monthIndex),
+    ]);
+
+  return {
+    workouts,
+    prs,
+    trainingDays: daysAndStreak.trainingDays,
+    longestStreak: daysAndStreak.longestStreak,
+    muscleDistribution,
+    mostImproved,
+    body,
+    nutrition,
+  };
+}

--- a/lib/db/tables.ts
+++ b/lib/db/tables.ts
@@ -19,14 +19,27 @@ function assertValidTable(table: string): void {
   }
 }
 
+// Validate SQL identifiers to prevent injection via column names or definitions.
+// Only allows alphanumeric, underscore, and common DDL keywords/types.
+// eslint-disable-next-line no-useless-escape
+const SAFE_SQL_FRAGMENT = /^[a-zA-Z_][a-zA-Z0-9_ (),'.\[\]"]*$/;
+function assertSafeSQL(value: string, label: string): void {
+  if (!SAFE_SQL_FRAGMENT.test(value)) {
+    throw new Error(`Unsafe ${label}: ${value}`);
+  }
+}
+
 export async function hasColumn(database: SQLite.SQLiteDatabase, table: string, column: string): Promise<boolean> {
   assertValidTable(table);
+  assertSafeSQL(column, "column name");
   const cols = await database.getAllAsync<{ name: string }>(`PRAGMA table_info(${table})`);
   return cols.some((c) => c.name === column);
 }
 
 export async function addColumnIfMissing(database: SQLite.SQLiteDatabase, table: string, column: string, definition: string): Promise<void> {
   assertValidTable(table);
+  assertSafeSQL(column, "column name");
+  assertSafeSQL(definition, "column definition");
   if (!(await hasColumn(database, table, column))) {
     await database.execAsync(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
   }

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -292,6 +292,28 @@ export function withOpacity(hex: string, opacity: number): string {
   return `rgba(${r}, ${g}, ${b}, ${opacity})`;
 }
 
+/**
+ * Longest run of consecutive calendar days in a set of YYYY-MM-DD strings.
+ */
+export function computeLongestDailyStreak(dates: string[]): number {
+  if (dates.length === 0) return 0;
+  const sorted = [...new Set(dates)].sort();
+  let max = 1;
+  let run = 1;
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = new Date(sorted[i - 1] + "T00:00:00");
+    const curr = new Date(sorted[i] + "T00:00:00");
+    const diffMs = curr.getTime() - prev.getTime();
+    if (diffMs === 86400000) {
+      run++;
+      if (run > max) max = run;
+    } else {
+      run = 1;
+    }
+  }
+  return max;
+}
+
 export function computeLongestStreak(timestamps: number[]): number {
   if (timestamps.length === 0) return 0;
   const weeks = new Set(timestamps.map((ts) => mondayOf(new Date(ts))));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cablesnap",
-  "version": "0.18.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cablesnap",
-      "version": "0.18.0",
+      "version": "0.22.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",


### PR DESCRIPTION
## Summary

Adds a Monthly Training Report accessible from the Progress tab that aggregates training data into a scannable, shareable digest — sessions, volume, duration, PRs, muscle distribution, body weight changes, nutrition adherence, and consistency metrics.

## Changes

- **lib/db/monthly-report.ts**: Data aggregation layer with `getMonthlyReport(year, monthIndex)` — runs 7 parallel queries for session stats, PRs, training days/streak, muscle distribution, most-improved exercise, body weight, and nutrition
- **hooks/useMonthlyReport.ts**: React hook with offset-based month navigation, caching of adjacent months, and text sharing
- **components/progress/MonthlyReportSegment.tsx**: Full-page scrollable report with month navigation, empty state, and share button
- **components/progress/MonthlyReportCards.tsx**: Individual stat cards (hero stats, consistency, PRs, muscle balance, most improved, body, nutrition) with accessibility labels and theme-aware delta colors
- **components/share/MonthlyShareCard.tsx**: Branded 1080px share card with 4 key stats
- **app/(tabs)/progress.tsx**: Added 5th 'Monthly' segment to Progress tab
- **lib/format.ts**: Added `computeLongestDailyStreak()` utility for consecutive day calculation
- **lib/db/index.ts**: Barrel exports for new module

## Testing

- 16 new tests across 3 files (budget: 1728/1800)
- All 1991 tests pass (137 suites)
- TypeScript: zero errors
- ESLint: zero warnings

## Edge Cases Handled

- Empty month (0 sessions): encouraging empty state
- Partial month (1 session): "Just getting started" message
- No PRs/nutrition/body data: sections hidden
- Month boundary: correct date range calculation
- Nutrition: only shown when macro targets exist
- Body weight: smoothed with 3-day moving average when ≥3 entries

## Issue

Resolves BLD-465