### PR TITLE
fix: remove maxHeight crop on workout summary muscle heatmap (BLD-482)

### DIFF
--- a/__tests__/acceptance/workout-summary.acceptance.test.tsx
+++ b/__tests__/acceptance/workout-summary.acceptance.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Acceptance test for BLD-480 / BLD-482:
+ * Workout summary muscle heatmap must not be height-cropped.
+ *
+ * Renders app/session/summary/[id].tsx with a completed-workout fixture
+ * and asserts:
+ *  - MusclesWorkedCard renders with correct accessibility label
+ *  - The muscle map container has no `maxHeight` constraint
+ *  - MuscleMap is rendered with the aggregated primary/secondary muscles
+ */
+
+jest.mock('../../lib/db', () => ({
+  getSessionById: jest.fn(),
+  getSessionSets: jest.fn().mockResolvedValue([]),
+  getBodySettings: jest.fn().mockResolvedValue({
+    weight_unit: 'kg',
+    measurement_unit: 'cm',
+    sex: 'male',
+    weight_goal: null,
+    body_fat_goal: null,
+  }),
+  getSessionPRs: jest.fn().mockResolvedValue([]),
+  getSessionRepPRs: jest.fn().mockResolvedValue([]),
+  getSessionDurationPRs: jest.fn().mockResolvedValue([]),
+  getSessionWeightIncreases: jest.fn().mockResolvedValue([]),
+  getSessionComparison: jest.fn().mockResolvedValue(null),
+  getSessionSetCount: jest.fn().mockResolvedValue(0),
+  getExercisesByIds: jest.fn().mockResolvedValue({}),
+  buildAchievementContext: jest.fn().mockResolvedValue({}),
+  getEarnedAchievementIds: jest.fn().mockResolvedValue([]),
+  saveEarnedAchievements: jest.fn().mockResolvedValue(undefined),
+  updateSession: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  useLocalSearchParams: () => ({ id: 'sess-completed' }),
+  usePathname: () => '/session/summary/sess-completed',
+  useFocusEffect: jest.fn(),
+  Stack: { Screen: () => null },
+  Redirect: () => null,
+}))
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({
+  useLayout: () => ({ wide: false, width: 375, scale: 1.0 }),
+}))
+jest.mock('../../lib/errors', () => ({
+  logError: jest.fn(),
+  generateReport: jest.fn().mockResolvedValue('{}'),
+  getRecentErrors: jest.fn().mockResolvedValue([]),
+  generateGitHubURL: jest.fn().mockReturnValue('https://github.com'),
+}))
+jest.mock('../../lib/interactions', () => ({
+  log: jest.fn(),
+  recent: jest.fn().mockResolvedValue([]),
+}))
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+  NotificationFeedbackType: { Success: 'success', Warning: 'warning' },
+}))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+jest.mock('../../lib/units', () => ({
+  toDisplay: (v: number) => v,
+  toKg: (v: number) => v,
+  KG_TO_LB: 2.20462,
+  LB_TO_KG: 0.453592,
+}))
+jest.mock('victory-native', () => ({
+  CartesianChart: 'CartesianChart',
+  Line: 'Line',
+  Bar: 'Bar',
+}))
+
+jest.mock('../../lib/useProfileGender', () => ({
+  useProfileGender: () => 'male',
+}))
+
+// Render MuscleMap as a plain host component so tree inspection works and we
+// can assert the primary/secondary muscles passed to it.
+jest.mock('../../components/MuscleMap', () => {
+  const React = require('react')
+  return {
+    MuscleMap: (props: Record<string, unknown>) =>
+      React.createElement('MuscleMap', props),
+  }
+})
+
+import React from 'react'
+import { StyleSheet } from 'react-native'
+import { renderScreen } from '../helpers/render'
+import { resetIds } from '../helpers/factories'
+import { createCompletedWorkoutFixture } from '../fixtures/completedWorkoutSummary'
+import Summary from '../../app/session/summary/[id]'
+
+const mockDb = require('../../lib/db') as Record<string, jest.Mock>
+
+describe('Workout Summary — muscle heatmap sizing (BLD-480)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+  })
+
+  it('renders MusclesWorkedCard without a maxHeight cap on the map container', async () => {
+    const { session, exercises, sets } = createCompletedWorkoutFixture()
+    mockDb.getSessionById.mockResolvedValue(session)
+    mockDb.getSessionSets.mockResolvedValue(sets)
+    mockDb.getExercisesByIds.mockResolvedValue(exercises)
+
+    const screen = renderScreen(<Summary />)
+
+    // Muscles card rendered with accessibility label covering chest + accessories
+    const card = await screen.findByLabelText(/Muscles worked:.*Chest/i)
+    expect(card).toBeTruthy()
+
+    // Map container is present and has no maxHeight style
+    const mapContainer = await screen.findByTestId('muscles-worked-map-container')
+    const flattened = StyleSheet.flatten(mapContainer.props.style) ?? {}
+    expect(flattened).not.toHaveProperty('maxHeight')
+
+    // MuscleMap receives aggregated primary/secondary muscles
+    const muscleMap = screen.UNSAFE_getByType('MuscleMap' as unknown as React.ComponentType)
+    expect(muscleMap.props.primary).toEqual(expect.arrayContaining(['chest']))
+    expect(muscleMap.props.secondary).toEqual(
+      expect.arrayContaining(['shoulders', 'triceps']),
+    )
+  })
+
+  it('accessibility label includes human-readable muscle names', async () => {
+    const { session, exercises, sets } = createCompletedWorkoutFixture()
+    mockDb.getSessionById.mockResolvedValue(session)
+    mockDb.getSessionSets.mockResolvedValue(sets)
+    mockDb.getExercisesByIds.mockResolvedValue(exercises)
+
+    const screen = renderScreen(<Summary />)
+
+    const card = await screen.findByLabelText(/Muscles worked:/i)
+    const label = card.props.accessibilityLabel as string
+    expect(label).toMatch(/Chest/i)
+    expect(label).toMatch(/Shoulders|Triceps/i)
+  })
+})

