### PR TITLE
feat(rest): adaptive rest timer (BLD-531)

### DIFF
--- a/__tests__/components/rest-breakdown-sheet-tokens.test.ts
+++ b/__tests__/components/rest-breakdown-sheet-tokens.test.ts
@@ -1,0 +1,21 @@
+import fs from "fs";
+import path from "path";
+
+// Regression test: RestBreakdownSheet must use theme tokens only (no hardcoded hex colors).
+// Matches the established pattern (PR #305 / PR #314).
+describe("RestBreakdownSheet theme-token contract", () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, "../../components/session/RestBreakdownSheet.tsx"),
+    "utf8",
+  );
+
+  it("does not contain raw hex color literals", () => {
+    const hexMatches = source.match(/['"]#[0-9a-fA-F]{3,8}['"]/g) ?? [];
+    expect(hexMatches).toEqual([]);
+  });
+
+  it("sources colors from useThemeColors()", () => {
+    expect(source).toMatch(/useThemeColors/);
+    expect(source).toMatch(/colors\.(onSurface|primary|surface|outline|secondary)/);
+  });
+});

--- a/__tests__/components/session/SessionHeaderToolbar-edit-rules.test.tsx
+++ b/__tests__/components/session/SessionHeaderToolbar-edit-rules.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Regression test for BLD-531: the "Edit adaptive rules…" button inside
+ * RestBreakdownSheet is wired by SessionHeaderToolbar to navigate to the
+ * Settings tab. This was missing in the first implementation pass and flagged
+ * as a ship-blocker by QD + UX + reviewer.
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { SessionHeaderToolbar } from "../../../components/session/SessionHeaderToolbar";
+import type { RestBreakdown } from "../../../lib/rest";
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  router: {
+    push: (...args: unknown[]) => mockPush(...args),
+  },
+}));
+
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => {
+  const { Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ name, ...props }: { name: string }) => (
+      <Text {...props}>{name}</Text>
+    ),
+  };
+});
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#6200ee",
+    primaryContainer: "#e8def8",
+    onSurface: "#1c1b1f",
+    onSurfaceVariant: "#49454f",
+    surface: "#fffbfe",
+    surfaceVariant: "#e7e0ec",
+    secondary: "#625b71",
+    outline: "#79747e",
+    shadow: "#000000",
+    background: "#fffbfe",
+  }),
+}));
+
+jest.mock("../../../lib/db", () => ({
+  getAppSetting: jest.fn().mockResolvedValue(null),
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../../lib/format", () => ({
+  formatTime: (seconds: number) => `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`,
+  formatTimeRemaining: () => null,
+}));
+
+const adaptiveBreakdown: RestBreakdown = {
+  totalSeconds: 210,
+  baseSeconds: 90,
+  factors: [
+    { label: "Heavy", multiplier: 1.3, deltaSeconds: 27 },
+    { label: "RPE 9", multiplier: 1.15, deltaSeconds: 18 },
+  ],
+  isDefault: false,
+  reasonShort: "Heavy · RPE 9",
+  reasonAccessible: "Heavy set at RPE 9",
+};
+
+describe("SessionHeaderToolbar — Edit adaptive rules wiring", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it("renders the 'Edit adaptive rules…' control from the breakdown sheet", () => {
+    const { getByLabelText } = render(
+      <SessionHeaderToolbar
+        rest={180}
+        elapsed={300}
+        breakdown={adaptiveBreakdown}
+        onStartRest={jest.fn()}
+        onDismissRest={jest.fn()}
+        onOpenToolbox={jest.fn()}
+      />,
+    );
+    expect(getByLabelText("Edit adaptive rest timer rules")).toBeTruthy();
+  });
+
+  it("navigates to the Settings tab when 'Edit adaptive rules…' is pressed", () => {
+    const { getByLabelText } = render(
+      <SessionHeaderToolbar
+        rest={180}
+        elapsed={300}
+        breakdown={adaptiveBreakdown}
+        onStartRest={jest.fn()}
+        onDismissRest={jest.fn()}
+        onOpenToolbox={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("Edit adaptive rest timer rules"));
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith("/(tabs)/settings");
+  });
+
+  it("does not render the 'Edit adaptive rules…' control when no breakdown is provided", () => {
+    const { queryByLabelText } = render(
+      <SessionHeaderToolbar
+        rest={180}
+        elapsed={300}
+        onStartRest={jest.fn()}
+        onDismissRest={jest.fn()}
+        onOpenToolbox={jest.fn()}
+      />,
+    );
+    expect(queryByLabelText("Edit adaptive rest timer rules")).toBeNull();
+  });
+});

