### PR TITLE
feat: PR Dashboard error state with retry button (BLD-506)

### DIFF
--- a/__tests__/components/progress/records.test.tsx
+++ b/__tests__/components/progress/records.test.tsx
@@ -112,4 +112,41 @@ describe('Records Page', () => {
     expect(await findByText('No Records Yet')).toBeTruthy()
     expect(await findByText('Complete your first workout to start tracking personal records!')).toBeTruthy()
   })
+
+  test('renders friendly error state with retry button when data fetch fails', async () => {
+    const prDashboard = require('@/lib/db/pr-dashboard')
+    prDashboard.getPRStats.mockRejectedValueOnce(new Error('database disk image is malformed'))
+
+    const { findByText, findByTestId } = render(<RecordsPage />)
+
+    expect(await findByText("Couldn't load your records")).toBeTruthy()
+    expect(await findByText(/Something went wrong/i)).toBeTruthy()
+    expect(await findByText('database disk image is malformed')).toBeTruthy()
+    expect(await findByText('Retry')).toBeTruthy()
+    const container = await findByTestId('pr-dashboard-error')
+    expect(container.props.accessibilityLiveRegion).toBe('polite')
+    expect(container.props.accessibilityRole).toBe('alert')
+  })
+
+  test('Retry button re-invokes data load and recovers from error', async () => {
+    const prDashboard = require('@/lib/db/pr-dashboard')
+    prDashboard.getPRStats
+      .mockRejectedValueOnce(new Error('transient failure'))
+      .mockResolvedValue({ totalPRs: 7, prsThisMonth: 3 })
+    prDashboard.getRecentPRsWithDelta.mockResolvedValue([])
+    prDashboard.getAllTimeBests.mockResolvedValue([])
+
+    const { findByText, queryByText } = render(<RecordsPage />)
+
+    const retryBtn = await findByText('Retry')
+    expect(retryBtn).toBeTruthy()
+
+    const { fireEvent } = require('@testing-library/react-native')
+    fireEvent.press(retryBtn)
+
+    expect(await findByText('7')).toBeTruthy()
+    expect(await findByText('3')).toBeTruthy()
+    expect(queryByText("Couldn't load your records")).toBeNull()
+    expect(prDashboard.getPRStats).toHaveBeenCalledTimes(2)
+  })
 })

--- a/app/progress/records.tsx
+++ b/app/progress/records.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 import { ActivityIndicator, ScrollView, StyleSheet, View } from "react-native";
 import { Stack, useRouter } from "expo-router";
-import { Text } from "@/components/ui/text";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { usePRDashboard } from "@/hooks/usePRDashboard";
 import EmptyState from "@/components/EmptyState";
 import PRStatsRow from "@/components/progress/records/PRStatsRow";
 import RecentPRList from "@/components/progress/records/RecentPRList";
 import AllTimeBestsSection from "@/components/progress/records/AllTimeBestsSection";
