### PR TITLE
fix(toast): replace hardcoded colors with theme tokens (BLD-507)

### DIFF
--- a/__tests__/components/toast-item-tokens.test.ts
+++ b/__tests__/components/toast-item-tokens.test.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+
+// Regression test for BLD-507: toast-item must use theme tokens, not hardcoded
+// hex color literals. Catches drift back to raw #RRGGBB values.
+describe('toast-item theme-token contract', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../components/ui/toast-item.tsx'),
+    'utf8',
+  );
+
+  it('does not contain raw hex color literals', () => {
+    // Match any #RGB or #RRGGBB or #RRGGBBAA string literal (quoted).
+    const hexMatches = source.match(/['"]#[0-9a-fA-F]{3,8}['"]/g) ?? [];
+    expect(hexMatches).toEqual([]);
+  });
+
+  it('sources variant colors from Colors.dark.* tokens', () => {
+    expect(source).toMatch(/success:\s*Colors\.dark\.green/);
+    expect(source).toMatch(/error:\s*Colors\.dark\.red/);
+    expect(source).toMatch(/warning:\s*Colors\.dark\.orange/);
+    expect(source).toMatch(/info:\s*Colors\.dark\.blue/);
+    expect(source).toMatch(/MUTED\s*=\s*Colors\.dark\.textMuted/);
+  });
+});

--- a/components/ui/toast-item.tsx
+++ b/components/ui/toast-item.tsx
@@ -14,8 +14,16 @@ interface ToastProps extends ToastData { onDismiss: (id: string) => void; index:
 
 const TOAST_HEIGHT = 52;
 const TOAST_MARGIN = 8;
-const MUTED = '#8E8E93';
-const VARIANT_COLORS: Record<ToastVariant, string> = { success: '#30D158', error: '#FF453A', warning: '#FF9F0A', info: '#007AFF', default: MUTED };
+// Toast island always renders on a dark surface (Colors.dark.card), so semantic
+// colors are sourced from the dark palette to guarantee legibility.
+const MUTED = Colors.dark.textMuted;
+const VARIANT_COLORS: Record<ToastVariant, string> = {
+  success: Colors.dark.green,
+  error: Colors.dark.red,
+  warning: Colors.dark.orange,
+  info: Colors.dark.blue,
+  default: MUTED,
+};
 const VARIANT_ICONS: Record<string, React.ComponentType<{ size: number; color: string }>> = { success: Check, error: X, warning: AlertCircle, info: Info };
 
 export function Toast({ id, title, description, variant = 'default', onDismiss, index, action }: ToastProps) {


### PR DESCRIPTION
## Summary

Toast item was using hardcoded hex values (`#8E8E93`, `#30D158`, `#FF453A`, `#FF9F0A`, `#007AFF`) for variant colors and muted text. This violated the "tokens only" design principle and prevents theme-level color adjustments.

Because the toast island always renders against `Colors.dark.card` (a dark surface), the semantic colors are pulled from the dark palette to preserve legibility.

## Changes

- `components/ui/toast-item.tsx` — `MUTED` now `Colors.dark.textMuted`; `VARIANT_COLORS` pulls `success/error/warning/info` from `Colors.dark.{green,red,orange,blue}`.
- `__tests__/components/toast-item-tokens.test.ts` — regression test forbidding raw hex literals in `toast-item.tsx` and pinning the token mapping.

## Testing

- `npx -p typescript tsc --noEmit` — passes, 0 errors
- `npx jest __tests__/components/toast-item-tokens.test.ts __tests__/components/bna-toast.test.tsx` — 15/15 pass

## Issue

Resolves BLD-507

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>