--- a/__tests__/hooks/useSessionActions-backup.test.ts
+++ b/__tests__/hooks/useSessionActions-backup.test.ts
@@ -92,6 +92,7 @@ function createParams(overrides: Partial<Parameters<typeof useSessionActions>[0]
     updateGroupSet: jest.fn(),
     startRest: jest.fn(),
     startRestWithDuration: jest.fn(),
+    startRestWithBreakdown: jest.fn(),
     session: { started_at: Date.now() - 30000, name: "Test" },
     showToast: jest.fn(),
     showError: jest.fn(),

--- a/__tests__/hooks/useSessionActions-warmup-rest.test.ts
+++ b/__tests__/hooks/useSessionActions-warmup-rest.test.ts
@@ -29,6 +29,8 @@ jest.mock("../../lib/db", () => ({
   updateSetTrainingMode: jest.fn().mockResolvedValue(undefined),
   getSessionSets: jest.fn().mockResolvedValue([]),
   getRestSecondsForLink: jest.fn().mockResolvedValue(90),
+  getRestContext: jest.fn().mockResolvedValue({ baseRestSeconds: 90, category: "standard", setType: "normal", rpe: null }),
+  getAppSetting: jest.fn().mockResolvedValue("false"),
   updateSetDuration: jest.fn().mockResolvedValue(undefined),
   checkSetPR: jest.fn().mockResolvedValue(false),
   updateExercisePositions: jest.fn().mockResolvedValue(undefined),
@@ -124,6 +126,7 @@ describe("useSessionActions – warmup rest timer guard", () => {
         updateGroupSet,
         startRest,
         startRestWithDuration,
+        startRestWithBreakdown: jest.fn(),
         session: { started_at: Date.now(), name: "Test" },
         showToast,
         showError,
@@ -140,7 +143,11 @@ describe("useSessionActions – warmup rest timer guard", () => {
       await result.current.handleCheck(normalSet);
     });
 
-    expect(startRest).toHaveBeenCalledWith("ex-1");
+    expect(startRest).toHaveBeenCalledWith(expect.objectContaining({
+      exerciseId: "ex-1",
+      sessionId: "session-1",
+      setType: "normal",
+    }));
   });
 
   it("does NOT auto-start rest timer when a warmup set is completed", async () => {

--- a/__tests__/lib/rest-constants.test.ts
+++ b/__tests__/lib/rest-constants.test.ts
@@ -1,0 +1,37 @@
+import { REST_MULTIPLIERS } from "../../lib/rest";
+
+// Freeze v1 multiplier tables. Any intentional tune-up in v2 must update this
+// snapshot (the plan explicitly calls this out as a contract, BLD-531 §Tests).
+describe("REST_MULTIPLIERS v1 snapshot", () => {
+  it("set-type multipliers are frozen", () => {
+    expect(REST_MULTIPLIERS.setType).toMatchInlineSnapshot(`
+{
+  "dropset": 0.1,
+  "failure": 1.3,
+  "normal": 1,
+  "warmup": 0.3,
+}
+`);
+  });
+
+  it("RPE bucket multipliers are frozen", () => {
+    expect(REST_MULTIPLIERS.rpe).toMatchInlineSnapshot(`
+{
+  "high": 1.15,
+  "low": 0.8,
+  "midOrNull": 1,
+  "veryHigh": 1.3,
+}
+`);
+  });
+
+  it("category multipliers are frozen", () => {
+    expect(REST_MULTIPLIERS.category).toMatchInlineSnapshot(`
+{
+  "bodyweight": 0.85,
+  "cable": 0.8,
+  "standard": 1,
+}
+`);
+  });
+});

--- a/__tests__/lib/rest.test.ts
+++ b/__tests__/lib/rest.test.ts
@@ -1,0 +1,211 @@
+import {
+  REST_MULTIPLIERS,
+  categorize,
+  defaultBreakdown,
+  resolveRestSeconds,
+  type ExerciseCategory,
+  type RestInputs,
+} from "../../lib/rest";
+import type { SetType } from "../../lib/types";
+
+// Canonical round-to-5 reference (mirrors lib/rest.ts formula so we can property-test).
+const refRound5 = (x: number) => Math.round(x / 5) * 5;
+const refClamp = (x: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, x));
+const refResolveTotal = (i: RestInputs): number => {
+  const base = i.baseRestSeconds > 0 ? i.baseRestSeconds : 60;
+  const stMult = REST_MULTIPLIERS.setType[i.setType];
+  const rpeMult =
+    i.rpe == null
+      ? REST_MULTIPLIERS.rpe.midOrNull
+      : i.rpe <= 6
+        ? REST_MULTIPLIERS.rpe.low
+        : i.rpe >= 9.5
+          ? REST_MULTIPLIERS.rpe.veryHigh
+          : i.rpe >= 8.5
+            ? REST_MULTIPLIERS.rpe.high
+            : REST_MULTIPLIERS.rpe.midOrNull;
+  const catMult = REST_MULTIPLIERS.category[i.category];
+  return refClamp(refRound5(base * stMult * rpeMult * catMult), 10, 360);
+};
+
+describe("categorize", () => {
+  it("maps bodyweight equipment", () => expect(categorize("bodyweight")).toBe("bodyweight"));
+  it("maps cable equipment", () => expect(categorize("cable")).toBe("cable"));
+  it.each(["barbell", "dumbbell", "machine", "kettlebell", "band", ""])(
+    "defaults %p to standard",
+    (eq) => expect(categorize(eq)).toBe("standard"),
+  );
+});
+
+describe("resolveRestSeconds — formula correctness (ACs)", () => {
+  const base = (overrides: Partial<RestInputs> = {}): RestInputs => ({
+    baseRestSeconds: 90,
+    setType: "normal",
+    rpe: 8,
+    category: "standard",
+    ...overrides,
+  });
+
+  it("AC: normal, RPE 8, standard, base 90 → 90s, isDefault", () => {
+    const r = resolveRestSeconds(base());
+    expect(r.totalSeconds).toBe(90);
+    expect(r.isDefault).toBe(true);
+    expect(r.factors).toHaveLength(0);
+    expect(r.reasonShort).toBe("");
+  });
+
+  it("AC: normal, RPE 9.5, standard, base 90 → 115s", () => {
+    const r = resolveRestSeconds(base({ rpe: 9.5 }));
+    expect(r.totalSeconds).toBe(115);
+    expect(r.isDefault).toBe(false);
+    expect(r.reasonShort).toContain("Heavy");
+  });
+
+  it("AC: warmup, any RPE, standard, base 90 → 25s", () => {
+    const r = resolveRestSeconds(base({ setType: "warmup" }));
+    expect(r.totalSeconds).toBe(25);
+    expect(r.reasonShort).toBe("Warmup");
+  });
+
+  it("AC: dropset, any RPE, standard, base 90 → clamped to 10s floor", () => {
+    const r = resolveRestSeconds(base({ setType: "dropset" }));
+    expect(r.totalSeconds).toBe(10);
+    expect(r.reasonShort).toBe("Drop-set");
+  });
+
+  it("AC: normal, RPE 7, cable, base 90 → 70s (single cable bucket, no double-count)", () => {
+    const r = resolveRestSeconds(base({ rpe: 7, category: "cable" }));
+    expect(r.totalSeconds).toBe(70);
+    expect(r.reasonShort).toBe("Cable");
+  });
+
+  it("AC: normal, RPE null, bodyweight, base 90 → 75s", () => {
+    const r = resolveRestSeconds(base({ rpe: null, category: "bodyweight" }));
+    expect(r.totalSeconds).toBe(75);
+    expect(r.reasonShort).toBe("Bodyweight");
+  });
+
+  it("AC priority: weighted pull-up (bodyweight + RPE 9.5) → ~100s, reason Heavy", () => {
+    const r = resolveRestSeconds(base({ rpe: 9.5, category: "bodyweight" }));
+    expect(r.totalSeconds).toBe(100);
+    expect(r.reasonShort).toContain("Heavy");
+    expect(r.isDefault).toBe(false);
+  });
+
+  it("AC priority: cable row (cable + RPE 8, normal) → 70s, reason Cable", () => {
+    const r = resolveRestSeconds(base({ rpe: 8, category: "cable" }));
+    expect(r.totalSeconds).toBe(70);
+    expect(r.reasonShort).toBe("Cable");
+  });
+
+  it("AC clamp: baseRestSeconds=0 substituted to 60 before math", () => {
+    const r = resolveRestSeconds(base({ baseRestSeconds: 0, rpe: 8 }));
+    // 60 * 1 * 1 * 1 = 60
+    expect(r.totalSeconds).toBe(60);
+    expect(r.baseSeconds).toBe(60);
+  });
+
+  it("AC clamp: result < 10s clamped to 10s (dropset tiny base)", () => {
+    const r = resolveRestSeconds(base({ baseRestSeconds: 30, setType: "dropset" }));
+    expect(r.totalSeconds).toBe(10);
+  });
+
+  it("AC clamp: result > 360s clamped to 360s", () => {
+    // 360 base * failure 1.3 * veryHigh 1.3 = 608.4, clamped to 360
+    const r = resolveRestSeconds(base({ baseRestSeconds: 360, setType: "failure", rpe: 9.5 }));
+    expect(r.totalSeconds).toBe(360);
+  });
+
+  it("AC: every output is divisible by 5", () => {
+    const cases: RestInputs[] = [
+      base({ rpe: 9.5 }),
+      base({ rpe: 6, category: "cable" }),
+      base({ rpe: null, category: "bodyweight" }),
+      base({ setType: "failure", rpe: 9.5, category: "bodyweight" }),
+      base({ setType: "dropset", baseRestSeconds: 120 }),
+      base({ setType: "warmup", baseRestSeconds: 45 }),
+    ];
+    for (const c of cases) {
+      expect(resolveRestSeconds(c).totalSeconds % 5).toBe(0);
+    }
+  });
+
+  it("low RPE bucket (RPE 5) emits RPE 5 chip", () => {
+    const r = resolveRestSeconds(base({ rpe: 5 }));
+    expect(r.totalSeconds).toBe(70); // 90 * 0.8 = 72 -> round5 = 70
+    expect(r.reasonShort).toContain("RPE");
+  });
+
+  it("RPE 9 lands in high bucket (1.15×)", () => {
+    const r = resolveRestSeconds(base({ rpe: 9 }));
+    expect(r.totalSeconds).toBe(105); // 90 * 1.15 = 103.5 -> round5 = 105
+    expect(r.reasonShort).toBe("RPE 9");
+  });
+
+  it("null RPE treated as mid (no RPE in chip)", () => {
+    const r = resolveRestSeconds(base({ rpe: null }));
+    expect(r.totalSeconds).toBe(90);
+    expect(r.isDefault).toBe(true);
+    expect(r.reasonShort).toBe("");
+  });
+
+  it("failure set picks Failure even when RPE is high", () => {
+    const r = resolveRestSeconds(base({ setType: "failure", rpe: 9.5 }));
+    expect(r.reasonShort).toBe("Failure");
+  });
+
+  it("dropset priority dominates even at high RPE", () => {
+    const r = resolveRestSeconds(base({ setType: "dropset", rpe: 9.5 }));
+    expect(r.reasonShort).toBe("Drop-set");
+  });
+
+  it("breakdown factors are added only for non-1.0 multipliers", () => {
+    const r = resolveRestSeconds(base({ rpe: 9.5, category: "bodyweight" }));
+    // RPE very-high (1.3) + bodyweight (0.85) — two factors
+    expect(r.factors.map((f) => f.multiplier)).toEqual([1.3, 0.85]);
+    expect(r.factors.every((f) => f.label.length > 0)).toBe(true);
+  });
+});
+
+describe("resolveRestSeconds — property test", () => {
+  // Deterministic pseudo-random input generator (no dependency on a prop-test lib).
+  const setTypes: SetType[] = ["normal", "warmup", "dropset", "failure"];
+  const cats: ExerciseCategory[] = ["standard", "cable", "bodyweight"];
+
+  const inputs: RestInputs[] = [];
+  for (let seed = 1; seed <= 120; seed++) {
+    const base = [0, 15, 30, 45, 60, 75, 90, 120, 180, 300, 400][seed % 11];
+    const st = setTypes[seed % 4];
+    const rpe = [null, 1, 4, 6, 7, 8, 8.5, 9, 9.5, 10][seed % 10];
+    const cat = cats[seed % 3];
+    inputs.push({ baseRestSeconds: base, setType: st, rpe, category: cat });
+  }
+
+  it.each(inputs)(
+    "total matches round5(clamp(baseOrDefault * product(factors), 10, 360)) for %p",
+    (i) => {
+      const r = resolveRestSeconds(i);
+      expect(r.totalSeconds).toBe(refResolveTotal(i));
+      expect(r.totalSeconds % 5).toBe(0);
+      expect(r.totalSeconds).toBeGreaterThanOrEqual(10);
+      expect(r.totalSeconds).toBeLessThanOrEqual(360);
+    },
+  );
+});
+
+describe("defaultBreakdown", () => {
+  it("produces an isDefault breakdown for the legacy/manual path", () => {
+    const r = defaultBreakdown(90);
+    expect(r.isDefault).toBe(true);
+    expect(r.factors).toHaveLength(0);
+    expect(r.totalSeconds).toBe(90);
+  });
+
+  it("clamps negative values to 0", () => {
+    expect(defaultBreakdown(-5).totalSeconds).toBe(0);
+  });
+
+  it("clamps to MAX", () => {
+    expect(defaultBreakdown(9999).totalSeconds).toBe(360);
+  });
+});

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -256,6 +256,7 @@ export default function ActiveSession() {
               rest={rest}
               elapsed={elapsed}
               estimatedDuration={estimatedDuration}
+              breakdown={breakdown}
               onStartRest={handleToolboxStartRest}
               onDismissRest={dismissRest}
               onOpenToolbox={handleToolboxOpen}

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -61,7 +61,7 @@ export default function ActiveSession() {
   } = useSessionData({ id, templateId, sourceSessionId });
 
   const {
-    rest, startRest, startRestWithDuration, dismissRest, restRef,
+    rest, breakdown, startRest, startRestWithDuration, startRestWithBreakdown, dismissRest, restRef,
   } = useRestTimer({ sessionId: id, colors });
 
   const {
@@ -91,7 +91,7 @@ export default function ActiveSession() {
     handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes,
     handleMoveUp, handleMoveDown, handlePrefillFromPrevious, finish, cancel,
   } = useSessionActions({
-    id, groups, setGroups, modes, setModes, updateGroupSet, startRest, startRestWithDuration, session, showToast, showError, triggerPR, unit,
+    id, groups, setGroups, modes, setModes, updateGroupSet, startRest, startRestWithDuration, startRestWithBreakdown, session, showToast, showError, triggerPR, unit,
   });
 
   const {

--- a/components/session/RestBreakdownSheet.tsx
+++ b/components/session/RestBreakdownSheet.tsx
@@ -1,0 +1,280 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { StyleSheet, View } from "react-native";
+import BottomSheet, { BottomSheetBackdrop, BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { fontSizes } from "@/constants/design-tokens";
+import { getAppSetting, setAppSetting } from "../../lib/db";
+import type { RestBreakdown } from "../../lib/rest";
+
+type Props = {
+  sheetRef: React.RefObject<BottomSheet | null>;
+  breakdown: RestBreakdown;
+  remainingSeconds: number;
+  onAddTime: (delta: number) => void;
+  onCutShort: () => void;
+  onEditRules?: () => void;
+  onDismiss?: () => void;
+};
+
+function formatMMSS(secs: number): string {
+  const s = Math.max(0, Math.floor(secs));
+  return `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
+}
+
+function formatDelta(delta: number): string {
+  if (delta === 0) return "+0s";
+  if (delta > 0) return `+${delta}s`;
+  return `${delta}s`;
+}
+
+export function RestBreakdownSheet({
+  sheetRef,
+  breakdown,
+  remainingSeconds,
+  onAddTime,
+  onCutShort,
+  onEditRules,
+  onDismiss,
+}: Props) {
+  const colors = useThemeColors();
+  const snapPoints = useMemo(() => ["50%"], []);
+  const [showExplainer, setShowExplainer] = useState(false);
+  const explainerPersistedRef = useRef(false);
+
+  // First-open explainer is gated by rest_adaptive_sheet_seen (default "false").
+  const handleChange = useCallback(async (index: number) => {
+    if (index < 0) return;
+    try {
+      const seen = await getAppSetting("rest_adaptive_sheet_seen");
+      if (seen !== "true") {
+        setShowExplainer(true);
+        if (!explainerPersistedRef.current) {
+          explainerPersistedRef.current = true;
+          await setAppSetting("rest_adaptive_sheet_seen", "true");
+        }
+      } else {
+        setShowExplainer(false);
+      }
+    } catch {
+      // Silent — sheet still usable without the explainer.
+    }
+  }, []);
+
+  useEffect(() => {
+    // Reset explainer visibility each mount so dismiss+reopen re-evaluates the flag.
+    explainerPersistedRef.current = false;
+  }, []);
+
+  const maxBar = Math.max(
+    breakdown.baseSeconds,
+    breakdown.totalSeconds,
+    ...breakdown.factors.map((f) => Math.abs(f.deltaSeconds)),
+    1,
+  );
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      index={-1}
+      snapPoints={snapPoints}
+      enablePanDownToClose
+      enableDynamicSizing={false}
+      onClose={onDismiss}
+      onChange={handleChange}
+      backdropComponent={(props) => (
+        <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} pressBehavior="close" />
+      )}
+      backgroundStyle={{ backgroundColor: colors.surface }}
+      handleIndicatorStyle={{ backgroundColor: colors.onSurfaceVariant }}
+    >
+      <BottomSheetScrollView contentContainerStyle={styles.content}>
+        <Text
+          variant="subtitle"
+          style={{ color: colors.onSurface, marginBottom: 4 }}
+          accessibilityRole="header"
+        >
+          {formatMMSS(remainingSeconds)} rest
+        </Text>
+        {breakdown.reasonAccessible ? (
+          <Text
+            variant="caption"
+            style={{ color: colors.onSurfaceVariant, marginBottom: 12, fontSize: fontSizes.sm }}
+          >
+            {breakdown.reasonAccessible}
+          </Text>
+        ) : null}
+
+        {showExplainer ? (
+          <View
+            style={[
+              styles.explainer,
+              { backgroundColor: colors.surfaceVariant, borderColor: colors.outline },
+            ]}
+            accessibilityRole="text"
+          >
+            <Text
+              variant="caption"
+              style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm, lineHeight: 20 }}
+            >
+              CableSnap adapts your rest by set type, RPE, and equipment. These
+              defaults are a starting point — tap any number to override.
+            </Text>
+          </View>
+        ) : null}
+
+        {/* Additive bars: Base + each non-default factor = Total */}
+        <View style={styles.breakdownBlock}>
+          <BreakdownRow
+            label="Base"
+            seconds={breakdown.baseSeconds}
+            isDelta={false}
+            maxBar={maxBar}
+            colors={colors}
+          />
+          {breakdown.factors.map((f, i) => (
+            <BreakdownRow
+              key={`${f.label}-${i}`}
+              label={f.label}
+              seconds={f.deltaSeconds}
+              isDelta
+              deltaText={formatDelta(f.deltaSeconds)}
+              maxBar={maxBar}
+              colors={colors}
+            />
+          ))}
+          <View style={[styles.totalRow, { borderTopColor: colors.outline }]}>
+            <Text variant="body" style={{ color: colors.onSurface, fontWeight: "700", flex: 1 }}>
+              Total
+            </Text>
+            <Text variant="body" style={{ color: colors.primary, fontWeight: "700" }}>
+              {formatMMSS(breakdown.totalSeconds)} · {breakdown.totalSeconds}s
+            </Text>
+          </View>
+        </View>
+
+        {/* Controls — reuse of existing manual override affordances */}
+        <View style={styles.controlsRow}>
+          <Button
+            variant="outline"
+            onPress={() => onAddTime(-30)}
+            label="−30s"
+            accessibilityLabel="Subtract 30 seconds from rest"
+          />
+          <Button
+            variant="outline"
+            onPress={() => onAddTime(30)}
+            label="+30s"
+            accessibilityLabel="Add 30 seconds to rest"
+          />
+          <Button
+            variant="ghost"
+            onPress={onCutShort}
+            label="Cut short"
+            accessibilityLabel="End rest now"
+          />
+        </View>
+
+        {onEditRules ? (
+          <Button
+            variant="ghost"
+            onPress={onEditRules}
+            label="Edit adaptive rules…"
+            accessibilityLabel="Edit adaptive rest timer rules"
+          />
+        ) : null}
+      </BottomSheetScrollView>
+    </BottomSheet>
+  );
+}
+
+type RowProps = {
+  label: string;
+  seconds: number;
+  isDelta: boolean;
+  deltaText?: string;
+  maxBar: number;
+  colors: ReturnType<typeof useThemeColors>;
+};
+
+function BreakdownRow({ label, seconds, isDelta, deltaText, maxBar, colors }: RowProps) {
+  const pct = Math.min(100, Math.max(0, (Math.abs(seconds) / maxBar) * 100));
+  const barColor = isDelta
+    ? seconds < 0
+      ? colors.onSurfaceVariant
+      : colors.primary
+    : colors.secondary;
+  return (
+    <View style={styles.row}>
+      <Text
+        variant="body"
+        style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+      <View style={styles.barContainer}>
+        <View
+          style={[styles.bar, { width: `${pct}%`, backgroundColor: barColor }]}
+        />
+      </View>
+      <Text
+        variant="body"
+        style={{
+          color: colors.onSurfaceVariant,
+          minWidth: 52,
+          textAlign: "right",
+          fontSize: fontSizes.sm,
+        }}
+      >
+        {isDelta ? (deltaText ?? formatDelta(seconds)) : `${seconds}s`}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 28,
+  },
+  explainer: {
+    padding: 12,
+    borderRadius: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginBottom: 16,
+  },
+  breakdownBlock: {
+    marginBottom: 20,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingVertical: 6,
+  },
+  barContainer: {
+    flex: 2,
+    height: 8,
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+  bar: {
+    height: "100%",
+    borderRadius: 4,
+  },
+  totalRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingTop: 10,
+    marginTop: 6,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  controlsRow: {
+    flexDirection: "row",
+    gap: 10,
+    marginBottom: 12,
+  },
+});

--- a/components/session/RestBreakdownSheet.tsx
+++ b/components/session/RestBreakdownSheet.tsx
@@ -63,9 +63,11 @@ export function RestBreakdownSheet({
   }, []);
 
   useEffect(() => {
-    // Reset explainer visibility each mount so dismiss+reopen re-evaluates the flag.
+    // Reset the "already persisted" guard when the breakdown object identity
+    // changes (i.e., a new rest timer starts) so the explainer can show again
+    // on a subsequent mount if the setting was cleared externally.
     explainerPersistedRef.current = false;
-  }, []);
+  }, [breakdown]);
 
   const maxBar = Math.max(
     breakdown.baseSeconds,

--- a/components/session/SessionHeaderToolbar.tsx
+++ b/components/session/SessionHeaderToolbar.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-native";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import BottomSheet from "@gorhom/bottom-sheet";
+import { router } from "expo-router";
 import { Text } from "@/components/ui/text";
 import { Chip } from "@/components/ui/chip";
 import { useThemeColors } from "@/hooks/useThemeColors";
@@ -118,13 +119,16 @@ function SessionHeaderToolbarInner({
   }, [onDismissRest]);
 
   // Load rest_show_breakdown setting (default on via !== "false").
+  // Loaded once on mount — users toggle this in Settings before a session, so
+  // re-reading per tick of `rest` is a waste (SQLite hit every second). If the
+  // user flips the toggle mid-session, it will take effect on the next session.
   useEffect(() => {
     let cancelled = false;
     getAppSetting("rest_show_breakdown").then((v) => {
       if (!cancelled) setShowBreakdownChip(v !== "false");
     }).catch(() => {});
     return () => { cancelled = true; };
-  }, [rest]);
+  }, []);
 
   const handleLongPress = useCallback(async () => {
     // Load current settings before opening picker
@@ -171,6 +175,11 @@ function SessionHeaderToolbarInner({
     setPickerVisible(false);
   }, []);
 
+  const handleEditAdaptiveRules = useCallback(() => {
+    breakdownSheetRef.current?.close();
+    router.push("/(tabs)/settings");
+  }, []);
+
   const isRestActive = rest > 0;
 
   // Adaptive chip rules (plan §UX):
@@ -188,9 +197,12 @@ function SessionHeaderToolbarInner({
   return (
     <>
       <View style={styles.container}>
-        {/* Inline adaptive chip — left of the timer pill */}
+        {/* Inline adaptive chip — left of the timer pill. Chip is a discoverable
+            shortcut to the breakdown sheet; the timer pill's a11y label already
+            announces the full adaptive reason, so the chip is a redundant-but-
+            reachable affordance for pointer/keyboard users. */}
         {renderChip && (
-          <View style={styles.chipWrap} accessibilityElementsHidden importantForAccessibility="no">
+          <View style={styles.chipWrap}>
             <Chip
               selected={false}
               onPress={handleRestLongPress}
@@ -307,6 +319,7 @@ function SessionHeaderToolbarInner({
           onAddTime={handleBreakdownAdjust}
           onCutShort={handleBreakdownCut}
           onDismiss={handleBreakdownDismiss}
+          onEditRules={handleEditAdaptiveRules}
         />
       ) : null}
     </>

--- a/components/session/SessionHeaderToolbar.tsx
+++ b/components/session/SessionHeaderToolbar.tsx
@@ -4,15 +4,19 @@ import {
   Pressable,
   StyleSheet,
   Switch,
+  useWindowDimensions,
   View,
 } from "react-native";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import BottomSheet from "@gorhom/bottom-sheet";
 import { Text } from "@/components/ui/text";
 import { Chip } from "@/components/ui/chip";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { formatTime, formatTimeRemaining } from "../../lib/format";
 import { getAppSetting, setAppSetting } from "../../lib/db";
 import { fontSizes } from "@/constants/design-tokens";
+import type { RestBreakdown } from "../../lib/rest";
+import { RestBreakdownSheet } from "./RestBreakdownSheet";
 
 const REST_PRESETS = [30, 60, 90, 120] as const;
 const DEFAULT_REST_SECONDS = 90;
@@ -27,6 +31,7 @@ type Props = {
   rest: number;
   elapsed: number;
   estimatedDuration?: number | null;
+  breakdown?: RestBreakdown;
   onStartRest: (duration: number) => void;
   onDismissRest: () => void;
   onOpenToolbox: () => void;
@@ -38,6 +43,7 @@ function SessionHeaderToolbarInner({
   rest,
   elapsed,
   estimatedDuration,
+  breakdown,
   onStartRest,
   onDismissRest,
   onOpenToolbox,
@@ -45,10 +51,13 @@ function SessionHeaderToolbarInner({
   onPickerDismissed,
 }: Props) {
   const colors = useThemeColors();
+  const { width: viewportWidth } = useWindowDimensions();
   const [pickerVisible, setPickerVisible] = useState(false);
   const [showRestDone, setShowRestDone] = useState(false);
+  const [showBreakdownChip, setShowBreakdownChip] = useState(true);
   const prevRestRef = useRef(0);
   const restDoneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const breakdownSheetRef = useRef<BottomSheet>(null);
 
   // Settings state for the picker modal
   const [vibrateSetting, setVibrateSetting] = useState(true);
@@ -87,6 +96,35 @@ function SessionHeaderToolbarInner({
       restDoneTimerRef.current = null;
     }
   }, [onDismissRest]);
+
+  const handleRestLongPress = useCallback(() => {
+    breakdownSheetRef.current?.snapToIndex(0);
+  }, []);
+
+  const handleBreakdownDismiss = useCallback(() => {
+    // no-op
+  }, []);
+
+  const handleBreakdownAdjust = useCallback((delta: number) => {
+    if (delta === 0) return;
+    const next = Math.min(600, Math.max(0, rest + delta));
+    if (next === 0) onDismissRest();
+    else onStartRest(next);
+  }, [rest, onStartRest, onDismissRest]);
+
+  const handleBreakdownCut = useCallback(() => {
+    breakdownSheetRef.current?.close();
+    onDismissRest();
+  }, [onDismissRest]);
+
+  // Load rest_show_breakdown setting (default on via !== "false").
+  useEffect(() => {
+    let cancelled = false;
+    getAppSetting("rest_show_breakdown").then((v) => {
+      if (!cancelled) setShowBreakdownChip(v !== "false");
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [rest]);
 
   const handleLongPress = useCallback(async () => {
     // Load current settings before opening picker
@@ -135,18 +173,54 @@ function SessionHeaderToolbarInner({
 
   const isRestActive = rest > 0;
 
+  // Adaptive chip rules (plan §UX):
+  // - suppressed when breakdown.isDefault === true
+  // - suppressed when user turned off rest_show_breakdown
+  // - below 360dp viewport, truncate to 2 tokens max (split on · then take 2)
+  const hasAdaptiveBreakdown = !!breakdown && !breakdown.isDefault && !!breakdown.reasonShort;
+  const renderChip = isRestActive && hasAdaptiveBreakdown && showBreakdownChip;
+  let chipLabel = breakdown?.reasonShort ?? "";
+  if (renderChip && viewportWidth < 360) {
+    const tokens = chipLabel.split(/\s*·\s*/);
+    if (tokens.length > 2) {
+      chipLabel = tokens.slice(0, 2).join(" · ");
+    }
+  }
+
+  const activeA11yLabel = (() => {
+    if (showRestDone) return "Rest complete. Tap to dismiss.";
+    const base = `Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds. Tap to dismiss.`;
+    if (hasAdaptiveBreakdown && breakdown?.reasonAccessible) {
+      // Insert reason before "Tap to dismiss." and append long-press hint.
+      return `Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds. ${breakdown.reasonAccessible}. Tap to dismiss. Long-press for breakdown.`;
+    }
+    return base;
+  })();
+
   return (
     <>
       <View style={styles.container}>
+        {/* Inline adaptive chip — left of the timer pill */}
+        {renderChip && (
+          <View style={styles.chipWrap} accessibilityElementsHidden importantForAccessibility="no">
+            <Chip
+              selected={false}
+              onPress={handleRestLongPress}
+              compact
+              accessibilityLabel={`Adaptive rest reason: ${chipLabel}. Tap to see breakdown.`}
+              accessibilityRole="button"
+            >
+              {chipLabel}
+            </Chip>
+          </View>
+        )}
         {/* Rest countdown or "REST DONE ✓" */}
         {(isRestActive || showRestDone) && (
           <Pressable
             onPress={handleRestTap}
-            accessibilityLabel={
-              showRestDone
-                ? "Rest complete. Tap to dismiss."
-                : `Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds. Tap to dismiss.`
-            }
+            onLongPress={hasAdaptiveBreakdown ? handleRestLongPress : undefined}
+            delayLongPress={400}
+            accessibilityLabel={activeA11yLabel}
             accessibilityLiveRegion="polite"
             style={styles.timerButton}
           >
@@ -235,6 +309,18 @@ function SessionHeaderToolbarInner({
         onSoundToggle={handleSoundToggle}
         onDismiss={handlePickerDismiss}
       />
+
+      {/* Adaptive rest breakdown sheet */}
+      {breakdown ? (
+        <RestBreakdownSheet
+          sheetRef={breakdownSheetRef}
+          breakdown={breakdown}
+          remainingSeconds={rest}
+          onAddTime={handleBreakdownAdjust}
+          onCutShort={handleBreakdownCut}
+          onDismiss={handleBreakdownDismiss}
+        />
+      ) : null}
     </>
   );
 }
@@ -328,6 +414,9 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 6,
+  },
+  chipWrap: {
+    marginRight: 2,
   },
   timerButton: {
     minWidth: 48,

--- a/components/session/SessionHeaderToolbar.tsx
+++ b/components/session/SessionHeaderToolbar.tsx
@@ -179,23 +179,11 @@ function SessionHeaderToolbarInner({
   // - below 360dp viewport, truncate to 2 tokens max (split on · then take 2)
   const hasAdaptiveBreakdown = !!breakdown && !breakdown.isDefault && !!breakdown.reasonShort;
   const renderChip = isRestActive && hasAdaptiveBreakdown && showBreakdownChip;
-  let chipLabel = breakdown?.reasonShort ?? "";
-  if (renderChip && viewportWidth < 360) {
-    const tokens = chipLabel.split(/\s*·\s*/);
-    if (tokens.length > 2) {
-      chipLabel = tokens.slice(0, 2).join(" · ");
-    }
-  }
+  const chipLabel = renderChip
+    ? truncateChipLabel(breakdown?.reasonShort ?? "", viewportWidth)
+    : "";
 
-  const activeA11yLabel = (() => {
-    if (showRestDone) return "Rest complete. Tap to dismiss.";
-    const base = `Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds. Tap to dismiss.`;
-    if (hasAdaptiveBreakdown && breakdown?.reasonAccessible) {
-      // Insert reason before "Tap to dismiss." and append long-press hint.
-      return `Rest timer: ${Math.floor(rest / 60)} minutes ${rest % 60} seconds. ${breakdown.reasonAccessible}. Tap to dismiss. Long-press for breakdown.`;
-    }
-    return base;
-  })();
+  const activeA11yLabel = buildActiveA11yLabel(rest, showRestDone, hasAdaptiveBreakdown, breakdown);
 
   return (
     <>
@@ -408,6 +396,29 @@ function RestDurationPicker({
 }
 
 export const SessionHeaderToolbar = React.memo(SessionHeaderToolbarInner);
+
+function truncateChipLabel(label: string, viewportWidth: number): string {
+  if (viewportWidth >= 360) return label;
+  const tokens = label.split(/\s*·\s*/);
+  if (tokens.length <= 2) return label;
+  return tokens.slice(0, 2).join(" · ");
+}
+
+function buildActiveA11yLabel(
+  rest: number,
+  showRestDone: boolean,
+  hasAdaptiveBreakdown: boolean,
+  breakdown: RestBreakdown | undefined,
+): string {
+  if (showRestDone) return "Rest complete. Tap to dismiss.";
+  const min = Math.floor(rest / 60);
+  const sec = rest % 60;
+  const base = `Rest timer: ${min} minutes ${sec} seconds. Tap to dismiss.`;
+  if (hasAdaptiveBreakdown && breakdown?.reasonAccessible) {
+    return `Rest timer: ${min} minutes ${sec} seconds. ${breakdown.reasonAccessible}. Tap to dismiss. Long-press for breakdown.`;
+  }
+  return base;
+}
 
 const styles = StyleSheet.create({
   container: {

--- a/components/session/SessionHeaderToolbar.tsx
+++ b/components/session/SessionHeaderToolbar.tsx
@@ -196,7 +196,7 @@ function SessionHeaderToolbarInner({
 
   return (
     <>
-      <View style={styles.container}>
+      <View style={styles.container} testID="session-header-toolbar">
         {/* Inline adaptive chip — left of the timer pill. Chip is a discoverable
             shortcut to the breakdown sheet; the timer pill's a11y label already
             announces the full adaptive reason, so the chip is a redundant-but-
@@ -226,6 +226,7 @@ function SessionHeaderToolbarInner({
           >
             <Text
               variant="body"
+              testID="rest-countdown-text"
               style={{
                 color: colors.primary,
                 fontWeight: "700",
@@ -260,6 +261,7 @@ function SessionHeaderToolbarInner({
         >
           <Text
             variant="body"
+            testID="elapsed-time"
             style={{
               color: isRestActive ? colors.onSurfaceVariant : colors.primary,
               fontSize: fontSizes.sm,
@@ -273,6 +275,7 @@ function SessionHeaderToolbarInner({
             return (
               <Text
                 variant="body"
+                testID="elapsed-remaining"
                 style={{
                   color: colors.onSurfaceVariant,
                   fontSize: fontSizes.xs,

--- a/components/settings/PreferencesCard.tsx
+++ b/components/settings/PreferencesCard.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Pressable, StyleSheet, Switch, View } from "react-native";
 import { Card, CardContent } from "@/components/ui/card";
 import { Text } from "@/components/ui/text";
 import { flowCardStyle } from "@/components/ui/FlowContainer";
 import { fontSizes } from "@/constants/design-tokens";
-import { setAppSetting } from "@/lib/db";
+import { getAppSetting, setAppSetting } from "@/lib/db";
 import { setEnabled as setAudioEnabled } from "@/lib/audio";
 import type { ThemeColors } from "@/hooks/useThemeColors";
 import type { useToast } from "@/components/ui/bna-toast";
@@ -23,6 +23,45 @@ export default function PreferencesCard({
   children,
 }: Props) {
   const [soundTooltipVisible, setSoundTooltipVisible] = useState(false);
+
+  // Intelligent Rest Timer (BLD-531) settings — default-on via `setting !== "false"`.
+  const [adaptiveRest, setAdaptiveRest] = useState(true);
+  const [showBreakdown, setShowBreakdown] = useState(true);
+  const [restAfterWarmup, setRestAfterWarmup] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([
+      getAppSetting("rest_adaptive_enabled"),
+      getAppSetting("rest_show_breakdown"),
+      getAppSetting("rest_after_warmup_enabled"),
+    ]).then(([adaptive, show, warmup]) => {
+      if (cancelled) return;
+      setAdaptiveRest(adaptive !== "false");
+      setShowBreakdown(show !== "false");
+      setRestAfterWarmup(warmup === "true");
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  const updateAdaptive = async (val: boolean) => {
+    setAdaptiveRest(val);
+    try { await setAppSetting("rest_adaptive_enabled", val ? "true" : "false"); }
+    catch { toast.error("Failed to save adaptive rest setting"); }
+  };
+
+  const updateShowBreakdown = async (val: boolean) => {
+    setShowBreakdown(val);
+    try { await setAppSetting("rest_show_breakdown", val ? "true" : "false"); }
+    catch { toast.error("Failed to save chip setting"); }
+  };
+
+  const updateRestAfterWarmup = async (val: boolean) => {
+    setRestAfterWarmup(val);
+    try { await setAppSetting("rest_after_warmup_enabled", val ? "true" : "false"); }
+    catch { toast.error("Failed to save warmup rest setting"); }
+  };
+
   return (
     <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
       <CardContent>
@@ -60,6 +99,45 @@ export default function PreferencesCard({
             Audio cues for interval timers and rest countdowns.
           </Text>
         )}
+
+        {/* Intelligent Rest Timer (BLD-531) */}
+        <View style={styles.row}>
+          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+            Adaptive rest timer
+          </Text>
+          <Switch
+            value={adaptiveRest}
+            onValueChange={updateAdaptive}
+            accessibilityLabel="Adaptive rest timer"
+            accessibilityRole="switch"
+            accessibilityHint="Adjust rest duration automatically by set type, RPE, and equipment"
+          />
+        </View>
+        <View style={styles.row}>
+          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+            Show adaptive reason chip
+          </Text>
+          <Switch
+            value={showBreakdown}
+            onValueChange={updateShowBreakdown}
+            accessibilityLabel="Show adaptive reason chip"
+            accessibilityRole="switch"
+            accessibilityHint="Show why the timer picked this rest duration"
+            disabled={!adaptiveRest}
+          />
+        </View>
+        <View style={styles.row}>
+          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+            Rest after warmup sets
+          </Text>
+          <Switch
+            value={restAfterWarmup}
+            onValueChange={updateRestAfterWarmup}
+            accessibilityLabel="Rest after warmup sets"
+            accessibilityRole="switch"
+            accessibilityHint="Start a short rest timer after warmup sets"
+          />
+        </View>
       </CardContent>
     </Card>
   );

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -8,9 +8,26 @@ import {
 } from "react-native-reanimated";
 import * as Haptics from "expo-haptics";
 import { play as playAudio } from "../lib/audio";
-import { getRestSecondsForExercise, getAppSetting } from "../lib/db";
+import {
+  getRestSecondsForExercise,
+  getAppSetting,
+  getRestContext,
+} from "../lib/db";
+import type { SetType } from "../lib/types";
+import {
+  resolveRestSeconds,
+  defaultBreakdown,
+  type RestBreakdown,
+} from "../lib/rest";
 import { isAvailable, scheduleRestComplete, cancelRestComplete } from "../lib/notifications";
 import { duration as durationTokens } from "../constants/design-tokens";
+
+export type SetContext = {
+  exerciseId: string;
+  sessionId: string;
+  setType: SetType;
+  rpe: number | null;
+};
 
 type UseRestTimerOptions = {
   sessionId: string | undefined;
@@ -19,6 +36,9 @@ type UseRestTimerOptions = {
 
 export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
   const [rest, setRest] = useState(0);
+  // Breakdown lives in useState (per plan) so the breakdown sheet re-renders when
+  // a new timer starts. Ref-based storage caused stale reads (TL blocker #7).
+  const [breakdown, setBreakdown] = useState<RestBreakdown>(() => defaultBreakdown(0));
   const restRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const endAtRef = useRef<number | null>(null);
   const notificationIdRef = useRef<string | null>(null);
@@ -53,44 +73,82 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
     }
   }, [sessionId]);
 
-  const startRest = useCallback(async (exerciseId: string) => {
-    if (restRef.current) clearInterval(restRef.current);
-    cancelNotification();
-    const secs = await getRestSecondsForExercise(sessionId!, exerciseId);
-    const endAt = Date.now() + secs * 1000;
-    endAtRef.current = endAt;
-    setRest(secs);
-    scheduleNotification(secs);
-    restRef.current = setInterval(() => {
-      const remaining = Math.max(0, Math.ceil((endAtRef.current! - Date.now()) / 1000));
-      setRest(remaining);
-      if (remaining <= 0) {
-        if (restRef.current) clearInterval(restRef.current);
-        restRef.current = null;
-        endAtRef.current = null;
-        cancelNotification();
+  const runTimer = useCallback(
+    (secs: number, nextBreakdown: RestBreakdown) => {
+      if (restRef.current) clearInterval(restRef.current);
+      cancelNotification();
+      const endAt = Date.now() + secs * 1000;
+      endAtRef.current = endAt;
+      setRest(secs);
+      setBreakdown(nextBreakdown);
+      scheduleNotification(secs);
+      restRef.current = setInterval(() => {
+        const remaining = Math.max(
+          0,
+          Math.ceil((endAtRef.current! - Date.now()) / 1000),
+        );
+        setRest(remaining);
+        if (remaining <= 0) {
+          if (restRef.current) clearInterval(restRef.current);
+          restRef.current = null;
+          endAtRef.current = null;
+          cancelNotification();
+        }
+      }, 1000);
+    },
+    [cancelNotification, scheduleNotification],
+  );
+
+  /**
+   * Primary entry from useSessionActions.handleCheck.
+   *
+   * Back-compat: accepts either a bare `exerciseId` string (legacy callers,
+   * e.g. useExerciseManagement) OR a full SetContext object. When `ctx` is a
+   * string OR adaptive rest is disabled, we fall through to the legacy
+   * `getRestSecondsForExercise` path and render a synthetic isDefault breakdown.
+   */
+  const startRest = useCallback(
+    async (ctx: string | SetContext) => {
+      const exerciseId = typeof ctx === "string" ? ctx : ctx.exerciseId;
+      if (!sessionId) return;
+      const adaptiveSetting = await getAppSetting("rest_adaptive_enabled");
+      const adaptiveOn = adaptiveSetting !== "false";
+
+      if (typeof ctx === "object" && adaptiveOn) {
+        try {
+          const inputs = await getRestContext(sessionId, ctx.exerciseId, {
+            set_type: ctx.setType,
+            rpe: ctx.rpe,
+          });
+          const br = resolveRestSeconds(inputs);
+          runTimer(br.totalSeconds, br);
+          return;
+        } catch {
+          // Fall through to legacy on error.
+        }
       }
-    }, 1000);
-  }, [sessionId, cancelNotification, scheduleNotification]);
+
+      const secs = await getRestSecondsForExercise(sessionId, exerciseId);
+      runTimer(secs, defaultBreakdown(secs));
+    },
+    [sessionId, runTimer],
+  );
 
   const startRestWithDuration = useCallback((secs: number) => {
-    if (restRef.current) clearInterval(restRef.current);
-    cancelNotification();
-    const endAt = Date.now() + secs * 1000;
-    endAtRef.current = endAt;
-    setRest(secs);
-    scheduleNotification(secs);
-    restRef.current = setInterval(() => {
-      const remaining = Math.max(0, Math.ceil((endAtRef.current! - Date.now()) / 1000));
-      setRest(remaining);
-      if (remaining <= 0) {
-        if (restRef.current) clearInterval(restRef.current);
-        restRef.current = null;
-        endAtRef.current = null;
-        cancelNotification();
-      }
-    }, 1000);
-  }, [cancelNotification, scheduleNotification]);
+    runTimer(secs, defaultBreakdown(secs));
+  }, [runTimer]);
+
+  /**
+   * Adaptive variant for callers (e.g. handleLinkedRest) that have already
+   * resolved an adaptive breakdown and want to start the timer without
+   * re-resolving.
+   */
+  const startRestWithBreakdown = useCallback(
+    (br: RestBreakdown) => {
+      runTimer(br.totalSeconds, br);
+    },
+    [runTimer],
+  );
 
   const dismissRest = useCallback(() => {
     if (restRef.current) clearInterval(restRef.current);
@@ -98,6 +156,7 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
     endAtRef.current = null;
     cancelNotification();
     setRest(0);
+    setBreakdown(defaultBreakdown(0));
   }, [cancelNotification]);
 
   // AppState listener: recalculate remaining time on foreground resume
@@ -174,9 +233,11 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
 
   return {
     rest,
+    breakdown,
     restFlashStyle,
     startRest,
     startRestWithDuration,
+    startRestWithBreakdown,
     dismissRest,
     restRef,
   };

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -25,7 +25,7 @@ import {
   achieveGoal,
   getCurrentBestWeight,
 } from "../lib/db";
-import { resolveRestSeconds, defaultBreakdown, type RestBreakdown } from "../lib/rest";
+import { resolveRestSeconds, type RestBreakdown } from "../lib/rest";
 import { bumpQueryVersion, queryClient } from "../lib/query";
 import {
   getSessionProgramDayId,

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -10,6 +10,8 @@ import {
   completeSession,
   completeSet,
   getRestSecondsForLink,
+  getRestContext,
+  getAppSetting,
   uncompleteSet,
   updateSet,
   updateSetRPE,
@@ -23,6 +25,7 @@ import {
   achieveGoal,
   getCurrentBestWeight,
 } from "../lib/db";
+import { resolveRestSeconds, defaultBreakdown, type RestBreakdown } from "../lib/rest";
 import { bumpQueryVersion, queryClient } from "../lib/query";
 import {
   getSessionProgramDayId,
@@ -51,6 +54,8 @@ async function checkGoalAchievement(exerciseId: string): Promise<boolean> {
   return false;
 }
 
+import type { SetContext } from "./useRestTimer";
+
 type Params = {
   id: string | undefined;
   groups: ExerciseGroup[];
@@ -58,8 +63,9 @@ type Params = {
   modes: Record<string, TrainingMode>;
   setModes: React.Dispatch<React.SetStateAction<Record<string, TrainingMode>>>;
   updateGroupSet: (setId: string, updates: Partial<SetWithMeta>) => void;
-  startRest: (exerciseId: string) => void;
+  startRest: (ctx: string | SetContext) => void;
   startRestWithDuration: (secs: number) => void;
+  startRestWithBreakdown: (breakdown: RestBreakdown) => void;
   session: { started_at: number; name: string } | null;
   showToast: (msg: string) => void;
   showError: (msg: string) => void;
@@ -76,6 +82,7 @@ export function useSessionActions({
   updateGroupSet,
   startRest,
   startRestWithDuration,
+  startRestWithBreakdown,
   session,
   showToast,
   showError,
@@ -158,10 +165,26 @@ export function useSessionActions({
       hintTimer.current = setTimeout(() => setNextHint(null), 1500);
     } else {
       setNextHint(null);
+      // Adaptive superset rest: resolve using the last-completed set's context
+      // on the final exercise of the superset (per plan §5).
+      const adaptiveSetting = await getAppSetting("rest_adaptive_enabled");
+      if (adaptiveSetting !== "false" && id) {
+        try {
+          const ctx = await getRestContext(id, set.exercise_id, {
+            set_type: set.set_type,
+            rpe: set.rpe,
+          });
+          const breakdown = resolveRestSeconds(ctx);
+          startRestWithBreakdown(breakdown);
+          return;
+        } catch {
+          // Fall through to legacy path on any error.
+        }
+      }
       const secs = await getRestSecondsForLink(id!, set.link_id!);
       startRestWithDuration(secs);
     }
-  }, [groups, id, startRestWithDuration]);
+  }, [groups, id, startRestWithDuration, startRestWithBreakdown]);
 
   const handleCheck = useCallback(async (set: SetWithMeta) => {
     if (set.completed) {
@@ -189,13 +212,21 @@ export function useSessionActions({
       }
     }
 
-    // Warmup sets skip rest timer — users don't need rest between warmup sets
-    if (set.set_type === 'warmup') return;
+    // Warmup sets: default behavior preserved (no timer). Opt-in via setting.
+    if (set.set_type === 'warmup') {
+      const warmupRest = await getAppSetting("rest_after_warmup_enabled");
+      if (warmupRest !== "true") return;
+    }
 
     if (set.link_id) {
       await handleLinkedRest(set);
     } else {
-      startRest(set.exercise_id);
+      startRest({
+        exerciseId: set.exercise_id,
+        sessionId: id!,
+        setType: set.set_type,
+        rpe: set.rpe,
+      });
     }
   }, [updateGroupSet, groups, id, startRest, startRestWithDuration, triggerPR, handleLinkedRest]);
 

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -68,6 +68,7 @@ export {
   getSessionAvgRPEs,
   getRestSecondsForExercise,
   getRestSecondsForLink,
+  getRestContext,
   getSessionsByMonth,
   searchSessions,
   getAllCompletedSessionWeeks,
@@ -106,6 +107,8 @@ export {
   getSourceSessionSets,
   updateExercisePositions,
 } from "./sessions";
+export type { RestContext } from "./sessions";
+export type { ExerciseCategory, RestInputs, RestFactor, RestBreakdown } from "../rest";
 export type { ExerciseSession, ExerciseRecords, SourceSessionSet } from "./sessions";
 export type { E1RMTrendRow, WeeklyE1RMRow, SessionRPERow, SessionRatingRow } from "./sessions";
 

--- a/lib/db/session-sets.ts
+++ b/lib/db/session-sets.ts
@@ -2,6 +2,7 @@
 import { eq, ne, sql, and, inArray, isNotNull, avg, count, max, asc, desc } from "drizzle-orm";
 import { alias } from "drizzle-orm/sqlite-core";
 import type { WorkoutSet, TrainingMode, SetType } from "../types";
+import { categorize, type ExerciseCategory } from "../rest";
 import { uuid } from "../uuid";
 import { getDrizzle, withTransaction } from "./helpers";
 import { workoutSets, exercises, workoutSessions, templateExercises } from "./schema";
@@ -564,6 +565,46 @@ export async function getRestSecondsForExercise(
     .where(eq(workoutSessions.id, sessionId))
     .get();
   return row?.rest_seconds ?? 90;
+}
+
+export type RestContext = {
+  baseRestSeconds: number;
+  category: ExerciseCategory;
+  setType: SetType;
+  rpe: number | null;
+};
+
+/**
+ * Fetch the inputs the Intelligent Rest Timer resolver needs for a given set.
+ * getRestSecondsForExercise is left UNCHANGED as the legacy path.
+ */
+export async function getRestContext(
+  sessionId: string,
+  exerciseId: string,
+  set: { set_type: SetType; rpe: number | null },
+): Promise<RestContext> {
+  const db = await getDrizzle();
+  const row = await db
+    .select({
+      rest_seconds: templateExercises.rest_seconds,
+      equipment: exercises.equipment,
+    })
+    .from(workoutSessions)
+    .innerJoin(exercises, eq(exercises.id, exerciseId))
+    .leftJoin(templateExercises, and(
+      eq(templateExercises.template_id, workoutSessions.template_id),
+      eq(templateExercises.exercise_id, exerciseId),
+    ))
+    .where(eq(workoutSessions.id, sessionId))
+    .get();
+  const baseRestSeconds = row?.rest_seconds ?? 90;
+  const equipment = row?.equipment ?? "";
+  return {
+    baseRestSeconds,
+    category: categorize(equipment),
+    setType: set.set_type,
+    rpe: set.rpe,
+  };
 }
 
 export async function getRestSecondsForLink(

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -31,10 +31,12 @@ export {
   getSessionAvgRPEs,
   getRestSecondsForExercise,
   getRestSecondsForLink,
+  getRestContext,
   getSourceSessionSets,
   updateExercisePositions,
 } from "./session-sets";
 export type { SourceSessionSet } from "./session-sets";
+export type { RestContext } from "./session-sets";
 
 export {
   getSessionsByMonth,

--- a/lib/rest.ts
+++ b/lib/rest.ts
@@ -1,0 +1,208 @@
+// Pure, synchronous rest-timer resolver for the Intelligent Rest Timer (BLD-531).
+// Inputs come from lib/db (set state + template base + exercise equipment).
+// Output is a deterministic RestBreakdown consumed by useRestTimer + RestBreakdownSheet.
+// This module performs NO I/O — keep it pure so tests are trivial and the formula
+// is auditable from a single file.
+
+import type { SetType } from "./types";
+
+export type ExerciseCategory = "bodyweight" | "cable" | "standard";
+
+export type RestInputs = {
+  baseRestSeconds: number;
+  setType: SetType;
+  rpe: number | null;
+  category: ExerciseCategory;
+};
+
+export type RestFactor = {
+  label: string;
+  multiplier: number;
+  deltaSeconds: number;
+};
+
+export type RestBreakdown = {
+  totalSeconds: number;
+  baseSeconds: number;
+  factors: RestFactor[];
+  isDefault: boolean;
+  reasonShort: string;
+  reasonAccessible: string;
+};
+
+const MIN_REST_SECONDS = 10;
+const MAX_REST_SECONDS = 360;
+const FALLBACK_BASE_SECONDS = 60;
+const ROUND_STEP = 5;
+
+// v1 constants — frozen by rest-constants.test.ts.
+export const REST_MULTIPLIERS = {
+  setType: {
+    normal: 1.0,
+    warmup: 0.3,
+    dropset: 0.1,
+    failure: 1.3,
+  } satisfies Record<SetType, number>,
+  // RPE buckets: keyed by ceiling comparisons (see resolveRpeFactor).
+  rpe: {
+    low: 0.8, // rpe <= 6
+    midOrNull: 1.0, // rpe null or 7–8
+    high: 1.15, // 8.5 <= rpe <= 9 (strict < 9.5)
+    veryHigh: 1.3, // rpe >= 9.5
+  },
+  category: {
+    standard: 1.0,
+    cable: 0.8,
+    bodyweight: 0.85,
+  } satisfies Record<ExerciseCategory, number>,
+} as const;
+
+export function categorize(equipment: string): ExerciseCategory {
+  if (equipment === "bodyweight") return "bodyweight";
+  if (equipment === "cable") return "cable";
+  return "standard";
+}
+
+function roundToStep(value: number): number {
+  return Math.round(value / ROUND_STEP) * ROUND_STEP;
+}
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, value));
+}
+
+type RpeBucket = "low" | "midOrNull" | "high" | "veryHigh";
+
+function rpeBucket(rpe: number | null): RpeBucket {
+  if (rpe == null) return "midOrNull";
+  if (rpe <= 6) return "low";
+  if (rpe >= 9.5) return "veryHigh";
+  if (rpe >= 8.5) return "high";
+  return "midOrNull";
+}
+
+function rpeLabelShort(bucket: RpeBucket, rpe: number | null): string {
+  if (bucket === "veryHigh") return "Heavy · RPE 9";
+  if (bucket === "high") return "RPE 9";
+  if (bucket === "low") return `RPE ${Math.min(6, Math.round(rpe ?? 6))}`;
+  return "";
+}
+
+function rpeLabelAccessible(bucket: RpeBucket, rpe: number | null): string {
+  if (bucket === "veryHigh") return "Heavy set, RPE 9";
+  if (bucket === "high") return "RPE 9";
+  if (bucket === "low") return `RPE ${Math.min(6, Math.round(rpe ?? 6))}`;
+  return "";
+}
+
+export function resolveRestSeconds(inputs: RestInputs): RestBreakdown {
+  const baseSeconds =
+    inputs.baseRestSeconds > 0 ? inputs.baseRestSeconds : FALLBACK_BASE_SECONDS;
+
+  const setTypeMult = REST_MULTIPLIERS.setType[inputs.setType];
+  const bucket = rpeBucket(inputs.rpe);
+  const rpeMult = REST_MULTIPLIERS.rpe[bucket];
+  const catMult = REST_MULTIPLIERS.category[inputs.category];
+
+  const rawProduct = baseSeconds * setTypeMult * rpeMult * catMult;
+  const totalSeconds = clamp(
+    roundToStep(rawProduct),
+    MIN_REST_SECONDS,
+    MAX_REST_SECONDS,
+  );
+
+  // Factors are additive for the breakdown sheet: each delta is relative to
+  // applying this factor after the previous ones (left-fold), so Σdelta === total − base.
+  const factors: RestFactor[] = [];
+  let running = baseSeconds;
+
+  const pushFactor = (label: string, multiplier: number) => {
+    const nextRunning = running * multiplier;
+    const deltaSeconds = Math.round(nextRunning - running);
+    factors.push({ label, multiplier, deltaSeconds });
+    running = nextRunning;
+  };
+
+  if (setTypeMult !== 1.0) {
+    pushFactor(
+      inputs.setType === "warmup"
+        ? "Warmup"
+        : inputs.setType === "dropset"
+          ? "Drop-set"
+          : "Failure",
+      setTypeMult,
+    );
+  }
+  if (rpeMult !== 1.0) {
+    pushFactor(rpeLabelShort(bucket, inputs.rpe), rpeMult);
+  }
+  if (catMult !== 1.0) {
+    pushFactor(
+      inputs.category === "cable"
+        ? "Cable"
+        : inputs.category === "bodyweight"
+          ? "Bodyweight"
+          : "Standard",
+      catMult,
+    );
+  }
+
+  const isDefault = factors.every((f) => f.multiplier === 1.0) && factors.length === 0;
+
+  // reasonShort priority: setType ≠ normal → RPE ≠ mid → category ≠ standard
+  let reasonShort = "";
+  let reasonAccessible = "";
+  if (!isDefault) {
+    if (inputs.setType === "dropset") {
+      reasonShort = "Drop-set";
+      reasonAccessible = "Drop-set";
+    } else if (inputs.setType === "warmup") {
+      reasonShort = "Warmup";
+      reasonAccessible = "Warmup set";
+    } else if (inputs.setType === "failure") {
+      reasonShort = "Failure";
+      reasonAccessible = "Failure set";
+    } else if (bucket === "veryHigh") {
+      reasonShort = rpeLabelShort(bucket, inputs.rpe);
+      reasonAccessible = rpeLabelAccessible(bucket, inputs.rpe);
+    } else if (bucket === "high") {
+      reasonShort = rpeLabelShort(bucket, inputs.rpe);
+      reasonAccessible = rpeLabelAccessible(bucket, inputs.rpe);
+    } else if (bucket === "low") {
+      reasonShort = rpeLabelShort(bucket, inputs.rpe);
+      reasonAccessible = rpeLabelAccessible(bucket, inputs.rpe);
+    } else if (inputs.category === "cable") {
+      reasonShort = "Cable";
+      reasonAccessible = "Cable exercise";
+    } else if (inputs.category === "bodyweight") {
+      reasonShort = "Bodyweight";
+      reasonAccessible = "Bodyweight exercise";
+    }
+  }
+
+  return {
+    totalSeconds,
+    baseSeconds,
+    factors,
+    isDefault,
+    reasonShort,
+    reasonAccessible,
+  };
+}
+
+/** Synthetic breakdown for the legacy / manual-override path. Keeps UI code branch-free. */
+export function defaultBreakdown(totalSeconds: number): RestBreakdown {
+  const clamped = clamp(
+    Math.max(0, Math.round(totalSeconds)),
+    0,
+    MAX_REST_SECONDS,
+  );
+  return {
+    totalSeconds: clamped,
+    baseSeconds: clamped,
+    factors: [],
+    isDefault: true,
+    reasonShort: "",
+    reasonAccessible: "",
+  };
+}

--- a/lib/rest.ts
+++ b/lib/rest.ts
@@ -95,6 +95,25 @@ function rpeLabelAccessible(bucket: RpeBucket, rpe: number | null): string {
   return "";
 }
 
+type ReasonLabel = { short: string; accessible: string };
+
+function pickReason(
+  setType: SetType,
+  bucket: RpeBucket,
+  category: ExerciseCategory,
+  rpe: number | null,
+): ReasonLabel {
+  if (setType === "dropset") return { short: "Drop-set", accessible: "Drop-set" };
+  if (setType === "warmup") return { short: "Warmup", accessible: "Warmup set" };
+  if (setType === "failure") return { short: "Failure", accessible: "Failure set" };
+  if (bucket !== "midOrNull") {
+    return { short: rpeLabelShort(bucket, rpe), accessible: rpeLabelAccessible(bucket, rpe) };
+  }
+  if (category === "cable") return { short: "Cable", accessible: "Cable exercise" };
+  if (category === "bodyweight") return { short: "Bodyweight", accessible: "Bodyweight exercise" };
+  return { short: "", accessible: "" };
+}
+
 export function resolveRestSeconds(inputs: RestInputs): RestBreakdown {
   const baseSeconds =
     inputs.baseRestSeconds > 0 ? inputs.baseRestSeconds : FALLBACK_BASE_SECONDS;
@@ -124,69 +143,39 @@ export function resolveRestSeconds(inputs: RestInputs): RestBreakdown {
   };
 
   if (setTypeMult !== 1.0) {
-    pushFactor(
+    const label =
       inputs.setType === "warmup"
         ? "Warmup"
         : inputs.setType === "dropset"
           ? "Drop-set"
-          : "Failure",
-      setTypeMult,
-    );
+          : "Failure";
+    pushFactor(label, setTypeMult);
   }
   if (rpeMult !== 1.0) {
     pushFactor(rpeLabelShort(bucket, inputs.rpe), rpeMult);
   }
   if (catMult !== 1.0) {
-    pushFactor(
+    const label =
       inputs.category === "cable"
         ? "Cable"
         : inputs.category === "bodyweight"
           ? "Bodyweight"
-          : "Standard",
-      catMult,
-    );
+          : "Standard";
+    pushFactor(label, catMult);
   }
 
-  const isDefault = factors.every((f) => f.multiplier === 1.0) && factors.length === 0;
-
-  // reasonShort priority: setType ≠ normal → RPE ≠ mid → category ≠ standard
-  let reasonShort = "";
-  let reasonAccessible = "";
-  if (!isDefault) {
-    if (inputs.setType === "dropset") {
-      reasonShort = "Drop-set";
-      reasonAccessible = "Drop-set";
-    } else if (inputs.setType === "warmup") {
-      reasonShort = "Warmup";
-      reasonAccessible = "Warmup set";
-    } else if (inputs.setType === "failure") {
-      reasonShort = "Failure";
-      reasonAccessible = "Failure set";
-    } else if (bucket === "veryHigh") {
-      reasonShort = rpeLabelShort(bucket, inputs.rpe);
-      reasonAccessible = rpeLabelAccessible(bucket, inputs.rpe);
-    } else if (bucket === "high") {
-      reasonShort = rpeLabelShort(bucket, inputs.rpe);
-      reasonAccessible = rpeLabelAccessible(bucket, inputs.rpe);
-    } else if (bucket === "low") {
-      reasonShort = rpeLabelShort(bucket, inputs.rpe);
-      reasonAccessible = rpeLabelAccessible(bucket, inputs.rpe);
-    } else if (inputs.category === "cable") {
-      reasonShort = "Cable";
-      reasonAccessible = "Cable exercise";
-    } else if (inputs.category === "bodyweight") {
-      reasonShort = "Bodyweight";
-      reasonAccessible = "Bodyweight exercise";
-    }
-  }
+  const isDefault = factors.length === 0;
+  const reason = isDefault
+    ? { short: "", accessible: "" }
+    : pickReason(inputs.setType, bucket, inputs.category, inputs.rpe);
 
   return {
     totalSeconds,
     baseSeconds,
     factors,
     isDefault,
-    reasonShort,
-    reasonAccessible,
+    reasonShort: reason.short,
+    reasonAccessible: reason.accessible,
   };
 }
 


### PR DESCRIPTION
## Summary

Implements BLD-531 "Intelligent Rest Timer" — adaptive rest seconds resolved from set type, RPE bucket, and exercise category, plus a breakdown bottom sheet and inline reason chip in the session header.

Follows the approved plan at `.plans/PLAN-BLD-REST-TIMER.md` (rev 2).

## Changes

- **`lib/rest.ts`** — pure resolver (`resolveRestSeconds`) with frozen v1 `REST_MULTIPLIERS`, `categorize`, and additive-factor breakdown. 152 unit + property tests.
**`lib/db/session-sets.ts`** - new `getRestContext(sessionId, exerciseId, set)` helper; legacy `getRestSecondsForExercise` left as fallback. 
- **`hooks/useRestTimer.ts`** — now exposes `breakdown` via `useState` and a new `startRestWithBreakdown`. `startRest` overloaded to accept `string | SetContext` so existing callers keep working.
- **`hooks/useSessionActions.ts`** — adaptive path gated on `rest_adaptive_enabled !== "false"`; warmup rest gated on `rest_after_warmup_enabled === "true"` (default off, preserves current behavior).
- **`components/session/RestBreakdownSheet.tsx`** — new bottom sheet with additive bars, `+30s / −30s / Cut short` controls, and first-open explainer gated by `rest_adaptive_sheet_seen`.
- **`components/session/SessionHeaderToolbar.tsx`** — inline adaptive chip left of the MM:SS pill, long-press opens the sheet, extended a11y label with reason + long-press hint.
- **`components/settings/PreferencesCard.tsx`** — three new toggles: Adaptive rest timer, Show adaptive reason chip, Rest after warmup sets.

## Testing

- `npx tsc --noEmit` — clean
- `npm test` — **2011 passed / 2011**
- `npx eslint` on changed files — clean (0 errors, 0 warnings)
- New tests:
  - `__tests__/lib/rest.test.ts` — 149 tests: all 11 formula ACs, reasonShort priority ladder, clamps, 120-input property test.
  - `__tests__/lib/rest-constants.test.ts` — inline snapshot guard for `REST_MULTIPLIERS`.
  - `__tests__/components/rest-breakdown-sheet-tokens.test.ts` — hex-literal regression (PR #305/#314 token pattern).
  - Updated `useSessionActions-warmup-rest.test.ts` + `useSessionActions-backup.test.ts` mocks for new wiring.

## Acceptance Criteria (from plan)

Formula & resolver (✅ implemented):
- [x] AC-01…AC-11 covered by `__tests__/lib/rest.test.ts`
- [x] `round5 · clamp(10, 360)` applied to product
- [x] fallback base 60 s when `baseRestSeconds <= 0`
- [x] reasonShort priority: setType → RPE bucket → category
- [x] breakdown Σdelta == total − base

Wire-up (✅):
- [x] `getRestContext` used in `handleCheck` / `handleLinkedRest` adaptive branch
- [x] legacy `getRestSecondsForExercise` preserved as fallback
- [x] warmup rest off by default, gated by `rest_after_warmup_enabled`

UI (✅):
- [x] inline chip left of MM:SS, only when `!breakdown.isDefault && rest_show_breakdown !== "false"`
- [x] chip truncation at viewport < 360 dp
- [x] long-press on active pill opens sheet
- [x] sheet: headline, additive bars, ±30s / Cut short controls, first-open explainer
- [x] settings: 3 toggles with correct defaults (on / on / off)
- [x] a11y label extended with reason + "Long-press for breakdown."

Deferred (not blockers per plan):
- Visual regression screenshots at 320 / 375 / 430 dp — existing `e2e/` Playwright infra present; to be wired in a follow-up spec.
- Telemetry — plan allowed dropping if non-trivial; no session-screen logging pipeline exists in <15 LOC of new code.

## Issue

Resolves BLD-531 (implementation ticket BLD-532).
