### PR TITLE
perf: batch N+1 goal insight queries (BLD-353)

### DIFF
--- a/__tests__/lib/db/strength-goals.test.ts
+++ b/__tests__/lib/db/strength-goals.test.ts
@@ -80,7 +80,9 @@ import {
   deleteGoal,
   getCompletedGoals,
   getCurrentBestWeight,
+  getCurrentBestWeightsByExercise,
   getCurrentBestReps,
+  getCurrentBestRepsByExercise,
 } from "../../../lib/db/strength-goals";
 
 beforeEach(() => {
@@ -293,5 +295,54 @@ describe("getCurrentBestReps", () => {
 
     const result = await getCurrentBestReps("ex-no-data");
     expect(result).toBeNull();
+  });
+});
+
+describe("getCurrentBestWeightsByExercise", () => {
+  it("returns empty record for empty input", async () => {
+    const result = await getCurrentBestWeightsByExercise([]);
+    expect(result).toEqual({});
+    expect(mockDb.getAllAsync).not.toHaveBeenCalled();
+  });
+
+  it("returns best weights keyed by exercise ID", async () => {
+    mockDb.getAllAsync.mockResolvedValue([
+      { exercise_id: "ex-1", best: 100 },
+      { exercise_id: "ex-3", best: 60 },
+    ]);
+
+    const result = await getCurrentBestWeightsByExercise(["ex-1", "ex-2", "ex-3"]);
+    expect(result).toEqual({ "ex-1": 100, "ex-2": null, "ex-3": 60 });
+  });
+
+  it("returns null for exercises with no completed sets", async () => {
+    mockDb.getAllAsync.mockResolvedValue([]);
+
+    const result = await getCurrentBestWeightsByExercise(["ex-empty"]);
+    expect(result).toEqual({ "ex-empty": null });
+  });
+});
+
+describe("getCurrentBestRepsByExercise", () => {
+  it("returns empty record for empty input", async () => {
+    const result = await getCurrentBestRepsByExercise([]);
+    expect(result).toEqual({});
+    expect(mockDb.getAllAsync).not.toHaveBeenCalled();
+  });
+
+  it("returns best reps keyed by exercise ID", async () => {
+    mockDb.getAllAsync.mockResolvedValue([
+      { exercise_id: "ex-pullups", best: 15 },
+    ]);
+
+    const result = await getCurrentBestRepsByExercise(["ex-pullups", "ex-pushups"]);
+    expect(result).toEqual({ "ex-pullups": 15, "ex-pushups": null });
+  });
+
+  it("returns null for exercises with no completed sets", async () => {
+    mockDb.getAllAsync.mockResolvedValue([]);
+
+    const result = await getCurrentBestRepsByExercise(["ex-none"]);
+    expect(result).toEqual({ "ex-none": null });
   });
 });

--- a/components/home/loadHomeData.ts
+++ b/components/home/loadHomeData.ts
@@ -9,6 +9,7 @@ import {
   getWeeklyE1RMTrends, getRecentSessionRPEs, getRecentSessionRatings,
   getWeeklyWorkouts, getBodySettings,
 } from "../../lib/db";
+import { getExercisesByIds, getActiveGoals, getCurrentBestWeightsByExercise, getCurrentBestRepsByExercise } from "../../lib/db";
 import { computeStreak, mondayOf } from "../../lib/format";
 import { computeAllTemplateReadiness, hasWorkoutHistory } from "../../lib/recovery-readiness";
 import { generateInsight, type GoalInsightRow } from "../../lib/insights";
@@ -18,8 +19,6 @@ import {
   isDismissed,
   type OverreachingResult,
 } from "../../lib/overreaching";