+import PRDashboardError from "@/components/progress/records/PRDashboardError";
 
 export default function RecordsPage() {
   const colors = useThemeColors();
   const router = useRouter();
-  const { stats, recentPRs, allTimeBests, weightUnit, loading, error } =
+  const { stats, recentPRs, allTimeBests, weightUnit, loading, error, reload } =
     usePRDashboard();
 
   const navigateToExercise = (exerciseId: string) => {
@@ -34,11 +34,7 @@ export default function RecordsPage() {
             <ActivityIndicator size="large" color={colors.primary} />
           </View>
         ) : error ? (
-          <View style={styles.center}>
-            <Text style={{ color: colors.error, textAlign: "center" }}>
-              {error}
-            </Text>
-          </View>
+          <PRDashboardError error={error} onRetry={reload} />
         ) : isEmpty ? (
           <EmptyState
             icon="trophy-outline"

--- a/components/progress/records/PRDashboardError.tsx
+++ b/components/progress/records/PRDashboardError.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { useThemeColors } from "@/hooks/useThemeColors";
+
+type Props = {
+  error: string;
+  onRetry: () => void;
+};
+
+export default function PRDashboardError({ error, onRetry }: Props) {
+  const colors = useThemeColors();
+  return (
+    <View
+      testID="pr-dashboard-error"
+      style={styles.container}
+      accessibilityLiveRegion="polite"
+      accessibilityRole="alert"
+    >
+      <MaterialCommunityIcons
+        name="alert-circle-outline"
+        size={48}
+        color={colors.error}
+      />
+      <Text
+        variant="subtitle"
+        style={[styles.title, { color: colors.onSurface }]}
+      >
+        Couldn&apos;t load your records
+      </Text>
+      <Text
+        variant="body"
+        style={[styles.subtitle, { color: colors.onSurfaceVariant }]}
+      >
+        Something went wrong while loading your personal records. Please try
+        again.
+      </Text>
+      <Text
+        variant="caption"
+        style={[styles.detail, { color: colors.onSurfaceVariant }]}
+        numberOfLines={2}
+      >
+        {error}
+      </Text>
+      <Button
+        variant="default"
+        onPress={onRetry}
+        style={styles.button}
+        accessibilityLabel="Retry loading records"
+      >
+        Retry
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 48,
+    paddingHorizontal: 24,
+  },
+  title: {
+    marginTop: 12,
+    textAlign: "center",
+  },
+  subtitle: {
+    marginTop: 4,
+    textAlign: "center",
+  },
+  detail: {
+    marginTop: 8,
+    textAlign: "center",
+    opacity: 0.7,
+  },
+  button: {
+    marginTop: 16,
+  },
+});

--- a/hooks/usePRDashboard.ts
+++ b/hooks/usePRDashboard.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useFocusEffect } from "expo-router";
 import {
   getPRStats,
@@ -15,6 +15,7 @@ export type PRDashboardData = {
   weightUnit: "kg" | "lb";
   loading: boolean;
   error: string | null;
+  reload: () => void;
 };
 
 export function usePRDashboard(): PRDashboardData {
@@ -24,39 +25,45 @@ export function usePRDashboard(): PRDashboardData {
   const [weightUnit, setWeightUnit] = useState<"kg" | "lb">("kg");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const cancelledRef = useRef(false);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const [s, r, a, settings] = await Promise.all([
+        getPRStats(),
+        getRecentPRsWithDelta(20),
+        getAllTimeBests(),
+        getBodySettings(),
+      ]);
+      if (cancelledRef.current) return;
+      setStats(s);
+      setRecentPRs(r);
+      setAllTimeBests(a);
+      setWeightUnit(settings.weight_unit as "kg" | "lb");
+    } catch (e) {
+      if (cancelledRef.current) return;
+      setError(e instanceof Error ? e.message : "Failed to load PR data");
+    } finally {
+      if (!cancelledRef.current) setLoading(false);
+    }
+  }, []);
 
   useFocusEffect(
     useCallback(() => {
-      let cancelled = false;
-
-      (async () => {
-        try {
-          setLoading(true);
-          setError(null);
-          const [s, r, a, settings] = await Promise.all([
-            getPRStats(),
-            getRecentPRsWithDelta(20),
-            getAllTimeBests(),
-            getBodySettings(),
-          ]);
-          if (cancelled) return;
-          setStats(s);
-          setRecentPRs(r);
-          setAllTimeBests(a);
-          setWeightUnit(settings.weight_unit as "kg" | "lb");
-        } catch (e) {
-          if (cancelled) return;
-          setError(e instanceof Error ? e.message : "Failed to load PR data");
-        } finally {
-          if (!cancelled) setLoading(false);
-        }
-      })();
-
+      cancelledRef.current = false;
+      void load();
       return () => {
-        cancelled = true;
+        cancelledRef.current = true;
       };
-    }, [])
+    }, [load])
   );
 
-  return { stats, recentPRs, allTimeBests, weightUnit, loading, error };
+  const reload = useCallback(() => {
+    cancelledRef.current = false;
+    void load();
+  }, [load]);
+
+  return { stats, recentPRs, allTimeBests, weightUnit, loading, error, reload };
 }


### PR DESCRIPTION
## Summary
Replaces the raw error text on the PR Dashboard (Personal Records screen) with a friendly, recoverable error state: alert icon, explanation, and a Retry button that re-invokes the data hook without leaving the screen.

## Changes
- **components/progress/records/PRDashboardError.tsx** (new) — Error view with `alert-circle-outline` icon, friendly title "Couldn't load your records", explanation, technical detail, and Retry button. Announces via `accessibilityLiveRegion='polite'` + `accessibilityRole='alert'` for screen readers.
- **hooks/usePRDashboard.ts** — Expose `reload()`. Refactored to `useRef`-based cancellation so the `useFocusEffect` cleanup and user-initiated reloads share the same cancellation model.
- **app/progress/records.tsx** — Swap raw-text error branch for `<PRDashboardError />`.
- **__tests__/components/progress/records.test.tsx** — Added 2 tests: error state rendering + a11y attributes, and retry-path regression covering transient failure recovery.

## Testing
- `npx jest __tests__/components/progress/records.test.tsx` → 6/6 pass (was 4/4, +2 new)
- `npx tsc --noEmit` → clean

## Issue
Resolves BLD-506