### PR TITLE
fix: repair starter template exercises on every launch (BLD-467)

### DIFF
--- a/__tests__/lib/db/seed-starter-templates.test.ts
+++ b/__tests__/lib/db/seed-starter-templates.test.ts
@@ -1,0 +1,133 @@
+import { STARTER_TEMPLATES, STARTER_PROGRAMS } from "../../../lib/starter-templates";
+import { seedExercises } from "../../../lib/seed";
+
+// ---- Data Integrity Tests ----
+
+describe("Starter Template Data Integrity", () => {
+  const allExercises = seedExercises();
+  const exerciseIds = new Set(allExercises.map((e) => e.id));
+
+  it("all template exercise IDs reference valid seed exercises", () => {
+    const missing: string[] = [];
+    for (const tpl of STARTER_TEMPLATES) {
+      for (const ex of tpl.exercises) {
+        if (!exerciseIds.has(ex.exercise_id)) {
+          missing.push(`${tpl.id}: ${ex.exercise_id}`);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("all template exercise IDs are unique across all templates", () => {
+    const ids = new Set<string>();
+    const dupes: string[] = [];
+    for (const tpl of STARTER_TEMPLATES) {
+      for (const ex of tpl.exercises) {
+        if (ids.has(ex.id)) dupes.push(ex.id);
+        ids.add(ex.id);
+      }
+    }
+    expect(dupes).toEqual([]);
+  });
+
+  it("Founder's Favourite A has exactly 5 exercises", () => {
+    const dayA = STARTER_TEMPLATES.find((t) => t.id === "starter-tpl-7a");
+    expect(dayA).toBeDefined();
+    expect(dayA!.exercises).toHaveLength(5);
+  });
+
+  it("Founder's Favourite B has exactly 5 exercises", () => {
+    const dayB = STARTER_TEMPLATES.find((t) => t.id === "starter-tpl-7b");
+    expect(dayB).toBeDefined();
+    expect(dayB!.exercises).toHaveLength(5);
+  });
+
+  it("all program day template_ids reference valid starter templates", () => {
+    const templateIds = new Set(STARTER_TEMPLATES.map((t) => t.id));
+    for (const prog of STARTER_PROGRAMS) {
+      for (const day of prog.days) {
+        expect(templateIds.has(day.template_id)).toBe(true);
+      }
+    }
+  });
+});
+
+// ---- Seed Function Tests ----
+
+describe("Seed — upsertTemplates repair logic", () => {
+  const mockDb = {
+    execAsync: jest.fn().mockResolvedValue(undefined),
+    getAllAsync: jest.fn().mockResolvedValue([]),
+    getFirstAsync: jest.fn().mockResolvedValue(null),
+    runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+    prepareAsync: jest.fn().mockResolvedValue({
+      executeAsync: jest.fn().mockResolvedValue(undefined),
+      finalizeAsync: jest.fn().mockResolvedValue(undefined),
+    }),
+    withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+  };
+
+  jest.mock("expo-sqlite", () => ({
+    openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+  }));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb.runAsync.mockResolvedValue({ changes: 1 });
+    mockDb.getFirstAsync.mockResolvedValue(null);
+  });
+
+  it("seed calls INSERT + UPDATE for each starter template exercise", async () => {
+    // countSeeded returns 0 to skip bulk exercise seeding
+    mockDb.getFirstAsync.mockResolvedValue({ count: 100 });
+
+    const { seed } = require("../../../lib/db/seed");
+    await seed(mockDb);
+
+    const insertCalls = mockDb.runAsync.mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("INSERT OR IGNORE INTO template_exercises")
+    );
+    const updateCalls = mockDb.runAsync.mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === "string" && (c[0] as string).includes("UPDATE template_exercises SET")
+    );
+
+    const totalStarterExercises = STARTER_TEMPLATES.reduce(
+      (sum, tpl) => sum + tpl.exercises.length, 0
+    );
+
+    expect(insertCalls.length).toBe(totalStarterExercises);
+    expect(updateCalls.length).toBe(totalStarterExercises);
+  });
+
+  it("seed calls upsertTemplates and upsertPrograms in separate transactions", async () => {
+    mockDb.getFirstAsync.mockResolvedValue({ count: 100 });
+
+    const { seed } = require("../../../lib/db/seed");
+    await seed(mockDb);
+
+    // withTransactionAsync should be called at least twice (templates + programs)
+    expect(mockDb.withTransactionAsync.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("seed backfills exercises referenced by starter templates", async () => {
+    // Return non-zero count so bulk seeding is skipped
+    mockDb.getFirstAsync
+      .mockResolvedValueOnce({ count: 50 }) // voltra count
+      .mockResolvedValueOnce({ count: 50 }) // non-voltra count
+      .mockResolvedValue(null); // starter_version
+
+    const { seed } = require("../../../lib/db/seed");
+    await seed(mockDb);
+
+    const backfillCalls = mockDb.runAsync.mock.calls.filter(
+      (c: unknown[]) =>
+        typeof c[0] === "string" &&
+        (c[0] as string).includes("INSERT OR IGNORE INTO exercises") &&
+        (c[0] as string).includes("is_voltra")
+    );
+
+    // Should have backfill calls for exercises referenced by starters
+    expect(backfillCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/db/seed.ts
+++ b/lib/db/seed.ts
@@ -1,5 +1,6 @@
 import * as SQLite from "expo-sqlite";
 import { seedExercises } from "../seed";
+import type { Exercise } from "../types";
 import {
   STARTER_TEMPLATES,
   STARTER_PROGRAMS,
@@ -50,7 +51,46 @@ export async function seed(database: SQLite.SQLiteDatabase): Promise<void> {
     });
   }
 
+  // Backfill exercises referenced by starter templates that upgrading users
+  // may be missing (e.g., community exercises added after initial install).
+  await backfillStarterExercises(database, exercises);
+
   await seedStarters(database);
+}
+
+async function backfillStarterExercises(
+  database: SQLite.SQLiteDatabase,
+  allExercises: Exercise[]
+): Promise<void> {
+  const neededIds = new Set<string>();
+  for (const tpl of STARTER_TEMPLATES) {
+    for (const ex of tpl.exercises) {
+      neededIds.add(ex.exercise_id);
+    }
+  }
+
+  const exerciseMap = new Map<string, Exercise>();
+  for (const ex of allExercises) {
+    if (neededIds.has(ex.id)) exerciseMap.set(ex.id, ex);
+  }
+
+  for (const id of neededIds) {
+    const ex = exerciseMap.get(id);
+    if (!ex) continue;
+    await database.runAsync(
+      `INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty, is_custom, mount_position, attachment, training_modes, is_voltra)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        ex.id, ex.name, ex.category,
+        JSON.stringify(ex.primary_muscles), JSON.stringify(ex.secondary_muscles),
+        ex.equipment, ex.instructions, ex.difficulty,
+        ex.is_custom ? 1 : 0,
+        ex.mount_position ?? null, ex.attachment ?? "handle",
+        JSON.stringify(ex.training_modes ?? ["weight"]),
+        ex.is_voltra ? 1 : 0,
+      ]
+    );
+  }
 }
 
 async function upsertTemplates(database: SQLite.SQLiteDatabase): Promise<void> {
@@ -65,9 +105,15 @@ async function upsertTemplates(database: SQLite.SQLiteDatabase): Promise<void> {
     );
     for (let i = 0; i < tpl.exercises.length; i++) {
       const ex = tpl.exercises[i];
+      // INSERT if missing, then UPDATE to repair canonical columns.
+      // INSERT OR IGNORE alone cannot fix corrupted rows (BLD-467).
       await database.runAsync(
         "INSERT OR IGNORE INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds, training_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         [ex.id, tpl.id, ex.exercise_id, i, ex.target_sets, ex.target_reps, ex.rest_seconds, ex.training_mode ?? null]
+      );
+      await database.runAsync(
+        "UPDATE template_exercises SET template_id = ?, exercise_id = ?, position = ?, target_sets = ?, target_reps = ?, rest_seconds = ?, training_mode = ? WHERE id = ?",
+        [tpl.id, ex.exercise_id, i, ex.target_sets, ex.target_reps, ex.rest_seconds, ex.training_mode ?? null, ex.id]
       );
     }
   }
@@ -98,27 +144,26 @@ async function seedStarters(database: SQLite.SQLiteDatabase): Promise<void> {
     "SELECT value FROM app_settings WHERE key = 'starter_version'"
   );
 
+  if (row) {
+    await database.runAsync(
+      "INSERT OR IGNORE INTO app_settings (key, value) VALUES ('onboarding_complete', '1')"
+    );
+  }
+
+  // Repair templates and programs in separate transactions so that a failure
+  // in one doesn't roll back the other (BLD-467).
   await database.withTransactionAsync(async () => {
-    if (row) {
-      await database.runAsync(
-        "INSERT OR IGNORE INTO app_settings (key, value) VALUES ('onboarding_complete', '1')"
-      );
-    }
-
-    // Always repair ALL canonical starter data — handles cases where import,
-    // migration, deletion, or prior incomplete seeding left starters corrupted.
-    // Each repair uses INSERT OR IGNORE (idempotent) to re-create deleted rows,
-    // then UPDATE to fix corrupted columns on existing rows.
-    // This covers: workout_templates, template_exercises, programs, program_days.
-    // See BLD-174, BLD-187, BLD-255 for the history of this recurring regression.
     await upsertTemplates(database);
-    await upsertPrograms(database);
-
-    if (!row || Number(row.value) < STARTER_VERSION) {
-      await database.runAsync(
-        "INSERT OR REPLACE INTO app_settings (key, value) VALUES ('starter_version', ?)",
-        [String(STARTER_VERSION)]
-      );
-    }
   });
+
+  await database.withTransactionAsync(async () => {
+    await upsertPrograms(database);
+  });
+
+  if (!row || Number(row.value) < STARTER_VERSION) {
+    await database.runAsync(
+      "INSERT OR REPLACE INTO app_settings (key, value) VALUES ('starter_version', ?)",
+      [String(STARTER_VERSION)]
+    );
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cablesnap",
-  "version": "0.22.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cablesnap",
-      "version": "0.22.0",
+      "version": "0.24.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",


### PR DESCRIPTION
## Summary

Fixes blank template screen for Founder's Favourite A (and potentially other starter templates) by hardening the seed/upsert logic to repair missing or corrupted template_exercises rows on every app launch.

## Root Cause

upsertTemplates() used INSERT OR IGNORE for template_exercises without a follow-up UPDATE. If rows were lost (due to transaction rollback, interrupted migration, or data corruption), they were never repaired. Additionally, all seed operations (templates + programs + settings) were in a single transaction — any failure rolled back everything.

## Changes

- **Repair UPDATE**: Added explicit UPDATE after each INSERT OR IGNORE for template_exercises, ensuring exercise_id, sort_order, sets, and reps are always correct
- **Split transactions**: Separated seedStarters() into independent transactions for templates and programs, reducing blast radius
- **Exercise backfill**: Added backfillStarterExercises() to ensure exercises referenced by starter templates exist for upgrading users who may have missed community exercise seeding
- **8 new tests**: Data integrity tests (exercise refs valid, unique IDs, correct counts) and seed repair behavior tests

## Testing

- All 1999 tests pass (138 suites)
- TypeScript: zero errors
- ESLint: zero warnings
- Test budget: 1736/1800

## Issue

Fixes GH #283
Resolves BLD-467