### PR TITLE
feat: Personal Records Dashboard (BLD-475)

### DIFF
--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -222,6 +222,12 @@ jest.mock('../../lib/db', () => ({
   getStravaConnection: jest.fn().mockResolvedValue(null),
 }))
 
+jest.mock('../../lib/db/pr-dashboard', () => ({
+  getPRStats: jest.fn().mockResolvedValue({ totalPRs: 0, prsThisMonth: 0 }),
+  getRecentPRsWithDelta: jest.fn().mockResolvedValue([]),
+  getAllTimeBests: jest.fn().mockResolvedValue([]),
+}))
+
 jest.mock('../../lib/strava', () => ({
   connectStrava: jest.fn().mockResolvedValue(null),
   disconnect: jest.fn().mockResolvedValue(undefined),

--- a/__tests__/acceptance/body-progress.acceptance.test.tsx
+++ b/__tests__/acceptance/body-progress.acceptance.test.tsx
@@ -61,6 +61,14 @@ jest.mock('../../lib/db', () => ({
   updateBodySettings: jest.fn().mockResolvedValue(undefined),
 }))
 
+jest.mock('../../lib/db/pr-dashboard', () => ({
+  getPRStats: jest.fn().mockResolvedValue({ totalPRs: 1, prsThisMonth: 0 }),
+  getRecentPRsWithDelta: jest.fn().mockResolvedValue([
+    { exercise_id: 'ex1', name: 'Bench Press', category: 'Push', weight: 100, reps: null, previous_best: 95, date: Date.now(), is_weighted: true },
+  ]),
+  getAllTimeBests: jest.fn().mockResolvedValue([]),
+}))
+
 jest.mock('../../lib/db/body', () => ({
   getBodySettings: jest.fn().mockResolvedValue({
     weight_unit: 'kg',
@@ -90,6 +98,7 @@ jest.mock('../../lib/units', () => ({ toDisplay: (v: number) => v, toKg: (v: num
 import Progress from '../../app/(tabs)/progress'
 
 const mockDb = require('../../lib/db') as Record<string, jest.Mock>
+const mockPRDashboard = require('../../lib/db/pr-dashboard') as Record<string, jest.Mock>
 
 async function switchToBody(utils: ReturnType<typeof renderScreen>) {
   const bodyBtn = await utils.findByLabelText('Body metrics')
@@ -114,6 +123,10 @@ describe('Body Progress Acceptance', () => {
     mockDb.getWeeklySessionCounts.mockResolvedValue([{ week: '2024-W02', count: 3 }])
     mockDb.getWeeklyVolume.mockResolvedValue([{ week: '2024-W02', volume: 5000 }])
     mockDb.getCompletedSessionsWithSetCount.mockResolvedValue([])
+    mockPRDashboard.getRecentPRsWithDelta.mockResolvedValue([
+      { exercise_id: 'ex1', name: 'Bench Press', category: 'Push', weight: 100, reps: null, previous_best: 95, date: Date.now(), is_weighted: true },
+    ])
+    mockPRDashboard.getPRStats.mockResolvedValue({ totalPRs: 1, prsThisMonth: 0 })
   })
 
   it('renders personal records on workouts segment', async () => {

--- a/__tests__/acceptance/body-tracking.acceptance.test.tsx
+++ b/__tests__/acceptance/body-tracking.acceptance.test.tsx
@@ -56,6 +56,12 @@ jest.mock('../../lib/db', () => ({
   updateBodySettings: jest.fn().mockResolvedValue(undefined),
 }))
 
+jest.mock('../../lib/db/pr-dashboard', () => ({
+  getPRStats: jest.fn().mockResolvedValue({ totalPRs: 0, prsThisMonth: 0 }),
+  getRecentPRsWithDelta: jest.fn().mockResolvedValue([]),
+  getAllTimeBests: jest.fn().mockResolvedValue([]),
+}))
+
 jest.mock('../../lib/units', () => ({
   toDisplay: (v: number) => v,
   toKg: (v: number) => v,

--- a/__tests__/acceptance/weekly-summary.acceptance.test.tsx
+++ b/__tests__/acceptance/weekly-summary.acceptance.test.tsx
@@ -140,6 +140,12 @@ jest.mock('../../lib/db', () => ({
   getWeeklySummary: jest.fn().mockResolvedValue(mockSummaryData),
 }))
 
+jest.mock('../../lib/db/pr-dashboard', () => ({
+  getPRStats: jest.fn().mockResolvedValue({ totalPRs: 1, prsThisMonth: 0 }),
+  getRecentPRsWithDelta: jest.fn().mockResolvedValue([]),
+  getAllTimeBests: jest.fn().mockResolvedValue([]),
+}))
+
 jest.mock('../../lib/units', () => ({
   toDisplay: (v: number) => v,
   toKg: (v: number) => v,

--- a/__tests__/components/progress/PRSummaryCard.test.tsx
+++ b/__tests__/components/progress/PRSummaryCard.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react-native'
 
-jest.mock('../../hooks/useThemeColors', () => ({
+jest.mock('@/hooks/useThemeColors', () => ({
   useThemeColors: () => ({
     primary: '#6200ee',
     onSurface: '#000',
@@ -13,29 +13,29 @@ jest.mock('../../hooks/useThemeColors', () => ({
   }),
 }))
 
-jest.mock('../../lib/format', () => ({
+jest.mock('@/lib/format', () => ({
   formatDateShort: () => 'Jan 15',
 }))
 
-jest.mock('../../lib/units', () => ({
+jest.mock('@/lib/units', () => ({
   toDisplay: (v: number) => v,
   toKg: (v: number) => v,
   KG_TO_LB: 2.20462,
   LB_TO_KG: 0.453592,
 }))
 
-jest.mock('../../components/ui/card', () => {
+jest.mock('@/components/ui/card', () => {
   const { View } = require('react-native')
   return { Card: ({ children, style }: { children: React.ReactNode; style?: object }) => <View style={style}>{children}</View> }
 })
 
-jest.mock('../../components/ui/separator', () => {
+jest.mock('@/components/ui/separator', () => {
   const { View } = require('react-native')
   return { Separator: ({ style }: { style?: object }) => <View style={style} /> }
 })
 
-import { PRSummaryCard } from '../../components/progress/PRSummaryCard'
-import type { RecentPR, PRStats } from '../../lib/db/pr-dashboard'
+import { PRSummaryCard } from '@/components/progress/PRSummaryCard'
+import type { RecentPR, PRStats } from '@/lib/db/pr-dashboard'
 
 describe('PRSummaryCard', () => {
   const mockOnSeeAll = jest.fn()

--- a/__tests__/components/progress/PRSummaryCard.test.tsx
+++ b/__tests__/components/progress/PRSummaryCard.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react-native'
+
+jest.mock('../../hooks/useThemeColors', () => ({
+  useThemeColors: () => ({
+    primary: '#6200ee',
+    onSurface: '#000',
+    onSurfaceVariant: '#666',
+    outlineVariant: '#ccc',
+    surface: '#fff',
+    background: '#fff',
+    error: '#f00',
+  }),
+}))
+
+jest.mock('../../lib/format', () => ({
+  formatDateShort: () => 'Jan 15',
+}))
+
+jest.mock('../../lib/units', () => ({
+  toDisplay: (v: number) => v,
+  toKg: (v: number) => v,
+  KG_TO_LB: 2.20462,
+  LB_TO_KG: 0.453592,
+}))
+
+jest.mock('../../components/ui/card', () => {
+  const { View } = require('react-native')
+  return { Card: ({ children, style }: { children: React.ReactNode; style?: object }) => <View style={style}>{children}</View> }
+})
+
+jest.mock('../../components/ui/separator', () => {
+  const { View } = require('react-native')
+  return { Separator: ({ style }: { style?: object }) => <View style={style} /> }
+})
+
+import { PRSummaryCard } from '../../components/progress/PRSummaryCard'
+import type { RecentPR, PRStats } from '../../lib/db/pr-dashboard'
+
+describe('PRSummaryCard', () => {
+  const mockOnSeeAll = jest.fn()
+
+  const recentPRs: RecentPR[] = [
+    { exercise_id: 'ex1', name: 'Bench Press', category: 'Push', weight: 100, reps: null, previous_best: 95, date: Date.now(), is_weighted: true },
+    { exercise_id: 'ex2', name: 'Pull-ups', category: 'Pull', weight: null, reps: 12, previous_best: 10, date: Date.now() - 86400000, is_weighted: false },
+    { exercise_id: 'ex3', name: 'Squat', category: 'Legs', weight: 140, reps: null, previous_best: 135, date: Date.now() - 172800000, is_weighted: true },
+  ]
+
+  const stats: PRStats = { totalPRs: 10, prsThisMonth: 3 }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('renders 3 recent PRs with exercise names', () => {
+    const { getByText } = render(
+      <PRSummaryCard
+        recentPRs={recentPRs}
+        stats={stats}
+        weightUnit="kg"
+        onSeeAll={mockOnSeeAll}
+      />
+    )
+    expect(getByText('Bench Press')).toBeTruthy()
+    expect(getByText('Pull-ups')).toBeTruthy()
+    expect(getByText('Squat')).toBeTruthy()
+  })
+
+  test('shows PRs this month count', () => {
+    const { getByText } = render(
+      <PRSummaryCard
+        recentPRs={recentPRs}
+        stats={stats}
+        weightUnit="kg"
+        onSeeAll={mockOnSeeAll}
+      />
+    )
+    expect(getByText('3 this month')).toBeTruthy()
+  })
+
+  test('See All button navigates when pressed', () => {
+    const { getByText } = render(
+      <PRSummaryCard
+        recentPRs={recentPRs}
+        stats={stats}
+        weightUnit="kg"
+        onSeeAll={mockOnSeeAll}
+      />
+    )
+    fireEvent.press(getByText('See All →'))
+    expect(mockOnSeeAll).toHaveBeenCalledTimes(1)
+  })
+
+  test('shows empty state when no PRs', () => {
+    const { getByText } = render(
+      <PRSummaryCard
+        recentPRs={[]}
+        stats={{ totalPRs: 0, prsThisMonth: 0 }}
+        weightUnit="kg"
+        onSeeAll={mockOnSeeAll}
+      />
+    )
+    expect(getByText('No records yet — start lifting!')).toBeTruthy()
+  })
+
+  test('displays weight values with correct unit', () => {
+    const { getByText } = render(
+      <PRSummaryCard
+        recentPRs={recentPRs}
+        stats={stats}
+        weightUnit="kg"
+        onSeeAll={mockOnSeeAll}
+      />
+    )
+    expect(getByText('100 kg')).toBeTruthy()
+    expect(getByText('12 reps')).toBeTruthy()
+  })
+})

--- a/__tests__/components/progress/records.test.tsx
+++ b/__tests__/components/progress/records.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+
+const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
+
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    useRouter: () => mockRouter,
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+    Stack: { Screen: () => null },
+  }
+})
+
+jest.mock('../../hooks/useThemeColors', () => ({
+  useThemeColors: () => ({
+    primary: '#6200ee',
+    onSurface: '#000',
+    onSurfaceVariant: '#666',
+    outlineVariant: '#ccc',
+    surface: '#fff',
+    background: '#f5f5f5',
+    error: '#f00',
+  }),
+}))
+
+jest.mock('../../lib/format', () => ({
+  formatDateShort: () => 'Jan 15',
+}))
+
+jest.mock('../../lib/units', () => ({
+  toDisplay: (v: number) => v,
+  toKg: (v: number) => v,
+  KG_TO_LB: 2.20462,
+  LB_TO_KG: 0.453592,
+}))
+
+jest.mock('../../components/ui/card', () => {
+  const { View } = require('react-native')
+  return { Card: ({ children, style }: { children: React.ReactNode; style?: object }) => <View style={style}>{children}</View> }
+})
+
+jest.mock('../../components/ui/separator', () => {
+  const { View } = require('react-native')
+  return { Separator: ({ style }: { style?: object }) => <View style={style} /> }
+})
+
+jest.mock('../../components/ui/button', () => {
+  const { Text: RNText, Pressable } = require('react-native')
+  return { Button: ({ children, onPress }: { children: React.ReactNode; onPress?: () => void }) => <Pressable onPress={onPress}><RNText>{children}</RNText></Pressable> }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+
+jest.mock('../../lib/db/pr-dashboard', () => ({
+  getPRStats: jest.fn().mockResolvedValue({ totalPRs: 5, prsThisMonth: 2 }),
+  getRecentPRsWithDelta: jest.fn().mockResolvedValue([
+    { exercise_id: 'ex1', name: 'Bench Press', category: 'Push', weight: 100, reps: null, previous_best: 95, date: Date.now(), is_weighted: true },
+    { exercise_id: 'ex2', name: 'Pull-ups', category: 'Pull', weight: null, reps: 12, previous_best: 10, date: Date.now() - 86400000, is_weighted: false },
+  ]),
+  getAllTimeBests: jest.fn().mockResolvedValue([
+    { exercise_id: 'ex1', name: 'Bench Press', category: 'Push', max_weight: 100, max_reps: null, best_set_weight: 90, best_set_reps: 5, est_1rm: 105, session_count: 10, is_weighted: true },
+    { exercise_id: 'ex2', name: 'Pull-ups', category: 'Pull', max_weight: null, max_reps: 15, best_set_weight: null, best_set_reps: null, est_1rm: null, session_count: 8, is_weighted: false },
+  ]),
+}))
+
+jest.mock('../../lib/db', () => ({
+  getBodySettings: jest.fn().mockResolvedValue({ weight_unit: 'kg', measurement_unit: 'cm' }),
+}))
+
+import RecordsPage from '../../app/progress/records'
+
+describe('Records Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('renders header stats with total PRs and PRs this month', async () => {
+    const { findByText } = render(<RecordsPage />)
+    expect(await findByText('5')).toBeTruthy()
+    expect(await findByText('2')).toBeTruthy()
+    expect(await findByText('Total PRs')).toBeTruthy()
+    expect(await findByText('PRs This Month')).toBeTruthy()
+  })
+
+  test('renders recent PRs section with exercise names', async () => {
+    const { findByText } = render(<RecordsPage />)
+    expect(await findByText('Recent PRs')).toBeTruthy()
+    expect(await findByText('Bench Press')).toBeTruthy()
+    expect(await findByText('Pull-ups')).toBeTruthy()
+  })
+
+  test('renders all-time bests section with categories', async () => {
+    const { findByText } = render(<RecordsPage />)
+    expect(await findByText('All-Time Bests')).toBeTruthy()
+    expect(await findByText('Push')).toBeTruthy()
+    expect(await findByText('Pull')).toBeTruthy()
+  })
+
+  test('renders empty state when no data', async () => {
+    const prDashboard = require('../../lib/db/pr-dashboard')
+    prDashboard.getPRStats.mockResolvedValue({ totalPRs: 0, prsThisMonth: 0 })
+    prDashboard.getRecentPRsWithDelta.mockResolvedValue([])
+    prDashboard.getAllTimeBests.mockResolvedValue([])
+
+    const { findByText } = render(<RecordsPage />)
+    expect(await findByText('No Records Yet')).toBeTruthy()
+    expect(await findByText('Complete your first workout to start tracking personal records!')).toBeTruthy()
+  })
+})

--- a/__tests__/components/progress/records.test.tsx
+++ b/__tests__/components/progress/records.test.tsx
@@ -17,7 +17,7 @@ jest.mock('expo-router', () => {
   }
 })
 
-jest.mock('../../hooks/useThemeColors', () => ({
+jest.mock('@/hooks/useThemeColors', () => ({
   useThemeColors: () => ({
     primary: '#6200ee',
     onSurface: '#000',
@@ -29,35 +29,35 @@ jest.mock('../../hooks/useThemeColors', () => ({
   }),
 }))
 
-jest.mock('../../lib/format', () => ({
+jest.mock('@/lib/format', () => ({
   formatDateShort: () => 'Jan 15',
 }))
 
-jest.mock('../../lib/units', () => ({
+jest.mock('@/lib/units', () => ({
   toDisplay: (v: number) => v,
   toKg: (v: number) => v,
   KG_TO_LB: 2.20462,
   LB_TO_KG: 0.453592,
 }))
 
-jest.mock('../../components/ui/card', () => {
+jest.mock('@/components/ui/card', () => {
   const { View } = require('react-native')
   return { Card: ({ children, style }: { children: React.ReactNode; style?: object }) => <View style={style}>{children}</View> }
 })
 
-jest.mock('../../components/ui/separator', () => {
+jest.mock('@/components/ui/separator', () => {
   const { View } = require('react-native')
   return { Separator: ({ style }: { style?: object }) => <View style={style} /> }
 })
 
-jest.mock('../../components/ui/button', () => {
+jest.mock('@/components/ui/button', () => {
   const { Text: RNText, Pressable } = require('react-native')
   return { Button: ({ children, onPress }: { children: React.ReactNode; onPress?: () => void }) => <Pressable onPress={onPress}><RNText>{children}</RNText></Pressable> }
 })
 
 jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
 
-jest.mock('../../lib/db/pr-dashboard', () => ({
+jest.mock('@/lib/db/pr-dashboard', () => ({
   getPRStats: jest.fn().mockResolvedValue({ totalPRs: 5, prsThisMonth: 2 }),
   getRecentPRsWithDelta: jest.fn().mockResolvedValue([
     { exercise_id: 'ex1', name: 'Bench Press', category: 'Push', weight: 100, reps: null, previous_best: 95, date: Date.now(), is_weighted: true },
@@ -69,11 +69,11 @@ jest.mock('../../lib/db/pr-dashboard', () => ({
   ]),
 }))
 
-jest.mock('../../lib/db', () => ({
+jest.mock('@/lib/db', () => ({
   getBodySettings: jest.fn().mockResolvedValue({ weight_unit: 'kg', measurement_unit: 'cm' }),
 }))
 
-import RecordsPage from '../../app/progress/records'
+import RecordsPage from '../../../app/progress/records'
 
 describe('Records Page', () => {
   beforeEach(() => {
@@ -89,10 +89,10 @@ describe('Records Page', () => {
   })
 
   test('renders recent PRs section with exercise names', async () => {
-    const { findByText } = render(<RecordsPage />)
+    const { findByText, findAllByText } = render(<RecordsPage />)
     expect(await findByText('Recent PRs')).toBeTruthy()
-    expect(await findByText('Bench Press')).toBeTruthy()
-    expect(await findByText('Pull-ups')).toBeTruthy()
+    expect((await findAllByText('Bench Press')).length).toBeGreaterThanOrEqual(1)
+    expect((await findAllByText('Pull-ups')).length).toBeGreaterThanOrEqual(1)
   })
 
   test('renders all-time bests section with categories', async () => {
@@ -103,7 +103,7 @@ describe('Records Page', () => {
   })
 
   test('renders empty state when no data', async () => {
-    const prDashboard = require('../../lib/db/pr-dashboard')
+    const prDashboard = require('@/lib/db/pr-dashboard')
     prDashboard.getPRStats.mockResolvedValue({ totalPRs: 0, prsThisMonth: 0 })
     prDashboard.getRecentPRsWithDelta.mockResolvedValue([])
     prDashboard.getAllTimeBests.mockResolvedValue([])

--- a/__tests__/lib/db/pr-dashboard.test.ts
+++ b/__tests__/lib/db/pr-dashboard.test.ts
@@ -1,0 +1,228 @@
+/**
+ * PR Dashboard data layer tests.
+ *
+ * Tests getPRStats, getRecentPRsWithDelta, getAllTimeBests using mocked DB helpers.
+ * Uses test.each for budget-efficient parameterized assertions.
+ */
+
+jest.mock('../../../lib/db/helpers', () => ({
+  getDrizzle: jest.fn(),
+  query: jest.fn(),
+  queryOne: jest.fn(),
+}))
+
+const helpers = require('../../../lib/db/helpers') as {
+  getDrizzle: jest.Mock
+  query: jest.Mock
+  queryOne: jest.Mock
+}
+
+import { getPRStats, getRecentPRsWithDelta, getAllTimeBests } from '../../../lib/db/pr-dashboard'
+
+describe('PR Dashboard Data Layer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    helpers.query.mockResolvedValue([])
+  })
+
+  // ── getPRStats ──────────────────────────────────────────────────
+
+  test.each([
+    [
+      'no data returns zeros',
+      [{ total: 0, this_month: 0 }], // weight PRs
+      [{ total: 0, this_month: 0 }], // rep PRs
+      { totalPRs: 0, prsThisMonth: 0 },
+    ],
+    [
+      'weight PRs only',
+      [{ total: 5, this_month: 2 }],
+      [{ total: 0, this_month: 0 }],
+      { totalPRs: 5, prsThisMonth: 2 },
+    ],
+    [
+      'rep PRs only (bodyweight exercises)',
+      [{ total: 0, this_month: 0 }],
+      [{ total: 3, this_month: 1 }],
+      { totalPRs: 3, prsThisMonth: 1 },
+    ],
+    [
+      'combined weight + rep PRs',
+      [{ total: 5, this_month: 2 }],
+      [{ total: 3, this_month: 1 }],
+      { totalPRs: 8, prsThisMonth: 3 },
+    ],
+    [
+      'null this_month treated as zero',
+      [{ total: 2, this_month: null }],
+      [{ total: 1, this_month: null }],
+      { totalPRs: 3, prsThisMonth: 0 },
+    ],
+  ])('getPRStats: %s', async (_name, weightResult, repResult, expected) => {
+    helpers.query
+      .mockResolvedValueOnce(weightResult)
+      .mockResolvedValueOnce(repResult)
+
+    const result = await getPRStats()
+    expect(result).toEqual(expected)
+    expect(helpers.query).toHaveBeenCalledTimes(2)
+  })
+
+  // ── getRecentPRsWithDelta ───────────────────────────────────────
+
+  test('getRecentPRsWithDelta merges weight + rep PRs sorted by date', async () => {
+    const now = Date.now()
+    const earlier = now - 86400000
+
+    helpers.query
+      .mockResolvedValueOnce([
+        { exercise_id: 'ex1', name: 'Bench Press', category: 'Push', weight: 100, previous_best: 95, date: now },
+      ])
+      .mockResolvedValueOnce([
+        { exercise_id: 'ex2', name: 'Pull-ups', category: 'Pull', reps: 12, previous_best: 10, date: earlier },
+      ])
+
+    const result = await getRecentPRsWithDelta(20)
+
+    expect(result).toHaveLength(2)
+    // Most recent first (weight PR)
+    expect(result[0]).toMatchObject({
+      exercise_id: 'ex1',
+      name: 'Bench Press',
+      is_weighted: true,
+      weight: 100,
+      previous_best: 95,
+    })
+    // Older (rep PR)
+    expect(result[1]).toMatchObject({
+      exercise_id: 'ex2',
+      name: 'Pull-ups',
+      is_weighted: false,
+      reps: 12,
+      previous_best: 10,
+    })
+  })
+
+  test('getRecentPRsWithDelta respects limit', async () => {
+    const now = Date.now()
+    helpers.query
+      .mockResolvedValueOnce([
+        { exercise_id: 'ex1', name: 'Bench', category: 'Push', weight: 100, previous_best: 95, date: now },
+        { exercise_id: 'ex2', name: 'Squat', category: 'Legs', weight: 140, previous_best: 135, date: now - 1000 },
+        { exercise_id: 'ex3', name: 'OHP', category: 'Push', weight: 60, previous_best: 55, date: now - 2000 },
+      ])
+      .mockResolvedValueOnce([])
+
+    const result = await getRecentPRsWithDelta(2)
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('Bench')
+    expect(result[1].name).toBe('Squat')
+  })
+
+  test('getRecentPRsWithDelta returns empty when no PRs', async () => {
+    helpers.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+
+    const result = await getRecentPRsWithDelta()
+    expect(result).toEqual([])
+  })
+
+  // ── getAllTimeBests ──────────────────────────────────────────────
+
+  test('getAllTimeBests computes e1RM from best single set', async () => {
+    helpers.query
+      .mockResolvedValueOnce([
+        {
+          exercise_id: 'ex1',
+          name: 'Bench Press',
+          category: 'Push',
+          max_weight: 100,
+          best_set_weight: 90,
+          best_set_reps: 5,
+          session_count: 10,
+        },
+      ])
+      .mockResolvedValueOnce([]) // no bodyweight
+
+    const result = await getAllTimeBests()
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      exercise_id: 'ex1',
+      name: 'Bench Press',
+      category: 'Push',
+      max_weight: 100,
+      is_weighted: true,
+      session_count: 10,
+    })
+    // e1RM from epley(90, 5) = 90 * (1 + 5/30) = 90 * 1.1667 = 105
+    expect(result[0].est_1rm).toBeCloseTo(105, 0)
+  })
+
+  test('getAllTimeBests includes bodyweight exercises', async () => {
+    helpers.query
+      .mockResolvedValueOnce([]) // no weighted
+      .mockResolvedValueOnce([
+        {
+          exercise_id: 'ex2',
+          name: 'Pull-ups',
+          category: 'Pull',
+          max_reps: 15,
+          session_count: 8,
+        },
+      ])
+
+    const result = await getAllTimeBests()
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      exercise_id: 'ex2',
+      name: 'Pull-ups',
+      is_weighted: false,
+      max_reps: 15,
+      est_1rm: null,
+    })
+  })
+
+  test('getAllTimeBests groups weighted and bodyweight, sorted by category', async () => {
+    helpers.query
+      .mockResolvedValueOnce([
+        { exercise_id: 'ex1', name: 'Bench Press', category: 'Push', max_weight: 100, best_set_weight: 90, best_set_reps: 5, session_count: 10 },
+        { exercise_id: 'ex3', name: 'Squat', category: 'Legs', max_weight: 140, best_set_weight: 120, best_set_reps: 3, session_count: 15 },
+      ])
+      .mockResolvedValueOnce([
+        { exercise_id: 'ex2', name: 'Pull-ups', category: 'Pull', max_reps: 15, session_count: 8 },
+      ])
+
+    const result = await getAllTimeBests()
+    expect(result).toHaveLength(3)
+    // Sorted by category: Legs, Pull, Push
+    expect(result[0].category).toBe('Legs')
+    expect(result[1].category).toBe('Pull')
+    expect(result[2].category).toBe('Push')
+  })
+
+  test('getAllTimeBests skips bodyweight exercise if it appears in weighted results', async () => {
+    // Same exercise_id in both weighted and bodyweight queries
+    helpers.query
+      .mockResolvedValueOnce([
+        { exercise_id: 'ex1', name: 'Dips', category: 'Push', max_weight: 20, best_set_weight: 20, best_set_reps: 8, session_count: 5 },
+      ])
+      .mockResolvedValueOnce([
+        { exercise_id: 'ex1', name: 'Dips', category: 'Push', max_reps: 15, session_count: 5 },
+      ])
+
+    const result = await getAllTimeBests()
+    // Should only appear once as weighted
+    expect(result).toHaveLength(1)
+    expect(result[0].is_weighted).toBe(true)
+  })
+
+  test('getAllTimeBests returns empty for no data', async () => {
+    helpers.query
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+
+    const result = await getAllTimeBests()
+    expect(result).toEqual([])
+  })
+})

--- a/app/progress/records.tsx
+++ b/app/progress/records.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { ActivityIndicator, ScrollView, StyleSheet, View } from "react-native";
+import { Stack, useRouter } from "expo-router";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { usePRDashboard } from "@/hooks/usePRDashboard";
+import EmptyState from "@/components/EmptyState";
+import PRStatsRow from "@/components/progress/records/PRStatsRow";
+import RecentPRList from "@/components/progress/records/RecentPRList";
+import AllTimeBestsSection from "@/components/progress/records/AllTimeBestsSection";
+
+export default function RecordsPage() {
+  const colors = useThemeColors();
+  const router = useRouter();
+  const { stats, recentPRs, allTimeBests, weightUnit, loading, error } =
+    usePRDashboard();
+
+  const navigateToExercise = (exerciseId: string) => {
+    router.push(`/exercise/${exerciseId}`);
+  };
+
+  const isEmpty =
+    !loading && stats.totalPRs === 0 && recentPRs.length === 0 && allTimeBests.length === 0;
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "Personal Records" }} />
+      <ScrollView
+        style={[styles.container, { backgroundColor: colors.background }]}
+        contentContainerStyle={styles.content}
+      >
+        {loading ? (
+          <View style={styles.center}>
+            <ActivityIndicator size="large" color={colors.primary} />
+          </View>
+        ) : error ? (
+          <View style={styles.center}>
+            <Text style={{ color: colors.error, textAlign: "center" }}>
+              {error}
+            </Text>
+          </View>
+        ) : isEmpty ? (
+          <EmptyState
+            icon="trophy-outline"
+            title="No Records Yet"
+            subtitle="Complete your first workout to start tracking personal records!"
+          />
+        ) : (
+          <>
+            <PRStatsRow stats={stats} />
+            <RecentPRList
+              prs={recentPRs}
+              weightUnit={weightUnit}
+              onPressExercise={navigateToExercise}
+            />
+            <AllTimeBestsSection
+              bests={allTimeBests}
+              weightUnit={weightUnit}
+              onPressExercise={navigateToExercise}
+            />
+          </>
+        )}
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 48,
+  },
+  center: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 48,
+  },
+});

--- a/components/progress/PRSummaryCard.tsx
+++ b/components/progress/PRSummaryCard.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Card } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { formatDateShort } from "@/lib/format";
+import { toDisplay } from "@/lib/units";
+import type { RecentPR, PRStats } from "@/lib/db/pr-dashboard";
+
+type Props = {
+  recentPRs: RecentPR[];
+  stats: PRStats;
+  weightUnit: "kg" | "lb";
+  onSeeAll: () => void;
+  style?: object;
+};
+
+export function PRSummaryCard({ recentPRs, stats, weightUnit, onSeeAll, style }: Props) {
+  const colors = useThemeColors();
+
+  return (
+    <Card style={[styles.card, style]}>
+      <View style={styles.headerRow}>
+        <Text variant="subtitle" style={{ color: colors.onSurface }}>
+          Personal Records
+        </Text>
+        {stats.prsThisMonth > 0 && (
+          <Text variant="caption" style={{ color: colors.primary, fontWeight: "600" }}>
+            {stats.prsThisMonth} this month
+          </Text>
+        )}
+      </View>
+
+      {recentPRs.length === 0 ? (
+        <Text style={{ color: colors.onSurfaceVariant, marginTop: 8 }}>
+          No records yet — start lifting!
+        </Text>
+      ) : (
+        <>
+          {recentPRs.slice(0, 3).map((pr) => (
+            <View
+              key={`${pr.exercise_id}-${pr.date}`}
+              style={[styles.prRow, { borderBottomColor: colors.outlineVariant }]}
+              accessibilityLabel={
+                pr.is_weighted
+                  ? `${pr.name}: ${pr.weight != null ? toDisplay(pr.weight, weightUnit) : '-'} ${weightUnit}, ${formatDateShort(pr.date)}`
+                  : `${pr.name}: ${pr.reps} reps, ${formatDateShort(pr.date)}`
+              }
+            >
+              <View style={{ flex: 1 }}>
+                <Text style={{ color: colors.onSurface }}>{pr.name}</Text>
+                <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                  {formatDateShort(pr.date)}
+                </Text>
+              </View>
+              <View style={styles.valueCol}>
+                <Text style={{ color: colors.primary, fontWeight: "600" }}>
+                  {pr.is_weighted && pr.weight != null
+                    ? `${toDisplay(pr.weight, weightUnit)} ${weightUnit}`
+                    : `${pr.reps} reps`}
+                </Text>
+                {pr.is_weighted && pr.weight != null && pr.previous_best != null && pr.previous_best > 0 && (
+                  <Text variant="caption" style={{ color: colors.primary }}>
+                    +{toDisplay(pr.weight - pr.previous_best, weightUnit)} {weightUnit}
+                  </Text>
+                )}
+                {!pr.is_weighted && pr.reps != null && pr.previous_best != null && pr.previous_best > 0 && (
+                  <Text variant="caption" style={{ color: colors.primary }}>
+                    +{pr.reps - pr.previous_best} reps
+                  </Text>
+                )}
+              </View>
+            </View>
+          ))}
+
+          <Separator style={{ marginTop: 4 }} />
+
+          <Pressable
+            style={styles.seeAllRow}
+            onPress={onSeeAll}
+            accessibilityRole="button"
+            accessibilityLabel="See all personal records"
+          >
+            <Text style={{ color: colors.primary, fontWeight: "600" }}>
+              See All →
+            </Text>
+          </Pressable>
+        </>
+      )}
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+  },
+  headerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  prRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  valueCol: {
+    alignItems: "flex-end",
+  },
+  seeAllRow: {
+    paddingVertical: 12,
+    alignItems: "center",
+    minHeight: 48,
+    justifyContent: "center",
+  },
+});

--- a/components/progress/WorkoutSegment.tsx
+++ b/components/progress/WorkoutSegment.tsx
@@ -11,14 +11,20 @@ import { useFocusEffect, useRouter } from "expo-router";
 import {
   getWeeklySessionCounts,
   getWeeklyVolume,
-  getPersonalRecords,
   getCompletedSessionsWithSetCount,
+  getBodySettings,
 } from "../../lib/db";
+import {
+  getRecentPRsWithDelta,
+  getPRStats,
+} from "../../lib/db/pr-dashboard";
+import type { RecentPR, PRStats } from "../../lib/db/pr-dashboard";
 import { useLayout } from "../../lib/layout";
 import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
 import WeeklySummary from "../../components/WeeklySummary";
 import { useThemeColors } from "@/hooks/useThemeColors";
-import { WorkoutChartCard, PRCard, SessionsCard } from "./WorkoutCards";
+import { WorkoutChartCard, SessionsCard } from "./WorkoutCards";
+import { PRSummaryCard } from "./PRSummaryCard";
 import CalendarView from "./CalendarView";
 import StrengthLevelsCard from "./StrengthLevelsCard";
 import ActiveGoalsCard from "./ActiveGoalsCard";
@@ -44,11 +50,6 @@ function getWeekStartDay(): number {
   return 0;
 }
 
-type PR = {
-  exercise_id: string;
-  name: string;
-  max_weight: number;
-};
 type SessionRow = {
   id: string;
   name: string;
@@ -68,22 +69,28 @@ export default function WorkoutSegment() {
 
   const [freq, setFreq] = useState<{ week: string; count: number }[]>([]);
   const [vol, setVol] = useState<{ week: string; volume: number }[]>([]);
-  const [prs, setPrs] = useState<PR[]>([]);
+  const [recentPRs, setRecentPRs] = useState<RecentPR[]>([]);
+  const [prStats, setPRStats] = useState<PRStats>({ totalPRs: 0, prsThisMonth: 0 });
+  const [weightUnit, setWeightUnit] = useState<"kg" | "lb">("kg");
   const [sessions, setSessions] = useState<SessionRow[]>([]);
 
   useFocusEffect(
     useCallback(() => {
       (async () => {
-        const [f, v, p, s] = await Promise.all([
+        const [f, v, rp, ps, s, settings] = await Promise.all([
           getWeeklySessionCounts(),
           getWeeklyVolume(),
-          getPersonalRecords(),
+          getRecentPRsWithDelta(3),
+          getPRStats(),
           getCompletedSessionsWithSetCount(),
+          getBodySettings(),
         ]);
         setFreq(f);
         setVol(v);
-        setPrs(p);
+        setRecentPRs(rp);
+        setPRStats(ps);
         setSessions(s);
+        setWeightUnit(settings.weight_unit as "kg" | "lb");
       })();
     }, []),
   );
@@ -213,7 +220,13 @@ export default function WorkoutSegment() {
               {volCard}
             </View>
             <View style={styles.grid}>
-              <PRCard prs={prs} style={wideCard} />
+              <PRSummaryCard
+                recentPRs={recentPRs}
+                stats={prStats}
+                weightUnit={weightUnit}
+                onSeeAll={() => router.push("/progress/records")}
+                style={wideCard}
+              />
               <SessionsCard sessions={sessions} style={wideCard} />
             </View>
             <ActiveGoalsCard />
@@ -226,7 +239,12 @@ export default function WorkoutSegment() {
             {achievementsCard}
             {freqCard}
             {volCard}
-            <PRCard prs={prs} />
+            <PRSummaryCard
+              recentPRs={recentPRs}
+              stats={prStats}
+              weightUnit={weightUnit}
+              onSeeAll={() => router.push("/progress/records")}
+            />
             <SessionsCard sessions={sessions} />
             <ActiveGoalsCard />
             <StrengthLevelsCard />

--- a/components/progress/records/AllTimeBestsSection.tsx
+++ b/components/progress/records/AllTimeBestsSection.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Separator } from "@/components/ui/separator";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { toDisplay } from "@/lib/units";
+import type { AllTimeBest } from "@/lib/db/pr-dashboard";
+
+type Props = {
+  bests: AllTimeBest[];
+  weightUnit: "kg" | "lb";
+  onPressExercise: (exerciseId: string) => void;
+};
+
+function groupByCategory(bests: AllTimeBest[]): { category: string; data: AllTimeBest[] }[] {
+  const map = new Map<string, AllTimeBest[]>();
+  for (const b of bests) {
+    const existing = map.get(b.category);
+    if (existing) existing.push(b);
+    else map.set(b.category, [b]);
+  }
+  return Array.from(map.entries()).map(([category, data]) => ({ category, data }));
+}
+
+export default function AllTimeBestsSection({ bests, weightUnit, onPressExercise }: Props) {
+  const colors = useThemeColors();
+
+  if (bests.length === 0) return null;
+
+  const sections = groupByCategory(bests);
+
+  return (
+    <View style={styles.container}>
+      <Text
+        variant="subtitle"
+        style={[styles.sectionTitle, { color: colors.onSurface }]}
+        accessibilityRole="header"
+      >
+        All-Time Bests
+      </Text>
+      {sections.map((section) => (
+        <View key={section.category} style={styles.categorySection}>
+          <Text
+            variant="caption"
+            style={[styles.categoryHeader, { color: colors.onSurfaceVariant }]}
+            accessibilityRole="header"
+          >
+            {section.category}
+          </Text>
+          {section.data.map((item, i) => (
+            <React.Fragment key={item.exercise_id}>
+              <Pressable
+                style={styles.bestRow}
+                onPress={() => onPressExercise(item.exercise_id)}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  item.is_weighted
+                    ? `${item.name}: ${item.max_weight != null ? toDisplay(item.max_weight, weightUnit) : '-'} ${weightUnit}${item.est_1rm ? `, estimated one rep max ${Math.round(toDisplay(item.est_1rm, weightUnit))} ${weightUnit}` : ''}, ${item.session_count} sessions`
+                    : `${item.name}: ${item.max_reps} reps, ${item.session_count} sessions`
+                }
+              >
+                <View style={{ flex: 1 }}>
+                  <Text style={{ color: colors.onSurface }}>{item.name}</Text>
+                  <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                    {item.session_count} session{item.session_count !== 1 ? "s" : ""}
+                  </Text>
+                </View>
+                <View style={styles.valueCol}>
+                  {item.is_weighted ? (
+                    <>
+                      <Text style={{ color: colors.onSurface, fontWeight: "600" }}>
+                        {item.max_weight != null ? toDisplay(item.max_weight, weightUnit) : "-"} {weightUnit}
+                      </Text>
+                      {item.est_1rm != null ? (
+                        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                          e1RM: {Math.round(toDisplay(item.est_1rm, weightUnit))} {weightUnit}
+                        </Text>
+                      ) : null}
+                    </>
+                  ) : (
+                    <Text style={{ color: colors.onSurface, fontWeight: "600" }}>
+                      {item.max_reps} reps
+                    </Text>
+                  )}
+                </View>
+              </Pressable>
+              {i < section.data.length - 1 && (
+                <Separator style={{ marginVertical: 2 }} />
+              )}
+            </React.Fragment>
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    marginBottom: 12,
+  },
+  categorySection: {
+    marginBottom: 12,
+  },
+  categoryHeader: {
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: 8,
+    fontWeight: "600",
+  },
+  bestRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 12,
+    minHeight: 48,
+  },
+  valueCol: {
+    alignItems: "flex-end",
+  },
+});

--- a/components/progress/records/PRStatsRow.tsx
+++ b/components/progress/records/PRStatsRow.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Card } from "@/components/ui/card";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { PRStats } from "@/lib/db/pr-dashboard";
+
+type Props = {
+  stats: PRStats;
+};
+
+export default function PRStatsRow({ stats }: Props) {
+  const colors = useThemeColors();
+
+  return (
+    <View style={styles.row} accessibilityRole="summary" accessibilityLabel={`${stats.totalPRs} total personal records, ${stats.prsThisMonth} this month`}>
+      <Card style={[styles.statCard, { backgroundColor: colors.surface }]}>
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+          Total PRs
+        </Text>
+        <Text style={[styles.statValue, { color: colors.onSurface }]}>
+          {stats.totalPRs}
+        </Text>
+      </Card>
+      <Card style={[styles.statCard, { backgroundColor: colors.surface }]}>
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+          PRs This Month
+        </Text>
+        <Text style={[styles.statValue, { color: colors.onSurface }]}>
+          {stats.prsThisMonth}
+        </Text>
+      </Card>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    gap: 12,
+    marginBottom: 16,
+  },
+  statCard: {
+    flex: 1,
+    alignItems: "center",
+    paddingVertical: 16,
+    paddingHorizontal: 12,
+  },
+  statValue: {
+    fontSize: 28,
+    fontWeight: "700",
+    marginTop: 4,
+  },
+});

--- a/components/progress/records/RecentPRList.tsx
+++ b/components/progress/records/RecentPRList.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Separator } from "@/components/ui/separator";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { formatDateShort } from "@/lib/format";
+import { toDisplay } from "@/lib/units";
+import type { RecentPR } from "@/lib/db/pr-dashboard";
+
+type Props = {
+  prs: RecentPR[];
+  weightUnit: "kg" | "lb";
+  onPressExercise: (exerciseId: string) => void;
+};
+
+function formatDelta(pr: RecentPR, unit: "kg" | "lb"): string {
+  if (pr.is_weighted && pr.weight != null && pr.previous_best != null) {
+    const delta = toDisplay(pr.weight - pr.previous_best, unit);
+    return `+${delta} ${unit}`;
+  }
+  if (!pr.is_weighted && pr.reps != null && pr.previous_best != null) {
+    const delta = pr.reps - pr.previous_best;
+    return `+${delta} reps`;
+  }
+  return "";
+}
+
+function formatValue(pr: RecentPR, unit: "kg" | "lb"): string {
+  if (pr.is_weighted && pr.weight != null) {
+    return `${toDisplay(pr.weight, unit)} ${unit}`;
+  }
+  if (!pr.is_weighted && pr.reps != null) {
+    return `${pr.reps} reps`;
+  }
+  return "-";
+}
+
+export default function RecentPRList({ prs, weightUnit, onPressExercise }: Props) {
+  const colors = useThemeColors();
+
+  if (prs.length === 0) return null;
+
+  return (
+    <View style={styles.container}>
+      <Text
+        variant="subtitle"
+        style={[styles.sectionTitle, { color: colors.onSurface }]}
+        accessibilityRole="header"
+      >
+        Recent PRs
+      </Text>
+      {prs.map((pr, i) => (
+        <React.Fragment key={`${pr.exercise_id}-${pr.date}`}>
+          <Pressable
+            style={styles.prRow}
+            onPress={() => onPressExercise(pr.exercise_id)}
+            accessibilityRole="button"
+            accessibilityLabel={`${pr.name}: ${formatValue(pr, weightUnit)}, ${formatDelta(pr, weightUnit)}, ${formatDateShort(pr.date)}`}
+          >
+            <View style={{ flex: 1 }}>
+              <Text style={{ color: colors.onSurface }}>{pr.name}</Text>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                {formatDateShort(pr.date)}
+              </Text>
+            </View>
+            <View style={styles.valueCol}>
+              <Text style={{ color: colors.onSurface, fontWeight: "600" }}>
+                {formatValue(pr, weightUnit)}
+              </Text>
+              {formatDelta(pr, weightUnit) ? (
+                <Text variant="caption" style={{ color: colors.primary, fontWeight: "600" }}>
+                  {formatDelta(pr, weightUnit)}
+                </Text>
+              ) : null}
+            </View>
+          </Pressable>
+          {i < prs.length - 1 && <Separator style={{ marginVertical: 2 }} />}
+        </React.Fragment>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    marginBottom: 12,
+  },
+  prRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 12,
+    minHeight: 48,
+  },
+  valueCol: {
+    alignItems: "flex-end",
+  },
+});

--- a/hooks/usePRDashboard.ts
+++ b/hooks/usePRDashboard.ts
@@ -1,0 +1,62 @@
+import { useCallback, useState } from "react";
+import { useFocusEffect } from "expo-router";
+import {
+  getPRStats,
+  getRecentPRsWithDelta,
+  getAllTimeBests,
+} from "../lib/db/pr-dashboard";
+import { getBodySettings } from "../lib/db";
+import type { PRStats, RecentPR, AllTimeBest } from "../lib/db/pr-dashboard";
+
+export type PRDashboardData = {
+  stats: PRStats;
+  recentPRs: RecentPR[];
+  allTimeBests: AllTimeBest[];
+  weightUnit: "kg" | "lb";
+  loading: boolean;
+  error: string | null;
+};
+
+export function usePRDashboard(): PRDashboardData {
+  const [stats, setStats] = useState<PRStats>({ totalPRs: 0, prsThisMonth: 0 });
+  const [recentPRs, setRecentPRs] = useState<RecentPR[]>([]);
+  const [allTimeBests, setAllTimeBests] = useState<AllTimeBest[]>([]);
+  const [weightUnit, setWeightUnit] = useState<"kg" | "lb">("kg");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false;
+
+      (async () => {
+        try {
+          setLoading(true);
+          setError(null);
+          const [s, r, a, settings] = await Promise.all([
+            getPRStats(),
+            getRecentPRsWithDelta(20),
+            getAllTimeBests(),
+            getBodySettings(),
+          ]);
+          if (cancelled) return;
+          setStats(s);
+          setRecentPRs(r);
+          setAllTimeBests(a);
+          setWeightUnit(settings.weight_unit as "kg" | "lb");
+        } catch (e) {
+          if (cancelled) return;
+          setError(e instanceof Error ? e.message : "Failed to load PR data");
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    }, [])
+  );
+
+  return { stats, recentPRs, allTimeBests, weightUnit, loading, error };
+}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -315,3 +315,10 @@ export {
   getCurrentBestReps,
 } from "./strength-goals";
 export type { StrengthGoalRow, CreateGoalInput, UpdateGoalInput } from "./strength-goals";
+
+export {
+  getPRStats,
+  getRecentPRsWithDelta,
+  getAllTimeBests,
+} from "./pr-dashboard";
+export type { PRStats, RecentPR, AllTimeBest } from "./pr-dashboard";

--- a/lib/db/pr-dashboard.ts
+++ b/lib/db/pr-dashboard.ts
@@ -1,0 +1,388 @@
+/**
+ * PR Dashboard data layer — read-only queries for the Personal Records Dashboard.
+ *
+ * Uses Drizzle ORM with sql tagged templates per project conventions.
+ * All queries filter for completed sets in completed sessions, excluding warmup sets.
+ *
+ * A "PR" is defined at exercise+session granularity: one PR event per exercise per session
+ * where the max weight (or max reps for bodyweight exercises) exceeds the prior historical best.
+ *
+ * Duration/isometric PRs are out of scope for V1.
+ */
+
+import { query } from "./helpers";
+import { epley } from "../rm";
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type PRStats = {
+  totalPRs: number;
+  prsThisMonth: number;
+};
+
+export type RecentPR = {
+  exercise_id: string;
+  name: string;
+  category: string;
+  weight: number | null;
+  reps: number | null;
+  previous_best: number | null;
+  date: number;
+  is_weighted: boolean;
+};
+
+export type AllTimeBest = {
+  exercise_id: string;
+  name: string;
+  category: string;
+  max_weight: number | null;
+  max_reps: number | null;
+  best_set_weight: number | null;
+  best_set_reps: number | null;
+  est_1rm: number | null;
+  session_count: number;
+  is_weighted: boolean;
+};
+
+// ─── Queries ────────────────────────────────────────────────────────────────
+
+/**
+ * Count total lifetime PRs and PRs this month.
+ * A weight PR = session where MAX(weight) for an exercise exceeds all prior sessions.
+ * A rep PR = session where MAX(reps) for a bodyweight exercise exceeds all prior sessions.
+ * Deduped to one PR per exercise per session.
+ */
+export async function getPRStats(): Promise<PRStats> {
+  const monthStart = new Date();
+  monthStart.setDate(1);
+  monthStart.setHours(0, 0, 0, 0);
+  const monthStartMs = monthStart.getTime();
+
+  // Weight PRs: sessions where an exercise's max weight exceeds all prior sessions' max
+  const weightPRs = await query<{ total: number; this_month: number }>(
+    `SELECT
+       COUNT(*) as total,
+       SUM(CASE WHEN date >= ? THEN 1 ELSE 0 END) as this_month
+     FROM (
+       SELECT ws.exercise_id, ws.session_id, wss.started_at as date,
+              MAX(ws.weight) as session_max
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1
+         AND ws.weight IS NOT NULL AND ws.weight > 0
+         AND ws.set_type != 'warmup'
+         AND wss.completed_at IS NOT NULL
+       GROUP BY ws.exercise_id, ws.session_id
+       HAVING session_max > (
+         SELECT COALESCE(MAX(ws2.weight), 0)
+         FROM workout_sets ws2
+         JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
+         WHERE ws2.exercise_id = ws.exercise_id
+           AND ws2.session_id != ws.session_id
+           AND ws2.completed = 1
+           AND ws2.weight IS NOT NULL AND ws2.weight > 0
+           AND ws2.set_type != 'warmup'
+           AND wss2.completed_at IS NOT NULL
+           AND wss2.started_at < wss.started_at
+       )
+     )`,
+    [monthStartMs]
+  );
+
+  // Rep PRs for bodyweight exercises (weight IS NULL or 0)
+  const repPRs = await query<{ total: number; this_month: number }>(
+    `SELECT
+       COUNT(*) as total,
+       SUM(CASE WHEN date >= ? THEN 1 ELSE 0 END) as this_month
+     FROM (
+       SELECT ws.exercise_id, ws.session_id, wss.started_at as date,
+              MAX(ws.reps) as session_max
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       LEFT JOIN exercises e ON ws.exercise_id = e.id
+       WHERE ws.completed = 1
+         AND ws.reps IS NOT NULL AND ws.reps > 0
+         AND (ws.weight IS NULL OR ws.weight = 0)
+         AND ws.set_type != 'warmup'
+         AND wss.completed_at IS NOT NULL
+       GROUP BY ws.exercise_id, ws.session_id
+       HAVING session_max > (
+         SELECT COALESCE(MAX(ws2.reps), 0)
+         FROM workout_sets ws2
+         JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
+         WHERE ws2.exercise_id = ws.exercise_id
+           AND ws2.session_id != ws.session_id
+           AND ws2.completed = 1
+           AND ws2.reps IS NOT NULL AND ws2.reps > 0
+           AND (ws2.weight IS NULL OR ws2.weight = 0)
+           AND ws2.set_type != 'warmup'
+           AND wss2.completed_at IS NOT NULL
+           AND wss2.started_at < wss.started_at
+       )
+     )`,
+    [monthStartMs]
+  );
+
+  const w = weightPRs[0] ?? { total: 0, this_month: 0 };
+  const r = repPRs[0] ?? { total: 0, this_month: 0 };
+
+  return {
+    totalPRs: (w.total ?? 0) + (r.total ?? 0),
+    prsThisMonth: (w.this_month ?? 0) + (r.this_month ?? 0),
+  };
+}
+
+/**
+ * Recent PRs with improvement delta.
+ * Returns weight PRs and rep PRs (bodyweight) ordered by date descending.
+ */
+export async function getRecentPRsWithDelta(
+  limit: number = 20
+): Promise<RecentPR[]> {
+  // Weight PRs
+  const weightPRs = await query<{
+    exercise_id: string;
+    name: string;
+    category: string;
+    weight: number;
+    previous_best: number;
+    date: number;
+  }>(
+    `SELECT
+       sub.exercise_id,
+       COALESCE(e.name, 'Deleted Exercise') as name,
+       COALESCE(e.category, 'Other') as category,
+       sub.session_max as weight,
+       sub.prev_max as previous_best,
+       sub.date
+     FROM (
+       SELECT ws.exercise_id, ws.session_id, wss.started_at as date,
+              MAX(ws.weight) as session_max,
+              (SELECT COALESCE(MAX(ws2.weight), 0)
+               FROM workout_sets ws2
+               JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
+               WHERE ws2.exercise_id = ws.exercise_id
+                 AND ws2.session_id != ws.session_id
+                 AND ws2.completed = 1
+                 AND ws2.weight IS NOT NULL AND ws2.weight > 0
+                 AND ws2.set_type != 'warmup'
+                 AND wss2.completed_at IS NOT NULL
+                 AND wss2.started_at < wss.started_at
+              ) as prev_max
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1
+         AND ws.weight IS NOT NULL AND ws.weight > 0
+         AND ws.set_type != 'warmup'
+         AND wss.completed_at IS NOT NULL
+       GROUP BY ws.exercise_id, ws.session_id
+       HAVING session_max > prev_max
+     ) sub
+     LEFT JOIN exercises e ON sub.exercise_id = e.id
+     ORDER BY sub.date DESC
+     LIMIT ?`,
+    [limit]
+  );
+
+  // Rep PRs for bodyweight exercises
+  const repPRs = await query<{
+    exercise_id: string;
+    name: string;
+    category: string;
+    reps: number;
+    previous_best: number;
+    date: number;
+  }>(
+    `SELECT
+       sub.exercise_id,
+       COALESCE(e.name, 'Deleted Exercise') as name,
+       COALESCE(e.category, 'Other') as category,
+       sub.session_max as reps,
+       sub.prev_max as previous_best,
+       sub.date
+     FROM (
+       SELECT ws.exercise_id, ws.session_id, wss.started_at as date,
+              MAX(ws.reps) as session_max,
+              (SELECT COALESCE(MAX(ws2.reps), 0)
+               FROM workout_sets ws2
+               JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
+               WHERE ws2.exercise_id = ws.exercise_id
+                 AND ws2.session_id != ws.session_id
+                 AND ws2.completed = 1
+                 AND ws2.reps IS NOT NULL AND ws2.reps > 0
+                 AND (ws2.weight IS NULL OR ws2.weight = 0)
+                 AND ws2.set_type != 'warmup'
+                 AND wss2.completed_at IS NOT NULL
+                 AND wss2.started_at < wss.started_at
+              ) as prev_max
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1
+         AND ws.reps IS NOT NULL AND ws.reps > 0
+         AND (ws.weight IS NULL OR ws.weight = 0)
+         AND ws.set_type != 'warmup'
+         AND wss.completed_at IS NOT NULL
+       GROUP BY ws.exercise_id, ws.session_id
+       HAVING session_max > prev_max
+     ) sub
+     LEFT JOIN exercises e ON sub.exercise_id = e.id
+     ORDER BY sub.date DESC
+     LIMIT ?`,
+    [limit]
+  );
+
+  // Merge and sort by date descending
+  const all: RecentPR[] = [
+    ...weightPRs.map((p) => ({
+      exercise_id: p.exercise_id,
+      name: p.name,
+      category: p.category,
+      weight: p.weight,
+      reps: null as number | null,
+      previous_best: p.previous_best,
+      date: p.date,
+      is_weighted: true,
+    })),
+    ...repPRs.map((p) => ({
+      exercise_id: p.exercise_id,
+      name: p.name,
+      category: p.category,
+      weight: null as number | null,
+      reps: p.reps,
+      previous_best: p.previous_best,
+      date: p.date,
+      is_weighted: false,
+    })),
+  ];
+
+  all.sort((a, b) => b.date - a.date);
+  return all.slice(0, limit);
+}
+
+/**
+ * All-time bests per exercise, grouped by category.
+ * For weighted exercises: best weight and est 1RM from best single set.
+ * For bodyweight exercises: best reps.
+ */
+export async function getAllTimeBests(): Promise<AllTimeBest[]> {
+  // Weighted exercises: max weight, best e1RM set, session count
+  const weighted = await query<{
+    exercise_id: string;
+    name: string;
+    category: string;
+    max_weight: number;
+    best_set_weight: number;
+    best_set_reps: number;
+    session_count: number;
+  }>(
+    `SELECT
+       ws.exercise_id,
+       COALESCE(e.name, 'Deleted Exercise') as name,
+       COALESCE(e.category, 'Other') as category,
+       MAX(ws.weight) as max_weight,
+       best.weight as best_set_weight,
+       best.reps as best_set_reps,
+       COUNT(DISTINCT ws.session_id) as session_count
+     FROM workout_sets ws
+     LEFT JOIN exercises e ON ws.exercise_id = e.id
+     INNER JOIN workout_sessions wss ON ws.session_id = wss.id
+     LEFT JOIN (
+       SELECT exercise_id, weight, reps,
+              ROW_NUMBER() OVER (
+                PARTITION BY exercise_id
+                ORDER BY (weight * (1.0 + COALESCE(reps, 1) / 30.0)) DESC
+              ) as rn
+       FROM workout_sets ws_inner
+       INNER JOIN workout_sessions wss_inner ON ws_inner.session_id = wss_inner.id
+       WHERE ws_inner.completed = 1
+         AND ws_inner.weight IS NOT NULL AND ws_inner.weight > 0
+         AND ws_inner.reps IS NOT NULL AND ws_inner.reps > 0
+         AND ws_inner.set_type != 'warmup'
+         AND wss_inner.completed_at IS NOT NULL
+     ) best ON best.exercise_id = ws.exercise_id AND best.rn = 1
+     WHERE ws.completed = 1
+       AND ws.weight IS NOT NULL AND ws.weight > 0
+       AND ws.set_type != 'warmup'
+       AND wss.completed_at IS NOT NULL
+     GROUP BY ws.exercise_id
+     ORDER BY e.category ASC, e.name ASC`
+  );
+
+  // Bodyweight exercises: max reps, session count
+  const bodyweight = await query<{
+    exercise_id: string;
+    name: string;
+    category: string;
+    max_reps: number;
+    session_count: number;
+  }>(
+    `SELECT
+       ws.exercise_id,
+       COALESCE(e.name, 'Deleted Exercise') as name,
+       COALESCE(e.category, 'Other') as category,
+       MAX(ws.reps) as max_reps,
+       COUNT(DISTINCT ws.session_id) as session_count
+     FROM workout_sets ws
+     LEFT JOIN exercises e ON ws.exercise_id = e.id
+     INNER JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.completed = 1
+       AND ws.reps IS NOT NULL AND ws.reps > 0
+       AND (ws.weight IS NULL OR ws.weight = 0)
+       AND ws.set_type != 'warmup'
+       AND wss.completed_at IS NOT NULL
+     GROUP BY ws.exercise_id
+     ORDER BY e.category ASC, e.name ASC`
+  );
+
+  const results: AllTimeBest[] = [];
+
+  // Weighted results with e1RM computation
+  for (const w of weighted) {
+    // Skip if this exercise also appears as bodyweight-only (avoid duplicates)
+    // In practice, an exercise with weight>0 sets is considered weighted
+    const e1rm =
+      w.best_set_weight > 0 && w.best_set_reps > 0
+        ? Math.round(epley(w.best_set_weight, w.best_set_reps) * 10) / 10
+        : null;
+
+    results.push({
+      exercise_id: w.exercise_id,
+      name: w.name,
+      category: w.category,
+      max_weight: w.max_weight,
+      max_reps: null,
+      best_set_weight: w.best_set_weight,
+      best_set_reps: w.best_set_reps,
+      est_1rm: e1rm,
+      session_count: w.session_count,
+      is_weighted: true,
+    });
+  }
+
+  // Bodyweight results (only those not already in weighted)
+  const weightedIds = new Set(weighted.map((w) => w.exercise_id));
+  for (const b of bodyweight) {
+    if (weightedIds.has(b.exercise_id)) continue;
+    results.push({
+      exercise_id: b.exercise_id,
+      name: b.name,
+      category: b.category,
+      max_weight: null,
+      max_reps: b.max_reps,
+      best_set_weight: null,
+      best_set_reps: null,
+      est_1rm: null,
+      session_count: b.session_count,
+      is_weighted: false,
+    });
+  }
+
+  // Sort by category then name
+  results.sort((a, b) => {
+    const catCmp = a.category.localeCompare(b.category);
+    if (catCmp !== 0) return catCmp;
+    return a.name.localeCompare(b.name);
+  });
+
+  return results;
+}


### PR DESCRIPTION
## Summary

Adds a new Personal Records (PR) Dashboard to the Progress tab. Replaces the simple flat-list PRCard with a compact PRSummaryCard on the workout overview, plus a full-screen records page accessible via "See All →".

## Changes

### New files
- `lib/db/pr-dashboard.ts` — DB queries (getPRStats, getRecentPRsWithDelta, getAllTimeBests)
- `hooks/usePRDashboard.ts` — Custom hook using useFocusEffect + useState with cancellation
- `components/progress/PRSummaryCard.tsx` — Compact card (3 recent PRs, "X this month", "See All")
- `app/progress/records.tsx` — Full PR Dashboard page (stats row, recent PRs, all-time bests by category)
- `components/progress/records/PRStatsRow.tsx` — Total PRs + PRs This Month stat boxes
- `components/progress/records/RecentPRList.tsx` — Recent PRs list with delta values
- `components/progress/records/AllTimeBestsSection.tsx` — Category-grouped all-time bests with e1RM

### Modified files
- `components/progress/WorkoutSegment.tsx` — Replaced PRCard with PRSummaryCard, updated data fetching
- `lib/db/index.ts` — Added pr-dashboard module exports

### Test files
- `__tests__/lib/db/pr-dashboard.test.ts` — 13 data layer tests
- `__tests__/components/progress/PRSummaryCard.test.tsx` — 5 component tests
- `__tests__/components/progress/records.test.tsx` — 4 page tests
- Updated 4 acceptance test suites with pr-dashboard mocks

## Key Decisions

1. **PR detection**: One PR per exercise per session where max weight (or reps for bodyweight) exceeds all-time historical best
2. **e1RM**: Epley formula applied to best single set (highest e1RM), not from aggregated maxima
3. **Bodyweight detection**: Uses weight IS NULL/0 heuristic (matching existing patterns)
4. **Data layer**: Raw SQL via query() for complex PR detection subqueries (parameterized)
5. **No PR streak in V1** per TL guidance
6. **Accessibility labels** on all interactive elements per UX designer requirement

## Testing

- 2049 tests pass across 144 suites (0 failures)
- Test budget: 1776/1800 (24 remaining)
- TypeScript: zero errors in new files
- ESLint: passes on all new files

## Issue

Resolves BLD-475