### PR TITLE
fix(session): taller + higher-contrast exercise notes textarea (BLD-544)

### DIFF
--- a/__tests__/acceptance/notes-panel-contrast.acceptance.test.tsx
+++ b/__tests__/acceptance/notes-panel-contrast.acceptance.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * BLD-544 (GH #330): In-session workout notes textarea — taller + higher contrast.
+ *
+ * Acceptance:
+ * - minHeight bumped from 48 → ~96 (≈3 lines)
+ * - fontSize bumped from fontSizes.sm → fontSizes.base or larger
+ * - Explicit theme text color (colors.onSurface) + placeholderTextColor
+ *   (colors.onSurfaceVariant) for WCAG AA contrast
+ * - textAlignVertical="top" so Android multiline starts top-left
+ */
+import fs from "fs";
+import path from "path";
+
+describe("ExerciseNotesPanel — taller + higher contrast (BLD-544, GH #330)", () => {
+  const src = fs.readFileSync(
+    path.resolve(__dirname, "../../components/session/ExerciseNotesPanel.tsx"),
+    "utf-8"
+  );
+
+  it("textarea minHeight is at least 96dp (≈3 lines)", () => {
+    const m = src.match(/minHeight:\s*(\d+)/);
+    expect(m).not.toBeNull();
+    expect(Number(m![1])).toBeGreaterThanOrEqual(96);
+  });
+
+  it("textarea fontSize is at least fontSizes.base (16) for legibility", () => {
+    const m = src.match(/input:\s*\{[^}]*fontSize:\s*fontSizes\.(\w+)/);
+    expect(m).not.toBeNull();
+    const fontSizeMap: Record<string, number> = { xs: 12, sm: 14, base: 16, lg: 18, xl: 20 };
+    expect(fontSizeMap[m![1]] ?? 0).toBeGreaterThanOrEqual(16);
+  });
+
+  it("placeholder text color is explicitly set from theme (AA contrast)", () => {
+    expect(src).toMatch(/placeholderTextColor=\{colors\.onSurfaceVariant\}/);
+  });
+
+  it("text color is explicitly set to colors.onSurface", () => {
+    expect(src).toMatch(/color:\s*colors\.onSurface/);
+  });
+
+  it("textAlignVertical is 'top' so Android multiline starts top-left", () => {
+    expect(src).toMatch(/textAlignVertical="top"/);
+  });
+
+  it("uses Input type='textarea' (rows-based sizing, not single-line input)", () => {
+    expect(src).toMatch(/type="textarea"/);
+    expect(src).toMatch(/rows=\{3\}/);
+  });
+
+  it("does not touch the post-session summary notes file", () => {
+    const summaryPath = path.resolve(__dirname, "../../app/session/summary/[id].tsx");
+    expect(fs.existsSync(summaryPath)).toBe(true);
+  });
+});

--- a/__tests__/acceptance/settings-card-notes.acceptance.test.tsx
+++ b/__tests__/acceptance/settings-card-notes.acceptance.test.tsx
@@ -57,7 +57,9 @@ describe("Session notes/delete button touch targets (BLD-258, GitHub #126)", () 
   it("notes input has minimum font size of 14", () => {
     const notesMatch = sessionSource.match(/input:\s*\{[^}]*fontSize:\s*fontSizes\.(\w+)/);
     expect(notesMatch).not.toBeNull();
-    expect(notesMatch![1]).toBe("sm"); // fontSizes.sm = 14
+    const token = notesMatch![1];
+    const fontSizeMap: Record<string, number> = { xs: 12, sm: 14, base: 16, lg: 18, xl: 20 };
+    expect(fontSizeMap[token] ?? 0).toBeGreaterThanOrEqual(14);
   });
 
   it("notes container has adequate padding", () => {

--- a/components/session/ExerciseNotesPanel.tsx
+++ b/components/session/ExerciseNotesPanel.tsx
@@ -17,13 +17,16 @@ export function ExerciseNotesPanel({ exerciseId, value, onDraftChange, onSave }:
   return (
     <View style={styles.container}>
       <Input
+        type="textarea"
+        rows={3}
         placeholder="Add exercise notes..."
+        placeholderTextColor={colors.onSurfaceVariant}
         value={value}
         onChangeText={(v) => onDraftChange(exerciseId, v)}
         onBlur={() => onSave(exerciseId, value)}
         maxLength={200}
-        multiline
-        style={styles.input}
+        textAlignVertical="top"
+        inputStyle={{ ...styles.input, color: colors.onSurface }}
         accessibilityLabel="Exercise notes"
       />
       <Text variant="caption" style={{ color: colors.onSurfaceVariant, textAlign: "right", fontSize: fontSizes.xs }}>
@@ -35,5 +38,5 @@ export function ExerciseNotesPanel({ exerciseId, value, onDraftChange, onSave }:
 
 const styles = StyleSheet.create({
   container: { paddingHorizontal: 8, paddingBottom: 8, paddingTop: 4 },
-  input: { fontSize: fontSizes.sm, minHeight: 48 },
+  input: { fontSize: fontSizes.base, minHeight: 96 },
 });


### PR DESCRIPTION
## Summary
Fixes GH #330 (alankyshum). In-session exercise notes textarea was too short (minHeight 48) and low contrast. Bump to ≈3-line height with WCAG AA body-text contrast in both themes.

## Changes
- `components/session/ExerciseNotesPanel.tsx`:
  - Switch `<Input>` to `type="textarea"` with `rows={3}` (minHeight 96dp)
  - `fontSize: fontSizes.base` (16) instead of `fontSizes.sm` (14)
  - Explicit `placeholderTextColor={colors.onSurfaceVariant}` + `color: colors.onSurface`
  - `textAlignVertical="top"` so Android multiline starts top-left
- `__tests__/acceptance/notes-panel-contrast.acceptance.test.tsx`: 7 new assertions
- `__tests__/acceptance/settings-card-notes.acceptance.test.tsx`: relax fontSize-token check from strict `sm` to any token ≥14 (base=16 still satisfies BLD-258's ≥14 requirement)

## Out of scope
- Post-session summary notes (`app/session/summary/[id].tsx`) — untouched per spec
- Character limit (stays 200)
- `<Input>` component API — `placeholderTextColor` already forwards via `...props`

## Testing
- `npx tsc --noEmit` → 0 errors
- Targeted jest suites: 14/14 pass

## Issue
Resolves BLD-544.