### PR TITLE
feat(summary): intercept Android hardware back via BackHandler (BLD-509)

### DIFF
--- a/__tests__/acceptance/summary-backhandler.acceptance.test.tsx
+++ b/__tests__/acceptance/summary-backhandler.acceptance.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Acceptance test for BLD-509:
+ * Android hardware back button on the workout summary screen must route
+ * through the same "Done" flow (tabs root) rather than the default
+ * behavior, which could navigate back into the live session or lose
+ * context.
+ */
+
+jest.mock('../../lib/db', () => ({
+  getSessionById: jest.fn().mockResolvedValue(null),
+  getSessionSets: jest.fn().mockResolvedValue([]),
+  getBodySettings: jest.fn().mockResolvedValue({
+    weight_unit: 'kg',
+    measurement_unit: 'cm',
+    sex: 'male',
+    weight_goal: null,
+    body_fat_goal: null,
+  }),
+  getSessionPRs: jest.fn().mockResolvedValue([]),
+  getSessionRepPRs: jest.fn().mockResolvedValue([]),
+  getSessionDurationPRs: jest.fn().mockResolvedValue([]),
+  getSessionWeightIncreases: jest.fn().mockResolvedValue([]),
+  getSessionComparison: jest.fn().mockResolvedValue(null),
+  getSessionSetCount: jest.fn().mockResolvedValue(0),
+  getExercisesByIds: jest.fn().mockResolvedValue({}),
+  buildAchievementContext: jest.fn().mockResolvedValue({}),
+  getEarnedAchievementIds: jest.fn().mockResolvedValue([]),
+  saveEarnedAchievements: jest.fn().mockResolvedValue(undefined),
+  updateSession: jest.fn().mockResolvedValue(undefined),
+}))
+
+const mockReplace = jest.fn()
+const mockUseFocusEffect = jest.fn((cb: () => void | (() => void)) => {
+  // Emulate expo-router/React Navigation: invoke the effect synchronously on
+  // focus so tests can observe subscription side-effects.
+  cb()
+})
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: mockReplace, back: jest.fn() }),
+  useLocalSearchParams: () => ({ id: 'sess-missing' }),
+  usePathname: () => '/session/summary/sess-missing',
+  useFocusEffect: (cb: () => void | (() => void)) => mockUseFocusEffect(cb),
+  Stack: { Screen: () => null },
+  Redirect: () => null,
+}))
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({
+  useLayout: () => ({ wide: false, width: 375, scale: 1.0 }),
+}))
+jest.mock('../../lib/errors', () => ({
+  logError: jest.fn(),
+  generateReport: jest.fn().mockResolvedValue('{}'),
+  getRecentErrors: jest.fn().mockResolvedValue([]),
+  generateGitHubURL: jest.fn().mockReturnValue('https://github.com'),
+}))
+jest.mock('../../lib/interactions', () => ({
+  log: jest.fn(),
+  recent: jest.fn().mockResolvedValue([]),
+}))
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+  NotificationFeedbackType: { Success: 'success', Warning: 'warning' },
+}))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+jest.mock('../../lib/units', () => ({
+  toDisplay: (v: number) => v,
+  toKg: (v: number) => v,
+  KG_TO_LB: 2.20462,
+  LB_TO_KG: 0.453592,
+}))
+jest.mock('victory-native', () => ({
+  CartesianChart: 'CartesianChart',
+  Line: 'Line',
+  Bar: 'Bar',
+}))
+jest.mock('../../lib/useProfileGender', () => ({
+  useProfileGender: () => 'male',
+}))
+jest.mock('../../components/MuscleMap', () => {
+  const React = require('react')
+  return {
+    MuscleMap: (props: Record<string, unknown>) =>
+      React.createElement('MuscleMap', props),
+  }
+})
+
+import React from 'react'
+import { BackHandler } from 'react-native'
+import { renderScreen } from '../helpers/render'
+import { resetIds } from '../helpers/factories'
+import Summary from '../../app/session/summary/[id]'
+
+describe('Workout Summary — Android hardware back handler (BLD-509)', () => {
+  let removeSpy: jest.Mock
+  let addSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIds()
+    removeSpy = jest.fn()
+    addSpy = jest
+      .spyOn(BackHandler, 'addEventListener')
+      .mockReturnValue({ remove: removeSpy } as unknown as ReturnType<typeof BackHandler.addEventListener>)
+  })
+
+  afterEach(() => {
+    addSpy.mockRestore()
+  })
+
+  it('registers a hardwareBackPress listener on focus', () => {
+    renderScreen(<Summary />)
+    expect(addSpy).toHaveBeenCalledWith('hardwareBackPress', expect.any(Function))
+  })
+
+  it('hardware back routes through the Done flow (replace to tabs root) and intercepts default behavior', () => {
+    renderScreen(<Summary />)
+    expect(addSpy).toHaveBeenCalled()
+    const handler = addSpy.mock.calls[0][1] as () => boolean
+
+    const result = handler()
+
+    // Returning true tells Android we handled the event — no default nav.
+    expect(result).toBe(true)
+    expect(mockReplace).toHaveBeenCalledWith('/(tabs)')
+  })
+
+  it('cleans up the listener when the screen loses focus', () => {
+    // The focus-effect callback returns a cleanup function. Our mock invokes
+    // the effect eagerly and returns the cleanup; call it to verify removal.
+    mockUseFocusEffect.mockImplementationOnce((cb: () => void | (() => void)) => {
+      const cleanup = cb()
+      if (typeof cleanup === 'function') cleanup()
+    })
+    renderScreen(<Summary />)
+    expect(removeSpy).toHaveBeenCalled()
+  })
+})

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -1,9 +1,9 @@
-import { useEffect, useMemo, useRef } from "react";
-import { Pressable, Share, StyleSheet, TextInput, View, FlatList } from "react-native";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { BackHandler, Pressable, Share, StyleSheet, TextInput, View, FlatList } from "react-native";
 import { Card, CardContent } from "@/components/ui/card";
 import { Text } from "@/components/ui/text";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