-import { getActiveGoals, getCurrentBestWeight, getCurrentBestReps } from "../../lib/db";
-import { getExerciseById } from "../../lib/db";
 
 export type WeeklyGoalProgress = {
   mode: "schedule" | "frequency" | "hidden";
@@ -128,18 +127,33 @@ export async function buildWeeklyGoalProgress(
   return { mode: "hidden", slots: [], completedCount: 0, targetCount: 0 };
 }
 
+function isBodyweightGoal(goal: { target_reps: number | null; target_weight: number | null }): boolean {
+  return goal.target_reps != null && goal.target_weight == null;
+}
+
 async function loadGoalInsights(): Promise<GoalInsightRow[]> {
   try {
     const activeGoals = await getActiveGoals();
+    const goals = activeGoals.slice(0, 3);
+    if (goals.length === 0) return [];
+
+    const exerciseIds = [...new Set(goals.map((g) => g.exercise_id))];
+    const weightGoalIds = goals.filter((g) => !isBodyweightGoal(g)).map((g) => g.exercise_id);
+    const repGoalIds = goals.filter((g) => isBodyweightGoal(g)).map((g) => g.exercise_id);
+
+    const [exercisesMap, bestWeights, bestReps] = await Promise.all([
+      getExercisesByIds(exerciseIds),
+      weightGoalIds.length > 0 ? getCurrentBestWeightsByExercise(weightGoalIds) : ({} as Record<string, number | null>),
+      repGoalIds.length > 0 ? getCurrentBestRepsByExercise(repGoalIds) : ({} as Record<string, number | null>),
+    ]);
+
     const results: GoalInsightRow[] = [];
-    for (const goal of activeGoals.slice(0, 3)) {
-      const exercise = await getExerciseById(goal.exercise_id);
+    for (const goal of goals) {
+      const exercise = exercisesMap[goal.exercise_id];
       if (!exercise) continue;
-      const isBodyweight = goal.target_reps != null && goal.target_weight == null;
-      const best = isBodyweight
-        ? await getCurrentBestReps(goal.exercise_id)
-        : await getCurrentBestWeight(goal.exercise_id);
-      const target = isBodyweight ? (goal.target_reps ?? 0) : (goal.target_weight ?? 0);
+      const bw = isBodyweightGoal(goal);
+      const best = bw ? (bestReps[goal.exercise_id] ?? null) : (bestWeights[goal.exercise_id] ?? null);
+      const target = bw ? (goal.target_reps ?? 0) : (goal.target_weight ?? 0);
       const pct = target > 0 && best != null ? Math.round((best / target) * 100) : 0;
       results.push({ exercise_id: goal.exercise_id, exercise_name: exercise.name, progressPct: pct });
     }

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -312,6 +312,8 @@ export {
   deleteGoal,
   getCompletedGoals,
   getCurrentBestWeight,
+  getCurrentBestWeightsByExercise,
   getCurrentBestReps,
+  getCurrentBestRepsByExercise,
 } from "./strength-goals";
 export type { StrengthGoalRow, CreateGoalInput, UpdateGoalInput } from "./strength-goals";

--- a/lib/db/strength-goals.ts
+++ b/lib/db/strength-goals.ts
@@ -105,6 +105,7 @@ export async function getCompletedGoals(): Promise<StrengthGoalRow[]> {
 }
 
 type CurrentBestRow = { best: number | null };
+type BestByExerciseRow = { exercise_id: string; best: number | null };
 
 /** Compute current best weight for an exercise from completed workout sets. */
 export async function getCurrentBestWeight(exerciseId: string): Promise<number | null> {
@@ -115,6 +116,20 @@ export async function getCurrentBestWeight(exerciseId: string): Promise<number |
   return rows[0]?.best ?? null;
 }
 
+/** Batch: best weight per exercise from completed workout sets. */
+export async function getCurrentBestWeightsByExercise(exerciseIds: string[]): Promise<Record<string, number | null>> {
+  if (exerciseIds.length === 0) return {};
+  const placeholders = exerciseIds.map(() => "?").join(", ");
+  const rows = await query<BestByExerciseRow>(
+    `SELECT exercise_id, MAX(weight) as best FROM workout_sets WHERE exercise_id IN (${placeholders}) AND completed = 1 AND weight IS NOT NULL GROUP BY exercise_id`,
+    exerciseIds,
+  );
+  const result: Record<string, number | null> = {};
+  for (const id of exerciseIds) result[id] = null;
+  for (const row of rows) result[row.exercise_id] = row.best;
+  return result;
+}
+
 /** Compute current best reps for a bodyweight exercise from completed workout sets. */
 export async function getCurrentBestReps(exerciseId: string): Promise<number | null> {
   const rows = await query<CurrentBestRow>(
@@ -122,4 +137,18 @@ export async function getCurrentBestReps(exerciseId: string): Promise<number | n
     [exerciseId],
   );
   return rows[0]?.best ?? null;
+}
+
+/** Batch: best reps per exercise from completed workout sets. */
+export async function getCurrentBestRepsByExercise(exerciseIds: string[]): Promise<Record<string, number | null>> {
+  if (exerciseIds.length === 0) return {};
+  const placeholders = exerciseIds.map(() => "?").join(", ");
+  const rows = await query<BestByExerciseRow>(
+    `SELECT exercise_id, MAX(reps) as best FROM workout_sets WHERE exercise_id IN (${placeholders}) AND completed = 1 AND reps IS NOT NULL GROUP BY exercise_id`,
+    exerciseIds,
+  );
+  const result: Record<string, number | null> = {};
+  for (const id of exerciseIds) result[id] = null;
+  for (const row of rows) result[row.exercise_id] = row.best;
+  return result;
 }


### PR DESCRIPTION
## Summary

Batch the sequential N+1 DB calls in `loadGoalInsights()` — the last remaining sequential query pattern in `loadHomeData()`. Replaces ~7 sequential DB round-trips with 3 parallel batch queries via `Promise.all`.

## Changes

- Add `getCurrentBestWeightsByExercise()` and `getCurrentBestRepsByExercise()` batch functions to `lib/db/strength-goals.ts` using `GROUP BY exercise_id`
- Refactor `loadGoalInsights()` to use `getExercisesByIds()` (existing) + new batch functions
- Goal-type partitioning: only queries weight or rep tables when needed
- Deduplicate exercise IDs before batching
- Extract `isBodyweightGoal()` helper to keep function complexity within ESLint limits
- Export new batch functions from `lib/db/index.ts`

## Testing

- 6 new unit tests for batch functions (empty input, mixed results, missing exercises)
- 28 total tests in strength-goals suite, all pass
- Full suite: 2030 tests pass, 141 suites, 0 failures
- TypeScript: only 2 pre-existing errors (unrelated fontSize.md)
- ESLint: passes with 0 warnings

## Issue

Resolves BLD-353