### PR TITLE
fix: replace missing fontSizes.md with fontSizes.base (BLD-499)

### DIFF
--- a/components/settings/AutoBackupSection.tsx
+++ b/components/settings/AutoBackupSection.tsx
@@ -238,6 +238,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  retentionValue: { fontWeight: "700", fontSize: fontSizes.md, minWidth: 24, textAlign: "center" },
+  retentionValue: { fontWeight: "700", fontSize: fontSizes.base, minWidth: 24, textAlign: "center" },
   buttonRow: { flexDirection: "row", gap: 8, marginTop: 4 },
 });

--- a/components/settings/FrequencyGoalPicker.tsx
+++ b/components/settings/FrequencyGoalPicker.tsx
@@ -93,7 +93,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  stepValue: { fontWeight: "700", fontSize: fontSizes.md, minWidth: 100, textAlign: "center" },
+  stepValue: { fontWeight: "700", fontSize: fontSizes.base, minWidth: 100, textAlign: "center" },
   setButton: { borderWidth: 1, borderRadius: 8, paddingVertical: 8, alignItems: "center" },
   clearButton: { paddingVertical: 4, paddingHorizontal: 8 },
 });


### PR DESCRIPTION
## Summary
Two components referenced a nonexistent `md` key in the `fontSizes` token scale (`xs/sm/base/lg/xl/...`), causing 2 pre-existing tsc errors on main. Both usages are large numeric value displays that logically map to the 16px base size; swapped to `fontSizes.base` to restore zero-error tsc.

## Changes
- `components/settings/AutoBackupSection.tsx`: retentionValue `fontSizes.md` → `fontSizes.base`
- `components/settings/FrequencyGoalPicker.tsx`: stepValue `fontSizes.md` → `fontSizes.base`

Rationale: the scale has no `md` token and the two sites logically sit at base (16px). Adding `md` as an alias would introduce a redundant token without design intent; swapping to the existing `base` is cleaner and preserves the existing visual size (16px).

## Testing
- `npx tsc --noEmit` → clean (previously 2 errors)
- No visual regression: `fontSizes.md` was undefined, so the previous runtime behavior was implicitly `undefined` fontSize. Setting it to `fontSizes.base` (16) explicitly matches the obvious intent for these numeric value displays.

## Issue
Resolves BLD-499