### PR TITLE
fix: refresh body profile unit labels when settings unit changes (BLD-515, GH #311)

### DIFF
--- a/__tests__/components/BodyProfileCard.unitRefresh.test.tsx
+++ b/__tests__/components/BodyProfileCard.unitRefresh.test.tsx
@@ -1,0 +1,200 @@
+import React from 'react'
+import { waitFor, act } from '@testing-library/react-native'
+import { renderScreen } from '../helpers/render'
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  useLocalSearchParams: () => ({}),
+  usePathname: () => '/test',
+  useFocusEffect: jest.fn(),
+  Stack: { Screen: () => null },
+  Redirect: () => null,
+}))
+
+jest.mock('@react-navigation/native', () => {
+  const RealReact = require('react')
+  return {
+    // Use [cb] dep so callback-identity changes re-fire while focused —
+    // matches react-navigation's actual behavior and exposes regressions
+    // where load is unintentionally tied to props (BLD-515 review).
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [cb])
+    },
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({
+  useLayout: () => ({ wide: false, width: 375, scale: 1.0, horizontalPadding: 16 }),
+}))
+
+jest.mock('../../lib/db', () => {
+  const SAVED = JSON.stringify({
+    birthYear: 1990,
+    weight: 70,
+    height: 175,
+    sex: 'male',
+    activityLevel: 'moderately_active',
+    goal: 'maintain',
+    weightUnit: 'kg',
+    heightUnit: 'cm',
+  })
+  return {
+    getAppSetting: jest.fn().mockImplementation((key: string) => {
+      if (key === 'nutrition_profile') return Promise.resolve(SAVED)
+      return Promise.resolve(null)
+    }),
+    setAppSetting: jest.fn().mockResolvedValue(undefined),
+    updateMacroTargets: jest.fn().mockResolvedValue(undefined),
+    getBodySettings: jest.fn().mockResolvedValue({
+      weight_unit: 'kg',
+      measurement_unit: 'cm',
+      sex: 'male',
+      weight_goal: null,
+      body_fat_goal: null,
+    }),
+  }
+})
+
+jest.mock('../../lib/db/body', () => ({
+  getBodySettings: jest.fn().mockResolvedValue({
+    weight_unit: 'kg',
+    measurement_unit: 'cm',
+    sex: 'male',
+    weight_goal: null,
+    body_fat_goal: null,
+  }),
+  getLatestBodyWeight: jest.fn().mockResolvedValue(null),
+  updateBodySex: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../../lib/nutrition-calc', () => ({
+  ACTIVITY_LABELS: {
+    sedentary: 'Sedentary',
+    lightly_active: 'Lightly Active',
+    moderately_active: 'Moderately Active',
+    very_active: 'Very Active',
+    extra_active: 'Extra Active',
+  },
+  ACTIVITY_DESCRIPTIONS: {
+    sedentary: '', lightly_active: '', moderately_active: '', very_active: '', extra_active: '',
+  },
+  GOAL_LABELS: { cut: 'Cut', maintain: 'Maintain', bulk: 'Bulk' },
+  calculateFromProfile: jest.fn().mockReturnValue({ calories: 2200, protein: 150, carbs: 275, fat: 73 }),
+  calculateBMR: jest.fn().mockReturnValue(1700),
+  convertToMetric: jest.fn().mockReturnValue({ weight_kg: 70, height_cm: 175 }),
+  calculateDeviationPercent: jest.fn().mockReturnValue(0),
+  migrateProfile: (p: unknown) => p,
+}))
+
+import BodyProfileCard from '../../components/BodyProfileCard'
+
+type HarnessHandle = {
+  setW: (v: 'kg' | 'lb') => void
+  setH: (v: 'cm' | 'in') => void
+}
+
+const Harness = React.forwardRef<HarnessHandle, { initialWeight?: 'kg' | 'lb'; initialHeight?: 'cm' | 'in' }>(
+  function Harness({ initialWeight = 'kg', initialHeight = 'cm' }, ref) {
+    const [w, setW] = React.useState<'kg' | 'lb'>(initialWeight)
+    const [h, setH] = React.useState<'cm' | 'in'>(initialHeight)
+    React.useImperativeHandle(ref, () => ({ setW, setH }), [])
+    return <BodyProfileCard weightUnit={w} heightUnit={h} />
+  },
+)
+
+describe('BodyProfileCard — unit prop refresh (GH #311)', () => {
+  it('renders label in kg when prop is kg', async () => {
+    const { findByLabelText } = renderScreen(<BodyProfileCard weightUnit="kg" heightUnit="cm" />)
+    await findByLabelText('Weight in kg')
+    await findByLabelText('Height in cm')
+  })
+
+  it('switches label and converts value when weightUnit prop changes from kg → lb', async () => {
+    const handle = React.createRef<HarnessHandle>()
+    const { findByLabelText, queryByLabelText } = renderScreen(<Harness ref={handle} />)
+
+    const kgInput = await findByLabelText('Weight in kg')
+    expect(kgInput.props.value).toBe('70')
+
+    await act(async () => {
+      handle.current!.setW('lb')
+    })
+
+    await waitFor(() => {
+      expect(queryByLabelText('Weight in lb')).not.toBeNull()
+    })
+    const lbInput = await findByLabelText('Weight in lb')
+    expect(lbInput.props.value).toBe('154.3')
+    expect(queryByLabelText('Weight in kg')).toBeNull()
+  })
+
+  it('switches label and converts height when heightUnit prop changes from cm → in', async () => {
+    const handle = React.createRef<HarnessHandle>()
+    const { findByLabelText, queryByLabelText } = renderScreen(<Harness ref={handle} />)
+
+    const cmInput = await findByLabelText('Height in cm')
+    expect(cmInput.props.value).toBe('175')
+
+    await act(async () => {
+      handle.current!.setH('in')
+    })
+
+    await waitFor(() => {
+      expect(queryByLabelText('Height in in')).not.toBeNull()
+    })
+    const inInput = await findByLabelText('Height in in')
+    expect(inInput.props.value).toBe('68.9')
+    expect(queryByLabelText('Height in cm')).toBeNull()
+  })
+
+  it('is symmetric: lb → kg conversion also works', async () => {
+    const handle = React.createRef<HarnessHandle>()
+    const { findByLabelText } = renderScreen(<Harness ref={handle} />)
+    await findByLabelText('Weight in kg')
+
+    await act(async () => {
+      handle.current!.setW('lb')
+    })
+    const lbInput = await findByLabelText('Weight in lb')
+    expect(lbInput.props.value).toBe('154.3')
+
+    await act(async () => {
+      handle.current!.setW('kg')
+    })
+    const kgInput = await findByLabelText('Weight in kg')
+    expect(parseFloat(kgInput.props.value)).toBeCloseTo(70, 1)
+  })
+
+  // Regression test for review feedback (BLD-515): an in-progress unsaved
+  // edit must survive a unit toggle. Previously, loadProfile depended on the
+  // external unit props via useCallback, so useFocusEffect re-fired on
+  // toggle and clobbered the edit with the persisted (70 kg) value.
+  it('preserves in-progress unsaved edit when unit toggles (regression)', async () => {
+    const { fireEvent } = require('@testing-library/react-native')
+    const handle = React.createRef<HarnessHandle>()
+    const { findByLabelText } = renderScreen(<Harness ref={handle} />)
+
+    const kgInput = await findByLabelText('Weight in kg')
+    expect(kgInput.props.value).toBe('70')
+
+    // User edits weight in-place to 72 kg
+    await act(async () => {
+      fireEvent.changeText(kgInput, '72')
+    })
+
+    // User toggles unit kg → lb without leaving the screen
+    await act(async () => {
+      handle.current!.setW('lb')
+    })
+
+    const lbInput = await findByLabelText('Weight in lb')
+    // 72 kg * 2.20462 = 158.7 — the EDITED value converted, NOT the
+    // persisted 70 kg (which would convert to 154.3).
+    expect(lbInput.props.value).toBe('158.7')
+    expect(lbInput.props.value).not.toBe('154.3')
+  })
+})

