### PR TITLE
fix(BLD-497): reset+clean before checkout in daily-audit cleanup trap

### DIFF
--- a/scripts/daily-audit.sh
+++ b/scripts/daily-audit.sh
@@ -48,6 +48,12 @@ fi
 
 cleanup() {
   echo "[daily-audit] restoring $ORIGINAL_REF"
+  # Discard any dirty state from the pinned-SHA section before returning to
+  # the original ref. The pre-fix section copies files (e.g. lib/db/test-seed.ts)
+  # onto an old tree that may lack them; checking out a branch that tracks
+  # those files without a reset first would fail with "would be overwritten".
+  git reset --hard --quiet || true
+  git clean -fdq || true
   git checkout --quiet "$ORIGINAL_REF" || true
 }
 trap cleanup EXIT


### PR DESCRIPTION
## Summary
Fixes the cleanup trap in `scripts/daily-audit.sh` (BLD-494 QD#4 follow-up). The pre-fix section copies `lib/db/test-seed.ts` (and other files) onto an old tree that lacks them; without discarding that dirty state first, `git checkout $ORIGINAL_REF` would fail when returning to a branch that tracks those files.

## Changes
- Add `git reset --hard --quiet` and `git clean -fdq` in the trap, before `git checkout $ORIGINAL_REF`.
- All three commands use `|| true` so an earlier failure doesn't prevent the rest of cleanup from running.

## Testing
- `bash -n scripts/daily-audit.sh` — syntax OK.
- Simulated the scenario in a scratch repo: created an orphan commit lacking `tracked.txt`, checked it out, created a dirty copy of `tracked.txt`, then exercised the trap logic. Result: `git reset --hard && git clean -fd && git checkout $ORIGINAL_REF` returned cleanly to main with file contents intact.
- Detached HEAD case unchanged: `ORIGINAL_REF` still falls back to a SHA in that case (lines 44–47), and checkout by SHA works the same way.

## Issue
Resolves BLD-497