### PR TITLE
fix: replace EAS build with expo prebuild + Gradle for CI APK (BLD-479)

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -188,14 +188,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install EAS CLI
-        run: npm install -g eas-cli
+      - name: Generate native project
+        run: npx expo prebuild --clean --platform android
 
       - name: Build APK
-        run: eas build -p android --profile production --local --output cablesnap.apk --non-interactive
-        env:
-          EAS_NO_VCS: '1'
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          cd android
+          ./gradlew assembleRelease
+          cd ..
+          cp android/app/build/outputs/apk/release/app-release.apk cablesnap.apk
 
       - name: Upload APK to release
         env:


### PR DESCRIPTION
## Summary

Fixes CI APK build by replacing `eas build --local` (which requires `EXPO_TOKEN`) with `npx expo prebuild --clean` + `./gradlew assembleRelease`. This eliminates the Expo authentication dependency entirely.

## Changes

- Removed 'Install EAS CLI' step (`npm install -g eas-cli`)
- Removed `EXPO_TOKEN` and `EAS_NO_VCS` env vars from the build step
- Added 'Generate native project' step using `npx expo prebuild --clean --platform android`
- Updated 'Build APK' step to use `./gradlew assembleRelease` and copy output to `cablesnap.apk`

## Testing

- CI-only change; verified YAML syntax and step ordering
- No application code modified
- Upload step unchanged — still references `cablesnap.apk`

## Issue

Resolves BLD-479