### PR TITLE
fix: use scrim tokens and numeric maxHeight in SummaryFooter (BLD-508)

### DIFF
--- a/__tests__/components/SummaryFooter.styles.test.tsx
+++ b/__tests__/components/SummaryFooter.styles.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * BLD-508: Lock style contract for SummaryFooter share preview modal.
+ * - shareCardWrapper must NOT contain `transformOrigin` (invalid in RN).
+ * - previewContainer `maxHeight` must be a number (not a percentage string).
+ * - previewOverlay / previewActions must use the `scrim` design tokens.
+ */
+
+import React from 'react'
+import { StyleSheet, Dimensions } from 'react-native'
+import { render } from '@testing-library/react-native'
+import SummaryFooter from '../../components/session/summary/SummaryFooter'
+import { scrim } from '../../constants/design-tokens'
+
+jest.mock('../../components/ShareCard', () => {
+  const React = require('react')
+  return {
+    __esModule: true,
+    default: (props: Record<string, unknown>) =>
+      React.createElement('ShareCard', props),
+  }
+})
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof SummaryFooter>> = {}) {
+  return {
+    colors: {
+      surface: '#fff',
+      surfaceVariant: '#eee',
+      onSurface: '#000',
+      onSurfaceDisabled: '#888',
+      outline: '#ccc',
+      primary: '#0af',
+    } as unknown as React.ComponentProps<typeof SummaryFooter>['colors'],
+    session: { completed_at: 1700000000, name: 'Test workout' },
+    completedSetCount: 5,
+    templateModalVisible: false,
+    setTemplateModalVisible: jest.fn(),
+    templateName: '',
+    setTemplateName: jest.fn(),
+    saving: false,
+    handleSaveAsTemplate: jest.fn(),
+    onDone: jest.fn(),
+    onViewDetails: jest.fn(),
+    onSharePress: jest.fn(),
+    previewVisible: true,
+    setPreviewVisible: jest.fn(),
+    imageLoading: false,
+    setImageLoading: jest.fn(),
+    shareCardRef: { current: null },
+    handleCaptureAndShare: jest.fn(),
+    shareCardDate: '2026-01-01',
+    duration: '1h',
+    completedCount: 5,
+    volumeDisplay: '1000',
+    unit: 'kg' as const,
+    rating: 4,
+    shareCardPrs: [],
+    shareCardExercises: [],
+    ...overrides,
+  }
+}
+
+describe('SummaryFooter — share preview style contract (BLD-508)', () => {
+  it('does not set transformOrigin on share card wrapper', () => {
+    const screen = render(<SummaryFooter {...makeProps()} />)
+    const wrapper = screen.getByTestId('summary-share-card-wrapper')
+    const flat = StyleSheet.flatten(wrapper.props.style) ?? {}
+    expect(flat).not.toHaveProperty('transformOrigin')
+  })
+
+  it('uses a numeric maxHeight on preview container (not percentage string)', () => {
+    const screen = render(<SummaryFooter {...makeProps()} />)
+    const container = screen.getByTestId('summary-preview-container')
+    const flat = StyleSheet.flatten(container.props.style) ?? {}
+    expect(typeof flat.maxHeight).toBe('number')
+    const expected = Dimensions.get('window').height * 0.85
+    expect(flat.maxHeight).toBeCloseTo(expected, 5)
+  })
+
+  it('preview overlay uses the heavy scrim token', () => {
+    const screen = render(<SummaryFooter {...makeProps()} />)
+    const overlay = screen.getByTestId('summary-preview-overlay')
+    const flat = StyleSheet.flatten(overlay.props.style) ?? {}
+    expect(flat.backgroundColor).toBe(scrim.heavy)
+  })
+
+  it('preview actions bar uses the light scrim token', () => {
+    const screen = render(<SummaryFooter {...makeProps()} />)
+    const actions = screen.getByTestId('summary-preview-actions')
+    const flat = StyleSheet.flatten(actions.props.style) ?? {}
+    expect(flat.backgroundColor).toBe(scrim.light)
+  })
+})

