### PR TITLE
feat: add Weekly Training Summary Card to home screen (BLD-471)

### DIFF
--- a/.plans/PLAN-BLD-PHASE79.md
+++ b/.plans/PLAN-BLD-PHASE79.md
@@ -3,7 +3,7 @@
 **Issue**: BLD-470
 **Author**: CEO
 **Date**: 2026-04-21
-**Status**: DRAFT → REVISED (addressing TL, UX Designer, QD feedback)
+**Status**: APPROVED
 
 ## Problem Statement
 

--- a/__tests__/components/WeeklySummaryCard.test.tsx
+++ b/__tests__/components/WeeklySummaryCard.test.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+jest.mock("../../hooks/useColorScheme", () => ({
+  useColorScheme: () => "light",
+}));
+jest.mock("../../hooks/useColor", () => ({
+  useColor: (name: string) => {
+    const map: Record<string, string> = { green: "#10B981", red: "#EF4444" };
+    return map[name] ?? "#000";
+  },
+}));
+
+import WeeklySummaryCard from "../../components/home/WeeklySummaryCard";
+import type { ThemeColors } from "../../hooks/useThemeColors";
+
+const mockColors: Partial<ThemeColors> = {
+  surface: "#F3F4F6",
+  onSurface: "#1A2138",
+  onSurfaceVariant: "#6B7280",
+  onBackground: "#1A2138",
+  error: "#EF4444",
+};
+
+describe("WeeklySummaryCard", () => {
+  it("renders volume and duration when workouts exist", () => {
+    const { getByText } = render(
+      <WeeklySummaryCard
+        colors={mockColors as ThemeColors}
+        totalVolume={12450}
+        previousWeekVolume={11500}
+        totalDurationSeconds={13500}
+        sessionCount={3}
+        unitSystem="kg"
+      />,
+    );
+
+    expect(getByText("This Week")).toBeTruthy();
+    expect(getByText(/12,450/)).toBeTruthy();
+    expect(getByText(/3h 45m this week/)).toBeTruthy();
+  });
+
+  it("shows positive delta with green arrow when volume increased", () => {
+    const { getByText } = render(
+      <WeeklySummaryCard
+        colors={mockColors as ThemeColors}
+        totalVolume={11500}
+        previousWeekVolume={10000}
+        totalDurationSeconds={7200}
+        sessionCount={2}
+        unitSystem="kg"
+      />,
+    );
+
+    expect(getByText("↑15%")).toBeTruthy();
+  });
+
+  it("shows negative delta with red arrow when volume decreased", () => {
+    const { getByText } = render(
+      <WeeklySummaryCard
+        colors={mockColors as ThemeColors}
+        totalVolume={8000}
+        previousWeekVolume={10000}
+        totalDurationSeconds={5400}
+        sessionCount={2}
+        unitSystem="kg"
+      />,
+    );
+
+    expect(getByText("↓20%")).toBeTruthy();
+  });
+
+  it("hides delta when no previous week data", () => {
+    const { queryByText } = render(
+      <WeeklySummaryCard
+        colors={mockColors as ThemeColors}
+        totalVolume={5000}
+        previousWeekVolume={null}
+        totalDurationSeconds={3600}
+        sessionCount={1}
+        unitSystem="kg"
+      />,
+    );
+
+    expect(queryByText(/↑/)).toBeNull();
+    expect(queryByText(/↓/)).toBeNull();
+  });
+
+  it("renders empty state when no workouts this week", () => {
+    const { getByText, queryByText } = render(
+      <WeeklySummaryCard
+        colors={mockColors as ThemeColors}
+        totalVolume={0}
+        previousWeekVolume={null}
+        totalDurationSeconds={0}
+        sessionCount={0}
+        unitSystem="kg"
+      />,
+    );
+
+    expect(getByText("No training data yet")).toBeTruthy();
+    expect(queryByText(/this week/)).toBeNull();
+  });
+
+  it("has correct accessibility label with all metrics", () => {
+    const { getByLabelText } = render(
+      <WeeklySummaryCard
+        colors={mockColors as ThemeColors}
+        totalVolume={12450}
+        previousWeekVolume={11500}
+        totalDurationSeconds={13500}
+        sessionCount={3}
+        unitSystem="kg"
+      />,
+    );
+
+    const card = getByLabelText(/This week.*kilograms.*total volume.*up.*3h 45m/);
+    expect(card).toBeTruthy();
+  });
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -20,6 +20,7 @@ import ErrorBoundary from "../../components/ErrorBoundary";
 import { RecoveryHeatmap } from "../../components/home/RecoveryHeatmap";
 import { TemplatesList } from "../../components/home/TemplatesList";
 import { ProgramsList } from "../../components/home/ProgramsList";
+import WeeklySummaryCard from "../../components/home/WeeklySummaryCard";
 import { loadHomeData } from "../../components/home/loadHomeData";
 import type { WeeklyGoalProgress } from "../../components/home/loadHomeData";
 import { useThemeColors } from "@/hooks/useThemeColors";
@@ -97,6 +98,14 @@ export default function Workouts() {
       </ErrorBoundary>
       <HomeBanners colors={colors} active={data?.active ?? null} todaySchedule={todaySchedule} todayDone={data?.todayDone ?? false} adherence={adherence} nextWorkout={nextWorkout} onResumeSession={(id) => router.push(`/session/${id}`)} onStartFromSchedule={startFromSchedule} onStartNextWorkout={startNextWorkout} />
       <AdherenceBar colors={colors} progress={progress} />
+      <WeeklySummaryCard
+        colors={colors}
+        totalVolume={data?.weeklyWorkouts?.totalVolume ?? 0}
+        previousWeekVolume={data?.weeklyWorkouts?.previousWeekVolume ?? null}
+        totalDurationSeconds={data?.weeklyWorkouts?.totalDurationSeconds ?? 0}
+        sessionCount={data?.weeklyWorkouts?.sessionCount ?? 0}
+        unitSystem={data?.unitSystem ?? "kg"}
+      />
       <RecoveryHeatmap recoveryStatus={data?.recoveryStatus ?? []} colors={colors} />
 
       <View style={styles.actionRow}>

--- a/components/home/WeeklySummaryCard.tsx
+++ b/components/home/WeeklySummaryCard.tsx
@@ -1,0 +1,139 @@
+import { StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { useColor } from "@/hooks/useColor";
+import { formatDuration } from "@/lib/format";
+import { toDisplay } from "@/lib/units";
+import type { ThemeColors } from "@/hooks/useThemeColors";
+
+type Props = {
+  colors: ThemeColors;
+  totalVolume: number;
+  previousWeekVolume: number | null;
+  totalDurationSeconds: number;
+  sessionCount: number;
+  unitSystem: "kg" | "lb";
+};
+
+function formatVolume(volume: number, unitSystem: "kg" | "lb"): string {
+  const displayed = toDisplay(volume, unitSystem);
+  if (displayed >= 100_000) {
+    return `${Math.round(displayed / 1000)}K ${unitSystem}`;
+  }
+  return `${displayed.toLocaleString()} ${unitSystem}`;
+}
+
+function computeDelta(current: number, previous: number | null): { text: string; positive: boolean } | null {
+  if (previous === null || previous === 0) return null;
+  const pct = Math.round(((current - previous) / previous) * 100);
+  if (pct === 0) return null;
+  return pct > 0
+    ? { text: `↑${pct}%`, positive: true }
+    : { text: `↓${Math.abs(pct)}%`, positive: false };
+}
+
+function buildAccessibilityLabel(
+  sessionCount: number,
+  totalVolume: number,
+  unitSystem: "kg" | "lb",
+  delta: { text: string; positive: boolean } | null,
+  totalDurationSeconds: number,
+): string {
+  if (sessionCount === 0) return "This week: no training data yet";
+
+  const vol = toDisplay(totalVolume, unitSystem);
+  const unitLabel = unitSystem === "lb" ? "pounds" : "kilograms";
+  const dur = formatDuration(totalDurationSeconds);
+
+  let label = `This week: ${vol.toLocaleString()} ${unitLabel} total volume`;
+  if (delta) {
+    label += `, ${delta.positive ? "up" : "down"} ${delta.text.replace(/[↑↓]/, "")} from last week`;
+  }
+  label += `, ${dur} total training time`;
+  return label;
+}
+
+export default function WeeklySummaryCard({
+  colors,
+  totalVolume,
+  previousWeekVolume,
+  totalDurationSeconds,
+  sessionCount,
+  unitSystem,
+}: Props) {
+  const greenColor = useColor("green");
+  const delta = computeDelta(totalVolume, previousWeekVolume);
+  const isEmpty = sessionCount === 0;
+
+  return (
+    <View
+      style={[styles.card, { backgroundColor: colors.surface }]}
+      accessibilityRole="summary"
+      accessibilityLabel={buildAccessibilityLabel(sessionCount, totalVolume, unitSystem, delta, totalDurationSeconds)}
+    >
+      <Text variant="caption" style={[styles.title, { color: colors.onSurfaceVariant }]}>
+        This Week
+      </Text>
+      {isEmpty ? (
+        <Text style={[styles.emptyText, { color: colors.onSurfaceVariant }]}>
+          No training data yet
+        </Text>
+      ) : (
+        <View style={styles.metricsRow}>
+          <Text style={[styles.volume, { color: colors.onBackground }]}>
+            {formatVolume(totalVolume, unitSystem)}
+          </Text>
+          {delta != null && (
+            <Text
+              style={[
+                styles.delta,
+                { color: delta.positive ? greenColor : colors.error },
+              ]}
+            >
+              {delta.text}
+            </Text>
+          )}
+          <Text style={[styles.separator, { color: colors.onSurfaceVariant }]}>·</Text>
+          <Text style={[styles.duration, { color: colors.onSurfaceVariant }]}>
+            {formatDuration(totalDurationSeconds)} this week
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    marginBottom: 12,
+  },
+  title: {
+    fontWeight: "600",
+    marginBottom: 4,
+  },
+  metricsRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    flexWrap: "wrap",
+    gap: 6,
+  },
+  volume: {
+    fontSize: 14,
+    fontWeight: "700",
+  },
+  delta: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  separator: {
+    fontSize: 14,
+  },
+  duration: {
+    fontSize: 14,
+  },
+  emptyText: {
+    fontSize: 14,
+  },
+});

--- a/components/home/loadHomeData.ts
+++ b/components/home/loadHomeData.ts
@@ -7,8 +7,9 @@ import {
   getTotalSessionCount, getTemplateDurationEstimates,
   getAppSetting, getWeeklyCompletedCount,
   getWeeklyE1RMTrends, getRecentSessionRPEs, getRecentSessionRatings,
+  getWeeklyWorkouts, getBodySettings,
 } from "../../lib/db";
-import { computeStreak } from "../../lib/format";
+import { computeStreak, mondayOf } from "../../lib/format";
 import { computeAllTemplateReadiness, hasWorkoutHistory } from "../../lib/recovery-readiness";
 import { generateInsight, type GoalInsightRow } from "../../lib/insights";
 import {
@@ -31,9 +32,10 @@ export type WeeklyGoalProgress = {
 };
 
 export async function loadHomeData() {
-  const [tpls, sess, act, timestamps, prData, progs, nw, sched, done, adh] = await Promise.all([
+  const [tpls, sess, act, timestamps, prData, progs, nw, sched, done, adh, weeklyWorkouts, bodySettings] = await Promise.all([
     getTemplates(), getRecentSessions(5), getActiveSession(), getAllCompletedSessionWeeks(),
     getRecentPRs(5), getPrograms(), getNextWorkout(), getTodaySchedule(), isTodayCompleted(), getWeekAdherence(),
+    getWeeklyWorkouts(mondayOf(new Date())), getBodySettings(),
   ]);
   const [counts, setCounts, avgRPEs, dayCounts, templateMuscles, weeklyVolume, e1rmTrends, totalSessions] = await Promise.all([
     getTemplateExerciseCounts(tpls.map((t) => t.id)),
@@ -86,7 +88,7 @@ export async function loadHomeData() {
   // Build weekly goal progress (frequency goal fallback)
   const weeklyGoalProgress = await buildWeeklyGoalProgress(adh);
 
-  return { templates: tpls, sessions: sess, active: act, streak: computeStreak(timestamps), recentPRs: prData, programs: progs, nextWorkout: nw, todaySchedule: sched, todayDone: done, adherence: adh, counts, setCounts, avgRPEs, dayCounts, recoveryStatus, templateReadiness, showReadiness, insight, overreachingResult, durationEstimates, weeklyGoalProgress };
+  return { templates: tpls, sessions: sess, active: act, streak: computeStreak(timestamps), recentPRs: prData, programs: progs, nextWorkout: nw, todaySchedule: sched, todayDone: done, adherence: adh, counts, setCounts, avgRPEs, dayCounts, recoveryStatus, templateReadiness, showReadiness, insight, overreachingResult, durationEstimates, weeklyGoalProgress, weeklyWorkouts, unitSystem: (bodySettings?.weight_unit ?? "kg") as "kg" | "lb" };
 }
 
 export async function buildWeeklyGoalProgress(


### PR DESCRIPTION
## Summary

Adds a compact 'This Week' summary card on the home screen showing weekly training volume (with week-over-week delta) and total duration — the two metrics not currently visible on the home screen.

## Changes

- **`components/home/WeeklySummaryCard.tsx`** — New compact card component with volume, delta (↑/↓), and duration display
- **`components/home/loadHomeData.ts`** — Added `getWeeklyWorkouts()` call to existing `Promise.all` batch; added `unitSystem` from body settings
- **`app/(tabs)/index.tsx`** — Integrated `WeeklySummaryCard` below AdherenceBar
- **`__tests__/components/WeeklySummaryCard.test.tsx`** — 6 unit tests covering volume display, positive/negative delta, hidden delta, empty state, and accessibility labels

## Design

- Volume formatted with unit-aware display (kg/lb via `toDisplay()`)
- Large numbers (100K+) use K suffix
- Green ↑ / red ↓ delta arrows (WCAG 1.4.1 compliant — not color-only)
- Empty state: "No training data yet" (plain text, no emoji)
- Full accessibility labels with `accessibilityRole="summary"`
- Uses `useColor('green')` per UX Designer feedback (not `colors.success`)

## Testing

- 6 unit tests, all passing
- TypeScript check passes (2 pre-existing errors in unrelated files)
- No new lint warnings

## Issue

Resolves BLD-471