### PR TITLE
feat(progress): improved empty state for Workouts tab (BLD-519)

### DIFF
--- a/__tests__/components/progress/WorkoutEmptyState.test.tsx
+++ b/__tests__/components/progress/WorkoutEmptyState.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react-native'
+
+jest.mock('expo-router', () => {
+  const push = jest.fn()
+  return {
+    useRouter: () => ({ push }),
+    __pushMock: push,
+  }
+})
+
+jest.mock('@/hooks/useThemeColors', () => ({
+  useThemeColors: () => ({
+    primary: '#6200ee',
+    onPrimary: '#fff',
+    onSurface: '#000',
+    onSurfaceVariant: '#666',
+    outlineVariant: '#ccc',
+    surface: '#fff',
+    surfaceVariant: '#eee',
+    background: '#fff',
+    error: '#f00',
+    onError: '#fff',
+  }),
+}))
+
+jest.mock('lucide-react-native', () => ({
+  TrendingUp: 'TrendingUp',
+}))
+
+import WorkoutEmptyState from '@/components/progress/WorkoutEmptyState'
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { __pushMock: pushMock } = require('expo-router') as { __pushMock: jest.Mock }
+
+describe('WorkoutEmptyState', () => {
+  beforeEach(() => {
+    pushMock.mockClear()
+  })
+
+  it('renders the headline, description, and CTA button', () => {
+    const { getByText, getByLabelText } = render(<WorkoutEmptyState />)
+    expect(getByText('Track your progress')).toBeTruthy()
+    expect(
+      getByText(/Complete your first workout to see sessions, PRs, and weekly trends here\./i),
+    ).toBeTruthy()
+    expect(getByLabelText('Start your first workout')).toBeTruthy()
+  })
+
+  it('has an accessibility label on the container for screen readers', () => {
+    const { getByLabelText } = render(<WorkoutEmptyState />)
+    expect(getByLabelText('No workouts logged yet')).toBeTruthy()
+  })
+
+  it('navigates home when the CTA is tapped with no onStart handler', () => {
+    const { getByLabelText } = render(<WorkoutEmptyState />)
+    fireEvent.press(getByLabelText('Start your first workout'))
+    expect(pushMock).toHaveBeenCalledWith('/')
+  })
+
+  it('invokes onStart and does not navigate when handler is provided', () => {
+    const onStart = jest.fn()
+    const { getByLabelText } = render(<WorkoutEmptyState onStart={onStart} />)
+    fireEvent.press(getByLabelText('Start your first workout'))
+    expect(onStart).toHaveBeenCalledTimes(1)
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+})

--- a/components/progress/WorkoutEmptyState.tsx
+++ b/components/progress/WorkoutEmptyState.tsx
@@ -1,0 +1,91 @@
+import { StyleSheet, View } from "react-native";
+import { useRouter } from "expo-router";
+import { TrendingUp } from "lucide-react-native";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { fontSizes } from "@/constants/design-tokens";
+
+type Props = {
+  onStart?: () => void;
+};
+
+export default function WorkoutEmptyState({ onStart }: Props) {
+  const colors = useThemeColors();
+  const router = useRouter();
+
+  const handleStart = () => {
+    if (onStart) {
+      onStart();
+      return;
+    }
+    router.push("/");
+  };
+
+  return (
+    <View
+      style={styles.container}
+      accessibilityLabel="No workouts logged yet"
+      testID="progress-workouts-empty"
+    >
+      <View
+        style={[
+          styles.iconCircle,
+          { backgroundColor: colors.surfaceVariant ?? colors.surface },
+        ]}
+      >
+        <TrendingUp size={40} color={colors.onSurfaceVariant} strokeWidth={1.5} />
+      </View>
+      <Text
+        style={[
+          styles.headline,
+          { color: colors.onSurface, fontSize: fontSizes.lg },
+        ]}
+      >
+        Track your progress
+      </Text>
+      <Text
+        style={[styles.description, { color: colors.onSurfaceVariant }]}
+      >
+        Complete your first workout to see sessions, PRs, and weekly trends here.
+      </Text>
+      <Button
+        variant="default"
+        onPress={handleStart}
+        accessibilityLabel="Start your first workout"
+        label="Start a workout"
+        style={styles.cta}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+    paddingVertical: 24,
+    gap: 12,
+  },
+  iconCircle: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 4,
+  },
+  headline: {
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  description: {
+    textAlign: "center",
+    maxWidth: 320,
+  },
+  cta: {
+    marginTop: 8,
+    minWidth: 180,
+  },
+});

--- a/components/progress/WorkoutSegment.tsx
+++ b/components/progress/WorkoutSegment.tsx
@@ -28,6 +28,7 @@ import { PRSummaryCard } from "./PRSummaryCard";
 import CalendarView from "./CalendarView";
 import StrengthLevelsCard from "./StrengthLevelsCard";
 import ActiveGoalsCard from "./ActiveGoalsCard";
+import WorkoutEmptyState from "./WorkoutEmptyState";
 import { fontSizes } from "@/constants/design-tokens";
 
 let cachedWeekStart: number | null = null;
@@ -133,15 +134,7 @@ export default function WorkoutSegment() {
           <WeeklySummary />
         </View>
         <View style={[styles.center, { flex: 1 }]}>
-          <Text
-            style={{
-              color: colors.onSurfaceVariant,
-              textAlign: "center",
-              padding: 32,
-            }}
-          >
-            Complete your first workout to see progress
-          </Text>
+          <WorkoutEmptyState />
         </View>
       </View>
     );


### PR DESCRIPTION
## Summary

Fixes the Progress → Workouts empty state where the 'Complete your first workout to see progress' message floated in ~400px of dead space below the weekly summary card, looking like a rendering bug to new users (GH visual UX audit BLD-519).

## Changes

- New component `components/progress/WorkoutEmptyState.tsx`:
  - TrendingUp icon inside a tinted circle (visual anchor)
  - Clear headline ("Track your progress")
  - Friendly description
  - Primary CTA button "Start a workout" → navigates to Home tab
- Replaced the inline empty-state text in `components/progress/WorkoutSegment.tsx` with the new component
- Unit tests: `__tests__/components/progress/WorkoutEmptyState.test.tsx` (4 tests — rendering, a11y label, router-push default, onStart override)

## Testing

- `npx -p typescript tsc --noEmit` → passes with 0 errors
- `npx jest __tests__/components/progress/WorkoutEmptyState.test.tsx` → 4/4 passing

## Issue

Resolves BLD-519