### PR TITLE
fix: remove PKCE from Strava OAuth (BLD-414)

### DIFF
--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -90,15 +90,15 @@ describe("Strava Integration — DB Operations", () => {
 });
 
 describe("Strava Integration — API Client", () => {
-  it("uses PKCE OAuth with SecureStore tokens and correct activity format", () => {
+  it("uses OAuth Authorization Code flow with SecureStore tokens and correct activity format", () => {
     // Token storage
     expect(stravaClientSrc).toContain("SecureStore.setItemAsync");
     expect(stravaClientSrc).toContain("SecureStore.getItemAsync");
     expect(stravaClientSrc).toContain("SecureStore.deleteItemAsync");
     expect(stravaClientSrc).not.toMatch(/execute.*token/i);
-    // PKCE
-    expect(stravaClientSrc).toContain("usePKCE: true");
-    expect(stravaClientSrc).toContain("code_verifier");
+    // Strava does NOT support PKCE — flag must not be set, and no code_verifier in request body
+    expect(stravaClientSrc).not.toContain("usePKCE: true");
+    expect(stravaClientSrc).not.toContain("code_verifier");
     // Activity format
     expect(stravaClientSrc).toMatch(/external_id.*cablesnap-/);
     expect(stravaClientSrc).toContain('"WeightTraining"');
@@ -302,10 +302,11 @@ describe("Strava Integration — Behavioral", () => {
     expect(db.saveStravaConnection).toHaveBeenCalledWith(42, "Jane Doe");
     // Verify proxy URL is used
     expect(mockFetch.mock.calls[0][0]).toBe("https://test-proxy.example.com/token");
-    // Verify body sends code + code_verifier but NOT client_id or grant_type
+    // Verify body sends code but NOT code_verifier (Strava does not support PKCE),
+    // and NOT client_id or grant_type (added by the proxy)
     const fetchBody = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(fetchBody.code).toBe("auth-code-123");
-    expect(fetchBody.code_verifier).toBe("test-verifier");
+    expect(fetchBody).not.toHaveProperty("code_verifier");
     expect(fetchBody).not.toHaveProperty("client_id");
     expect(fetchBody).not.toHaveProperty("grant_type");
   });

--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -314,7 +314,6 @@ describe("Strava Integration — Behavioral", () => {
   it("connectStrava returns null when user cancels OAuth", async () => {
     AuthSession.AuthRequest.mockImplementation(() => ({
       promptAsync: jest.fn().mockResolvedValue({ type: "cancel" }),
-      codeVerifier: "v",
     }));
     const result = await strava.connectStrava();
     expect(result).toBeNull();

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -147,7 +147,9 @@ async function getValidAccessToken(): Promise<string | null> {
   return await refreshAccessToken();
 }
 
-// ---- OAuth2 PKCE Flow ----
+// ---- OAuth2 Authorization Code Flow ----
+// Note: Strava does not support PKCE. Tokens are exchanged via the
+// Cloudflare Worker proxy which holds the client_secret server-side.
 
 export async function connectStrava(): Promise<{
   athleteId: number;
@@ -166,7 +168,6 @@ export async function connectStrava(): Promise<{
     clientId,
     scopes: ["activity:write"],
     redirectUri,
-    usePKCE: true,
     responseType: AuthSession.ResponseType.Code,
   });
 
@@ -184,7 +185,6 @@ export async function connectStrava(): Promise<{
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       code: result.params.code,
-      code_verifier: authRequest.codeVerifier,
     }),
   });
 


### PR DESCRIPTION
## Summary

Strava OAuth was failing with "Invalid redirect URI". Root cause: the AuthRequest was configured with `usePKCE: true`, but Strava does not support PKCE. Removing the flag (and the corresponding `code_verifier` from the proxy token exchange) aligns the client with what Strava accepts.

The Strava Authorization Callback Domain has already been configured on the Strava API dashboard by the board (app ID 227474), so no further external change is required.

## Changes

- `lib/strava.ts`: drop `usePKCE: true` from the `AuthSession.AuthRequest` and stop sending `code_verifier` in the `/token` proxy POST.
- `lib/strava.ts`: update flow comment.
- `__tests__/lib/strava.test.ts`: invert the assertions — now verifies `usePKCE` and `code_verifier` are absent.

No change to the Cloudflare Worker proxy (`workers/strava-proxy`) — it already treats `code_verifier` as optional.

## Testing

- `npx jest __tests__/lib/strava.test.ts` → 26/26 pass.
- Full suite: 2030 passing; 1 flaky acceptance test (`workout-session.acceptance.test.tsx`) that passes in isolation and is unrelated to Strava.
- Manual end-to-end verification of the OAuth flow (connect → proxy token exchange → activity upload) is pending on-device and will be performed after merge + build.

## Issue

Resolves BLD-414