-import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { Stack, useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
 import { useLayout } from "../../../lib/layout";
 import { toDisplay } from "../../../lib/units";
 import { formatTime } from "../../../lib/format";
@@ -28,6 +28,19 @@ export default function Summary() {
   const layout = useLayout();
   const router = useRouter();
   const { id } = useLocalSearchParams<{ id: string }>();
+
+  // Intercept Android hardware back so post-workout summary always routes through
+  // the same "Done" flow (tabs root) rather than going back into the live session
+  // screen, which could confuse users or lose context (BLD-509).
+  useFocusEffect(
+    useCallback(() => {
+      const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+        router.replace("/(tabs)");
+        return true;
+      });
+      return () => sub.remove();
+    }, [router])
+  );
 
   const data = useSummaryData(id);
   const { session, completed, grouped, prs, repPrs, increases, comparison, unit, volume, setsBreakdown, newAchievements, completedSetCount, primaryMuscles, secondaryMuscles } = data;


### PR DESCRIPTION
## Summary

Adds a BackHandler listener (via `useFocusEffect`) to the workout summary screen so Android hardware back presses route through the same Done flow (`router.replace('/(tabs)')`) as the Done button. Without this, hardware back could navigate users back into the just-completed session screen and lose context.

## Changes

- `app/session/summary/[id].tsx`: register `BackHandler.addEventListener('hardwareBackPress', …)` inside `useFocusEffect`; handler replaces to tabs root and returns `true` to suppress default nav.
- `__tests__/acceptance/summary-backhandler.acceptance.test.tsx`: new acceptance test covering listener registration, hardware-back interception, and cleanup on unfocus.

## Testing

- `npx jest __tests__/acceptance/summary-backhandler.acceptance.test.tsx` ✅ 3 passing
- `npx jest __tests__/acceptance/workout-summary.acceptance.test.tsx` ✅ existing tests still green
- `npx -p typescript tsc --noEmit` ✅ zero errors
- `npx eslint app/session/summary/ __tests__/acceptance/summary-backhandler.acceptance.test.tsx` ✅ clean

## Issue

Resolves BLD-509