### PR TITLE
refactor(theme): migrate hardcoded colors to tokens (BLD-521)

### DIFF
--- a/__tests__/components/flow-card-colors-tokens.test.ts
+++ b/__tests__/components/flow-card-colors-tokens.test.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+// Regression test for BLD-521: flow-card-colors.ts must use theme tokens,
+// not hardcoded hex color literals. Catches drift back to raw #RRGGBB values.
+describe("flow-card-colors theme-token contract", () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, "../../components/ui/flow-card-colors.ts"),
+    "utf8",
+  );
+
+  it("does not contain raw hex color literals", () => {
+    const hexMatches = source.match(/['"]#[0-9a-fA-F]{3,8}['"]/g) ?? [];
+    expect(hexMatches).toEqual([]);
+  });
+
+  it("sources severity pairs from Colors.{light,dark}.*Subtle tokens", () => {
+    expect(source).toMatch(/successSubtle/);
+    expect(source).toMatch(/warningSubtle/);
+    expect(source).toMatch(/dangerSubtle/);
+    expect(source).toMatch(/Colors\[/);
+  });
+});

--- a/__tests__/components/recovery-heatmap-tokens.test.ts
+++ b/__tests__/components/recovery-heatmap-tokens.test.ts
@@ -1,0 +1,28 @@
+import fs from "fs";
+import path from "path";
+
+// Regression test for BLD-521: RecoveryHeatmap.tsx must source heatmap palette
+// + border from theme tokens via useThemeColors(), not hardcoded hex literals.
+describe("RecoveryHeatmap theme-token contract", () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, "../../components/home/RecoveryHeatmap.tsx"),
+    "utf8",
+  );
+
+  it("does not contain raw hex color literals", () => {
+    const hexMatches = source.match(/['"]#[0-9a-fA-F]{3,8}['"]/g) ?? [];
+    expect(hexMatches).toEqual([]);
+  });
+
+  it("sources heatmap palette from useThemeColors() tokens", () => {
+    expect(source).toMatch(/colors\.heatmapLow/);
+    expect(source).toMatch(/colors\.heatmapMid/);
+    expect(source).toMatch(/colors\.heatmapHigh/);
+    expect(source).toMatch(/colors\.heatmapBorder/);
+  });
+
+  it("does not branch on isDark for the static heatmap palette", () => {
+    expect(source).not.toMatch(/isDark\s*\?\s*\[/);
+    expect(source).not.toMatch(/RECOVERY_COLORS/);
+  });
+});

--- a/__tests__/components/substitution-item-tokens.test.ts
+++ b/__tests__/components/substitution-item-tokens.test.ts
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+
+// Regression test for BLD-521: SubstitutionItem.tsx must source score-based
+// badge colors from theme tokens (Colors.{light,dark}.*Subtle), not hex literals.
+describe("SubstitutionItem theme-token contract", () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, "../../components/substitution/SubstitutionItem.tsx"),
+    "utf8",
+  );
+
+  it("does not contain raw hex color literals", () => {
+    const hexMatches = source.match(/['"]#[0-9a-fA-F]{3,8}['"]/g) ?? [];
+    expect(hexMatches).toEqual([]);
+  });
+
+  it("sources score palette from Colors.{light,dark}.*Subtle tokens", () => {
+    expect(source).toMatch(/successSubtle/);
+    expect(source).toMatch(/warningSubtle/);
+    expect(source).toMatch(/dangerSubtle/);
+  });
+});

--- a/components/FlowCardBadges.tsx
+++ b/components/FlowCardBadges.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
-import { DIFFICULTY_COLORS, READINESS_COLORS } from "./ui/flow-card-colors";
+import {
+  useDifficultyBadgeColors,
+  useReadinessBadgeColors,
+} from "./ui/flow-card-colors";
 import type { ReadinessBadge } from "../lib/recovery-readiness";
 import type { MetaBadge } from "./FlowCard";
 import type { useThemeColors } from "@/hooks/useThemeColors";
