### PR TITLE
feat(strava): Sentry lifecycle logs for connection actions (BLD-523)

### DIFF
--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -254,6 +254,16 @@ jest.mock("../../lib/db", () => ({
   getSessionSets: jest.fn(),
   getBodySettings: jest.fn(),
 }));
+jest.mock("@sentry/react-native", () => ({
+  __esModule: true,
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  addBreadcrumb: jest.fn(),
+  captureException: jest.fn(),
+}));
 
 const AuthSession = require("expo-auth-session");
 const SecureStore = require("expo-secure-store");
@@ -409,6 +419,154 @@ describe("Strava Integration — Behavioral", () => {
     // retry_count >= MAX_RETRIES (3) → permanently failed without attempting upload
     expect(db.markSyncPermanentlyFailed).toHaveBeenCalledWith("s-old");
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("Strava Integration — Sentry lifecycle logs (BLD-523)", () => {
+  const mockFetch = jest.fn();
+  const originalFetch = global.fetch;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Sentry = require("@sentry/react-native");
+
+  const SECRET_ACCESS_TOKEN = "at-super-secret-123";
+  const SECRET_REFRESH_TOKEN = "rt-super-secret-456";
+  const SECRET_AUTH_CODE = "auth-code-xyz-secret";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockFetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  function scanLoggerCallsForSecrets(): void {
+    const loggerMocks = [Sentry.logger.info, Sentry.logger.warn, Sentry.logger.error];
+    for (const m of loggerMocks) {
+      for (const call of m.mock.calls) {
+        const serialized = JSON.stringify(call);
+        expect(serialized).not.toContain(SECRET_ACCESS_TOKEN);
+        expect(serialized).not.toContain(SECRET_REFRESH_TOKEN);
+        expect(serialized).not.toContain(SECRET_AUTH_CODE);
+      }
+    }
+  }
+
+  it("connectStrava emits lifecycle logs and never leaks tokens or auth codes", async () => {
+    AuthSession.AuthRequest.mockImplementation(() => ({
+      promptAsync: jest.fn().mockResolvedValue({
+        type: "success",
+        params: { code: SECRET_AUTH_CODE },
+      }),
+    }));
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        access_token: SECRET_ACCESS_TOKEN,
+        refresh_token: SECRET_REFRESH_TOKEN,
+        expires_at: 9999999999,
+        athlete: { id: 42, firstname: "Jane", lastname: "Doe" },
+      }),
+    });
+
+    await strava.connectStrava();
+
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ flow: "strava_connect", step: "start" }),
+    );
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ flow: "strava_connect", step: "auth_prompt", resultType: "success", hasCode: true }),
+    );
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ flow: "strava_connect", step: "token_exchange_ok" }),
+    );
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ flow: "strava_connect", step: "success", athleteId: 42 }),
+    );
+
+    scanLoggerCallsForSecrets();
+  });
+
+  it("connectStrava logs user_cancelled when OAuth is cancelled (no tokens in logs)", async () => {
+    AuthSession.AuthRequest.mockImplementation(() => ({
+      promptAsync: jest.fn().mockResolvedValue({ type: "cancel" }),
+    }));
+
+    const result = await strava.connectStrava();
+
+    expect(result).toBeNull();
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ flow: "strava_connect", step: "user_cancelled", resultType: "cancel" }),
+    );
+    scanLoggerCallsForSecrets();
+  });
+
+  it("disconnect emits start + success lifecycle logs", async () => {
+    SecureStore.getItemAsync.mockResolvedValueOnce(SECRET_ACCESS_TOKEN);
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    await strava.disconnect();
+
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ flow: "strava_disconnect", step: "start" }),
+    );
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ flow: "strava_disconnect", step: "success" }),
+    );
+    scanLoggerCallsForSecrets();
+  });
+
+  it("syncSessionToStrava emits start + success lifecycle logs with sessionId and activityId", async () => {
+    db.getStravaConnection.mockResolvedValue({ athlete_id: 1 });
+    db.getSessionSets.mockResolvedValue([
+      { exercise_name: "Squat", weight: 100, reps: 5, completed: true, set_type: "working" },
+    ]);
+    db.getSessionById.mockResolvedValue({
+      id: "s1", name: "Leg Day", started_at: Date.now(), duration_seconds: 3600,
+    });
+    db.getBodySettings.mockResolvedValue({ weight_unit: "kg" });
+    SecureStore.getItemAsync.mockImplementation(async (key: string) => {
+      if (key === "strava_token_expires_at") return String(Math.floor(Date.now() / 1000) + 7200);
+      if (key === "strava_access_token") return SECRET_ACCESS_TOKEN;
+      return null;
+    });
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ id: 98765 }) });
+
+    await strava.syncSessionToStrava("s1");
+
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ flow: "strava_upload", step: "start", sessionId: "s1" }),
+    );
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ flow: "strava_upload", step: "success", sessionId: "s1", activityId: "98765" }),
+    );
+    scanLoggerCallsForSecrets();
+  });
+
+  it("does not throw when Sentry.logger is undefined (older SDK compatibility)", async () => {
+    const original = Sentry.logger;
+    // Simulate older SDK without logger export
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Sentry as any).logger = undefined;
+    try {
+      AuthSession.AuthRequest.mockImplementation(() => ({
+        promptAsync: jest.fn().mockResolvedValue({ type: "cancel" }),
+      }));
+      await expect(strava.connectStrava()).resolves.toBeNull();
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (Sentry as any).logger = original;
+    }
   });
 });
 

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -235,6 +235,7 @@ async function refreshAccessToken(): Promise<string | null> {
 
     const data = await response.json();
     await saveTokens(data.access_token, data.refresh_token, data.expires_at);
+    stravaLog("info", "strava refresh succeeded", { flow: "strava_refresh", step: "success" });
     return data.access_token;
   } catch (err) {
     console.error("Strava token refresh failed:", err);
@@ -268,6 +269,39 @@ function captureStravaError(
 
 function stravaBreakcrumb(message: string, data?: Record<string, unknown>): void {
   Sentry.addBreadcrumb({ category: "strava", message, data });
+}
+
+/**
+ * Emit a structured Sentry log for a Strava lifecycle checkpoint.
+ *
+ * Unlike `stravaBreakcrumb` (which only attaches to exception events),
+ * these calls go to the Sentry logs (`ourlogs`) dataset so we have
+ * verifiable happy-path signal. Init config sets `enableLogs: true`
+ * (see `app/_layout.tsx`).
+ *
+ * Never pass secrets (tokens, client_secret, raw auth codes, Authorization
+ * headers). Scalars only (IDs, status codes, resultType).
+ *
+ * Uses optional chaining so older @sentry/react-native SDKs that do not
+ * export `logger` do not throw at runtime.
+ */
+function stravaLog(
+  level: "info" | "warn" | "error",
+  message: string,
+  attrs?: Record<string, unknown>,
+): void {
+  try {
+    const logger = (Sentry as unknown as {
+      logger?: {
+        info?: (msg: string, attrs?: Record<string, unknown>) => void;
+        warn?: (msg: string, attrs?: Record<string, unknown>) => void;
+        error?: (msg: string, attrs?: Record<string, unknown>) => void;
+      };
+    }).logger;
+    logger?.[level]?.(message, attrs);
+  } catch {
+    // Logging must never break the app flow.
+  }
 }
 
 // ---- Token Exchange ----
@@ -304,7 +338,9 @@ async function exchangeCodeForTokens(
     throw err;
   }
 
-  return tokenResponse.json() as Promise<Record<string, unknown>>;
+  const tokens = (await tokenResponse.json()) as Record<string, unknown>;
+  stravaLog("info", "strava token exchange succeeded", { flow: "strava_connect", step: "token_exchange_ok" });
+  return tokens;
 }
 
 // ---- OAuth2 Authorization Code Flow ----
@@ -337,6 +373,7 @@ export async function connectStrava(): Promise<{
   }
 
   stravaBreakcrumb("connectStrava started", { clientId, redirectUri, proxyUrl });
+  stravaLog("info", "strava connect started", { flow: "strava_connect", step: "start" });
 
   const authRequest = new AuthSession.AuthRequest({
     clientId,
@@ -349,9 +386,21 @@ export async function connectStrava(): Promise<{
     authorizationEndpoint: STRAVA_AUTH_URL,
   });
 
-  stravaBreakcrumb("auth prompt completed", { resultType: result.type, hasCode: !!(result.type === "success" && result.params?.code) });
+  const hasCode = !!(result.type === "success" && result.params?.code);
+  stravaBreakcrumb("auth prompt completed", { resultType: result.type, hasCode });
+  stravaLog("info", "strava auth prompt completed", {
+    flow: "strava_connect",
+    step: "auth_prompt",
+    resultType: result.type,
+    hasCode,
+  });
 
   if (result.type !== "success" || !result.params.code) {
+    stravaLog("info", "strava connect user cancelled", {
+      flow: "strava_connect",
+      step: "user_cancelled",
+      resultType: result.type,
+    });
     return null;
   }
 
@@ -371,11 +420,17 @@ export async function connectStrava(): Promise<{
   await saveStravaConnection(athleteId, athleteName);
 
   stravaBreakcrumb("connectStrava succeeded", { athleteId });
+  stravaLog("info", "strava connect succeeded", {
+    flow: "strava_connect",
+    step: "success",
+    athleteId,
+  });
 
   return { athleteId, athleteName };
 }
 
 export async function disconnect(): Promise<void> {
+  stravaLog("info", "strava disconnect started", { flow: "strava_disconnect", step: "start" });
   // Attempt to revoke on Strava (best-effort)
   try {
     const token = await getAccessToken();
@@ -391,6 +446,7 @@ export async function disconnect(): Promise<void> {
 
   await clearTokens();
   await deleteStravaConnection();
+  stravaLog("info", "strava disconnect succeeded", { flow: "strava_disconnect", step: "success" });
 }
 
 export async function isStravaConnected(): Promise<boolean> {
@@ -501,6 +557,7 @@ async function uploadActivity(
 // ---- Sync Orchestration ----
 
 export async function syncSessionToStrava(sessionId: string): Promise<boolean> {
+  stravaLog("info", "strava upload started", { flow: "strava_upload", step: "start", sessionId });
   const connected = await isStravaConnected();
   if (!connected) return false;
 
@@ -514,6 +571,12 @@ export async function syncSessionToStrava(sessionId: string): Promise<boolean> {
   try {
     const activityId = await uploadActivity(sessionId);
     await markSyncSuccess(sessionId, activityId);
+    stravaLog("info", "strava upload succeeded", {
+      flow: "strava_upload",
+      step: "success",
+      sessionId,
+      activityId,
+    });
     return true;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Fixes the happy-path Sentry-signal gap for Strava connection flows. Previously, only exceptions fired Sentry events — successful `connectStrava`/`disconnect`/`syncSessionToStrava`/`refreshAccessToken` produced **zero events**, making it impossible for agents (via `cablesnap--sentry-debug` skill) to verify that a live action was triggered.

Now emits structured logs via `Sentry.logger.info()` at every lifecycle checkpoint. Breadcrumbs are preserved so exception events still have rich context.

Closes BLD-523 (parent). Implements BLD-524.

## Changes

### \`lib/strava.ts\`
- New helper \`stravaLog(level, message, attrs)\` — optional-chains through \`Sentry.logger?.[level]?.\` so older SDK versions without the \`logger\` export don't throw at runtime. Wrapped in try/catch for belt-and-braces safety.
- 10 lifecycle log call-sites:

| Function | Event | Level | Attrs |
|---|---|---|---|
| \`connectStrava\` | started | info | \`flow=strava_connect, step=start\` |
| \`connectStrava\` | auth prompt result | info | \`flow=strava_connect, step=auth_prompt, resultType, hasCode\` |
| \`exchangeCodeForTokens\` | token exchange ok | info | \`flow=strava_connect, step=token_exchange_ok\` |
| \`connectStrava\` | user cancelled | info | \`flow=strava_connect, step=user_cancelled, resultType\` |
| \`connectStrava\` | succeeded | info | \`flow=strava_connect, step=success, athleteId\` |
| \`disconnect\` | started | info | \`flow=strava_disconnect, step=start\` |
| \`disconnect\` | succeeded | info | \`flow=strava_disconnect, step=success\` |
| \`refreshAccessToken\` | succeeded | info | \`flow=strava_refresh, step=success\` |
| \`syncSessionToStrava\` | started | info | \`flow=strava_upload, step=start, sessionId\` |
| \`syncSessionToStrava\` | succeeded | info | \`flow=strava_upload, step=success, sessionId, activityId\` |

### Secret redaction
Never logs: \`access_token\`, \`refresh_token\`, \`client_secret\`, raw auth codes, \`Authorization\` headers.
Logs only: scalars (athleteId, sessionId, activityId, resultType, hasCode, status).

Tests scan every \`Sentry.logger.*\` call's JSON-serialized args for the known secret values and assert they don't appear.

### \`__tests__/lib/strava.test.ts\`
- Mocks \`@sentry/react-native\` with \`jest.fn()\` logger.
- 5 new test cases asserting \`connectStrava\` / \`disconnect\` / \`syncSessionToStrava\` call \`Sentry.logger.info\` with the correct flow+step attrs.
- Secret-redaction scan after every assertion.
- Compatibility test: sets \`Sentry.logger = undefined\` to simulate an older SDK and asserts \`connectStrava\` does not throw.

## Acceptance criteria

- [x] At least 8 lifecycle log call-sites in \`lib/strava.ts\` — **10** \`stravaLog\` call-sites (each routes through \`Sentry.logger.<level>\` in the helper).
- [x] No test-token/secret value passed to any \`Sentry.logger.*\` call (asserted by \`scanLoggerCallsForSecrets\` scanner).
- [x] \`npx tsc --noEmit\` passes.
- [x] \`npm test -- __tests__/lib/strava.test.ts\` passes (47/47).
- [x] Full test suite passes (1841/1841).
- [x] ESLint clean with \`--max-warnings=0\`.

## Note on grep-literal acceptance criterion

The ticket states: \`grep -n 'Sentry.logger' lib/strava.ts\` shows at least 8 calls. Because the spec also requires a \`stravaLog\` helper, the literal \`Sentry.logger\` token appears only inside that helper (single site). Runtime semantics satisfy the intent — 10 lifecycle log calls fan out through \`Sentry.logger.<level>\`. Happy to inline if the reviewer prefers the literal count.

## SKILL.md update (blocked by read-only FS)

\`/skills/claude-skills/cablesnap--sentry-debug/SKILL.md\` is on a read-only mount for this agent, so I cannot commit the doc update directly. Requesting CEO/skill-owner to append the following:

<details><summary>Proposed SKILL.md addition</summary>

\`\`\`markdown
## Strava-Specific Tags  (replace existing table)

| Tag | Values | Description |
|-----|--------|-------------|
| \`flow\` | \`strava_connect\`, \`strava_refresh\`, \`strava_upload\`, \`strava_disconnect\` | Which Strava flow this event belongs to |
| \`step\` | \`config_check\`, \`auth_prompt\`, \`token_exchange\`, \`token_exchange_ok\`, \`start\`, \`success\`, \`user_cancelled\`, \`api_call\` | Where in the flow it happened |
| \`severity\` | \`info\`, \`warn\`, \`error\` | Log level (logs dataset only) |

Extra attrs on Strava logs (\`ourlogs\` dataset): \`flow\`, \`step\`, \`resultType\`, \`hasCode\`, \`athleteId\`, \`sessionId\`, \`activityId\`.

## Querying Logs (happy-path signal)

Exception-only instrumentation produces zero events when a flow succeeds. Query the **logs (\`ourlogs\`) dataset** to verify a live action actually fired:

\`\`\`bash
curl -s -H \"Authorization: Bearer \$SENTRY_TOKEN\" \\
  \"\$SENTRY_BASE/organizations/\$SENTRY_ORG/events/?field=timestamp&field=message&field=severity&field=flow&field=step&dataset=ourlogs&project=4511267125133312&per_page=50&statsPeriod=7d&query=flow:strava_connect\" \\
  | python3 -m json.tool
\`\`\`

Swap \`flow:strava_connect\` for \`flow:strava_disconnect\`, \`flow:strava_refresh\`, \`flow:strava_upload\`, or \`step:user_cancelled\`.

### Verification workflow
1. Query logs dataset with \`flow:strava_connect\` and tight \`statsPeriod=1h\`.
2. Expected successful-connect trail: \`step:start\` → \`step:auth_prompt\` → \`step:token_exchange_ok\` → \`step:success\`.
3. Zero results means the client never invoked the action, is offline, or is on a pre-BLD-523 build.
4. \`step:start\` without \`step:token_exchange_ok\` → token proxy failed (cross-ref issues dataset for \`captureException\` with \`flow:strava_connect, step:token_exchange\`).
\`\`\`

</details>

## Manual verification after merge

After this merges and the next app release ships (F-Droid or test APK), trigger a Strava connect attempt on a real device, then run:

\`\`\`bash
SENTRY_TOKEN=... SENTRY_ORG=cablesnap SENTRY_BASE=https://sentry.io/api/0
curl -s -H \"Authorization: Bearer \$SENTRY_TOKEN\" \\
  \"\$SENTRY_BASE/organizations/\$SENTRY_ORG/events/?field=timestamp&field=message&field=severity&field=flow&field=step&dataset=ourlogs&project=4511267125133312&per_page=50&statsPeriod=1h&query=flow:strava_connect\"
\`\`\`

Expect at least one event with \`step:start\` — and \`step:success\` if the connect completed.

## Out of scope
- Sentry init config (\`app/_layout.tsx\` already has \`enableLogs: true\`)
- Other integrations (Health Connect etc.)
- Source map / release tagging