--- a/__tests__/fixtures/completedWorkoutSummary.ts
+++ b/__tests__/fixtures/completedWorkoutSummary.ts
@@ -1,0 +1,69 @@
+import { createExercise, createSession, createSet } from '../helpers/factories'
+import type { Exercise, WorkoutSession, WorkoutSet } from '../../lib/types'
+
+export type CompletedWorkoutFixture = {
+  session: WorkoutSession
+  exercises: Record<string, Exercise>
+  sets: (WorkoutSet & { exercise_name?: string })[]
+}
+
+/**
+ * Creates a realistic completed-workout summary fixture suitable for
+ * rendering the Summary screen (app/session/summary/[id].tsx).
+ *
+ * Default: a completed bench-press session (chest primary,
+ * shoulders + triceps secondary) with two working sets.
+ */
+export function createCompletedWorkoutFixture(
+  overrides: Partial<{
+    sessionId: string
+    exercise: Exercise
+    setCount: number
+    weight: number
+    reps: number
+    durationSeconds: number
+  }> = {},
+): CompletedWorkoutFixture {
+  const sessionId = overrides.sessionId ?? 'sess-completed'
+  const exercise =
+    overrides.exercise ??
+    createExercise({
+      id: 'ex-bench',
+      name: 'Bench Press',
+      primary_muscles: ['chest'],
+      secondary_muscles: ['shoulders', 'triceps'],
+    })
+  const setCount = overrides.setCount ?? 2
+  const weight = overrides.weight ?? 100
+  const reps = overrides.reps ?? 5
+  const durationSeconds = overrides.durationSeconds ?? 1800
+  const completedAt = Date.now()
+
+  const session = createSession({
+    id: sessionId,
+    name: 'Chest Day',
+    started_at: completedAt - durationSeconds * 1000,
+    completed_at: completedAt,
+    duration_seconds: durationSeconds,
+  })
+
+  const sets = Array.from({ length: setCount }, (_, i) => ({
+    ...createSet({
+      id: `${sessionId}-set-${i + 1}`,
+      session_id: sessionId,
+      exercise_id: exercise.id,
+      set_number: i + 1,
+      weight,
+      reps,
+      completed: true,
+      completed_at: completedAt,
+    }),
+    exercise_name: exercise.name,
+  }))
+
+  return {
+    session,
+    exercises: { [exercise.id]: exercise },
+    sets,
+  }
+}

