### PR TITLE
perf(session): pause 1Hz timers on AppState background (BLD-553)

### DIFF
--- a/__tests__/hooks/useRestTimer.test.ts
+++ b/__tests__/hooks/useRestTimer.test.ts
@@ -245,6 +245,40 @@ describe("useRestTimer", () => {
     expect(result.current.rest).toBe(0);
   });
 
+  it("BLD-553: pauses 1Hz interval when backgrounded (no re-renders while backgrounded)", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    act(() => {
+      result.current.startRestWithDuration(60);
+    });
+    expect(result.current.rest).toBe(60);
+
+    // Go to background
+    act(() => {
+      for (const listener of appStateListeners) listener("background");
+    });
+
+    // Advance wall-clock timers by 10s while backgrounded
+    // (jest.advanceTimersByTime also advances Date.now in modern fake timers)
+    act(() => { jest.advanceTimersByTime(10000); });
+
+    // rest state must NOT have been updated while backgrounded
+    // (proves the 1Hz interval is paused, saving battery)
+    expect(result.current.rest).toBe(60);
+
+    // Resume foreground
+    act(() => {
+      for (const listener of appStateListeners) listener("active");
+    });
+
+    // rest catches up via endAt recompute (60s budget - 10s elapsed = 50)
+    expect(result.current.rest).toBe(50);
+
+    // 1Hz interval must have been restarted
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current.rest).toBe(49);
+  });
+
   it("does not schedule notification when notifications unavailable", async () => {
     mockIsAvailable.mockReturnValue(false);
     const { result } = renderHook(() => useRestTimer(defaultOptions));

--- a/__tests__/hooks/useSessionActions-autoprefill.test.ts
+++ b/__tests__/hooks/useSessionActions-autoprefill.test.ts
@@ -102,6 +102,10 @@ jest.mock("react-native", () => ({
   },
   Keyboard: { dismiss: jest.fn() },
   Platform: { OS: "ios" },
+  AppState: {
+    currentState: "active",
+    addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
 }));
 
 import { renderHook, act } from "@testing-library/react-native";

--- a/__tests__/lib/render-counter.test.ts
+++ b/__tests__/lib/render-counter.test.ts
@@ -1,0 +1,39 @@
+/**
+ * BLD-553: Unit tests for the dev-only render counter.
+ */
+import {
+  countRender,
+  resetRenderCounts,
+  dumpRenderCounts,
+} from "../../lib/dev/render-counter";
+
+describe("render-counter", () => {
+  beforeEach(() => {
+    resetRenderCounts();
+  });
+
+  it("increments per name, sorts desc, resets, and emits integer rpm", () => {
+    // increment
+    countRender("A");
+    countRender("A");
+    countRender("B");
+    let rows = dumpRenderCounts();
+    expect(rows.find((r) => r.name === "A")?.renders).toBe(2);
+    expect(rows.find((r) => r.name === "B")?.renders).toBe(1);
+    expect(rows[0].rpm).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(rows[0].rpm)).toBe(true);
+
+    // sort order (on a fresh reset)
+    resetRenderCounts();
+    countRender("low");
+    for (let i = 0; i < 5; i++) countRender("high");
+    countRender("mid");
+    countRender("mid");
+    rows = dumpRenderCounts();
+    expect(rows.map((r) => r.name)).toEqual(["high", "mid", "low"]);
+
+    // reset clears
+    resetRenderCounts();
+    expect(dumpRenderCounts()).toEqual([]);
+  });
+});

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -73,30 +73,51 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
     }
   }, [sessionId]);
 