--- a/components/session/summary/SummaryFooter.tsx
+++ b/components/session/summary/SummaryFooter.tsx
@@ -1,11 +1,11 @@
-import { ActivityIndicator, Modal, StyleSheet, TextInput, View } from "react-native";
+import { ActivityIndicator, Dimensions, Modal, StyleSheet, TextInput, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import ShareCard from "@/components/ShareCard";
 import type { ShareCardExercise, ShareCardPR } from "@/components/ShareCard";
 import type { ThemeColors } from "@/hooks/useThemeColors";
 import type { RefObject } from "react";
-import { fontSizes } from "@/constants/design-tokens";
+import { fontSizes, scrim } from "@/constants/design-tokens";
 
 type Props = {
   colors: ThemeColors;
@@ -104,10 +104,10 @@ export default function SummaryFooter({
         onRequestClose={() => { setPreviewVisible(false); setImageLoading(false); }}
         accessibilityViewIsModal
       >
-        <View style={styles.previewOverlay}>
-          <View style={styles.previewContainer}>
+        <View style={styles.previewOverlay} testID="summary-preview-overlay">
+          <View style={styles.previewContainer} testID="summary-preview-container">
             <View style={styles.previewScrollContent}>
-              <View ref={shareCardRef} collapsable={false} style={styles.shareCardWrapper}>
+              <View ref={shareCardRef} collapsable={false} style={styles.shareCardWrapper} testID="summary-share-card-wrapper">
                 <ShareCard
                   name={session?.name ?? "Workout"}
                   date={shareCardDate}
@@ -121,7 +121,7 @@ export default function SummaryFooter({
                 />
               </View>
             </View>
-            <View style={styles.previewActions}>
+            <View style={styles.previewActions} testID="summary-preview-actions">
               {imageLoading ? (
                 <ActivityIndicator size="large" color={colors.primary} />
               ) : (
@@ -141,14 +141,14 @@ export default function SummaryFooter({
 const styles = StyleSheet.create({
   actions: { marginTop: 16, gap: 12 },
   actionBtn: { borderRadius: 8 },
-  modalOverlay: { flex: 1, backgroundColor: "rgba(0,0,0,0.5)", justifyContent: "center", alignItems: "center", padding: 24 },
+  modalOverlay: { flex: 1, backgroundColor: scrim.light, justifyContent: "center", alignItems: "center", padding: 24 },
   modalContent: { width: "100%", maxWidth: 400, borderRadius: 16, padding: 24 },
   modalInput: { borderWidth: 1, borderRadius: 8, padding: 12, fontSize: fontSizes.base, marginBottom: 16 },
   modalActions: { flexDirection: "row", justifyContent: "flex-end", gap: 8 },
-  previewOverlay: { flex: 1, backgroundColor: "rgba(0,0,0,0.7)", justifyContent: "center", alignItems: "center", padding: 16 },
-  previewContainer: { width: "100%", maxWidth: 400, maxHeight: "85%", borderRadius: 16, overflow: "hidden" },
+  previewOverlay: { flex: 1, backgroundColor: scrim.heavy, justifyContent: "center", alignItems: "center", padding: 16 },
+  previewContainer: { width: "100%", maxWidth: 400, maxHeight: Dimensions.get("window").height * 0.85, borderRadius: 16, overflow: "hidden" },
   previewScrollContent: { alignItems: "center", padding: 8 },
-  shareCardWrapper: { alignSelf: "center", transform: [{ scale: 0.3 }], transformOrigin: "top center" },
-  previewActions: { flexDirection: "row", justifyContent: "center", gap: 12, paddingVertical: 16, paddingHorizontal: 24, backgroundColor: "rgba(0,0,0,0.5)" },
+  shareCardWrapper: { alignSelf: "center", transform: [{ scale: 0.3 }] },
+  previewActions: { flexDirection: "row", justifyContent: "center", gap: 12, paddingVertical: 16, paddingHorizontal: 24, backgroundColor: scrim.light },
   previewBtn: { flex: 1, borderRadius: 8 },
 });

--- a/constants/design-tokens.ts
+++ b/constants/design-tokens.ts
@@ -151,4 +151,5 @@ export type SpringConfigKey = keyof typeof springConfig;
 export const scrim = {
   light: "rgba(0,0,0,0.5)",
   dark: "rgba(0,0,0,0.5)",
+  heavy: "rgba(0,0,0,0.7)",
 } as const;


### PR DESCRIPTION
## Summary

Addresses UX audit findings (BLD-508) on `components/session/summary/SummaryFooter.tsx`.

## Changes

- Remove invalid `transformOrigin: 'top center'` (CSS-only; ignored on RN native, noisy on web).
- Replace hardcoded `rgba(0,0,0,0.5)` / `rgba(0,0,0,0.7)` overlays with `scrim.light` / `scrim.heavy` design tokens.
- Add `scrim.heavy` (`rgba(0,0,0,0.7)`) to `constants/design-tokens.ts`.
- Replace fragile `maxHeight: '85%'` with `Dimensions.get('window').height * 0.85`.
- Add `testID`s and a style-contract unit test (`__tests__/components/SummaryFooter.styles.test.tsx`) that locks:
  - no `transformOrigin` on the share card wrapper
  - numeric `maxHeight` on preview container
  - correct scrim token on preview overlay + actions bar

## Testing

- `npx -p typescript tsc --noEmit` — 0 errors
- `npx jest` — 148 suites / 1805 tests pass (includes 4 new BLD-508 tests)

## Issue

Resolves BLD-508