### PR TITLE
fix: restore fontSizes.xs token on previous-performance chip (BLD-550)

### DIFF
--- a/__tests__/app/previous-perf-fontsize-token.test.ts
+++ b/__tests__/app/previous-perf-fontsize-token.test.ts
@@ -1,0 +1,32 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const groupCardHeaderSrc = fs.readFileSync(
+  path.resolve(__dirname, "../../components/session/GroupCardHeader.tsx"),
+  "utf-8",
+);
+
+describe("GroupCardHeader previousPerf uses design tokens (BLD-550)", () => {
+  it("imports fontSizes from design-tokens", () => {
+    expect(groupCardHeaderSrc).toMatch(/import\s*\{[^}]*fontSizes[^}]*\}\s*from\s*["'][^"']*design-tokens["']/);
+  });
+
+  it("previousPerf style references fontSizes.xs (not a hardcoded number)", () => {
+    const match = groupCardHeaderSrc.match(/previousPerf:\s*\{[^}]+\}/);
+    expect(match).not.toBeNull();
+    const decl = match![0];
+    expect(decl).toContain("fontSizes.xs");
+    // Must not reintroduce the off-token 11
+    expect(decl).not.toMatch(/fontSize:\s*11\b/);
+  });
+
+  it("documents hitSlop dependency on previousPerfBtn minHeight", () => {
+    // Future refactors must know hitSlop compensates for the below-44dp minHeight.
+    expect(groupCardHeaderSrc).toMatch(/hitSlop[\s\S]{0,200}previousPerfBtn|previousPerfBtn[\s\S]{0,400}hitSlop/);
+    // Explicit comment near previousPerfBtn style decl
+    const btnIdx = groupCardHeaderSrc.indexOf("previousPerfBtn: {");
+    expect(btnIdx).toBeGreaterThan(-1);
+    const preceding = groupCardHeaderSrc.slice(Math.max(0, btnIdx - 400), btnIdx);
+    expect(preceding).toMatch(/hitSlop/i);
+  });
+});

--- a/components/session/GroupCardHeader.tsx
+++ b/components/session/GroupCardHeader.tsx
@@ -9,6 +9,7 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { ExerciseNotesPanel } from "./ExerciseNotesPanel";
 import type { SetWithMeta, ExerciseGroup } from "./types";
 import type { TrainingMode } from "../../lib/types";
+import { fontSizes } from "../../constants/design-tokens";
 
 export type GroupCardHeaderProps = {
   group: ExerciseGroup;
@@ -61,7 +62,7 @@ export function GroupCardHeader({ group, modes, exerciseNotesOpen, exerciseNotes
                 accessibilityHint="Tap to refill from previous"
               >
                 <ProgressionIcon suggested={group.progressionSuggested} color={colors.primary} />
-                <Text style={[styles.previousPerf, { color: colors.primary }]}>
+                <Text numberOfLines={1} style={[styles.previousPerf, { color: colors.primary }]}>
                   {previousPerformance}
                 </Text>
               </Pressable>
@@ -125,7 +126,10 @@ const styles = StyleSheet.create({
   headerRow2: { flexDirection: "row", alignItems: "center", gap: 8, flexWrap: "wrap" },
   headerActions: { flexDirection: "row", alignItems: "center" },
   groupTitle: { fontWeight: "700" },
-  previousPerf: { fontSize: 11, lineHeight: 14, flexShrink: 1 },
+  previousPerf: { fontSize: fontSizes.xs, lineHeight: 16, flexShrink: 1 },
+  // minHeight:36 is below the 44dp touch target minimum; compensated by hitSlop
+  // ({ top:12, bottom:12, left:8, right:8 }) on the Pressable above → ~60dp tap-zone.
+  // Keep hitSlop in sync if you change minHeight.
   previousPerfBtn: { flexDirection: "row", alignItems: "center", gap: 4, minHeight: 36, flexWrap: "wrap" },
   previousPerfPressed: { opacity: 0.7 },
   iconBtn: { padding: 8 },


### PR DESCRIPTION
## Summary

Restores the design-token `fontSizes.xs` on the previous-performance chip in `GroupCardHeader`. PR #335 (BLD-542) inadvertently replaced `fontSizes.xs` (12) with hardcoded `fontSize: 11`, which is not part of the scale and sits below the 12px accessibility minimum.

## Changes

- `components/session/GroupCardHeader.tsx`
  - Import `fontSizes` from `constants/design-tokens`.
  - `previousPerf`: `fontSize: fontSizes.xs`, `lineHeight: 16`.
  - Add `numberOfLines={1}` on the Text so overflow truncates instead of shrinking the font.
  - Document the `hitSlop` ↔ `minHeight` relationship so future refactors keep the touch-target compensation.
- `__tests__/app/previous-perf-fontsize-token.test.ts` — new regression test asserting the token import, the `fontSizes.xs` reference, the absence of `fontSize: 11`, and the hitSlop comment.

## Testing

- `npx jest __tests__/app/previous-perf-fontsize-token.test.ts __tests__/app/workout-header-overflow.test.ts` → 8/8 pass
- `npx tsc --noEmit` → clean
- Lint (lint-staged pre-commit) passed

## Issue

Resolves BLD-550