### PR TITLE
feat: friendly user messages for Strava connection errors (BLD-505)

### DIFF
--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -411,3 +411,123 @@ describe("Strava Integration — Behavioral", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });
+
+describe("Strava Integration — Friendly Error Mapping (BLD-505)", () => {
+  const strava = require("../../lib/strava");
+
+  describe("getStravaUserMessage", () => {
+    it("maps auth_expired and auth_revoked to 'Connection expired' message", () => {
+      expect(strava.getStravaUserMessage(new strava.StravaError("auth_expired", "Token exchange failed: 401", 401)))
+        .toBe("Connection expired. Please try again.");
+      expect(strava.getStravaUserMessage(new strava.StravaError("auth_revoked", "revoked")))
+        .toBe("Connection expired. Please try again.");
+    });
+
+    it("maps network errors to 'Check your internet' message", () => {
+      expect(strava.getStravaUserMessage(new strava.StravaError("network", "Network request failed")))
+        .toBe("Check your internet and try again.");
+      // Raw TypeError from fetch is also treated as network
+      const fetchErr = new TypeError("Network request failed");
+      expect(strava.getStravaUserMessage(fetchErr)).toBe("Check your internet and try again.");
+    });
+
+    it("maps rate_limit to a 'too many requests' message", () => {
+      expect(strava.getStravaUserMessage(new strava.StravaError("rate_limit", "429", 429)))
+        .toMatch(/too many requests/i);
+    });
+
+    it("maps server errors to a polite 'try again soon' message", () => {
+      expect(strava.getStravaUserMessage(new strava.StravaError("server", "500", 500)))
+        .toMatch(/strava is having trouble/i);
+    });
+
+    it("maps config errors to a contact-support message", () => {
+      expect(strava.getStravaUserMessage(new strava.StravaError("config", "Strava proxy URL not configured")))
+        .toMatch(/isn't set up correctly.*contact support/i);
+    });
+
+    it("falls back to generic message for unknown errors (no raw API text leaks)", () => {
+      expect(strava.getStravaUserMessage(new Error("Token exchange failed: 500")))
+        .toBe("Something went wrong connecting to Strava.");
+      expect(strava.getStravaUserMessage("some random thing"))
+        .toBe("Something went wrong connecting to Strava.");
+      expect(strava.getStravaUserMessage(new strava.StravaError("unknown", "??")))
+        .toBe("Something went wrong connecting to Strava.");
+    });
+  });
+
+  describe("connectStrava throws typed StravaError", () => {
+    const AuthSession = require("expo-auth-session");
+    const mockFetch = jest.fn();
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      global.fetch = mockFetch;
+      AuthSession.AuthRequest.mockImplementation(() => ({
+        promptAsync: jest.fn().mockResolvedValue({
+          type: "success",
+          params: { code: "auth-code-xyz" },
+        }),
+      }));
+    });
+
+    afterAll(() => {
+      global.fetch = originalFetch;
+    });
+
+    it("throws StravaError(auth_expired) on 401 from token exchange", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+      await expect(strava.connectStrava()).rejects.toMatchObject({
+        name: "StravaError",
+        code: "auth_expired",
+        status: 401,
+      });
+    });
+
+    it("throws StravaError(server) on 5xx from token exchange", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 503 });
+      await expect(strava.connectStrava()).rejects.toMatchObject({
+        name: "StravaError",
+        code: "server",
+        status: 503,
+      });
+    });
+
+    it("throws StravaError(network) when fetch rejects with a network error", async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError("Network request failed"));
+      await expect(strava.connectStrava()).rejects.toMatchObject({
+        name: "StravaError",
+        code: "network",
+      });
+    });
+
+    it("thrown errors map to user-friendly toast copy (no raw status leakage)", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+      try {
+        await strava.connectStrava();
+        throw new Error("expected throw");
+      } catch (err) {
+        const msg = strava.getStravaUserMessage(err);
+        expect(msg).toBe("Connection expired. Please try again.");
+        expect(msg).not.toMatch(/401|token exchange/i);
+      }
+    });
+  });
+});
+
+describe("Strava Integration — IntegrationsCard wiring (BLD-505)", () => {
+  const fs = require("fs");
+  const path = require("path");
+  const integrationsSrc = fs.readFileSync(
+    path.resolve(__dirname, "../../components/settings/IntegrationsCard.tsx"),
+    "utf-8"
+  );
+
+  it("uses getStravaUserMessage for the connect error path", () => {
+    expect(integrationsSrc).toContain("getStravaUserMessage");
+    expect(integrationsSrc).toContain("toast.error(getStravaUserMessage(err))");
+    // Old raw-message path must be gone
+    expect(integrationsSrc).not.toMatch(/toast\.error\(err instanceof Error \? err\.message/);
+  });
+});

--- a/components/settings/IntegrationsCard.tsx
+++ b/components/settings/IntegrationsCard.tsx
@@ -9,7 +9,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import { flowCardStyle } from "@/components/ui/FlowContainer";
 import { fontSizes } from "@/constants/design-tokens";
 import { setAppSetting } from "@/lib/db";
-import { connectStrava, disconnect as disconnectStrava } from "@/lib/strava";
+import { connectStrava, disconnect as disconnectStrava, getStravaUserMessage } from "@/lib/strava";
 import type { ThemeColors } from "@/hooks/useThemeColors";
 import type { useToast } from "@/components/ui/bna-toast";
 
@@ -78,7 +78,10 @@ export default function IntegrationsCard({
                     const result = await connectStrava();
                     if (result) { setStravaAthlete(result.athleteName); toast.success("Connected to Strava!"); }
                   } catch (err) {
-                    toast.error(err instanceof Error ? err.message : "Connection failed");
+                    if (__DEV__) {
+                      console.warn("Strava connect failed:", err);
+                    }
+                    toast.error(getStravaUserMessage(err));
                   } finally { setStravaLoading(false); }
                 }}
                 loading={stravaLoading}

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -17,6 +17,75 @@ import {
   getBodySettings,
 } from "./db";
 
