### PR TITLE
feat(session): auto-prefill reps/weight from last template session (BLD-542)

### DIFF
--- a/__tests__/hooks/useSessionActions-autoprefill.test.ts
+++ b/__tests__/hooks/useSessionActions-autoprefill.test.ts
@@ -224,4 +224,44 @@ describe("useSessionActions — auto-prefill (BLD-542)", () => {
     const haptics = jest.requireMock("expo-haptics");
     expect(haptics.impactAsync).toHaveBeenCalled();
   });
+
+  it("rollback + warn when silent auto-prefill persistence fails (BLD-542 QD/reviewer blocker)", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    mockUpdateSet.mockRejectedValueOnce(new Error("DB locked"));
+
+    const params = makeParams([makeGroup()]);
+    params.setGroups = jest.fn();
+
+    renderHook(() => useSessionActions(params));
+    await act(async () => { await flush(); });
+
+    // Silent contract intact: no toast, no showError, no haptic
+    expect(params.showToast).not.toHaveBeenCalled();
+    expect(params.showError).not.toHaveBeenCalled();
+    const haptics = jest.requireMock("expo-haptics");
+    expect(haptics.impactAsync).not.toHaveBeenCalled();
+
+    // No a11y announce on failure (we never reached success path)
+    expect(mockAnnounce).not.toHaveBeenCalled();
+
+    // Diagnostic breadcrumb surfaced
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[prefillFromPrevious] persist failed"),
+      expect.any(Error),
+    );
+
+    // setGroups called twice: optimistic apply + rollback
+    const setGroupsMock = params.setGroups as jest.Mock;
+    expect(setGroupsMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    // Apply both updaters sequentially to an initial state; final state equals initial (rollback).
+    const initial = [makeGroup()];
+    let state: any = initial;
+    for (const [updater] of setGroupsMock.mock.calls) {
+      state = updater(state);
+    }
+    expect(state[0].sets.every((s: any) => s.weight == null && s.reps == null && s.duration_seconds == null)).toBe(true);
+
+    warnSpy.mockRestore();
+  });
 });

