### PR TITLE
fix: add missing db mocks for WeeklySummaryCard acceptance tests (BLD-473)

### DIFF
--- a/__tests__/acceptance/dashboard.test.tsx
+++ b/__tests__/acceptance/dashboard.test.tsx
@@ -158,6 +158,15 @@ jest.mock('../../lib/db', () => ({
   getRecentSessionRPEs: jest.fn().mockResolvedValue([]),
   getRecentSessionRatings: jest.fn().mockResolvedValue([]),
   setAppSetting: jest.fn().mockResolvedValue(undefined),
+  getTemplateDurationEstimates: jest.fn().mockResolvedValue({}),
+  getWeeklyCompletedCount: jest.fn().mockResolvedValue(0),
+  getActiveGoals: jest.fn().mockResolvedValue([]),
+  getCurrentBestWeight: jest.fn().mockResolvedValue(null),
+  getCurrentBestReps: jest.fn().mockResolvedValue(null),
+  getExerciseById: jest.fn().mockResolvedValue(null),
+  getWeeklyWorkouts: jest.fn().mockResolvedValue({ totalVolume: 0, previousWeekVolume: null, totalDurationSeconds: 0, sessionCount: 0 }),
+  getBodySettings: jest.fn().mockResolvedValue(null),
+  getAppSetting: jest.fn().mockResolvedValue(null),
 }))
 
 const mockGetPrograms = jest.fn().mockResolvedValue([program1])

--- a/__tests__/acceptance/program-lifecycle.acceptance.test.tsx
+++ b/__tests__/acceptance/program-lifecycle.acceptance.test.tsx
@@ -84,6 +84,16 @@ jest.mock('../../lib/db', () => ({
   deleteTemplate: (...args: unknown[]) => mockDeleteTemplate(...args),
   duplicateTemplate: (...args: unknown[]) => mockDuplicateTemplate(...args),
   duplicateProgram: (...args: unknown[]) => mockDuplicateProgram(...args),
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+  getTemplateDurationEstimates: jest.fn().mockResolvedValue({}),
+  getWeeklyCompletedCount: jest.fn().mockResolvedValue(0),
+  getActiveGoals: jest.fn().mockResolvedValue([]),
+  getCurrentBestWeight: jest.fn().mockResolvedValue(null),
+  getCurrentBestReps: jest.fn().mockResolvedValue(null),
+  getExerciseById: jest.fn().mockResolvedValue(null),
+  getWeeklyWorkouts: jest.fn().mockResolvedValue({ totalVolume: 0, previousWeekVolume: null, totalDurationSeconds: 0, sessionCount: 0 }),
+  getBodySettings: jest.fn().mockResolvedValue(null),
+  getAppSetting: jest.fn().mockResolvedValue(null),
 }))
 
 const mockGetNextWorkout = jest.fn().mockResolvedValue(null)

--- a/__tests__/acceptance/template-sections-merge.acceptance.test.tsx
+++ b/__tests__/acceptance/template-sections-merge.acceptance.test.tsx
@@ -79,6 +79,16 @@ jest.mock('../../lib/db', () => ({
   deleteTemplate: jest.fn().mockResolvedValue(undefined),
   duplicateTemplate: jest.fn().mockResolvedValue('dup-1'),
   duplicateProgram: jest.fn().mockResolvedValue('dup-p1'),
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+  getTemplateDurationEstimates: jest.fn().mockResolvedValue({}),
+  getWeeklyCompletedCount: jest.fn().mockResolvedValue(0),
+  getActiveGoals: jest.fn().mockResolvedValue([]),
+  getCurrentBestWeight: jest.fn().mockResolvedValue(null),
+  getCurrentBestReps: jest.fn().mockResolvedValue(null),
+  getExerciseById: jest.fn().mockResolvedValue(null),
+  getWeeklyWorkouts: jest.fn().mockResolvedValue({ totalVolume: 0, previousWeekVolume: null, totalDurationSeconds: 0, sessionCount: 0 }),
+  getBodySettings: jest.fn().mockResolvedValue(null),
+  getAppSetting: jest.fn().mockResolvedValue(null),
 }))
 
 jest.mock('../../lib/programs', () => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cablesnap",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cablesnap",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",


### PR DESCRIPTION
## Summary

BLD-471 (Weekly Training Summary Card) added `getWeeklyWorkouts` and `getBodySettings` to `loadHomeData`'s main `Promise.all`, but the acceptance test mocks didn't include them. This caused `loadHomeData` to reject, leaving the component with no data and breaking 20 tests across 3 suites.

## Changes

- Added mocks for `getWeeklyWorkouts`, `getBodySettings`, `getTemplateDurationEstimates`, `getWeeklyCompletedCount`, `getActiveGoals`, `getCurrentBestWeight`, `getCurrentBestReps`, `getExerciseById`, and `getAppSetting` to:
  - `__tests__/acceptance/dashboard.test.tsx`
  - `__tests__/acceptance/program-lifecycle.acceptance.test.tsx`
  - `__tests__/acceptance/template-sections-merge.acceptance.test.tsx`

## Testing

- All 2024 tests pass (0 failures)
- No tests removed or skipped
- WeeklySummaryCard still renders on the home screen
- ESLint passes with 0 warnings

## Issue

Resolves BLD-473