### PR TITLE
ci(e2e): drop push: trigger from e2e-update-snapshots.yml (BLD-527)

### DIFF
--- a/.github/workflows/e2e-update-snapshots.yml
+++ b/.github/workflows/e2e-update-snapshots.yml
@@ -13,18 +13,14 @@ name: E2E Update Snapshots
 # regeneration happens here.
 
 on:
-  # workflow_dispatch requires the file to exist on the default branch, which
-  # defeats the purpose for a one-shot baseline regeneration on a feature
-  # branch. A push trigger scoped to branches named `bld-*-e2e-*` works
-  # immediately once the workflow is pushed.
-  push:
-    branches:
-      - "bld-*-e2e-*"
-    paths:
-      - ".github/workflows/e2e-update-snapshots.yml"
-      - "e2e/**.ts"
-      - "package.json"
-      - "package-lock.json"
+  # `workflow_dispatch` only. The earlier `push:` trigger (scoped to
+  # `bld-*-e2e-*` branches) was a bootstrap workaround so this file could be
+  # exercised on a feature branch before it existed on `main`. Now that the
+  # workflow is on `main`, `workflow_dispatch` works against any branch via
+  # the Actions UI or `gh workflow run`, and the push trigger is a footgun
+  # (any future branch matching the pattern that edits an e2e spec would
+  # silently overwrite all baselines and auto-push the diff). Removed in
+  # BLD-527.
   workflow_dispatch:
     inputs:
       spec:


### PR DESCRIPTION
Closes BLD-527. Follow-up flagged on PR #316 / parent BLD-517.

## Why
The `push:` trigger scoped to `bld-*-e2e-*` was a bootstrap so this workflow could run on a feature branch before it existed on `main`. Now that the workflow lives on `main`, that constraint is gone — `workflow_dispatch` works against any ref via the Actions UI or `gh workflow run`.

The push trigger is also a **footgun**: any future branch matching `bld-*-e2e-*` that edits an e2e spec would auto-regenerate ALL baselines and push the diff back with no human review.

## What
- Drop the entire `push:` block from `.github/workflows/e2e-update-snapshots.yml`.
- Keep `workflow_dispatch` (with existing `spec` and `projects` inputs) as the sole entry point.
- Update the doc comment to explain the rationale and link the ticket.

## AC
- [x] Editing an e2e spec on a new `bld-*-e2e-*` branch does NOT auto-trigger the regen workflow
- [x] `workflow_dispatch` from the Actions UI still works
- [ ] CI green on this PR (non-workflow paths → only Bundle Gate after BLD-525 lands; this PR is workflow-only so currently neither runs by default — branch protection should still allow merge once required checks settle)

## Out of scope
- Changing snapshot commit semantics or rewriting the regen workflow

Reviewer: @quality-director.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>