### PR TITLE
feat: Strava OAuth proxy — Cloudflare Worker + app integration (BLD-477)

### DIFF
--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -185,7 +185,7 @@ describe("Strava Integration — Config", () => {
   it("has stravaClientId, stravaProxyUrl, and required plugins in app.config.ts", () => {
     expect(configSrc).toContain("stravaClientId");
     expect(configSrc).toContain("stravaProxyUrl");
-    expect(configSrc).toContain("strava-proxy.persoack.workers.dev");
+    expect(configSrc).toContain("strava-proxy.alan200994.workers.dev");
     expect(configSrc).toContain("expo-web-browser");
     expect(configSrc).toContain("expo-secure-store");
     // No client_secret in app config

--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -43,6 +43,11 @@ const configSrc = fs.readFileSync(
   "utf-8"
 );
 
+const workerSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../workers/strava-proxy/src/index.ts"),
+  "utf-8"
+);
+
 describe("Strava Integration — DB Schema (Phase 48)", () => {
   it("creates strava tables with correct structure", () => {
     expect(helpersSrc).toContain("CREATE TABLE IF NOT EXISTS strava_connection");
@@ -101,10 +106,22 @@ describe("Strava Integration — API Client", () => {
     expect(stravaClientSrc).toContain("getBodySettings");
   });
 
-  it("handles token refresh, 401 disconnect, and redirect URI", () => {
+  it("uses proxy for token exchange and refresh instead of direct Strava calls", () => {
+    expect(stravaClientSrc).toContain("getProxyUrl");
+    expect(stravaClientSrc).toContain("stravaProxyUrl");
+    expect(stravaClientSrc).toMatch(/\$\{proxyUrl\}\/token/);
+    expect(stravaClientSrc).toMatch(/\$\{proxyUrl\}\/refresh/);
+    // No direct Strava token URL
+    expect(stravaClientSrc).not.toContain("strava.com/oauth/token");
+    // client_id and grant_type not sent in token exchange/refresh body
+    expect(stravaClientSrc).not.toMatch(/body:.*client_id.*grant_type/s);
+  });
+
+  it("handles token refresh, disconnect on 401/400, and redirect URI", () => {
     expect(stravaClientSrc).toContain("refreshAccessToken");
     expect(stravaClientSrc).toContain("getValidAccessToken");
     expect(stravaClientSrc).toContain("401");
+    expect(stravaClientSrc).toContain("400");
     expect(stravaClientSrc).toContain("await disconnect()");
     expect(stravaClientSrc).toContain("No completed sets to sync");
     expect(stravaClientSrc).toContain('scheme: "cablesnap"');
@@ -165,10 +182,53 @@ describe("Strava Integration — Session & Startup", () => {
 });
 
 describe("Strava Integration — Config", () => {
-  it("has stravaClientId and required plugins in app.config.ts", () => {
+  it("has stravaClientId, stravaProxyUrl, and required plugins in app.config.ts", () => {
     expect(configSrc).toContain("stravaClientId");
+    expect(configSrc).toContain("stravaProxyUrl");
+    expect(configSrc).toContain("strava-proxy.persoack.workers.dev");
     expect(configSrc).toContain("expo-web-browser");
     expect(configSrc).toContain("expo-secure-store");
+    // No client_secret in app config
+    expect(configSrc).not.toContain("client_secret");
+    expect(configSrc).not.toContain("stravaClientSecret");
+  });
+});
+
+describe("Strava Integration — Worker Proxy", () => {
+  it("has /token and /refresh endpoints with input validation", () => {
+    expect(workerSrc).toContain('"/token"');
+    expect(workerSrc).toContain('"/refresh"');
+    expect(workerSrc).toContain("missing required field: code");
+    expect(workerSrc).toContain("missing required field: refresh_token");
+  });
+
+  it("sends form-encoded requests to Strava (not JSON)", () => {
+    expect(workerSrc).toContain("URLSearchParams");
+    expect(workerSrc).toContain("application/x-www-form-urlencoded");
+  });
+
+  it("adds client_id and client_secret from env bindings", () => {
+    expect(workerSrc).toContain("env.STRAVA_CLIENT_ID");
+    expect(workerSrc).toContain("env.STRAVA_CLIENT_SECRET");
+    // No hardcoded secrets
+    expect(workerSrc).not.toMatch(/client_secret:\s*"/);
+  });
+
+  it("returns 404 for unknown routes and 405 for non-POST methods", () => {
+    expect(workerSrc).toContain("not found");
+    expect(workerSrc).toContain("404");
+    expect(workerSrc).toContain("method not allowed");
+    expect(workerSrc).toContain("405");
+  });
+
+  it("handles CORS preflight with OPTIONS", () => {
+    expect(workerSrc).toContain("OPTIONS");
+    expect(workerSrc).toContain("Access-Control-Allow-Origin");
+    expect(workerSrc).toContain("204");
+  });
+
+  it("proxies Strava response status codes", () => {
+    expect(workerSrc).toContain("stravaRes.status");
   });
 });
 
@@ -178,7 +238,7 @@ describe("Strava Integration — Config", () => {
 jest.mock("expo-constants", () => ({
   __esModule: true,
   default: {
-    expoConfig: { extra: { stravaClientId: "test-client-id" } },
+    expoConfig: { extra: { stravaClientId: "test-client-id", stravaProxyUrl: "https://test-proxy.example.com" } },
   },
 }));
 jest.mock("../../lib/db", () => ({
@@ -216,7 +276,7 @@ describe("Strava Integration — Behavioral", () => {
     global.fetch = originalFetch;
   });
 
-  it("connectStrava exchanges auth code for tokens and saves connection", async () => {
+  it("connectStrava exchanges auth code for tokens via proxy and saves connection", async () => {
     AuthSession.AuthRequest.mockImplementation(() => ({
       promptAsync: jest.fn().mockResolvedValue({
         type: "success",
@@ -240,10 +300,14 @@ describe("Strava Integration — Behavioral", () => {
     expect(SecureStore.setItemAsync).toHaveBeenCalledWith("strava_access_token", "at-1");
     expect(SecureStore.setItemAsync).toHaveBeenCalledWith("strava_refresh_token", "rt-1");
     expect(db.saveStravaConnection).toHaveBeenCalledWith(42, "Jane Doe");
-    // Verify PKCE code_verifier is sent in token exchange
+    // Verify proxy URL is used
+    expect(mockFetch.mock.calls[0][0]).toBe("https://test-proxy.example.com/token");
+    // Verify body sends code + code_verifier but NOT client_id or grant_type
     const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(fetchBody.code).toBe("auth-code-123");
     expect(fetchBody.code_verifier).toBe("test-verifier");
-    expect(fetchBody.grant_type).toBe("authorization_code");
+    expect(fetchBody).not.toHaveProperty("client_id");
+    expect(fetchBody).not.toHaveProperty("grant_type");
   });
 
   it("connectStrava returns null when user cancels OAuth", async () => {

--- a/app.config.ts
+++ b/app.config.ts
@@ -69,5 +69,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       projectId: "24dc5f10-9a21-4336-bac0-6334a5f6b82b",
     },
     stravaClientId: "227474",
+    stravaProxyUrl: "https://strava-proxy.persoack.workers.dev",
   },
 });

--- a/app.config.ts
+++ b/app.config.ts
@@ -69,6 +69,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       projectId: "24dc5f10-9a21-4336-bac0-6334a5f6b82b",
     },
     stravaClientId: "227474",
-    stravaProxyUrl: "https://strava-proxy.persoack.workers.dev",
+    stravaProxyUrl: "https://strava-proxy.alan200994.workers.dev",
   },
 });

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -19,7 +19,6 @@ import {
 
 // Strava API constants
 const STRAVA_AUTH_URL = "https://www.strava.com/oauth/mobile/authorize";
-const STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token";
 const STRAVA_API_BASE = "https://www.strava.com/api/v3";
 
 // SecureStore keys
@@ -31,6 +30,12 @@ const MAX_RETRIES = 3;
 
 function getClientId(): string {
   return Constants.expoConfig?.extra?.stravaClientId ?? "";
+}
+
+function getProxyUrl(): string {
+  const url = Constants.expoConfig?.extra?.stravaProxyUrl;
+  if (!url) throw new Error("Strava proxy URL not configured");
+  return url as string;
 }
 
 const redirectUri = AuthSession.makeRedirectUri({
@@ -96,23 +101,25 @@ async function refreshAccessToken(): Promise<string | null> {
   const refreshToken = await getRefreshToken();
   if (!refreshToken) return null;
 
-  const clientId = getClientId();
-  if (!clientId) return null;
+  let proxyUrl: string;
+  try {
+    proxyUrl = getProxyUrl();
+  } catch {
+    return null;
+  }
 
   try {
-    const response = await fetch(STRAVA_TOKEN_URL, {
+    const response = await fetch(`${proxyUrl}/refresh`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        client_id: clientId,
-        grant_type: "refresh_token",
         refresh_token: refreshToken,
       }),
     });
 
     if (!response.ok) {
-      if (response.status === 401) {
-        // Refresh token revoked — disconnect
+      if (response.status === 401 || response.status === 400) {
+        // Token revoked or invalid — disconnect
         await disconnect();
         return null;
       }
@@ -153,6 +160,8 @@ export async function connectStrava(): Promise<{
     throw new Error("Strava client ID not configured");
   }
 
+  const proxyUrl = getProxyUrl();
+
   const authRequest = new AuthSession.AuthRequest({
     clientId,
     scopes: ["activity:write"],
@@ -169,14 +178,12 @@ export async function connectStrava(): Promise<{
     return null;
   }
 
-  // Exchange authorization code for tokens
-  const tokenResponse = await fetch(STRAVA_TOKEN_URL, {
+  // Exchange authorization code for tokens via proxy
+  const tokenResponse = await fetch(`${proxyUrl}/token`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      client_id: clientId,
       code: result.params.code,
-      grant_type: "authorization_code",
       code_verifier: authRequest.codeVerifier,
     }),
   });

--- a/workers/strava-proxy/package.json
+++ b/workers/strava-proxy/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "strava-proxy",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20241230.0",
+    "wrangler": "^3.99.0"
+  }
+}

--- a/workers/strava-proxy/src/index.ts
+++ b/workers/strava-proxy/src/index.ts
@@ -1,0 +1,109 @@
+interface Env {
+  STRAVA_CLIENT_ID: string;
+  STRAVA_CLIENT_SECRET: string;
+}
+
+const STRAVA_TOKEN_URL = "https://www.strava.com/oauth/token";
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+  });
+}
+
+async function handleToken(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as Record<string, unknown>;
+  const code = body.code as string | undefined;
+  const codeVerifier = body.code_verifier as string | undefined;
+
+  if (!code) {
+    return jsonResponse({ error: "missing required field: code" }, 400);
+  }
+
+  const params = new URLSearchParams({
+    client_id: env.STRAVA_CLIENT_ID,
+    client_secret: env.STRAVA_CLIENT_SECRET,
+    grant_type: "authorization_code",
+    code,
+  });
+  if (codeVerifier) {
+    params.set("code_verifier", codeVerifier);
+  }
+
+  const stravaRes = await fetch(STRAVA_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+
+  const data = await stravaRes.text();
+  return new Response(data, {
+    status: stravaRes.status,
+    headers: {
+      "Content-Type": stravaRes.headers.get("Content-Type") ?? "application/json",
+      ...CORS_HEADERS,
+    },
+  });
+}
+
+async function handleRefresh(request: Request, env: Env): Promise<Response> {
+  const body = (await request.json()) as Record<string, unknown>;
+  const refreshToken = body.refresh_token as string | undefined;
+
+  if (!refreshToken) {
+    return jsonResponse({ error: "missing required field: refresh_token" }, 400);
+  }
+
+  const params = new URLSearchParams({
+    client_id: env.STRAVA_CLIENT_ID,
+    client_secret: env.STRAVA_CLIENT_SECRET,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  });
+
+  const stravaRes = await fetch(STRAVA_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: params.toString(),
+  });
+
+  const data = await stravaRes.text();
+  return new Response(data, {
+    status: stravaRes.status,
+    headers: {
+      "Content-Type": stravaRes.headers.get("Content-Type") ?? "application/json",
+      ...CORS_HEADERS,
+    },
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // CORS preflight
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+
+    if (request.method !== "POST") {
+      return jsonResponse({ error: "method not allowed" }, 405);
+    }
+
+    switch (url.pathname) {
+      case "/token":
+        return handleToken(request, env);
+      case "/refresh":
+        return handleRefresh(request, env);
+      default:
+        return jsonResponse({ error: "not found" }, 404);
+    }
+  },
+};

--- a/workers/strava-proxy/tsconfig.json
+++ b/workers/strava-proxy/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers/strava-proxy/wrangler.toml
+++ b/workers/strava-proxy/wrangler.toml
@@ -1,0 +1,7 @@
+name = "strava-proxy"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"
+
+# STRAVA_CLIENT_ID is set via: npx wrangler secret put STRAVA_CLIENT_ID
+# STRAVA_CLIENT_SECRET is set via: npx wrangler secret put STRAVA_CLIENT_SECRET
+# Never commit secrets to this file.


### PR DESCRIPTION
## Summary

Moves Strava `client_secret` out of the APK by introducing a Cloudflare Worker proxy. The app now sends token exchange and refresh requests to the proxy, which adds `client_id` and `client_secret` server-side before forwarding to Strava.

## Changes

- **New**: `workers/strava-proxy/` — Cloudflare Worker with `/token` and `/refresh` endpoints
  - Input validation (400 for missing fields)
  - Form-encoded requests to Strava (URLSearchParams)
  - CORS preflight (OPTIONS) support
  - Proxies Strava response status codes
  - Secrets via env bindings (no hardcoded credentials)
- **Modified**: `lib/strava.ts` — token exchange and refresh now route through proxy
  - `getProxyUrl()` helper reads from `app.config.ts` extra config
  - `connectStrava()` POSTs `{code, code_verifier}` to `/token`
  - `refreshAccessToken()` POSTs `{refresh_token}` to `/refresh`
  - Handles both 400 and 401 for revoked token detection
  - App no longer sends `client_id` or `grant_type` for token ops
- **Modified**: `app.config.ts` — added `stravaProxyUrl` to extra config
- **Modified**: `__tests__/lib/strava.test.ts` — updated for proxy integration
  - Behavioral tests verify proxy URL usage and correct request bodies
  - New structural tests for Worker (endpoints, CORS, form-encoding, env bindings)
  - Config tests verify no `client_secret` in app config

## Testing

- 26/26 strava tests pass
- 2030/2031 total tests pass (1 pre-existing flaky test in workout-session)
- TypeScript: 0 new errors (2 pre-existing in unrelated files)
- ESLint: passes via lint-staged on all commits

## ⚠️ Do NOT merge

The app code changes depend on the Worker being deployed to Cloudflare. PR should be reviewed but NOT merged until Worker is live at `https://strava-proxy.persoack.workers.dev`.

## Issue

Resolves BLD-477