### PR TITLE
fix: apply floating tab bar inset to exercise detail right pane (BLD-540)

### DIFF
--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -190,7 +190,7 @@ export default function Exercises() {
   return (
     <View style={[styles.container, styles.wideRow, { backgroundColor: colors.background }]}>
       {list}
-      <ExerciseDetailPane detail={detail} colors={colors} profileGender={profileGender} />
+      <ExerciseDetailPane detail={detail} colors={colors} profileGender={profileGender} bottomInset={tabBarHeight} />
     </View>
   );
 }

--- a/components/exercises/ExerciseDetailPane.tsx
+++ b/components/exercises/ExerciseDetailPane.tsx
@@ -12,9 +12,10 @@ export interface ExerciseDetailPaneProps {
   detail: Exercise | null;
   colors: ThemeColors;
   profileGender: "male" | "female" | undefined;
+  bottomInset?: number;
 }
 
-export function ExerciseDetailPane({ detail, colors, profileGender }: ExerciseDetailPaneProps) {
+export function ExerciseDetailPane({ detail, colors, profileGender, bottomInset }: ExerciseDetailPaneProps) {
   const steps = detail?.instructions
     .split("\n")
     .map((s) => s.trim())
@@ -26,7 +27,7 @@ export function ExerciseDetailPane({ detail, colors, profileGender }: ExerciseDe
         <FlatList
           data={[]}
           renderItem={null}
-          contentContainerStyle={styles.detailContent}
+          contentContainerStyle={[styles.detailContent, { paddingBottom: (bottomInset ?? 0) + 32 }]}
           ListHeaderComponent={
             <>
               <Text variant="heading" style={{ color: colors.onSurface, marginBottom: 12 }}>
@@ -172,7 +173,6 @@ const styles = StyleSheet.create({
   },
   detailContent: {
     padding: 24,
-    paddingBottom: 32,
   },
   detailEmpty: {
     flex: 1,


### PR DESCRIPTION
## Summary

On wide/tablet layouts (Z Fold6 unfolded, ≥medium breakpoint), the Exercise Detail right pane on the Exercises screen had its bottom content hidden behind the floating tab bar due to a static `paddingBottom: 32`.

## Changes

- `components/exercises/ExerciseDetailPane.tsx`: add optional `bottomInset` prop; compose `contentContainerStyle` paddingBottom as `(bottomInset ?? 0) + 32` to preserve existing 32pt breathing room above the tab bar. Removed the now-redundant static `paddingBottom: 32` from the base style.
- `app/(tabs)/exercises.tsx`: pass existing `tabBarHeight` (from `useFloatingTabBarHeight()`) as `bottomInset` to the detail pane.

## Testing

- `npx tsc --noEmit` passes (zero errors)
- Jest: `__tests__/app/visual-polish.test.ts` and `__tests__/app/fta-decomposition.test.ts` pass (28/28)
- Phone layout untouched (<medium breakpoint doesn't render the right pane)

## Issue

Resolves BLD-540 / GH [#325](https://github.com/alankyshum/cablesnap/issues/325)