--- a/__tests__/hooks/useSessionActions-autoprefill.test.ts
+++ b/__tests__/hooks/useSessionActions-autoprefill.test.ts
@@ -1,0 +1,227 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Tests for auto-prefill useEffect in useSessionActions (BLD-542).
+ *
+ * AC:
+ * - Runs once per session open for groups with previousSets + no touched working sets
+ * - Silent: no toast/haptic, but still announces for a11y
+ * - Idempotent: ref-guarded against re-render
+ * - Skipped for groups with any touched working set (completed or has values)
+ * - Manual tap still goes through the normal (toasting) path
+ */
+
+const mockUpdateSet = jest.fn().mockResolvedValue(undefined);
+const mockAnnounce = jest.fn();
+
+jest.mock("../../lib/db", () => ({
+  addSet: jest.fn(),
+  cancelSession: jest.fn(),
+  deleteSet: jest.fn(),
+  completeSession: jest.fn(),
+  completeSet: jest.fn(),
+  getRestSecondsForLink: jest.fn(),
+  getRestContext: jest.fn(),
+  getAppSetting: jest.fn().mockResolvedValue(null),
+  uncompleteSet: jest.fn(),
+  updateSet: (...args: any[]) => mockUpdateSet(...args),
+  updateSetRPE: jest.fn(),
+  updateSetNotes: jest.fn(),
+  updateSetTrainingMode: jest.fn(),
+  getSessionSets: jest.fn().mockResolvedValue([]),
+  updateSetDuration: jest.fn(),
+  checkSetPR: jest.fn().mockResolvedValue(null),
+  checkSetBodyweightModifierPR: jest.fn().mockResolvedValue(null),
+  updateExercisePositions: jest.fn(),
+  getGoalForExercise: jest.fn().mockResolvedValue(null),
+  achieveGoal: jest.fn(),
+  getCurrentBestWeight: jest.fn(),
+}));
+
+jest.mock("../../lib/db/session-sets", () => ({
+  getLastBodyweightModifier: jest.fn(),
+  updateSetBodyweightModifier: jest.fn(),
+}));
+
+jest.mock("../../lib/query", () => ({
+  bumpQueryVersion: jest.fn(),
+  queryClient: { removeQueries: jest.fn() },
+}));
+
+jest.mock("../../lib/programs", () => ({
+  getSessionProgramDayId: jest.fn().mockResolvedValue(null),
+  getProgramDayById: jest.fn(),
+  advanceProgram: jest.fn(),
+}));
+
+jest.mock("../../lib/strava", () => ({
+  syncSessionToStrava: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock("../../lib/health-connect", () => ({
+  syncToHealthConnect: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: "light" },
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ replace: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock("../../lib/confirm", () => ({
+  confirmAction: jest.fn(),
+}));
+
+jest.mock("../../lib/rest", () => ({
+  resolveRestSeconds: jest.fn(),
+}));
+
+jest.mock("../../lib/format", () => ({
+  formatTime: jest.fn(() => "0:30"),
+  computePrefillSets: jest.fn((currentSets: any[], previousSets: any[]) => {
+    // Stub: return a fill for each working current set that has a matching prev
+    const working = currentSets.filter((s) => s.set_type !== "warmup");
+    const out: any[] = [];
+    for (let i = 0; i < working.length && i < previousSets.length; i++) {
+      const cur = working[i];
+      if (cur.completed) continue;
+      if (cur.weight != null || cur.reps != null || cur.duration_seconds != null) continue;
+      const p = previousSets[i];
+      out.push({ setId: cur.id, weight: p.weight, reps: p.reps, duration_seconds: p.duration_seconds });
+    }
+    return out;
+  }),
+}));
+
+jest.mock("react-native", () => ({
+  AccessibilityInfo: {
+    announceForAccessibility: (...args: any[]) => mockAnnounce(...args),
+  },
+  Keyboard: { dismiss: jest.fn() },
+  Platform: { OS: "ios" },
+}));
+
+import { renderHook, act } from "@testing-library/react-native";
+import { useSessionActions } from "../../hooks/useSessionActions";
+
+function makeGroup(overrides: any = {}) {
+  return {
+    exercise_id: "ex-1",
+    name: "Bench",
+    previousSets: [
+      { weight: 100, reps: 5, duration_seconds: null },
+      { weight: 100, reps: 5, duration_seconds: null },
+    ],
+    progressionSuggested: false,
+    trackingMode: "reps" as const,
+    is_bodyweight: false,
+    sets: [
+      { id: "s1", weight: null, reps: null, duration_seconds: null, completed: false, set_type: "working" },
+      { id: "s2", weight: null, reps: null, duration_seconds: null, completed: false, set_type: "working" },
+    ],
+    ...overrides,
+  };
+}
+
+function makeParams(groups: any[] = []) {
+  return {
+    id: "session-1",
+    groups: groups as any,
+    setGroups: jest.fn(),
+    modes: {},
+    setModes: jest.fn(),
+    updateGroupSet: jest.fn(),
+    startRest: jest.fn(),
+    startRestWithDuration: jest.fn(),
+    startRestWithBreakdown: jest.fn(),
+    session: { started_at: Date.now() - 1000, name: "Test" },
+    showToast: jest.fn(),
+    showError: jest.fn(),
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 50));
+
+describe("useSessionActions — auto-prefill (BLD-542)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("auto-prefills eligible groups silently on session open (no toast, no haptic, a11y announce only)", async () => {
+    const params = makeParams([makeGroup()]);
+    renderHook(() => useSessionActions(params));
+    await act(async () => { await flush(); });
+
+    expect(mockUpdateSet).toHaveBeenCalledTimes(2);
+    expect(params.showToast).not.toHaveBeenCalled();
+    // Haptics.impactAsync not called (silent path)
+    const haptics = jest.requireMock("expo-haptics");
+    expect(haptics.impactAsync).not.toHaveBeenCalled();
+    expect(mockAnnounce).toHaveBeenCalledWith(expect.stringContaining("Prefilled 2 sets"));
+  });
+
+  it.each([
+    ["has completed working set", { sets: [
+      { id: "s1", weight: null, reps: null, duration_seconds: null, completed: true, set_type: "working" },
+      { id: "s2", weight: null, reps: null, duration_seconds: null, completed: false, set_type: "working" },
+    ] }],
+    ["has user-entered weight", { sets: [
+      { id: "s1", weight: 50, reps: null, duration_seconds: null, completed: false, set_type: "working" },
+      { id: "s2", weight: null, reps: null, duration_seconds: null, completed: false, set_type: "working" },
+    ] }],
+    ["has user-entered reps", { sets: [
+      { id: "s1", weight: null, reps: 3, duration_seconds: null, completed: false, set_type: "working" },
+    ] }],
+    ["has no previousSets", { previousSets: null }],
+    ["has empty previousSets", { previousSets: [] }],
+  ])("skips group when %s", async (_label, override) => {
+    const params = makeParams([makeGroup(override)]);
+    renderHook(() => useSessionActions(params));
+    await act(async () => { await flush(); });
+
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+    expect(mockAnnounce).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent: does not re-fire on re-render with same session id", async () => {
+    const params = makeParams([makeGroup()]);
+    const { rerender } = renderHook<unknown, { p: any }>(({ p }) => useSessionActions(p), { initialProps: { p: params } });
+    await act(async () => { await flush(); });
+    expect(mockUpdateSet).toHaveBeenCalledTimes(2);
+
+    mockUpdateSet.mockClear();
+    mockAnnounce.mockClear();
+    // Simulate groups re-computation (new array reference, same session)
+    rerender({ p: makeParams([makeGroup()]) });
+    await act(async () => { await flush(); });
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+  });
+
+  it("manual tap still shows toast + haptic (non-silent path)", async () => {
+    const params = makeParams([makeGroup({
+      // Touched so auto-prefill skips; then manual tap resets to untouched-like via fresh call path.
+      sets: [
+        { id: "s1", weight: 999, reps: 1, duration_seconds: null, completed: false, set_type: "working" },
+      ],
+    })]);
+    const { result, rerender } = renderHook<ReturnType<typeof useSessionActions>, { p: any }>(({ p }) => useSessionActions(p), { initialProps: { p: params } });
+    await act(async () => { await flush(); });
+    expect(mockUpdateSet).not.toHaveBeenCalled(); // auto skipped (touched)
+
+    // Now rerender with an untouched group so a manual tap produces fills
+    const freshGroup = makeGroup();
+    const freshParams = { ...params, groups: [freshGroup] as any };
+    rerender({ p: freshParams });
+
+    await act(async () => {
+      await result.current.handlePrefillFromPrevious("ex-1");
+    });
+    expect(mockUpdateSet).toHaveBeenCalledTimes(2);
+    expect(freshParams.showToast).toHaveBeenCalledWith(expect.stringContaining("Filled 2"));
+    const haptics = jest.requireMock("expo-haptics");
+    expect(haptics.impactAsync).toHaveBeenCalled();
+  });
+});

--- a/components/session/GroupCardHeader.tsx
+++ b/components/session/GroupCardHeader.tsx
@@ -9,7 +9,6 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { ExerciseNotesPanel } from "./ExerciseNotesPanel";
 import type { SetWithMeta, ExerciseGroup } from "./types";
 import type { TrainingMode } from "../../lib/types";
-import { fontSizes } from "@/constants/design-tokens";
 
 export type GroupCardHeaderProps = {
   group: ExerciseGroup;
@@ -59,16 +58,12 @@ export function GroupCardHeader({ group, modes, exerciseNotesOpen, exerciseNotes
                 style={({ pressed }) => [styles.previousPerfBtn, pressed && styles.previousPerfPressed]}
                 accessibilityRole="button"
                 accessibilityLabel={previousPerformanceA11y ?? previousPerformance}
-                accessibilityHint="Tap to fill sets from last session"
+                accessibilityHint="Tap to refill from previous"
               >
                 <ProgressionIcon suggested={group.progressionSuggested} color={colors.primary} />
-                <Text
-                  numberOfLines={1}
-                  style={[styles.previousPerf, { color: colors.primary }]}
-                >
+                <Text style={[styles.previousPerf, { color: colors.primary }]}>
                   {previousPerformance}
                 </Text>
-                <MaterialCommunityIcons name="arrow-collapse-down" size={14} color={colors.primary} />
               </Pressable>
             )}
           </View>
@@ -130,8 +125,8 @@ const styles = StyleSheet.create({
   headerRow2: { flexDirection: "row", alignItems: "center", gap: 8, flexWrap: "wrap" },
   headerActions: { flexDirection: "row", alignItems: "center" },
   groupTitle: { fontWeight: "700" },
-  previousPerf: { fontSize: fontSizes.xs, lineHeight: 16 },
-  previousPerfBtn: { flexDirection: "row", alignItems: "center", gap: 4, minHeight: 36 },
+  previousPerf: { fontSize: 11, lineHeight: 14, flexShrink: 1 },
+  previousPerfBtn: { flexDirection: "row", alignItems: "center", gap: 4, minHeight: 36, flexWrap: "wrap" },
   previousPerfPressed: { opacity: 0.7 },
   iconBtn: { padding: 8 },
   moveBtn: { width: 56, height: 56, alignItems: "center", justifyContent: "center" },

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -375,6 +375,14 @@ export function useSessionActions({
       return;
     }
 
+    // Snapshot pre-fill set values for this exercise so we can roll back on DB failure.
+    const preFillSnapshot = group.sets.map((s) => ({
+      id: s.id,
+      weight: s.weight,
+      reps: s.reps,
+      duration_seconds: s.duration_seconds,
+    }));
+
     // Update local state in one batch
     setGroups((prev) =>
       prev.map((g) => {
@@ -395,7 +403,24 @@ export function useSessionActions({
       for (const fill of toFill) {
         await updateSet(fill.setId, fill.weight, fill.reps, fill.duration_seconds);
       }
-    } catch {
+    } catch (err) {
+      // Rollback optimistic UI update so UI ↔ DB stays in sync when persistence fails.
+      setGroups((prev) =>
+        prev.map((g) => {
+          if (g.exercise_id !== exerciseId) return g;
+          return {
+            ...g,
+            sets: g.sets.map((s) => {
+              const snap = preFillSnapshot.find((p) => p.id === s.id);
+              if (!snap) return s;
+              return { ...s, weight: snap.weight, reps: snap.reps, duration_seconds: snap.duration_seconds };
+            }),
+          };
+        })
+      );
+      // Always leave a diagnostic breadcrumb, even on the silent auto-prefill path.
+      // eslint-disable-next-line no-console
+      console.warn(`[prefillFromPrevious] persist failed (exercise=${exerciseId}, silent=${silent}):`, err);
       if (!silent) showError("Failed to save prefilled values");
       return;
     }

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -357,7 +357,8 @@ export function useSessionActions({
     handleMoveExercise(exerciseId, "down");
   }, [handleMoveExercise]);
 
-  const handlePrefillFromPrevious = useCallback(async (exerciseId: string) => {
+  const prefillFromPrevious = useCallback(async (exerciseId: string, opts?: { silent?: boolean }) => {
+    const silent = opts?.silent ?? false;
     const group = groups.find((g) => g.exercise_id === exerciseId);
     if (!group?.previousSets) return;
 
@@ -366,9 +367,11 @@ export function useSessionActions({
       : undefined;
     const toFill = computePrefillSets(group.sets, group.previousSets, group.trackingMode, progression);
     if (toFill.length === 0) {
-      const workingSets = group.sets.filter((s) => s.set_type !== "warmup");
-      const allCompleted = workingSets.every((s) => s.completed);
-      showToast(allCompleted ? "All sets already completed" : "Sets already have values");
+      if (!silent) {
+        const workingSets = group.sets.filter((s) => s.set_type !== "warmup");
+        const allCompleted = workingSets.every((s) => s.completed);
+        showToast(allCompleted ? "All sets already completed" : "Sets already have values");
+      }
       return;
     }
 
@@ -393,14 +396,57 @@ export function useSessionActions({
         await updateSet(fill.setId, fill.weight, fill.reps, fill.duration_seconds);
       }
     } catch {
-      showError("Failed to save prefilled values");
+      if (!silent) showError("Failed to save prefilled values");
       return;
     }
 
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    showToast(`Filled ${toFill.length} set${toFill.length !== 1 ? "s" : ""} from last session`);
-    AccessibilityInfo.announceForAccessibility(`Filled ${toFill.length} sets from last session`);
+    if (!silent) {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      showToast(`Filled ${toFill.length} set${toFill.length !== 1 ? "s" : ""} from last session`);
+    }
+    AccessibilityInfo.announceForAccessibility(`Prefilled ${toFill.length} sets from last session`);
   }, [groups, setGroups, showToast, showError, unit]);
+
+  const handlePrefillFromPrevious = useCallback((exerciseId: string) => {
+    return prefillFromPrevious(exerciseId);
+  }, [prefillFromPrevious]);
+
+  // Auto-prefill once per session open. Fires after groups + previousSets are loaded.
+  // Skips any group where the user has already touched working sets (completed OR has values).
+  const autoPrefillFiredForSessionRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!id) return;
+    if (groups.length === 0) return;
+    if (autoPrefillFiredForSessionRef.current === id) return;
+    autoPrefillFiredForSessionRef.current = id;
+
+    // Snapshot of candidate exercise ids to auto-prefill. We evaluate synchronously
+    // against the current `groups` state so later async DB work doesn't depend on
+    // stale refs, and so we never re-trigger.
+    const candidates = groups
+      .filter((g) => {
+        if (!g.previousSets || g.previousSets.length === 0) return false;
+        const workingSets = g.sets.filter((s) => s.set_type !== "warmup");
+        if (workingSets.length === 0) return false;
+        // Skip if any working set was already touched by the user.
+        const anyTouched = workingSets.some((s) =>
+          s.completed || s.weight != null || s.reps != null || s.duration_seconds != null,
+        );
+        return !anyTouched;
+      })
+      .map((g) => g.exercise_id);
+
+    if (candidates.length === 0) return;
+
+    void (async () => {
+      for (const eid of candidates) {
+        await prefillFromPrevious(eid, { silent: true });
+      }
+    })();
+    // We intentionally omit `groups` and `prefillFromPrevious` from deps —
+    // this is a once-per-session effect guarded by the ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, groups.length > 0]);
 
   const finish = () => {
     confirmAction(


### PR DESCRIPTION
## Summary

Auto-prefill reps/weight/duration on session open from the last template session, so the owner no longer has to tap the previous-performance chip every set. Chip stays as a manual re-fill escape hatch.

## Changes
- `hooks/useSessionActions.ts`: Extracted `prefillFromPrevious({ silent })`. Added a once-per-session `useEffect` guarded by `autoPrefillFiredForSessionRef` keyed on session id. Skips any group where a working set is touched (completed or has weight/reps/duration). Silent path emits no toast/haptic but still calls `AccessibilityInfo.announceForAccessibility("Prefilled N sets from last session")`.
- `components/session/GroupCardHeader.tsx`: Removed `numberOfLines={1}` truncation on the previous-performance chip, reduced font to 11px with 14px lineHeight, removed the `arrow-collapse-down` icon (previously implied "tap to fill"), updated a11y hint to "Tap to refill from previous".
- Tests: 8 new cases in `__tests__/hooks/useSessionActions-autoprefill.test.ts` — silent auto-fill, 5 skip conditions (it.each), idempotency across re-render, manual-tap toast+haptic path.

## Acceptance Criteria (from scope)
- [x] Auto-prefill runs on session open when group has `previousSets` and no working-set is touched — no toast.
- [x] Manual chip tap still works as re-fill (existing toast preserved).
- [x] No `previousSets` → chip not rendered (unchanged).
- [x] Resumed partially-logged session → auto-prefill skipped, values preserved.
- [x] Chip renders full text (no truncation); font visibly smaller (12 → 11).
- [x] `tsc --noEmit` passes.
- [x] New `useSessionActions-autoprefill` tests cover auto-prefill useEffect (idempotency + skip-when-touched).

## Edge Cases Verified (tests)
- Any completed working set → skip
- User-entered weight or reps → skip
- No/empty `previousSets` → skip
- Re-render with same session id → no re-fire (ref-guarded)
- Manual tap still toasts + haptics

## Out of Scope
- Template reordering (separate issue)
- ProgressionIcon behavior (unchanged)
- BLD-541 bodyweight-modifier paths (untouched)

Resolves BLD-542 / GH #328.