+// ---- Error classification ----
+
+export type StravaErrorCode =
+  | "auth_expired"
+  | "auth_revoked"
+  | "network"
+  | "rate_limit"
+  | "server"
+  | "config"
+  | "unknown";
+
+export class StravaError extends Error {
+  public readonly code: StravaErrorCode;
+  public readonly status?: number;
+  constructor(code: StravaErrorCode, message: string, status?: number) {
+    super(message);
+    this.name = "StravaError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function classifyHttpStatus(status: number): StravaErrorCode {
+  if (status === 401 || status === 403) return "auth_expired";
+  if (status === 429) return "rate_limit";
+  if (status >= 500) return "server";
+  return "unknown";
+}
+
+function isNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  // React Native fetch surfaces TypeError with "Network request failed"
+  // Node/browsers use TypeError with "Failed to fetch".
+  const msg = err.message || "";
+  return (
+    err.name === "TypeError" ||
+    /network request failed|failed to fetch|networkerror|timeout|timed out/i.test(msg)
+  );
+}
+
+/**
+ * Maps any thrown value from Strava flows into a user-friendly message.
+ * Leaves technical details (status, raw message) for logs only.
+ */
+export function getStravaUserMessage(err: unknown): string {
+  if (err instanceof StravaError) {
+    switch (err.code) {
+      case "auth_expired":
+      case "auth_revoked":
+        return "Connection expired. Please try again.";
+      case "network":
+        return "Check your internet and try again.";
+      case "rate_limit":
+        return "Too many requests. Please wait a moment and try again.";
+      case "server":
+        return "Strava is having trouble right now. Please try again soon.";
+      case "config":
+        return "Strava isn't set up correctly. Please contact support.";
+      case "unknown":
+      default:
+        return "Something went wrong connecting to Strava.";
+    }
+  }
+  if (isNetworkError(err)) {
+    return "Check your internet and try again.";
+  }
+  return "Something went wrong connecting to Strava.";
+}
+
 // Strava API constants
 const STRAVA_AUTH_URL = "https://www.strava.com/oauth/mobile/authorize";
 const STRAVA_API_BASE = "https://www.strava.com/api/v3";
@@ -159,10 +228,18 @@ export async function connectStrava(): Promise<{
 
   const clientId = getClientId();
   if (!clientId) {
-    throw new Error("Strava client ID not configured");
+    throw new StravaError("config", "Strava client ID not configured");
   }
 
-  const proxyUrl = getProxyUrl();
+  let proxyUrl: string;
+  try {
+    proxyUrl = getProxyUrl();
+  } catch (err) {
+    throw new StravaError(
+      "config",
+      err instanceof Error ? err.message : "Strava proxy URL not configured"
+    );
+  }
 
   const authRequest = new AuthSession.AuthRequest({
     clientId,
@@ -180,16 +257,34 @@ export async function connectStrava(): Promise<{
   }
 
   // Exchange authorization code for tokens via proxy
-  const tokenResponse = await fetch(`${proxyUrl}/token`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      code: result.params.code,
-    }),
-  });
+  let tokenResponse: Response;
+  try {
+    tokenResponse = await fetch(`${proxyUrl}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        code: result.params.code,
+      }),
+    });
+  } catch (err) {
+    if (isNetworkError(err)) {
+      throw new StravaError(
+        "network",
+        err instanceof Error ? err.message : "Network request failed"
+      );
+    }
+    throw new StravaError(
+      "unknown",
+      err instanceof Error ? err.message : String(err)
+    );
+  }
 
   if (!tokenResponse.ok) {
-    throw new Error(`Token exchange failed: ${tokenResponse.status}`);
+    throw new StravaError(
+      classifyHttpStatus(tokenResponse.status),
+      `Token exchange failed: ${tokenResponse.status}`,
+      tokenResponse.status
+    );
   }
 
   const data = await tokenResponse.json();


### PR DESCRIPTION
## Summary
Replaces raw API error strings (e.g. "Token exchange failed: 401") surfaced to users in the Strava connect toast with friendly, human-readable copy that matches the BLD-503 UX spec.

## Changes
- **lib/strava.ts** — New `StravaError` class with typed codes (`auth_expired`, `auth_revoked`, `network`, `rate_limit`, `server`, `config`, `unknown`). `connectStrava()` now classifies HTTP status + catches fetch-level network errors and throws typed errors. New `getStravaUserMessage(err)` exports a safe, friendly mapper used by the UI.
- **components/settings/IntegrationsCard.tsx** — Connect error branch now calls `getStravaUserMessage(err)` for the toast. Original error is logged via `console.warn` in `__DEV__` so we don't lose debugging signal.
- **__tests__/lib/strava.test.ts** — +11 tests covering mapper behaviour (auth/network/429/5xx/config/fallback), typed errors thrown from `connectStrava` on 401/5xx/network, no-leakage assertion, and a structural guard that IntegrationsCard wires the mapper.

## Message map (per spec)
| Code | Toast copy |
| --- | --- |
| 401 / 403 | Connection expired. Please try again. |
| Network  | Check your internet and try again. |
| 429      | Too many requests. Please wait a moment and try again. |
| 5xx      | Strava is having trouble right now. Please try again soon. |
| Config   | Strava isn't set up correctly. Please contact support. |
| Other    | Something went wrong connecting to Strava. |

## Testing
- `npx jest __tests__/lib/strava.test.ts` → 37/37 pass (+11 new)
- `npx tsc --noEmit` → clean

## Issue
Resolves BLD-505