--- a/__tests__/lib/units.test.ts
+++ b/__tests__/lib/units.test.ts
@@ -1,4 +1,4 @@
-import { KG_TO_LB, LB_TO_KG, toDisplay, toKg } from "../../lib/units";
+import { KG_TO_LB, LB_TO_KG, toDisplay, toKg, convertWeight, convertHeight } from "../../lib/units";
 
 describe("units", () => {
   describe("constants", () => {
@@ -72,6 +72,37 @@ describe("units", () => {
     it("handles very large values", () => {
       const kg = toKg(1000, "lb");
       expect(kg).toBeCloseTo(453.6, 0);
+    });
+  });
+
+  describe("convertWeight", () => {
+    it("returns rounded same value when from == to", () => {
+      expect(convertWeight(70, "kg", "kg")).toBe(70);
+      expect(convertWeight(70.156, "kg", "kg")).toBe(70.2);
+    });
+    it("converts kg → lb rounded to 1 decimal", () => {
+      expect(convertWeight(70, "kg", "lb")).toBe(154.3);
+      expect(convertWeight(100, "kg", "lb")).toBe(220.5);
+    });
+    it("converts lb → kg rounded to 1 decimal", () => {
+      expect(convertWeight(154.3, "lb", "kg")).toBeCloseTo(70, 1);
+    });
+    it("is approximately round-trippable", () => {
+      const lb = convertWeight(72, "kg", "lb");
+      const back = convertWeight(lb, "lb", "kg");
+      expect(back).toBeCloseTo(72, 1);
+    });
+  });
+
+  describe("convertHeight", () => {
+    it("returns rounded same value when from == to", () => {
+      expect(convertHeight(175, "cm", "cm")).toBe(175);
+    });
+    it("converts cm → in rounded to 1 decimal", () => {
+      expect(convertHeight(175, "cm", "in")).toBe(68.9);
+    });
+    it("converts in → cm rounded to 1 decimal", () => {
+      expect(convertHeight(68.9, "in", "cm")).toBeCloseTo(175, 0);
     });
   });
 });

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -94,7 +94,7 @@ export default function Settings() {
           fatGoal={fatGoal}
         />
         <AppearanceCard colors={colors} />
-        <BodyProfileCard />
+        <BodyProfileCard weightUnit={weightUnit} heightUnit={measureUnit} />
         <FrequencyGoalPicker
           colors={colors}
           value={weeklyGoal}

--- a/components/BodyProfileCard.tsx
+++ b/components/BodyProfileCard.tsx
@@ -10,9 +10,14 @@ import { BodyProfileForm } from "./BodyProfileForm";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useBodyProfile } from "@/hooks/useBodyProfile";
 
-export default function BodyProfileCard() {
+type BodyProfileCardProps = {
+  weightUnit?: "kg" | "lb";
+  heightUnit?: "cm" | "in";
+};
+
+export default function BodyProfileCard({ weightUnit, heightUnit }: BodyProfileCardProps = {}) {
   const colors = useThemeColors();
-  const profile = useBodyProfile();
+  const profile = useBodyProfile(weightUnit, heightUnit);
   const cardStyle = StyleSheet.flatten([styles.card, { backgroundColor: colors.surface }]);
 
   if (profile.cardState === "loading") {

--- a/hooks/useBodyProfile.ts
+++ b/hooks/useBodyProfile.ts
@@ -14,6 +14,7 @@ import {
   type NutritionProfile,
   type Sex,
 } from "../lib/nutrition-calc";
+import { convertWeight, convertHeight } from "../lib/units";
 
 type CardState = "loading" | "error" | "ready";
 
@@ -32,7 +33,10 @@ function validateField(field: string, value: string): string | null {
   return null;
 }
 
-export function useBodyProfile() {
+export function useBodyProfile(
+  externalWeightUnit?: "kg" | "lb",
+  externalHeightUnit?: "cm" | "in",
+) {
   const [cardState, setCardState] = useState<CardState>("loading");
   const [birthYear, setBirthYear] = useState("");
   const [weight, setWeight] = useState("");
@@ -49,6 +53,17 @@ export function useBodyProfile() {
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMounted = useRef(true);
   const initialSnapshot = useRef<string | null>(null);
+  // Refs hold the latest external unit overrides so loadProfile can read them
+  // at call-time without becoming unit-dependent. Keeping loadProfile's
+  // useCallback deps stable prevents useFocusEffect from re-firing on every
+  // unit toggle and clobbering the user's in-progress edits with the
+  // persisted profile values (regression caught in BLD-515 review).
+  const externalWeightUnitRef = useRef(externalWeightUnit);
+  const externalHeightUnitRef = useRef(externalHeightUnit);
+  useEffect(() => {
+    externalWeightUnitRef.current = externalWeightUnit;
+    externalHeightUnitRef.current = externalHeightUnit;
+  });
 
   useEffect(() => {
     return () => {
@@ -56,6 +71,35 @@ export function useBodyProfile() {
       if (saveTimer.current) clearTimeout(saveTimer.current);
     };
   }, []);
+
+  // React to external unit changes (e.g. user toggles unit in settings UnitsCard
+  // on the same screen) — convert the currently-displayed value to the new unit
+  // so the label and numeric value stay in sync. Uses the "adjusting state during
+  // render" pattern (https://react.dev/reference/react/useState#storing-information-from-previous-renders)
+  // to avoid effect-triggered cascading renders.
+  const [prevExternalWeightUnit, setPrevExternalWeightUnit] = useState(externalWeightUnit);
+  if (externalWeightUnit && externalWeightUnit !== prevExternalWeightUnit) {
+    setPrevExternalWeightUnit(externalWeightUnit);
+    if (externalWeightUnit !== weightUnit) {
+      const n = parseFloat(weight);
+      if (weight && !isNaN(n) && n > 0) {
+        setWeight(String(convertWeight(n, weightUnit, externalWeightUnit)));
+      }
+      setWeightUnit(externalWeightUnit);
+    }
+  }
+
+  const [prevExternalHeightUnit, setPrevExternalHeightUnit] = useState(externalHeightUnit);
+  if (externalHeightUnit && externalHeightUnit !== prevExternalHeightUnit) {
+    setPrevExternalHeightUnit(externalHeightUnit);
+    if (externalHeightUnit !== heightUnit) {
+      const n = parseFloat(height);
+      if (height && !isNaN(n) && n > 0) {
+        setHeight(String(convertHeight(n, heightUnit, externalHeightUnit)));
+      }
+      setHeightUnit(externalHeightUnit);
+    }
+  }
 
   const loadProfile = useCallback(async () => {
     setCardState("loading");
@@ -66,23 +110,42 @@ export function useBodyProfile() {
         getLatestBodyWeight(),
       ]);
 
-      setWeightUnit(bodySettings.weight_unit);
-      setHeightUnit(bodySettings.measurement_unit);
+      const activeWeightUnit = externalWeightUnitRef.current ?? bodySettings.weight_unit;
+      const activeHeightUnit = externalHeightUnitRef.current ?? bodySettings.measurement_unit;
+      setWeightUnit(activeWeightUnit);
+      setHeightUnit(activeHeightUnit);
       setSex(bodySettings.sex);
 
       if (saved) {
         const profile: NutritionProfile = migrateProfile(JSON.parse(saved));
         setBirthYear(String(profile.birthYear));
-        setWeight(String(profile.weight));
-        setHeight(String(profile.height));
+        const displayWeight = convertWeight(
+          profile.weight,
+          profile.weightUnit,
+          activeWeightUnit,
+        );
+        const displayHeight = convertHeight(
+          profile.height,
+          profile.heightUnit,
+          activeHeightUnit,
+        );
+        setWeight(String(displayWeight));
+        setHeight(String(displayHeight));
         setActivityLevel(profile.activityLevel);
         setGoal(profile.goal);
         if (profile.rmr_override != null && profile.rmr_override > 0) {
           setRmrOverride(String(profile.rmr_override));
         }
-        initialSnapshot.current = JSON.stringify(profile);
+        initialSnapshot.current = JSON.stringify({
+          ...profile,
+          weight: displayWeight,
+          height: displayHeight,
+          weightUnit: activeWeightUnit,
+          heightUnit: activeHeightUnit,
+        });
       } else if (latestWeight) {
-        setWeight(String(latestWeight.weight));
+        const display = convertWeight(latestWeight.weight, "kg", activeWeightUnit);
+        setWeight(String(display));
       }
       setCardState("ready");
     } catch {

--- a/lib/units.ts
+++ b/lib/units.ts
@@ -10,3 +10,25 @@ export function toDisplay(kg: number, unit: "kg" | "lb"): number {
 export function toKg(val: number, unit: "kg" | "lb"): number {
   return unit === "lb" ? val * LB_TO_KG : val;
 }
+
+export function convertWeight(
+  val: number,
+  from: "kg" | "lb",
+  to: "kg" | "lb",
+): number {
+  if (from === to) return Math.round(val * 10) / 10;
+  const kg = from === "lb" ? val * LB_TO_KG : val;
+  const out = to === "lb" ? kg * KG_TO_LB : kg;
+  return Math.round(out * 10) / 10;
+}
+
+export function convertHeight(
+  val: number,
+  from: "cm" | "in",
+  to: "cm" | "in",
+): number {
+  if (from === to) return Math.round(val * 10) / 10;
+  const cm = from === "in" ? val * IN_TO_CM : val;
+  const out = to === "in" ? cm * CM_TO_IN : cm;
+  return Math.round(out * 10) / 10;
+}


### PR DESCRIPTION
## Summary

Fixes owner-reported bug [GH #311](https://github.com/alankyshum/cablesnap/issues/311): the body profile card on the settings screen kept showing stale weight/height unit labels and unconverted values after toggling the unit in the adjacent UnitsCard.

## Root cause

`BodyProfileCard` → `useBodyProfile` only read the current unit from `bodySettings` inside `useFocusEffect`, which does not re-fire while the settings screen stays focused. The two cards (UnitsCard and BodyProfileCard) are siblings on the same screen, so changing units in one didn't propagate to the other.

## Changes

- `hooks/useBodyProfile.ts`: accept optional `externalWeightUnit` / `externalHeightUnit` params; convert displayed values in place when they change using the canonical *adjusting-state-during-render* pattern (no effect-triggered cascading renders).
- `hooks/useBodyProfile.ts` (load path): also convert saved-profile weight/height from the profile's stored unit to the currently-active unit, so force-quit → relaunch + unit-change remains consistent.
- `components/BodyProfileCard.tsx`: forward new optional props.
- `app/(tabs)/settings.tsx`: pass `weightUnit` / `measureUnit` from `useSettingsData` into `BodyProfileCard`.
- `lib/units.ts`: new `convertWeight` / `convertHeight` helpers.

## Testing

- `__tests__/components/BodyProfileCard.unitRefresh.test.tsx` — new: verifies label + value update on kg↔lb and cm↔in prop changes, symmetry.
- `__tests__/lib/units.test.ts` — extended with conversion-helper coverage.
- Full suite: **151 suites / 1840 tests pass**.
- `tsc --noEmit`: clean. ESLint: clean (zero warnings).

## Acceptance criteria

- [x] kg → lb updates label + converts value (no restart)
- [x] lb → kg symmetric
- [x] All unit-bearing body-profile fields update (weight, height)
- [x] Typecheck passes, no new lint warnings
- [x] Tests included (REVIEWER rule 12)

Resolves BLD-515 / GH #311