### PR TITLE
ci: wire bundle-gate script into CI (BLD-495)

### DIFF
--- a/.github/workflows/bundle-gate.yml
+++ b/.github/workflows/bundle-gate.yml
@@ -1,0 +1,66 @@
+name: Bundle Gate
+
+# Production-hygiene gate: verifies the `__TEST_SCENARIO__` literal from the
+# dev-only scenario seed hook never leaks into the exported web bundle.
+#
+# Guards the `if (__DEV__)` dead-code-elimination contract established in
+# BLD-494 (see scripts/verify-scenario-hook-not-in-bundle.sh).
+#
+# Refs: BLD-494, BLD-495.
+
+on:
+  pull_request:
+    paths:
+      - 'lib/db/**'
+      - 'hooks/**'
+      - 'e2e/**'
+      - 'scripts/verify-scenario-hook-not-in-bundle.sh'
+      - '.github/workflows/bundle-gate.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'app.config.ts'
+      - 'metro.config.js'
+      - 'babel.config.js'
+  push:
+    branches:
+      - main
+    paths:
+      - 'lib/db/**'
+      - 'hooks/**'
+      - 'e2e/**'
+      - 'scripts/verify-scenario-hook-not-in-bundle.sh'
+      - '.github/workflows/bundle-gate.yml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'app.config.ts'
+      - 'metro.config.js'
+      - 'babel.config.js'
+
+# Cancel in-progress runs on new commits to the same PR to save CI minutes.
+concurrency:
+  group: bundle-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  bundle-gate:
+    name: Verify scenario hook not in production bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run bundle gate
+        run: bash scripts/verify-scenario-hook-not-in-bundle.sh


### PR DESCRIPTION
## Summary

Wires the BLD-494 bundle-gate script (`scripts/verify-scenario-hook-not-in-bundle.sh`) into GitHub Actions so the production-hygiene contract — `__TEST_SCENARIO__` MUST NOT leak into the exported web bundle — is enforced automatically on PRs, not just by convention.

## Changes

- Adds `.github/workflows/bundle-gate.yml`
- Triggers on `pull_request` and `push` to `main` for the paths that can affect the web bundle:
  - `lib/db/**`, `hooks/**`, `e2e/**` (the covered surfaces)
  - `scripts/verify-scenario-hook-not-in-bundle.sh` (the script itself)
  - `.github/workflows/bundle-gate.yml` (self-modification)
  - `package.json`, `package-lock.json`, `app.config.ts`, `metro.config.js`, `babel.config.js` (build-config changes that could alter DCE behavior)
- Node 22 + `actions/setup-node` npm cache for fast installs
- `npm ci --legacy-peer-deps` (repo convention)
- `concurrency` group cancels superseded runs on the same ref
- `timeout-minutes: 10` (expo export + grep typically <3 min, well under the <5min AC)

## Testing

- YAML validated with `python -c 'yaml.safe_load(...)'`
- Script was already validated in BLD-494; this PR only wires it into CI
- CI will run this workflow on the PR itself because it touches `.github/workflows/bundle-gate.yml` (self-test)

## Follow-up — Required Status Check (repo-admin action)

Marking `bundle-gate / Verify scenario hook not in production bundle` as a **required status check** is configured in **Settings → Branches → Branch protection rules**, not in YAML. GitHub surfaces the check name to the settings UI only after its first successful run, so the sequence is:

1. Merge this PR
2. Repo admin adds `Verify scenario hook not in production bundle` to the required checks list on `main`

The workflow YAML change alone cannot enforce "required"; that flip is documented here so a CEO/admin can complete it.

## Issue

Resolves BLD-495 (follow-up to BLD-494)