### PR TITLE
fix(ux): use typography.statValue token in PRStatsRow (BLD-504)

### DIFF
--- a/components/progress/records/PRStatsRow.tsx
+++ b/components/progress/records/PRStatsRow.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Card } from "@/components/ui/card";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { typography } from "@/constants/design-tokens";
 import type { PRStats } from "@/lib/db/pr-dashboard";
 
 type Props = {
@@ -47,8 +48,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
   },
   statValue: {
-    fontSize: 28,
-    fontWeight: "700",
+    ...typography.statValue,
+    fontVariant: ["tabular-nums"],
     marginTop: 4,
   },
 });


### PR DESCRIPTION
## Summary

Replace hardcoded `fontSize: 28` / `fontWeight: 700` in `PRStatsRow` with the canonical `typography.statValue` design token from `@/constants/design-tokens`.

## Changes

- `components/progress/records/PRStatsRow.tsx`: spread `typography.statValue` into the `statValue` StyleSheet entry and re-declare `fontVariant: ['tabular-nums']` as a mutable array (same pattern used in `TimerRing.tsx`) to satisfy RN's `TextStyle` typing.
- Preserves existing `marginTop: 4` layout spacing.
- No other files changed.

## Effect

- Stat numbers now render at `fontSize 32` with `lineHeight 40`, `fontWeight 700`, and `tabular-nums` — matching the design system.

## Verification

- `npx -p typescript tsc --noEmit` passes with zero errors.
- `npx jest --findRelatedTests components/progress/records/PRStatsRow.tsx` — 6/6 pass (Records page acceptance suite).

## Issue

Resolves BLD-504.