### PR TITLE
ci(bundle-gate): run on every PR so required check always reports (BLD-525)

### DIFF
--- a/.github/workflows/bundle-gate.yml
+++ b/.github/workflows/bundle-gate.yml
@@ -9,18 +9,11 @@ name: Bundle Gate
 # Refs: BLD-494, BLD-495.
 
 on:
-  pull_request:
-    paths:
-      - 'lib/db/**'
-      - 'hooks/**'
-      - 'e2e/**'
-      - 'scripts/verify-scenario-hook-not-in-bundle.sh'
-      - '.github/workflows/bundle-gate.yml'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'app.config.ts'
-      - 'metro.config.js'
-      - 'babel.config.js'
+  # Runs on every PR. The underlying script (~2 min) passes trivially when none
+  # of the guarded paths have changed, so leaving it unfiltered is cheaper than
+  # the operational cost of PRs being stuck in BLOCKED mergeStateStatus because
+  # a required check never reported (BLD-525).
+  pull_request: {}
   push:
     branches:
       - main


### PR DESCRIPTION
Closes BLD-525.

## Why
The Bundle Gate (`Verify scenario hook not in production bundle`) is a **required** status check on `main`. Its `pull_request` trigger was filtered to only a handful of paths (`lib/db/**`, `hooks/**`, `e2e/**`, `package.json`, `package-lock.json`, `app.config.ts`, `metro.config.js`, `babel.config.js`, the script itself). Any PR outside those paths got `mergeStateStatus=BLOCKED` because the required check never reported.

Known affected PRs in the last 24h:
- BLD-518 / #316 (theme tokens) — blocked, required intervention
- BLD-523 / #317 (Strava Sentry logs) — blocked, admin-merged

## What
Drop the `paths:` filter on the `pull_request` trigger of `.github/workflows/bundle-gate.yml`. The workflow now runs on every PR.

The underlying `scripts/verify-scenario-hook-not-in-bundle.sh` runs in ~2 min (full `expo export -p web`), and when the guarded files haven't changed it passes trivially. That's a bounded and acceptable cost for honoring the required-check contract — and far cheaper than `--admin` merges that bypass CI.

The `push:` trigger keeps its paths filter: main-branch runs are purely monitoring and can stay narrow.

## Expected cost impact
- Before: 0 min on non-guarded PRs → stuck at BLOCKED; 2 min on guarded PRs.
- After: ~2 min on every PR; guarded verification semantics unchanged.
- We accept ~2 min × n PRs/day of CI spend in exchange for auto-reporting required checks.

## AC
- [x] `Bundle Gate` reports a status (pass/fail) within ~3 min of every PR open
- [x] PRs touching guarded files still get the real verification
- [x] No regression to existing guarded-path semantics
- [x] Cost increase documented

## Out of scope
- Branch protection rules (unchanged)

Reviewer: @quality-director per standard gating.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>