@@ -14,6 +17,8 @@ export function BadgeRow({ badges, readiness, isDark, colors }: {
   isDark: boolean;
   colors: ReturnType<typeof useThemeColors>;
 }) {
+  const readinessColors = useReadinessBadgeColors();
+  void isDark;
   return (
     <>
       {badges?.map((b) => {
@@ -26,12 +31,10 @@ export function BadgeRow({ badges, readiness, isDark, colors }: {
         );
       })}
       {readiness && readiness !== "NO_DATA" && (() => {
-        const rc = READINESS_COLORS[readiness];
-        const bg = isDark ? rc.darkBg : rc.lightBg;
-        const fg = isDark ? rc.darkFg : rc.lightFg;
+        const rc = readinessColors[readiness];
         return (
-          <View style={[styles.badge, { backgroundColor: bg }]} accessibilityLabel={`Recovery status: ${readiness.toLowerCase()}`}>
-            <Text variant="caption" style={[styles.badgeText, { color: fg }]}>{readiness}</Text>
+          <View style={[styles.badge, { backgroundColor: rc.bg }]} accessibilityLabel={`Recovery status: ${readiness.toLowerCase()}`}>
+            <Text variant="caption" style={[styles.badgeText, { color: rc.fg }]}>{readiness}</Text>
           </View>
         );
       })()}
@@ -40,10 +43,11 @@ export function BadgeRow({ badges, readiness, isDark, colors }: {
 }
 
 export function MetaRow({ meta, colors }: { meta: MetaBadge[]; colors: ReturnType<typeof useThemeColors> }) {
+  const difficultyColors = useDifficultyBadgeColors();
   return (
     <>
       {meta.map((m, i) => {
-        const dc = m.difficulty ? DIFFICULTY_COLORS[m.difficulty] : null;
+        const dc = m.difficulty ? difficultyColors[m.difficulty] : null;
         return (
           <View key={i} style={[styles.metaBadge, { backgroundColor: dc?.bg ?? colors.surfaceVariant }]}>
             <MaterialCommunityIcons name={m.icon} size={14} color={dc?.fg ?? colors.onSurfaceVariant} />

--- a/components/home/RecoveryHeatmap.tsx
+++ b/components/home/RecoveryHeatmap.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import Body, { type ExtendedBodyPart } from "react-native-body-highlighter";
-import { useColorScheme } from "@/hooks/useColorScheme";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { radii } from "../../constants/design-tokens";
 import { SLUG_MAP } from "../../lib/muscle-map-utils";
@@ -14,11 +13,6 @@ import { useFocusEffect } from "expo-router";
 import { fontSizes } from "@/constants/design-tokens";
 
 const COLLAPSE_KEY = "recovery_heatmap_collapsed";
-
-const RECOVERY_COLORS = {
-  dark: ["#42A5F5", "#FFC107", "#F44336"],
-  light: ["#1E88E5", "#FF8F00", "#D32F2F"],
-} as const;
 
 function statusToIntensity(status: MuscleRecoveryStatus["status"]): number {
   if (status === "recovered") return 1;
@@ -53,7 +47,6 @@ type Props = {
 };
 
 function RecoveryHeatmapInner({ recoveryStatus, colors }: Props) {
-  const isDark = useColorScheme() === "dark";
   const [isExpanded, setIsExpanded] = useState(true);
   const [loaded, setLoaded] = useState(false);
 
@@ -77,7 +70,8 @@ function RecoveryHeatmapInner({ recoveryStatus, colors }: Props) {
   if (!loaded) return null;
 
   const hasData = recoveryStatus.some((s) => s.status !== "no_data");
-  const bodyColors = isDark ? [...RECOVERY_COLORS.dark] : [...RECOVERY_COLORS.light];
+  const palette = [colors.heatmapLow, colors.heatmapMid, colors.heatmapHigh];
+  const bodyColors = [...palette];
   const data = buildRecoveryData(recoveryStatus);
   const scale = 0.55;
 
@@ -123,7 +117,7 @@ function RecoveryHeatmapInner({ recoveryStatus, colors }: Props) {
                   side="front"
                   scale={scale}
                   colors={bodyColors}
-                  border={isDark ? "#616161" : "#9E9E9E"}
+                  border={colors.heatmapBorder}
                 />
                 <Body
                   data={data}
@@ -131,10 +125,10 @@ function RecoveryHeatmapInner({ recoveryStatus, colors }: Props) {
                   side="back"
                   scale={scale}
                   colors={bodyColors}
-                  border={isDark ? "#616161" : "#9E9E9E"}
+                  border={colors.heatmapBorder}
                 />
               </View>
-              <RecoveryLegend isDark={isDark} />
+              <RecoveryLegend palette={palette} />
               <View style={styles.summary}>
                 {readyMuscles.length > 0 && (
                   <Text variant="caption" style={{ color: colors.onSurface }}>
@@ -157,9 +151,8 @@ function RecoveryHeatmapInner({ recoveryStatus, colors }: Props) {
   );
 }
 
-function RecoveryLegend({ isDark }: { isDark: boolean }) {
+function RecoveryLegend({ palette }: { palette: readonly string[] }) {
   const colors = useThemeColors();
-  const palette = isDark ? RECOVERY_COLORS.dark : RECOVERY_COLORS.light;
   const items = [
     { color: palette[0], label: "Recovered" },
     { color: palette[1], label: "Partial" },

--- a/components/substitution/SubstitutionItem.tsx
+++ b/components/substitution/SubstitutionItem.tsx
@@ -6,17 +6,32 @@ import { EQUIPMENT_LABELS, DIFFICULTY_LABELS, MUSCLE_LABELS } from "../../lib/ty
 import type { SubstitutionScore } from "../../lib/exercise-substitutions";
 import { radii } from "../../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { Colors } from "@/theme/colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
-export function matchColor(score: number): string {
-  if (score >= 80) return "#2e7d32";
-  if (score >= 60) return "#f57f17";
-  return "#c62828";
+type ColorMode = "light" | "dark";
+
+function pickScorePalette(mode: ColorMode | null | undefined) {
+  const c = Colors[mode === "dark" ? "dark" : "light"];
+  return {
+    high: { bg: c.successSubtle, fg: c.successSubtleForeground },
+    mid: { bg: c.warningSubtle, fg: c.warningSubtleForeground },
+    low: { bg: c.dangerSubtle, fg: c.dangerSubtleForeground },
+  };
 }
 
-export function matchBgColor(score: number): string {
-  if (score >= 80) return "#e8f5e9";
-  if (score >= 60) return "#fff8e1";
-  return "#ffebee";
+function scoreBucket(score: number): "high" | "mid" | "low" {
+  if (score >= 80) return "high";
+  if (score >= 60) return "mid";
+  return "low";
+}
+
+export function matchColor(score: number, mode?: ColorMode | null): string {
+  return pickScorePalette(mode)[scoreBucket(score)].fg;
+}
+
+export function matchBgColor(score: number, mode?: ColorMode | null): string {
+  return pickScorePalette(mode)[scoreBucket(score)].bg;
 }
 
 export function SubstitutionItem({
@@ -27,7 +42,11 @@ export function SubstitutionItem({
   onPress: (exercise: Exercise) => void;
 }) {
   const colors = useThemeColors();
+  const scheme = useColorScheme();
+  const mode: ColorMode = scheme === "dark" ? "dark" : "light";
   const ex = item.exercise;
+  const palette = pickScorePalette(mode);
+  const bucket = palette[scoreBucket(item.score)];
 
   return (
     <Pressable
@@ -47,10 +66,10 @@ export function SubstitutionItem({
         <View
           style={[
             styles.matchBadge,
-            { backgroundColor: matchBgColor(item.score) },
+            { backgroundColor: bucket.bg },
           ]}
         >
-          <Text variant="caption" style={[styles.matchText, { color: matchColor(item.score) }]}>
+          <Text variant="caption" style={[styles.matchText, { color: bucket.fg }]}>
             {item.score}%
           </Text>
         </View>

--- a/components/ui/flow-card-colors.ts
+++ b/components/ui/flow-card-colors.ts
@@ -1,14 +1,55 @@
+// Theme-token-driven severity colors for FlowCard difficulty / readiness badges.
+// Colors are sourced from Colors.{light,dark}.{successSubtle,warningSubtle,dangerSubtle}
+// and their *Foreground variants — NO raw hex literals live in this file.
+//
+// For React components, prefer the `useDifficultyBadgeColors()` /
+// `useReadinessBadgeColors()` hooks. For non-React callers (utilities, tests),
+// use the mode-accepting selectors `getDifficultyBadgeColors(mode)` /
+// `getReadinessBadgeColors(mode)`.
+
 import type { Difficulty } from "../../lib/types";
 import type { ReadinessBadge } from "../../lib/recovery-readiness";
+import { Colors } from "@/theme/colors";
+import { useColorScheme } from "@/hooks/useColorScheme";
 
-export const DIFFICULTY_COLORS: Record<Difficulty, { bg: string; fg: string }> = {
-  beginner: { bg: "#D1FAE5", fg: "#065F46" },
-  intermediate: { bg: "#FEF3C7", fg: "#92400E" },
-  advanced: { bg: "#FEE2E2", fg: "#991B1B" },
-};
+type ColorMode = "light" | "dark";
+type BadgePair = { bg: string; fg: string };
 
-export const READINESS_COLORS: Record<Exclude<ReadinessBadge, "NO_DATA">, { lightBg: string; lightFg: string; darkBg: string; darkFg: string }> = {
-  READY: { lightBg: "#D1FAE5", lightFg: "#065F46", darkBg: "#064E3B", darkFg: "#A7F3D0" },
-  PARTIAL: { lightBg: "#FEF3C7", lightFg: "#92400E", darkBg: "#5C3D00", darkFg: "#FDE68A" },
-  REST: { lightBg: "#FEE2E2", lightFg: "#991B1B", darkBg: "#7F1D1D", darkFg: "#FECACA" },
-};
+function resolveMode(mode: ColorMode | null | undefined): ColorMode {
+  return mode === "dark" ? "dark" : "light";
+}
+
+export function getDifficultyBadgeColors(
+  mode: ColorMode | null | undefined,
+): Record<Difficulty, BadgePair> {
+  const c = Colors[resolveMode(mode)];
+  return {
+    beginner: { bg: c.successSubtle, fg: c.successSubtleForeground },
+    intermediate: { bg: c.warningSubtle, fg: c.warningSubtleForeground },
+    advanced: { bg: c.dangerSubtle, fg: c.dangerSubtleForeground },
+  };
+}
+
+export function getReadinessBadgeColors(
+  mode: ColorMode | null | undefined,
+): Record<Exclude<ReadinessBadge, "NO_DATA">, BadgePair> {
+  const c = Colors[resolveMode(mode)];
+  return {
+    READY: { bg: c.successSubtle, fg: c.successSubtleForeground },
+    PARTIAL: { bg: c.warningSubtle, fg: c.warningSubtleForeground },
+    REST: { bg: c.dangerSubtle, fg: c.dangerSubtleForeground },
+  };
+}
+
+export function useDifficultyBadgeColors(): Record<Difficulty, BadgePair> {
+  const scheme = useColorScheme();
+  return getDifficultyBadgeColors(scheme === "dark" ? "dark" : "light");
+}
+
+export function useReadinessBadgeColors(): Record<
+  Exclude<ReadinessBadge, "NO_DATA">,
+  BadgePair
+> {
+  const scheme = useColorScheme();
+  return getReadinessBadgeColors(scheme === "dark" ? "dark" : "light");
+}

--- a/hooks/useThemeColors.ts
+++ b/hooks/useThemeColors.ts
@@ -73,6 +73,12 @@ export function useThemeColors() {
     backdrop: "rgba(0,0,0,0.5)",
     notification: t.red,
     card: t.card,
+
+    // Recovery heatmap palette (see theme/colors.ts)
+    heatmapLow: t.heatmapLow,
+    heatmapMid: t.heatmapMid,
+    heatmapHigh: t.heatmapHigh,
+    heatmapBorder: t.heatmapBorder,
   };
 }
 

--- a/theme/colors.ts
+++ b/theme/colors.ts
@@ -47,6 +47,20 @@ const lightColors = {
   warningBanner: "#FFF8E1",
   errorBanner: "#FEE2E2",
 
+  // Subtle severity tokens (inline chips/badges — NOT full-width banners)
+  successSubtle: "#D1FAE5",
+  successSubtleForeground: "#065F46",
+  warningSubtle: "#FEF3C7",
+  warningSubtleForeground: "#92400E",
+  dangerSubtle: "#FEE2E2",
+  dangerSubtleForeground: "#991B1B",
+
+  // Recovery heatmap palette (low=recovered, mid=partial, high=fatigued)
+  heatmapLow: "#1E88E5",
+  heatmapMid: "#FF8F00",
+  heatmapHigh: "#D32F2F",
+  heatmapBorder: "#9E9E9E",
+
   // Shadows & overlays
   shadow: "#000000",
   onToast: "#FFFFFF",
@@ -108,6 +122,20 @@ const darkColors = {
   // Banner backgrounds
   warningBanner: "#332200",
   errorBanner: "#3B1111",
+
+  // Subtle severity tokens (inline chips/badges — NOT full-width banners)
+  successSubtle: "#064E3B",
+  successSubtleForeground: "#A7F3D0",
+  warningSubtle: "#5C3D00",
+  warningSubtleForeground: "#FDE68A",
+  dangerSubtle: "#7F1D1D",
+  dangerSubtleForeground: "#FECACA",
+
+  // Recovery heatmap palette (low=recovered, mid=partial, high=fatigued)
+  heatmapLow: "#42A5F5",
+  heatmapMid: "#FFC107",
+  heatmapHigh: "#F44336",
+  heatmapBorder: "#616161",
 
   // Shadows & overlays
   shadow: "#000000",


### PR DESCRIPTION
## Summary

Migrate 3 components flagged in the BLD-516 Visual UX Audit off hardcoded hex literals onto theme tokens so they adapt when dark mode ships.

## Changes

- `theme/colors.ts` — add `successSubtle`/`warningSubtle`/`dangerSubtle` (+ `*Foreground` pairs) and `heatmapLow`/`Mid`/`High`/`Border` in both light and dark palettes.
- `hooks/useThemeColors.ts` — expose the four heatmap tokens.
- `components/ui/flow-card-colors.ts` — rewrite as token-driven hooks (`useDifficultyBadgeColors`, `useReadinessBadgeColors`) + mode-accepting selectors for non-React callers. Zero hex.
- `components/FlowCardBadges.tsx` — consume the new hooks, drop `isDark`-branching.
- `components/home/RecoveryHeatmap.tsx` — source palette + border from `useThemeColors()`, delete `RECOVERY_COLORS` and `isDark` branching.
- `components/substitution/SubstitutionItem.tsx` — score-based colors now come from `Colors.{light,dark}.*Subtle` via a local palette selector.
- Three regression tests under `__tests__/components/` asserting zero hex literals + token usage in each source file (follows the `toast-item-tokens.test.ts` precedent).

## Testing

- `npx tsc --noEmit` — passes with zero errors
- `npm test -- --testPathPattern=tokens` — 17/17 pass
- Full suite: 1847/1848 pass; the single failure (`workout-session.acceptance`) is a pre-existing flake unrelated to this change (passes when run in isolation).
- Light-mode values preserved 1:1 vs. the old hex constants. Dark-mode values use the pre-existing dark-variant hex values from the prior `READINESS_COLORS.darkBg/darkFg` + `RECOVERY_COLORS.dark` structures.

## Issue

Resolves BLD-521