+  // BLD-553: extracted tick so we can pause/restart the 1Hz interval on
+  // AppState background/foreground transitions (battery drain mitigation).
+  const startRestInterval = useCallback(() => {
+    if (restRef.current) return;
+    restRef.current = setInterval(() => {
+      if (endAtRef.current == null) {
+        if (restRef.current) clearInterval(restRef.current);
+        restRef.current = null;
+        return;
+      }
+      const remaining = Math.max(
+        0,
+        Math.ceil((endAtRef.current - Date.now()) / 1000),
+      );
+      setRest(remaining);
+      if (remaining <= 0) {
+        if (restRef.current) clearInterval(restRef.current);
+        restRef.current = null;
+        endAtRef.current = null;
+        cancelNotification();
+      }
+    }, 1000);
+  }, [cancelNotification]);
+
+  const stopRestInterval = useCallback(() => {
+    if (restRef.current) {
+      clearInterval(restRef.current);
+      restRef.current = null;
+    }
+  }, []);
+
   const runTimer = useCallback(
     (secs: number, nextBreakdown: RestBreakdown) => {
-      if (restRef.current) clearInterval(restRef.current);
+      stopRestInterval();
       cancelNotification();
       const endAt = Date.now() + secs * 1000;
       endAtRef.current = endAt;
       setRest(secs);
       setBreakdown(nextBreakdown);
       scheduleNotification(secs);
-      restRef.current = setInterval(() => {
-        const remaining = Math.max(
-          0,
-          Math.ceil((endAtRef.current! - Date.now()) / 1000),
-        );
-        setRest(remaining);
-        if (remaining <= 0) {
-          if (restRef.current) clearInterval(restRef.current);
-          restRef.current = null;
-          endAtRef.current = null;
-          cancelNotification();
-        }
-      }, 1000);
+      // Start unconditionally; AppState change listener will stop the interval
+      // immediately if the app is actually backgrounded.
+      startRestInterval();
     },
-    [cancelNotification, scheduleNotification],
+    [cancelNotification, scheduleNotification, startRestInterval, stopRestInterval],
   );
 
   /**
@@ -159,23 +180,44 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
     setBreakdown(defaultBreakdown(0));
   }, [cancelNotification]);
 
-  // AppState listener: recalculate remaining time on foreground resume
+  // BLD-553 battery fix: AppState listener pauses the 1Hz interval when
+  // backgrounded (native notification still fires) and restarts it on
+  // foreground with a recomputed remaining from absolute endAt.
   useEffect(() => {
     const handleAppState = (nextState: AppStateStatus) => {
-      if (nextState === "active" && endAtRef.current) {
-        const remaining = Math.max(0, Math.ceil((endAtRef.current - Date.now()) / 1000));
-        setRest(remaining);
-        if (remaining <= 0) {
-          if (restRef.current) clearInterval(restRef.current);
-          restRef.current = null;
-          endAtRef.current = null;
-          cancelNotification();
+      if (nextState === "active") {
+        if (endAtRef.current) {
+          const remaining = Math.max(
+            0,
+            Math.ceil((endAtRef.current - Date.now()) / 1000),
+          );
+          setRest(remaining);
+          if (remaining <= 0) {
+            stopRestInterval();
+            endAtRef.current = null;
+            cancelNotification();
+          } else {
+            startRestInterval();
+          }
         }
+      } else {
+        // Pause ticking while backgrounded to save battery/CPU.
+        stopRestInterval();
       }
     };
     const sub = AppState.addEventListener("change", handleAppState);
     return () => sub.remove();
-  }, [cancelNotification]);
+  }, [cancelNotification, startRestInterval, stopRestInterval]);
+
+  // BLD-553: ensure haptic setTimeouts are cleared on unmount and stop the
+  // interval in case the hook unmounts mid-rest.
+  useEffect(() => {
+    return () => {
+      restHapticTimers.current.forEach((t) => clearTimeout(t));
+      restHapticTimers.current = [];
+      stopRestInterval();
+    };
+  }, [stopRestInterval]);
 
   // Haptic + audio feedback on rest timer completion and countdown
   useEffect(() => {

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines-per-function, react-hooks/exhaustive-deps */
 import { useCallback, useEffect, useRef, useState } from "react";