--- a/components/session/summary/MusclesWorkedCard.tsx
+++ b/components/session/summary/MusclesWorkedCard.tsx
@@ -39,7 +39,7 @@ function MusclesWorkedCardInner({ primaryMuscles, secondaryMuscles, colors }: Pr
             Muscles Worked
           </Text>
         </View>
-        <View style={styles.mapContainer}>
+        <View style={styles.mapContainer} testID="muscles-worked-map-container">
           <MuscleMap
             primary={primaryMuscles}
             secondary={secondaryMuscles}
@@ -62,5 +62,5 @@ export default function MusclesWorkedCard(props: Props) {
 const styles = StyleSheet.create({
   section: { marginBottom: 16 },
   sectionHeader: { flexDirection: "row", alignItems: "center", marginBottom: 12 },
-  mapContainer: { maxHeight: 200 },
+  mapContainer: { alignItems: "center" },
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,7 @@ module.exports = {
   moduleNameMapper: {
     'react-native-reanimated': '<rootDir>/__mocks__/react-native-reanimated.js',
   },
-  testPathIgnorePatterns: ['/node_modules/', '__tests__/helpers/', '/e2e/'],
+  testPathIgnorePatterns: ['/node_modules/', '__tests__/helpers/', '__tests__/fixtures/', '/e2e/'],
   setupFiles: ['./jest.setup.js'],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],


### PR DESCRIPTION
## Summary

Fixes muscle heatmap cropping on the workout completion screen. The `mapContainer` style in `components/session/summary/MusclesWorkedCard.tsx` had a hard `maxHeight: 200` cap, but the `MuscleMap` component renders two Body silhouettes at ~280pt tall plus a Legend — well over 200pt — so the bottom of the figures was clipped on phone viewports.

## Changes

- `components/session/summary/MusclesWorkedCard.tsx`: remove `maxHeight: 200`; add `alignItems: "center"` so the figure stays horizontally centered. Add `testID` on the map container for targeted style assertions.
- `__tests__/fixtures/completedWorkoutSummary.ts`: new reusable fixture factory `createCompletedWorkoutFixture()` for rendering the Summary screen in tests with realistic completed-workout data.
- `__tests__/acceptance/workout-summary.acceptance.test.tsx`: new acceptance suite that renders `app/session/summary/[id].tsx` with a chest/shoulders/triceps completed workout and asserts:
  - MusclesWorkedCard renders with proper accessibility label
  - Map container's flattened style has no `maxHeight`
  - MuscleMap receives aggregated primary/secondary muscles
  - Accessibility label contains human-readable muscle names
- `jest.config.js`: add `__tests__/fixtures/` to `testPathIgnorePatterns` so fixture files don't register as empty test suites.

## Testing

- `npx jest __tests__/acceptance/workout-summary.acceptance.test.tsx` — 2 tests pass
- `npx jest` — full suite: **142 suites / 2033 tests pass**
- `npx tsc --noEmit` — no new errors (2 pre-existing errors on `main` unrelated to this change)

## Acceptance Criteria

- [x] `maxHeight: 200` removed from `MusclesWorkedCard` mapContainer style
- [x] Acceptance test asserts map container's flattened style has no `maxHeight`
- [x] Figures still horizontally centered (alignItems: center on container)
- [x] New acceptance test at `__tests__/acceptance/workout-summary.acceptance.test.tsx`
- [x] Reusable mock factory at `__tests__/fixtures/completedWorkoutSummary.ts`
- [x] `npx tsc --noEmit` passes (no new errors)
- [x] All existing tests still pass

## Issue

Resolves BLD-482 (parent: BLD-480).