-import { AccessibilityInfo, Keyboard, Platform } from "react-native";
+import { AccessibilityInfo, AppState, Keyboard, Platform } from "react-native";
 import { useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
 import {
@@ -100,16 +100,38 @@ export function useSessionActions({
   const [nextHint, setNextHint] = useState<string | null>(null);
   const hintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Timer
+  // Session-elapsed clock.
+  // BLD-553 battery fix: pause setInterval when app is backgrounded. On some
+  // RN runtimes setInterval continues to schedule wake-ups with the screen
+  // off, and if it doesn't, React still triggers a render-burst as Date.now()
+  // jumps on resume. We recompute elapsed from session.started_at on resume,
+  // so there's no drift.
   useEffect(() => {
     if (!session) return;
     const update = () => {
       setElapsed(Math.floor((Date.now() - session.started_at) / 1000));
     };
-    update();
-    timer.current = setInterval(update, 1000);
+    const start = () => {
+      if (timer.current) return;
+      update();
+      timer.current = setInterval(update, 1000);
+    };
+    const stop = () => {
+      if (timer.current) {
+        clearInterval(timer.current);
+        timer.current = null;
+      }
+    };
+    // Start unconditionally; the AppState change listener will stop the
+    // interval immediately if the app is actually backgrounded.
+    start();
+    const sub = AppState.addEventListener("change", (next) => {
+      if (next === "active") start();
+      else stop();
+    });
     return () => {
-      if (timer.current) clearInterval(timer.current);
+      stop();
+      sub.remove();
     };
   }, [session]);
 

--- a/lib/dev/render-counter.ts
+++ b/lib/dev/render-counter.ts
@@ -1,0 +1,71 @@
+/**
+ * BLD-553: Dev-only render counter for battery/perf investigation.
+ *
+ * Usage (inside a component, gated by __DEV__):
+ *
+ *   import { countRender } from "@/lib/dev/render-counter";
+ *   export function GroupCardHeader(props) {
+ *     if (__DEV__) countRender("GroupCardHeader");
+ *     // ...
+ *   }
+ *
+ * Then from a React Native dev menu / console:
+ *   require("@/lib/dev/render-counter").dumpRenderCounts();
+ *
+ * The counter is guarded by `__DEV__` at the call site so Metro removes all
+ * references in production bundles (see verify-scenario-hook-not-in-bundle.sh
+ * for the bundle-hygiene pattern). This file is still importable in prod
+ * bundles but is a no-op there because callers never invoke it.
+ *
+ * To investigate BLD-553 (battery drain during workout):
+ *   1. Instrument the suspected hot components (GroupCardHeader, SetRow,
+ *      SessionHeaderToolbar) with `countRender("Name")` behind `__DEV__`.
+ *   2. Run a real workout for ~1 min with timer active.
+ *   3. Call `dumpRenderCounts()` — anything re-rendering >60x/min while idle
+ *      is a hot path and a battery-drain candidate.
+ *   4. After profiling, remove the instrumentation (or leave only behind a
+ *      feature flag) so the prod bundle stays clean.
+ */
+
+const counts = new Map<string, number>();
+let startedAt = Date.now();
+
+export function countRender(name: string): void {
+  if (!__DEV__) return;
+  counts.set(name, (counts.get(name) ?? 0) + 1);
+}
+
+export function resetRenderCounts(): void {
+  counts.clear();
+  startedAt = Date.now();
+}
+
+/**
+ * Dump render counts + rate-per-minute to the console.
+ * Returns the snapshot for programmatic inspection (tests).
+ */
+export function dumpRenderCounts(): Array<{
+  name: string;
+  renders: number;
+  rpm: number;
+}> {
+  const elapsedMs = Math.max(1, Date.now() - startedAt);
+  const rows = Array.from(counts.entries())
+    .map(([name, renders]) => ({
+      name,
+      renders,
+      rpm: Math.round((renders * 60000) / elapsedMs),
+    }))
+    .sort((a, b) => b.renders - a.renders);
+
+  if (__DEV__) {
+    const elapsedS = (elapsedMs / 1000).toFixed(1);
+    // eslint-disable-next-line no-console
+    console.log(`[render-counter] ${elapsedS}s elapsed`);
+    for (const r of rows) {
+      // eslint-disable-next-line no-console
+      console.log(`  ${r.name.padEnd(32)} ${String(r.renders).padStart(6)} renders  (${r.rpm}/min)`);
+    }
+  }
+  return rows;
+}


### PR DESCRIPTION
## Summary

Mitigates battery drain reported in GH #336 (BLD-553) — ~17% drain over 1hr on Z Fold6. Two 1Hz `setInterval` loops in the workout session kept ticking while the app was backgrounded, causing wasted React re-renders even with the screen off.

## Root cause (identified via code inspection)

1. `hooks/useSessionActions.ts` — session-elapsed clock (`setInterval(update, 1000)`) had no AppState guard.
2. `hooks/useRestTimer.ts` — rest countdown had a foreground-resume listener but never stopped its `setInterval` when backgrounded.
3. Haptic setTimeouts in the rest timer leaked if the hook unmounted mid-rest.

## Changes

- **`hooks/useSessionActions.ts`**: `start()`/`stop()` the elapsed interval from the AppState change listener. On resume, `update()` recomputes elapsed from `session.started_at` (absolute timestamp) — no drift.
- **`hooks/useRestTimer.ts`**: extract `startRestInterval()`/`stopRestInterval()`. Stop on background, recompute-and-restart on foreground. Also clear `restHapticTimers` on unmount.
- **`lib/dev/render-counter.ts`**: `__DEV__`-only render-count utility for ongoing perf investigation. Metro strips all call sites in prod via the existing `if (__DEV__)` guard pattern.

## Testing

- `useRestTimer` — new test covers BLD-553 pause (no state updates while backgrounded, correct recompute on resume).
- `render-counter` — unit tests for count/sort/reset.
- `useSessionActions-autoprefill` — added `AppState` to the RN mock so the new effect doesn't crash.
- **Full suite: 2031/2031 pass.**
- `tsc --noEmit`: clean.
- `scripts/verify-scenario-hook-not-in-bundle.sh`: passes (no new `__DEV__` globals introduced).

## Acceptance criteria (from issue)

- [x] Root cause(s) of battery drain identified — 1Hz setIntervals not AppState-gated.
- [x] At least one concrete mitigation committed.
- [x] Dev perf harness utility for follow-up investigation.
- [x] No new lint warnings, tests pass, bundle gate passes.

## Out of scope / follow-ups

- Full Systrace + memoization pass on `GroupCardHeader` / `SetRow` — if render-counter reveals additional hot paths, split to a follow-up issue.
- Crash repro (from GH #336): not reproduced from code inspection; no console-logs in the report to trace. Will need a device-side crash-log capture path (Sentry or similar, out of scope per issue).

## Issue

Resolves BLD-553. GH #336.