### PR TITLE
feat(exercise-illustrations): pipeline + renderer + bundle gate (BLD-561)

### DIFF
--- a/.github/workflows/bundle-gate.yml
+++ b/.github/workflows/bundle-gate.yml
@@ -21,7 +21,9 @@ on:
       - 'lib/db/**'
       - 'hooks/**'
       - 'e2e/**'
+      - 'assets/exercise-illustrations/**'
       - 'scripts/verify-scenario-hook-not-in-bundle.sh'
+      - 'scripts/verify-exercise-illustrations-size.sh'
       - '.github/workflows/bundle-gate.yml'
       - 'package.json'
       - 'package-lock.json'
@@ -57,3 +59,6 @@ jobs:
 
       - name: Run bundle gate
         run: bash scripts/verify-scenario-hook-not-in-bundle.sh
+
+      - name: Verify exercise illustration bundle size (BLD-561)
+        run: bash scripts/verify-exercise-illustrations-size.sh

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -11,6 +11,16 @@ if [ -f "scripts/check-license.sh" ]; then
   fi
 fi
 
+# ─── Exercise Illustration Bundle Gate (BLD-561) ────────────────
+if [ -f "scripts/verify-exercise-illustrations-size.sh" ]; then
+  echo "🖼️  Verifying exercise illustration bundle size..."
+  if ! ./scripts/verify-exercise-illustrations-size.sh; then
+    echo ""
+    echo "Exercise illustration assets exceeded the hard-fail bundle budget."
+    exit 1
+  fi
+fi
+
 # ─── Test Budget Gate ────────────────────────────────────────────
 # Blocks push if test count exceeds budget (1800 test cases)
 if [ -f "scripts/audit-tests.sh" ]; then

--- a/__tests__/components/ExerciseIllustrationCards.test.tsx
+++ b/__tests__/components/ExerciseIllustrationCards.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * BLD-561: ExerciseIllustrationCards renderer.
+ *
+ * Verifies:
+ *   - Voltra with complete manifest → 2 image pressables with startAlt/endAlt.
+ *   - Custom exercise without images → 0 images + "Add your own illustration" hint.
+ *   - Container width breakpoint: stacked vs side-by-side via onLayout.
+ *
+ * Uses `it.each` where practical per QD budget guidance.
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { ExerciseIllustrationCards } from "../../components/exercises/ExerciseIllustrationCards";
+
+jest.mock("../../assets/exercise-illustrations/manifest.generated", () => ({
+  manifest: {
+    "voltra-test-1": {
+      start: 1,
+      end: 2,
+      startAlt: "Supine with cable overhead",
+      endAlt: "Torso curled up, abs engaged",
+    },
+  },
+}));
+
+// Avoid pulling the real theme for Node JSDOM simplicity.
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    surfaceAlt: "#eee",
+    surfaceVariant: "#eee",
+    onSurfaceVariant: "#666",
+    onPrimary: "#fff",
+  }),
+}));
+
+describe("ExerciseIllustrationCards", () => {
+  const voltra = { id: "voltra-test-1", name: "Test Exercise", is_custom: false };
+  const custom = { id: "custom-1", name: "My Ex", is_custom: true };
+  const customWithImages = {
+    id: "custom-2",
+    name: "My Ex With Images",
+    is_custom: true,
+    start_image_uri: "file:///a.jpg",
+    end_image_uri: "file:///b.jpg",
+  };
+
+  it("renders 2 illustration pressables for a voltra exercise with manifest entry", () => {
+    const { getByTestId } = render(
+      <ExerciseIllustrationCards exercise={voltra} initialWidth={600} />
+    );
+    expect(getByTestId("exercise-illustration-start")).toBeTruthy();
+    expect(getByTestId("exercise-illustration-end")).toBeTruthy();
+  });
+
+  it("applies substantive AI alt-text as accessibilityLabel (not a stub)", () => {
+    const { getByTestId } = render(
+      <ExerciseIllustrationCards exercise={voltra} initialWidth={600} />
+    );
+    const start = getByTestId("exercise-illustration-start");
+    const end = getByTestId("exercise-illustration-end");
+    expect(start.props.accessibilityLabel).toBe("Supine with cable overhead");
+    expect(end.props.accessibilityLabel).toBe("Torso curled up, abs engaged");
+  });
+
+  it("renders nothing for seeded exercise missing from manifest (no placeholder)", () => {
+    const { queryByTestId } = render(
+      <ExerciseIllustrationCards
+        exercise={{ id: "voltra-unknown", name: "Unknown", is_custom: false }}
+        initialWidth={600}
+      />
+    );
+    expect(queryByTestId("exercise-illustration-start")).toBeNull();
+    expect(queryByTestId("exercise-illustration-end")).toBeNull();
+  });
+
+  it("renders empty-state hint for a custom exercise without images", () => {
+    const { getByLabelText, queryByTestId } = render(
+      <ExerciseIllustrationCards exercise={custom} initialWidth={600} />
+    );
+    expect(getByLabelText("Add your own illustration — coming soon")).toBeTruthy();
+    expect(queryByTestId("exercise-illustration-start")).toBeNull();
+  });
+
+  it("renders images for a custom exercise when both URIs are supplied", () => {
+    const { getByTestId } = render(
+      <ExerciseIllustrationCards exercise={customWithImages} initialWidth={600} />
+    );
+    expect(getByTestId("exercise-illustration-start")).toBeTruthy();
+    expect(getByTestId("exercise-illustration-end")).toBeTruthy();
+  });
+
+  it.each([
+    { width: 320, layout: "column" as const, label: "narrow stacks vertically" },
+    { width: 600, layout: "row" as const, label: "wide renders side-by-side" },
+  ])("$label (width $width)", ({ width, layout }) => {
+    const { getByTestId } = render(
+      <ExerciseIllustrationCards exercise={voltra} initialWidth={width} />
+    );
+    const row = getByTestId("exercise-illustration-row");
+    const styles = Array.isArray(row.props.style) ? row.props.style.flat() : [row.props.style];
+    const flex = styles.reduce(
+      (acc: string | undefined, s: Record<string, unknown> | undefined) =>
+        (s && typeof s === "object" && (s as Record<string, unknown>).flexDirection)
+          ? ((s as Record<string, unknown>).flexDirection as string)
+          : acc,
+      undefined as string | undefined
+    );
+    expect(flex).toBe(layout);
+  });
+
+  it("re-layouts on onLayout container width change", () => {
+    const { getByTestId } = render(
+      <ExerciseIllustrationCards exercise={voltra} initialWidth={320} />
+    );
+    const row = getByTestId("exercise-illustration-row");
+    fireEvent(row, "layout", { nativeEvent: { layout: { width: 600, height: 200, x: 0, y: 0 } } });
+    // After wide layout, row should now use horizontal direction.
+    const styles = Array.isArray(row.props.style) ? row.props.style.flat() : [row.props.style];
+    const flex = styles.reduce(
+      (acc: string | undefined, s: Record<string, unknown> | undefined) =>
+        (s && typeof s === "object" && (s as Record<string, unknown>).flexDirection)
+          ? ((s as Record<string, unknown>).flexDirection as string)
+          : acc,
+      undefined as string | undefined
+    );
+    expect(flex).toBe("row");
+  });
+});

--- a/__tests__/exercise-illustrations-manifest.test.ts
+++ b/__tests__/exercise-illustrations-manifest.test.ts
@@ -1,0 +1,48 @@
+/**
+ * BLD-561: Exercise illustration manifest completeness.
+ *
+ * Until the pilot images are generated (OPENAI_API_KEY required for
+ * `npm run generate:exercise-images`), the manifest is intentionally empty
+ * and every pilot exercise falls back to text-only via the both-or-neither
+ * rule in `resolveExerciseImages`. That's fine; the resolver test exercises
+ * the null-path.
+ *
+ * When the generator populates the manifest, each pilot id MUST have all
+ * four keys. We lock that in here: if a pilot id appears in the manifest
+ * at all, it must be complete.
+ */
+import { manifest } from "../assets/exercise-illustrations/manifest.generated";
+import { PILOT_EXERCISE_IDS } from "../assets/exercise-illustrations/pilot-ids";
+
+describe("exercise-illustrations manifest", () => {
+  it("has a valid module shape (empty or populated)", () => {
+    expect(manifest).toBeDefined();
+    expect(typeof manifest).toBe("object");
+  });
+
+  it("is deterministic-sorted by id (localeCompare)", () => {
+    const ids = Object.keys(manifest);
+    const sorted = [...ids].sort((a, b) => a.localeCompare(b));
+    expect(ids).toEqual(sorted);
+  });
+
+  it("every present pilot entry has all four keys", () => {
+    for (const id of PILOT_EXERCISE_IDS) {
+      const entry = manifest[id];
+      if (!entry) continue; // allowed while pilot not yet generated
+      expect(entry.start).toBeDefined();
+      expect(entry.end).toBeDefined();
+      expect(typeof entry.startAlt).toBe("string");
+      expect(typeof entry.endAlt).toBe("string");
+      expect(entry.startAlt.length).toBeGreaterThan(0);
+      expect(entry.endAlt.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no stray non-pilot entries", () => {
+    const pilotSet = new Set(PILOT_EXERCISE_IDS);
+    for (const id of Object.keys(manifest)) {
+      expect(pilotSet.has(id)).toBe(true);
+    }
+  });
+});

--- a/__tests__/exercise-illustrations-resolver.test.ts
+++ b/__tests__/exercise-illustrations-resolver.test.ts
@@ -1,0 +1,102 @@
+/**
+ * BLD-561: resolveExerciseImages — both-or-neither contract.
+ *
+ * Uses `it.each` per QD budget guidance to keep this suite compact.
+ */
+import { resolveExerciseImages } from "../assets/exercise-illustrations/resolve";
+
+// Mock the generated manifest so we can test both populated and missing paths
+// without depending on whether the generator has been run yet.
+jest.mock("../assets/exercise-illustrations/manifest.generated", () => ({
+  manifest: {
+    "voltra-seeded-complete": {
+      start: 1001,
+      end: 1002,
+      startAlt: "seeded start alt",
+      endAlt: "seeded end alt",
+    },
+    "voltra-seeded-partial": {
+      start: 2001,
+      end: 0,
+      startAlt: "seeded start alt",
+      endAlt: "",
+    },
+  },
+}));
+
+type Case = {
+  name: string;
+  ex: Parameters<typeof resolveExerciseImages>[0];
+  expectedNull: boolean;
+  expectStart?: unknown;
+  expectEnd?: unknown;
+  expectAltIncludes?: string;
+};
+
+const cases: Case[] = [
+  {
+    name: "seeded voltra with full manifest → resolved",
+    ex: { id: "voltra-seeded-complete", name: "Complete", is_custom: false },
+    expectedNull: false,
+    expectStart: 1001,
+    expectEnd: 1002,
+  },
+  {
+    name: "seeded voltra with partial manifest → null (both-or-neither)",
+    ex: { id: "voltra-seeded-partial", name: "Partial", is_custom: false },
+    expectedNull: true,
+  },
+  {
+    name: "seeded voltra not in manifest → null",
+    ex: { id: "voltra-missing", name: "Missing", is_custom: false },
+    expectedNull: true,
+  },
+  {
+    name: "custom exercise with both URIs → resolved",
+    ex: {
+      id: "custom-1",
+      name: "MyExercise",
+      is_custom: true,
+      start_image_uri: "file:///tmp/start.jpg",
+      end_image_uri: "file:///tmp/end.jpg",
+    },
+    expectedNull: false,
+    expectStart: { uri: "file:///tmp/start.jpg" },
+    expectEnd: { uri: "file:///tmp/end.jpg" },
+    expectAltIncludes: "MyExercise",
+  },
+  {
+    name: "custom exercise with only start URI → null",
+    ex: {
+      id: "custom-2",
+      name: "Half",
+      is_custom: true,
+      start_image_uri: "file:///tmp/start.jpg",
+    },
+    expectedNull: true,
+  },
+  {
+    name: "custom exercise with no URIs → null",
+    ex: { id: "custom-3", name: "Empty", is_custom: true },
+    expectedNull: true,
+  },
+];
+
+describe("resolveExerciseImages", () => {
+  it.each(cases)("$name", ({ ex, expectedNull, expectStart, expectEnd, expectAltIncludes }) => {
+    const result = resolveExerciseImages(ex);
+    if (expectedNull) {
+      expect(result).toBeNull();
+      return;
+    }
+    expect(result).not.toBeNull();
+    if (expectStart !== undefined) expect(result!.start).toEqual(expectStart);
+    if (expectEnd !== undefined) expect(result!.end).toEqual(expectEnd);
+    expect(result!.startAlt.length).toBeGreaterThan(0);
+    expect(result!.endAlt.length).toBeGreaterThan(0);
+    if (expectAltIncludes) {
+      expect(result!.startAlt).toContain(expectAltIncludes);
+      expect(result!.endAlt).toContain(expectAltIncludes);
+    }
+  });
+});

--- a/assets/exercise-illustrations/CURATION.md
+++ b/assets/exercise-illustrations/CURATION.md
@@ -1,0 +1,70 @@
+# Exercise Illustration Curation — BLD-561
+
+Two-gate review for every pilot exercise image pair. Per R2 plan:
+
+- **Visual plausibility** — no extra limbs, no text artifacts, style consistent.
+- **Technique** — cable path matches `mount_position` + `attachment`; joint angles plausible; no injury-risk poses.
+
+Both gates must be ✅ before an image pair ships in `manifest.generated.ts`.
+If either gate is ❌ or missing, the exercise is **excluded from the manifest** and
+`resolveExerciseImages()` returns `null` (both-or-neither rule) — user sees text steps only.
+
+## Provider
+
+- Model: `gpt-image-1` (OpenAI). Commercial-rights ToS clean.
+- Image spec: 384×384 webp Q75, transparent alpha background.
+- Generator: `scripts/generate-exercise-images.ts`.
+
+## Status
+
+**Pipeline landed in PR1 (BLD-561). Pilot image generation is pending a run of
+`npm run generate:exercise-images` with `OPENAI_API_KEY` present.**
+
+Run from an environment with the key set (owner device or CI secret):
+
+```bash
+export OPENAI_API_KEY=sk-...
+npm run generate:exercise-images
+# then paste review--sports-science output below per exercise
+# and sign off visual + technique gates
+```
+
+The pilot manifest is intentionally empty in PR1 so the both-or-neither rule
+keeps every Voltra exercise at text-only until a curator has signed off on
+the generated images. Shipping the pipeline + renderer ahead of the image
+batch lets the renderer and bundle gate be reviewed independently of
+model-output quality.
+
+## Pilot batch sign-off template
+
+For each pilot exercise, append a block below:
+
+```
+## voltra-XXX — <Exercise Name>
+- Visual plausibility: ✅/❌ <reviewer> <date> (notes)
+- Technique: ✅/❌ <reviewer> <date> (notes)
+- Model: gpt-image-1 <model-version>
+- review--sports-science: <paste skill output here, include commit hash / timestamp>
+- Regeneration notes: <N regens, what changed>
+```
+
+Note: reviewer handles `alan` and `alankyshum` are equivalent per techlead.
+
+## Pilot exercise list (10)
+
+See `assets/exercise-illustrations/pilot-ids.ts`:
+
+1. voltra-001 — Abdominal Crunches (low mount, 2-arm)
+2. voltra-013 — Bicep Curls (low mount, 2-arm)
+3. voltra-029 — Chest Press (mid mount, 2-arm)
+4. voltra-045 — Lat Pulldown (high mount, 2-arm)
+5. voltra-003 — Half Kneeling Chop (high mount, 1-arm diagonal)
+6. voltra-005 — One-arm Chest Fly with Rotation (mid mount, 1-arm)
+7. voltra-007 — Single Arm Chest Press with Spinal Rotation (mid mount, 1-arm)
+8. voltra-010 — (low-mount coverage)
+9. voltra-020 — (mid-mount coverage)
+10. voltra-035 — (high-mount 1-arm coverage)
+
+## Sign-offs
+
+_None yet — awaiting first generator run with `OPENAI_API_KEY`._

--- a/assets/exercise-illustrations/manifest.generated.ts
+++ b/assets/exercise-illustrations/manifest.generated.ts
@@ -1,0 +1,19 @@
+// @generated — do not edit. Regenerate via `npm run generate:exercise-images`.
+//
+// BLD-561: Exercise illustrations pilot manifest.
+// Entries are deterministic-sorted by exercise id (localeCompare).
+// Each entry must have ALL FOUR keys (start, end, startAlt, endAlt) or
+// resolveExerciseImages() will return null per the both-or-neither rule.
+//
+// To populate: run `npm run generate:exercise-images` with OPENAI_API_KEY in env.
+// See scripts/generate-exercise-images.ts and CURATION.md.
+/* eslint-disable */
+
+export type ManifestEntry = {
+  start: number;
+  end: number;
+  startAlt: string;
+  endAlt: string;
+};
+
+export const manifest: Record<string, ManifestEntry> = {};

--- a/assets/exercise-illustrations/pilot-ids.ts
+++ b/assets/exercise-illustrations/pilot-ids.ts
@@ -1,0 +1,26 @@
+// BLD-561: Pilot exercise selection.
+//
+// R2 plan calls for 10 Voltra pilot exercises stress-testing prompt coverage:
+//   4 by popularity (owner-facing) + 6 by prompt-stress (mount × arm coverage).
+//
+// Selection below covers {low, mid, high} mount × {1-arm, 2-arm} stance,
+// with the first 4 biased toward the canonical seed-order popularity set.
+// Adjust with owner confirmation before expanding to BLD-556-P2.
+//
+// This list is consumed by the generator script AND by the
+// manifest-completeness test.
+
+export const PILOT_EXERCISE_IDS: readonly string[] = [
+  // Popular / canonical
+  "voltra-001", // Abdominal Crunches — low mount, 2-arm
+  "voltra-013", // Bicep Curls — low mount, 2-arm (see seed)
+  "voltra-029", // Chest Press — mid mount, 2-arm (see seed)
+  "voltra-045", // Lat Pulldown — high mount, 2-arm (see seed)
+  // Prompt-stress grid
+  "voltra-003", // Half Kneeling Chop — high mount, 1-arm diagonal
+  "voltra-005", // One-arm Chest Fly with Rotation — mid mount, 1-arm
+  "voltra-007", // Single Arm Chest Press with Spinal Rotation — mid mount, 1-arm
+  "voltra-010", // mount stress — additional low-mount coverage
+  "voltra-020", // mid mount 2-arm alt
+  "voltra-035", // high mount 1-arm alt
+];

--- a/assets/exercise-illustrations/resolve.ts
+++ b/assets/exercise-illustrations/resolve.ts
@@ -1,0 +1,42 @@
+// BLD-561: Exercise illustration resolver.
+//
+// Single source of truth for "does this exercise have illustrations?".
+// Enforces the both-or-neither rule: a lone start image reads as a data bug,
+// so if either position is missing we return null and the caller falls back
+// to text-only rendering.
+import type { Exercise } from "@/lib/types";
+import { manifest } from "./manifest.generated";
+
+export type ResolvedExerciseImages = {
+  start: number | { uri: string };
+  end: number | { uri: string };
+  startAlt: string;
+  endAlt: string;
+};
+
+export function resolveExerciseImages(
+  ex: Pick<
+    Exercise,
+    "id" | "name" | "is_custom" | "start_image_uri" | "end_image_uri"
+  >
+): ResolvedExerciseImages | null {
+  if (ex.is_custom) {
+    if (!ex.start_image_uri || !ex.end_image_uri) return null;
+    return {
+      start: { uri: ex.start_image_uri },
+      end: { uri: ex.end_image_uri },
+      startAlt: `${ex.name} start position — user-supplied illustration.`,
+      endAlt: `${ex.name} end position — user-supplied illustration.`,
+    };
+  }
+  const entry = manifest[ex.id];
+  if (!entry) return null;
+  if (!entry.start || !entry.end) return null;
+  if (!entry.startAlt || !entry.endAlt) return null;
+  return {
+    start: entry.start,
+    end: entry.end,
+    startAlt: entry.startAlt,
+    endAlt: entry.endAlt,
+  };
+}

--- a/components/exercises/ExerciseDetailPane.tsx
+++ b/components/exercises/ExerciseDetailPane.tsx
@@ -7,6 +7,7 @@ import { CATEGORY_LABELS, type Exercise } from "../../lib/types";
 import { difficultyText, DIFFICULTY_COLORS } from "../../constants/theme";
 import { MuscleMap } from "../../components/MuscleMap";
 import { BodyweightModifierNotice } from "./BodyweightModifierNotice";
+import { ExerciseIllustrationCards } from "@/components/exercises/ExerciseIllustrationCards";
 import { fontSizes } from "@/constants/design-tokens";
 
 export interface ExerciseDetailPaneProps {
@@ -140,6 +141,7 @@ export function ExerciseDetailPane({ detail, colors, profileGender, bottomInset 
                   <Text variant="body" style={{ color: colors.onSurfaceVariant, marginTop: 16 }}>
                     Instructions
                   </Text>
+                  <ExerciseIllustrationCards exercise={detail} />
                   {steps.map((step, i) => {
                     const text = step.replace(/^\d+\.\s*/, "");
                     return (

--- a/components/exercises/ExerciseIllustrationCards.tsx
+++ b/components/exercises/ExerciseIllustrationCards.tsx
@@ -1,0 +1,149 @@
+// BLD-561: Inline start/end position illustrations for exercise detail views.
+//
+// Renders above the numbered text steps in both ExerciseDetailDrawer and
+// ExerciseDetailPane. Uses onLayout container width (≥480px → side-by-side,
+// <480px → stacked) so tablet bottom-sheets render correctly too.
+//
+// Tap any image opens ExerciseImageZoomModal with full-screen pinch-zoom.
+import React, { useCallback, useMemo, useState } from "react";
+import { Pressable, StyleSheet, View, type LayoutChangeEvent } from "react-native";
+import { Image } from "expo-image";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { Exercise } from "@/lib/types";
+import { resolveExerciseImages, type ResolvedExerciseImages } from "../../assets/exercise-illustrations/resolve";
+import { ExerciseImageZoomModal } from "./ExerciseImageZoomModal";
+
+const SIDE_BY_SIDE_MIN_WIDTH = 480;
+
+interface Props {
+  exercise: Pick<Exercise, "id" | "name" | "is_custom" | "start_image_uri" | "end_image_uri">;
+  /** Initial width hint (optional). We rely primarily on onLayout. */
+  initialWidth?: number;
+}
+
+export function ExerciseIllustrationCards({ exercise, initialWidth }: Props) {
+  const colors = useThemeColors();
+  const [containerWidth, setContainerWidth] = useState<number>(initialWidth ?? 0);
+  const [zoom, setZoom] = useState<"start" | "end" | null>(null);
+
+  const resolved = useMemo<ResolvedExerciseImages | null>(
+    () => resolveExerciseImages(exercise),
+    [exercise]
+  );
+
+  const onLayout = useCallback((e: LayoutChangeEvent) => {
+    const w = e.nativeEvent.layout.width;
+    if (Math.abs(w - containerWidth) > 1) setContainerWidth(w);
+  }, [containerWidth]);
+
+  // Hint for custom exercises without images. For seeded exercises with a
+  // missing manifest entry we render nothing (no placeholder, no error) per
+  // the R2 renderer decisions.
+  if (!resolved) {
+    if (exercise.is_custom) {
+      return (
+        <View onLayout={onLayout} style={styles.hintWrap}>
+          <Text
+            variant="body"
+            style={{ color: colors.onSurfaceVariant, fontSize: 12 }}
+            accessibilityLabel="Add your own illustration — coming soon"
+          >
+            Add your own illustration — coming soon
+          </Text>
+        </View>
+      );
+    }
+    return <View onLayout={onLayout} />;
+  }
+
+  const sideBySide = containerWidth >= SIDE_BY_SIDE_MIN_WIDTH;
+
+  const cardStyle = [styles.card, { backgroundColor: colors.surfaceAlt }];
+
+  return (
+    <>
+      <View
+        onLayout={onLayout}
+        style={[styles.row, sideBySide ? styles.rowHorizontal : styles.rowVertical]}
+        testID="exercise-illustration-row"
+      >
+        <Pressable
+          onPress={() => setZoom("start")}
+          accessibilityRole="image"
+          accessibilityLabel={resolved.startAlt}
+          accessibilityHint="Tap to view full-screen"
+          style={[cardStyle, sideBySide ? styles.halfWidth : styles.fullWidth]}
+          testID="exercise-illustration-start"
+        >
+          <Image
+            source={resolved.start}
+            style={styles.image}
+            contentFit="contain"
+            transition={0}
+            accessible={false}
+          />
+          <Text style={[styles.caption, { color: colors.onSurfaceVariant }]}>Start position</Text>
+        </Pressable>
+        <Pressable
+          onPress={() => setZoom("end")}
+          accessibilityRole="image"
+          accessibilityLabel={resolved.endAlt}
+          accessibilityHint="Tap to view full-screen"
+          style={[cardStyle, sideBySide ? styles.halfWidth : styles.fullWidth]}
+          testID="exercise-illustration-end"
+        >
+          <Image
+            source={resolved.end}
+            style={styles.image}
+            contentFit="contain"
+            transition={0}
+            accessible={false}
+          />
+          <Text style={[styles.caption, { color: colors.onSurfaceVariant }]}>End position</Text>
+        </Pressable>
+      </View>
+      <ExerciseImageZoomModal
+        visible={zoom !== null}
+        source={zoom === "start" ? resolved.start : zoom === "end" ? resolved.end : null}
+        accessibilityLabel={zoom === "start" ? resolved.startAlt : resolved.endAlt}
+        onClose={() => setZoom(null)}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    marginTop: 8,
+    marginBottom: 16,
+    gap: 8,
+  },
+  rowHorizontal: {
+    flexDirection: "row",
+  },
+  rowVertical: {
+    flexDirection: "column",
+  },
+  card: {
+    padding: 8,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  halfWidth: { flex: 1 },
+  fullWidth: { width: "100%" },
+  image: {
+    width: "100%",
+    aspectRatio: 1,
+    maxHeight: 240,
+  },
+  caption: {
+    marginTop: 6,
+    fontSize: 12,
+    fontWeight: "500",
+  },
+  hintWrap: {
+    marginTop: 12,
+    marginBottom: 8,
+  },
+});

--- a/components/exercises/ExerciseIllustrationCards.tsx
+++ b/components/exercises/ExerciseIllustrationCards.tsx
@@ -54,7 +54,7 @@ export function ExerciseIllustrationCards({ exercise, initialWidth }: Props) {
         </View>
       );
     }
-    return <View onLayout={onLayout} />;
+    return null;
   }
 
   const sideBySide = containerWidth >= SIDE_BY_SIDE_MIN_WIDTH;
@@ -70,7 +70,7 @@ export function ExerciseIllustrationCards({ exercise, initialWidth }: Props) {
       >
         <Pressable
           onPress={() => setZoom("start")}
-          accessibilityRole="image"
+          accessibilityRole="button"
           accessibilityLabel={resolved.startAlt}
           accessibilityHint="Tap to view full-screen"
           style={[cardStyle, sideBySide ? styles.halfWidth : styles.fullWidth]}
@@ -87,7 +87,7 @@ export function ExerciseIllustrationCards({ exercise, initialWidth }: Props) {
         </Pressable>
         <Pressable
           onPress={() => setZoom("end")}
-          accessibilityRole="image"
+          accessibilityRole="button"
           accessibilityLabel={resolved.endAlt}
           accessibilityHint="Tap to view full-screen"
           style={[cardStyle, sideBySide ? styles.halfWidth : styles.fullWidth]}

--- a/components/exercises/ExerciseImageZoomModal.tsx
+++ b/components/exercises/ExerciseImageZoomModal.tsx
@@ -1,0 +1,179 @@
+// BLD-561: Full-screen image viewer with pinch-zoom + swipe-down dismiss.
+//
+// Usage:
+//   <ExerciseImageZoomModal
+//     visible={open}
+//     source={resolved.start}
+//     accessibilityLabel={resolved.startAlt}
+//     onClose={() => setOpen(false)}
+//   />
+//
+// Why not package this as a general-purpose modal: gesture composition needs
+// to be tight (Pinch + Tap on the MODAL, not the drawer inline image) to
+// avoid intercepting bottom-sheet drag. This component owns that contract.
+import React, { useCallback } from "react";
+import { Modal, Pressable, StyleSheet, View } from "react-native";
+import Animated, { useAnimatedStyle, useSharedValue, withSpring, runOnJS } from "react-native-reanimated";
+import { Gesture, GestureDetector, GestureHandlerRootView } from "react-native-gesture-handler";
+import { Image } from "expo-image";
+import { X } from "lucide-react-native";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+
+type Source = number | { uri: string };
+
+interface Props {
+  visible: boolean;
+  source: Source | null;
+  accessibilityLabel: string;
+  onClose: () => void;
+}
+
+function ZoomContents({ source, accessibilityLabel, onClose }: { source: Source; accessibilityLabel: string; onClose: () => void }) {
+  const colors = useThemeColors();
+  const scale = useSharedValue(1);
+  const savedScale = useSharedValue(1);
+  const translateY = useSharedValue(0);
+
+  const reset = useCallback(() => {
+    scale.value = 1;
+    savedScale.value = 1;
+    translateY.value = 0;
+  }, [scale, savedScale, translateY]);
+
+  const handleClose = useCallback(() => {
+    reset();
+    onClose();
+  }, [reset, onClose]);
+
+  const pinch = Gesture.Pinch()
+    .onUpdate((e) => {
+      scale.value = Math.max(1, Math.min(4, savedScale.value * e.scale));
+    })
+    .onEnd(() => {
+      savedScale.value = scale.value;
+      if (scale.value < 1.05) {
+        scale.value = withSpring(1);
+        savedScale.value = 1;
+      }
+    });
+
+  const swipeDown = Gesture.Pan()
+    .onUpdate((e) => {
+      if (savedScale.value <= 1.05) {
+        translateY.value = Math.max(0, e.translationY);
+      }
+    })
+    .onEnd(() => {
+      if (translateY.value > 120) {
+        runOnJS(handleClose)();
+      } else {
+        translateY.value = withSpring(0);
+      }
+    });
+
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onEnd(() => {
+      if (savedScale.value > 1) {
+        scale.value = withSpring(1);
+        savedScale.value = 1;
+      } else {
+        scale.value = withSpring(2);
+        savedScale.value = 2;
+      }
+    });
+
+  const composed = Gesture.Exclusive(pinch, Gesture.Exclusive(doubleTap, swipeDown));
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }, { scale: scale.value }],
+  }));
+
+  return (
+    <GestureHandlerRootView style={styles.root}>
+      <View style={[styles.backdrop, { backgroundColor: "rgba(0,0,0,0.92)" }]}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Close zoomed image"
+          onPress={handleClose}
+          style={styles.closeBtn}
+          hitSlop={12}
+        >
+          <X size={28} color={colors.onPrimary} />
+        </Pressable>
+        <GestureDetector gesture={composed}>
+          <Animated.View style={[styles.imageWrap, animatedStyle]}>
+            <Image
+              source={source}
+              style={styles.image}
+              contentFit="contain"
+              accessible
+              accessibilityRole="image"
+              accessibilityLabel={accessibilityLabel}
+              transition={150}
+            />
+          </Animated.View>
+        </GestureDetector>
+        <Text
+          variant="body"
+          style={[styles.hint, { color: colors.onSurfaceVariant }]}
+        >
+          Pinch to zoom • Swipe down to close
+        </Text>
+      </View>
+    </GestureHandlerRootView>
+  );
+}
+
+export function ExerciseImageZoomModal({ visible, source, accessibilityLabel, onClose }: Props) {
+  // Only mount the gesture-heavy contents while visible so tests that don't
+  // open the modal never construct gesture objects. Modal transparent scrim
+  // remains cheap to render.
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      accessibilityViewIsModal
+    >
+      {visible && source ? (
+        <ZoomContents source={source} accessibilityLabel={accessibilityLabel} onClose={onClose} />
+      ) : null}
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1 },
+  backdrop: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  closeBtn: {
+    position: "absolute",
+    top: 48,
+    right: 16,
+    padding: 8,
+    zIndex: 10,
+  },
+  imageWrap: {
+    width: "90%",
+    aspectRatio: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  image: {
+    width: "100%",
+    height: "100%",
+  },
+  hint: {
+    position: "absolute",
+    bottom: 36,
+    alignSelf: "center",
+    opacity: 0.7,
+    fontSize: 12,
+  },
+});

--- a/components/session/ExerciseDetailDrawer.tsx
+++ b/components/session/ExerciseDetailDrawer.tsx
@@ -9,6 +9,7 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { CATEGORY_LABELS, ATTACHMENT_LABELS } from "../../lib/types";
 import { difficultyText, DIFFICULTY_COLORS } from "../../constants/theme";
 import { ExerciseDrawerStats } from "./ExerciseDrawerStats";
+import { ExerciseIllustrationCards } from "@/components/exercises/ExerciseIllustrationCards";
 import type { Exercise } from "../../lib/types";
 import { fontSizes } from "@/constants/design-tokens";
 
@@ -100,6 +101,7 @@ export function ExerciseDetailDrawerContent({ exercise, unit }: Props) {
 
   const instructions = steps.length > 0 ? (
     <View style={styles.detailSection}>
+      <ExerciseIllustrationCards exercise={exercise} />
       <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.xs }}>
         Instructions
       </Text>
@@ -109,7 +111,9 @@ export function ExerciseDetailDrawerContent({ exercise, unit }: Props) {
         </Text>
       ))}
     </View>
-  ) : null;
+  ) : (
+    <ExerciseIllustrationCards exercise={exercise} />
+  );
 
   const mapWidth = layout.atLeastMedium
     ? Math.min(screenWidth - 64, 600)

--- a/hooks/useThemeColors.ts
+++ b/hooks/useThemeColors.ts
@@ -32,6 +32,8 @@ export function useThemeColors() {
     // Surface / Background
     surface: t.card,
     surfaceVariant: t.muted,
+    // BLD-561: neutral tinted card for illustrations (aliased to surfaceVariant).
+    surfaceAlt: t.muted,
     onSurface: t.foreground,
     onSurfaceVariant: t.mutedForeground,
     background: t.background,

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -29,6 +29,10 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   await addColumnIfMissing(database, "exercises", "attachment", "TEXT DEFAULT 'handle'");
   await addColumnIfMissing(database, "exercises", "training_modes", `TEXT DEFAULT '["weight"]'`);
   await addColumnIfMissing(database, "exercises", "is_voltra", "INTEGER DEFAULT 0");
+  // BLD-561: Exercise illustrations — URI columns for custom-exercise images.
+  // Seeded Voltra exercises use the bundled manifest instead of these columns.
+  await addColumnIfMissing(database, "exercises", "start_image_uri", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "exercises", "end_image_uri", "TEXT DEFAULT NULL");
 
   // workout_templates table
   await addColumnIfMissing(database, "workout_templates", "is_starter", "INTEGER DEFAULT 0");

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -29,6 +29,9 @@ export const exercises = sqliteTable("exercises", {
   attachment: text("attachment").default("handle"),
   training_modes: text("training_modes").default('["weight"]'),
   is_voltra: integer("is_voltra").default(0),
+  // BLD-561: Exercise illustrations — URI columns for custom-exercise images.
+  start_image_uri: text("start_image_uri"),
+  end_image_uri: text("end_image_uri"),
 });
 
 export const workoutTemplates = sqliteTable("workout_templates", {

--- a/lib/db/tables.ts
+++ b/lib/db/tables.ts
@@ -61,7 +61,9 @@ export async function createCoreTables(database: SQLite.SQLiteDatabase): Promise
       mount_position TEXT DEFAULT NULL,
       attachment TEXT DEFAULT 'handle',
       training_modes TEXT DEFAULT '["weight"]',
-      is_voltra INTEGER DEFAULT 0
+      is_voltra INTEGER DEFAULT 0,
+      start_image_uri TEXT DEFAULT NULL,
+      end_image_uri TEXT DEFAULT NULL
     );
 
     CREATE TABLE IF NOT EXISTS workout_templates (

--- a/lib/db/templates.ts
+++ b/lib/db/templates.ts
@@ -96,6 +96,8 @@ export async function getTemplateById(
           attachment: null,
           training_modes: null,
           is_voltra: null,
+          start_image_uri: null,
+          end_image_uri: null,
         })
       : undefined,
   }));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -70,6 +70,11 @@ export type Exercise = {
   attachment?: Attachment;
   training_modes?: TrainingMode[];
   is_voltra?: boolean;
+  // BLD-561: Exercise illustrations — user-supplied image URIs for custom exercises.
+  // Seeded Voltra exercises get their images from assets/exercise-illustrations/manifest.generated.ts,
+  // not these columns. Both-or-neither: resolver returns null unless both are present.
+  start_image_uri?: string;
+  end_image_uri?: string;
 };
 
 export const CATEGORIES: Category[] = [

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "screenshots:raw": "playwright test e2e/screenshot-capture.spec.ts --project=store-pixel9 --project=store-fold7",
     "screenshots:frame": "tsx scripts/generate-store-screenshots.ts",
     "screenshots": "npm run screenshots:raw && npm run screenshots:frame",
+    "generate:exercise-images": "tsx scripts/generate-exercise-images.ts",
     "prepare": "husky"
   },
   "dependencies": {

--- a/scripts/generate-exercise-images.ts
+++ b/scripts/generate-exercise-images.ts
@@ -181,10 +181,21 @@ async function describePose(prompt: string, position: "start" | "end", ex: Exerc
     }),
   });
   if (!res.ok) {
-    return `${ex.name} ${position} position.`;
+    // Hard-fail: never persist stub alt-text. Accessibility labels must be
+    // substantive AI output or the generator must fail the run so the
+    // manifest entry is not written.
+    throw new Error(
+      `alt-text generation failed for ${ex.id} (${position}): HTTP ${res.status} ${res.statusText}`
+    );
   }
   const body = (await res.json()) as { choices: Array<{ message: { content: string } }> };
-  return body.choices?.[0]?.message?.content?.trim() || `${ex.name} ${position} position.`;
+  const content = body.choices?.[0]?.message?.content?.trim();
+  if (!content) {
+    throw new Error(
+      `alt-text generation returned empty content for ${ex.id} (${position}); aborting run so manifest is not polluted with stub text.`
+    );
+  }
+  return content;
 }
 
 function encodeWebp(pngPath: string, webpPath: string): void {
@@ -239,7 +250,11 @@ function writeManifest(entries: Map<string, { startAlt: string; endAlt: string }
     lines.push(`  },`);
   }
   lines.push("};", "");
-  fs.writeFileSync(MANIFEST_PATH, lines.join("\n"));
+  // Atomic write: tmp + rename so a mid-batch failure leaves the prior
+  // manifest intact (QD R2 recommendation).
+  const tmp = `${MANIFEST_PATH}.tmp`;
+  fs.writeFileSync(tmp, lines.join("\n"));
+  fs.renameSync(tmp, MANIFEST_PATH);
   console.log(`[gen] wrote ${MANIFEST_PATH} with ${sorted.length} entries`);
 }
 
@@ -268,6 +283,22 @@ async function main(): Promise<void> {
   if (!cli.dryRun && !apiKey) {
     console.error("[gen] OPENAI_API_KEY is required (pass --dry-run to preview prompts without hitting the API).");
     process.exit(1);
+  }
+
+  // Preflight external binaries so we fail fast rather than deep in the loop.
+  if (!cli.dryRun) {
+    try {
+      execFileSync("cwebp", ["-version"], { stdio: "ignore" });
+    } catch {
+      console.error("[gen] 'cwebp' not found on PATH. Install libwebp (e.g., `brew install webp`).");
+      process.exit(1);
+    }
+    try {
+      execFileSync("identify", ["-version"], { stdio: "ignore" });
+    } catch {
+      console.error("[gen] 'identify' (ImageMagick) not found on PATH. Install ImageMagick (e.g., `brew install imagemagick`).");
+      process.exit(1);
+    }
   }
 
   const all = seedExercises();

--- a/scripts/generate-exercise-images.ts
+++ b/scripts/generate-exercise-images.ts
@@ -1,0 +1,348 @@
+#!/usr/bin/env tsx
+/**
+ * BLD-561 — Exercise illustration generator.
+ *
+ * Generates start + end position illustrations for pilot Voltra exercises
+ * using OpenAI `gpt-image-1` (per approved R2 plan).
+ *
+ * Usage:
+ *   OPENAI_API_KEY=sk-... npx tsx scripts/generate-exercise-images.ts
+ *   OPENAI_API_KEY=sk-... npx tsx scripts/generate-exercise-images.ts --force-regen
+ *   OPENAI_API_KEY=sk-... npx tsx scripts/generate-exercise-images.ts --contact-sheet
+ *
+ * Behavior:
+ *   - Idempotent: fingerprint sidecar per exercise; skip if unchanged.
+ *   - Fingerprint drift → warn and require `--force-regen`.
+ *   - Output: 384×384 webp Q75, transparent alpha. Requires `cwebp` on PATH.
+ *   - Writes manifest.generated.ts in deterministic id-sort order.
+ *   - Never logs the API key.
+ *   - Not a CI job; dev-only.
+ *
+ * Dry-run (no key needed): pass `--dry-run` to print prompt payloads only.
+ */
+/* eslint-disable no-console */
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+// NOTE: tsx can resolve tsconfig paths; using relative import for safety.
+import { seedExercises } from "../lib/seed";
+import { PILOT_EXERCISE_IDS } from "../assets/exercise-illustrations/pilot-ids";
+import type { Exercise } from "../lib/types";
+
+const ROOT = path.resolve(__dirname, "..");
+const ASSET_DIR = path.join(ROOT, "assets/exercise-illustrations");
+const MANIFEST_PATH = path.join(ASSET_DIR, "manifest.generated.ts");
+const MODEL = "gpt-image-1";
+const MODEL_VERSION = "2025-09"; // pinned per techlead; update alongside re-run
+const IMAGE_SIZE = 384;
+const WEBP_QUALITY = 75;
+
+const PROMPT_TEMPLATE_VERSION = "1.0.0";
+const PROMPT_TEMPLATE = `Minimalist educational illustration of a single person performing a cable-machine exercise.
+Style: clean line-art with subtle flat shading, transparent background, no text, no watermarks, no brand logos, no equipment labels.
+Framing: full body visible, centered, neutral pose, plausible anatomy.
+Cable machine: render only the cable + handle + relevant mount point; no extra gym furniture.
+Exercise: {NAME}
+Category: {CATEGORY}
+Mount position: {MOUNT}
+Attachment: {ATTACHMENT}
+Instructions (for pose reference): {INSTRUCTIONS}
+Generate {POSITION} position only.
+Also return a 1-2 sentence alt-text description of the pose in the same call output.`;
+
+type Cli = {
+  forceRegen: boolean;
+  dryRun: boolean;
+  contactSheet: boolean;
+};
+
+function parseArgs(argv: string[]): Cli {
+  return {
+    forceRegen: argv.includes("--force-regen"),
+    dryRun: argv.includes("--dry-run"),
+    contactSheet: argv.includes("--contact-sheet"),
+  };
+}
+
+function fingerprintInput(ex: Exercise): string {
+  return JSON.stringify({
+    id: ex.id,
+    name: ex.name,
+    category: ex.category,
+    mount_position: ex.mount_position ?? null,
+    attachment: ex.attachment ?? null,
+    instructions: ex.instructions,
+    template: PROMPT_TEMPLATE,
+    templateVersion: PROMPT_TEMPLATE_VERSION,
+    model: MODEL,
+    modelVersion: MODEL_VERSION,
+  });
+}
+
+function sha256(data: string): string {
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+type Fingerprint = {
+  promptHash: string;
+  model: string;
+  modelVersion: string;
+  generatedAt: string;
+};
+
+function readFingerprint(dir: string): Fingerprint | null {
+  const fpPath = path.join(dir, "fingerprint.json");
+  if (!fs.existsSync(fpPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(fpPath, "utf8")) as Fingerprint;
+  } catch {
+    return null;
+  }
+}
+
+function writeFingerprint(dir: string, fp: Fingerprint): void {
+  fs.writeFileSync(path.join(dir, "fingerprint.json"), JSON.stringify(fp, null, 2) + "\n");
+}
+
+function buildPrompt(ex: Exercise, position: "start" | "end"): string {
+  return PROMPT_TEMPLATE
+    .replace("{NAME}", ex.name)
+    .replace("{CATEGORY}", ex.category)
+    .replace("{MOUNT}", ex.mount_position ?? "n/a")
+    .replace("{ATTACHMENT}", ex.attachment ?? "n/a")
+    .replace("{INSTRUCTIONS}", ex.instructions.replace(/\n/g, " "))
+    .replace("{POSITION}", position);
+}
+
+type GenerationResult = {
+  pngBuffer: Buffer;
+  altText: string;
+};
+
+async function callOpenAI(prompt: string, apiKey: string): Promise<GenerationResult> {
+  // Ask the image endpoint for a transparent-background PNG sized 1024×1024,
+  // we downscale + re-encode to webp Q75 @ 384×384 ourselves (guarantees the
+  // alpha contract regardless of provider tweaks).
+  const res = await fetch("https://api.openai.com/v1/images/generations", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      prompt,
+      size: "1024x1024",
+      background: "transparent",
+      n: 1,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`OpenAI image gen failed (${res.status}): ${text.slice(0, 500)}`);
+  }
+  const body = (await res.json()) as { data: Array<{ b64_json?: string; revised_prompt?: string }> };
+  const first = body.data?.[0];
+  if (!first?.b64_json) {
+    throw new Error("OpenAI response missing b64_json payload");
+  }
+  // Use the revised_prompt as a weak alt-text fallback; the real alt text
+  // should be requested from a text model (cheap, separate call) if we
+  // want richer accessibility. See TODO below.
+  const altText = first.revised_prompt?.trim() || "";
+  return { pngBuffer: Buffer.from(first.b64_json, "base64"), altText };
+}
+
+async function describePose(prompt: string, position: "start" | "end", ex: Exercise, apiKey: string): Promise<string> {
+  // Separate small text call for substantive accessibility alt-text.
+  // Kept in the same script so one command produces both image and alt.
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "gpt-4o-mini",
+      temperature: 0.2,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You write 1-2 sentence descriptive alt-text for an exercise illustration. Describe body position, cable path, and key joint angles. No second person, no bullet points.",
+        },
+        {
+          role: "user",
+          content: `Exercise: ${ex.name} (${ex.category}). Mount: ${ex.mount_position}. Attachment: ${ex.attachment}. Position: ${position}. Instructions: ${ex.instructions}`,
+        },
+      ],
+    }),
+  });
+  if (!res.ok) {
+    return `${ex.name} ${position} position.`;
+  }
+  const body = (await res.json()) as { choices: Array<{ message: { content: string } }> };
+  return body.choices?.[0]?.message?.content?.trim() || `${ex.name} ${position} position.`;
+}
+
+function encodeWebp(pngPath: string, webpPath: string): void {
+  // cwebp preserves alpha when present in the PNG input. -q 75 matches plan.
+  // -m 6 and -pass 10 give best compression at a cost of encode time (fine for
+  // offline generation).
+  execFileSync("cwebp", ["-q", String(WEBP_QUALITY), "-m", "6", "-pass", "10", "-resize", String(IMAGE_SIZE), String(IMAGE_SIZE), pngPath, "-o", webpPath], { stdio: "inherit" });
+}
+
+function verifyAlpha(webpPath: string): void {
+  // `identify` from ImageMagick reports alpha channel presence via %A.
+  // Blob on RGB-only outputs so we don't silently ship a non-transparent image.
+  try {
+    const out = execFileSync("identify", ["-format", "%A", webpPath]).toString().trim();
+    if (out !== "Blend" && out !== "True") {
+      throw new Error(`Expected alpha channel on ${webpPath}, got '${out}'`);
+    }
+  } catch (err) {
+    throw new Error(`Alpha verification failed for ${webpPath}: ${(err as Error).message}`);
+  }
+}
+
+function writeManifest(entries: Map<string, { startAlt: string; endAlt: string }>): void {
+  const sorted = Array.from(entries.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  const lines: string[] = [
+    "// @generated — do not edit. Regenerate via `npm run generate:exercise-images`.",
+    "//",
+    "// BLD-561: Exercise illustrations pilot manifest.",
+    "// Entries are deterministic-sorted by exercise id (localeCompare).",
+    "// Each entry must have ALL FOUR keys (start, end, startAlt, endAlt) or",
+    "// resolveExerciseImages() will return null per the both-or-neither rule.",
+    "//",
+    "// To populate: run `npm run generate:exercise-images` with OPENAI_API_KEY in env.",
+    "// See scripts/generate-exercise-images.ts and CURATION.md.",
+    "/* eslint-disable */",
+    "",
+    "export type ManifestEntry = {",
+    "  start: number;",
+    "  end: number;",
+    "  startAlt: string;",
+    "  endAlt: string;",
+    "};",
+    "",
+    "export const manifest: Record<string, ManifestEntry> = {",
+  ];
+  for (const [id, { startAlt, endAlt }] of sorted) {
+    lines.push(`  "${id}": {`);
+    lines.push(`    start: require("./${id}/start.webp"),`);
+    lines.push(`    end: require("./${id}/end.webp"),`);
+    lines.push(`    startAlt: ${JSON.stringify(startAlt)},`);
+    lines.push(`    endAlt: ${JSON.stringify(endAlt)},`);
+    lines.push(`  },`);
+  }
+  lines.push("};", "");
+  fs.writeFileSync(MANIFEST_PATH, lines.join("\n"));
+  console.log(`[gen] wrote ${MANIFEST_PATH} with ${sorted.length} entries`);
+}
+
+function writeContactSheet(entries: Map<string, { startAlt: string; endAlt: string }>): void {
+  const sorted = Array.from(entries.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  const rows = sorted
+    .map(([id, v]) => `<tr><td>${id}</td><td><img src="./${id}/start.webp" width="192"><br><small>${escapeHtml(v.startAlt)}</small></td><td><img src="./${id}/end.webp" width="192"><br><small>${escapeHtml(v.endAlt)}</small></td></tr>`)
+    .join("\n");
+  const html = `<!doctype html><meta charset="utf-8"><title>Exercise illustration contact sheet</title>
+<style>body{font:14px system-ui;background:#111;color:#eee}table{border-collapse:collapse;width:100%}td{border:1px solid #333;padding:8px;vertical-align:top}small{color:#aaa}</style>
+<h1>BLD-561 — Exercise illustration contact sheet</h1>
+<table><thead><tr><th>id</th><th>start</th><th>end</th></tr></thead><tbody>${rows}</tbody></table>`;
+  const outPath = path.join(ASSET_DIR, "curation");
+  fs.mkdirSync(outPath, { recursive: true });
+  fs.writeFileSync(path.join(outPath, "contact-sheet.html"), html);
+  console.log(`[gen] wrote contact sheet to ${outPath}/contact-sheet.html`);
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] || c));
+}
+
+async function main(): Promise<void> {
+  const cli = parseArgs(process.argv.slice(2));
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!cli.dryRun && !apiKey) {
+    console.error("[gen] OPENAI_API_KEY is required (pass --dry-run to preview prompts without hitting the API).");
+    process.exit(1);
+  }
+
+  const all = seedExercises();
+  const pilot = all.filter((ex) => PILOT_EXERCISE_IDS.includes(ex.id));
+  const missing = PILOT_EXERCISE_IDS.filter((id) => !pilot.find((p) => p.id === id));
+  if (missing.length > 0) {
+    console.warn(`[gen] pilot ids not present in seed: ${missing.join(", ")}`);
+  }
+  console.log(`[gen] pilot exercises: ${pilot.length}/${PILOT_EXERCISE_IDS.length} resolved`);
+
+  const manifestEntries = new Map<string, { startAlt: string; endAlt: string }>();
+
+  for (const ex of pilot) {
+    const exDir = path.join(ASSET_DIR, ex.id);
+    fs.mkdirSync(exDir, { recursive: true });
+    const fpInput = fingerprintInput(ex);
+    const promptHash = sha256(fpInput);
+    const existing = readFingerprint(exDir);
+    const haveFiles = fs.existsSync(path.join(exDir, "start.webp")) && fs.existsSync(path.join(exDir, "end.webp"));
+
+    if (haveFiles && existing?.promptHash === promptHash && !cli.forceRegen) {
+      console.log(`[gen] ${ex.id}: up to date — skip`);
+      // Attempt to read alt text from prior manifest.
+      try {
+        const prior = await import(MANIFEST_PATH);
+        const entry = prior.manifest?.[ex.id];
+        if (entry?.startAlt && entry?.endAlt) {
+          manifestEntries.set(ex.id, { startAlt: entry.startAlt, endAlt: entry.endAlt });
+        }
+      } catch {
+        // ignore — will regenerate on next run if alt missing
+      }
+      continue;
+    }
+    if (haveFiles && existing && existing.promptHash !== promptHash && !cli.forceRegen) {
+      console.warn(`[gen] ${ex.id}: prompt fingerprint drift detected — pass --force-regen to regenerate.`);
+      continue;
+    }
+
+    for (const position of ["start", "end"] as const) {
+      const prompt = buildPrompt(ex, position);
+      if (cli.dryRun) {
+        console.log(`[gen:dry] ${ex.id} ${position}: ${prompt.slice(0, 120)}...`);
+        continue;
+      }
+      console.log(`[gen] ${ex.id} ${position}: calling ${MODEL}...`);
+      const { pngBuffer } = await callOpenAI(prompt, apiKey!);
+      const pngPath = path.join(exDir, `${position}.png`);
+      const webpPath = path.join(exDir, `${position}.webp`);
+      fs.writeFileSync(pngPath, pngBuffer);
+      encodeWebp(pngPath, webpPath);
+      verifyAlpha(webpPath);
+      fs.unlinkSync(pngPath);
+    }
+    if (cli.dryRun) continue;
+
+    const startAlt = await describePose(buildPrompt(ex, "start"), "start", ex, apiKey!);
+    const endAlt = await describePose(buildPrompt(ex, "end"), "end", ex, apiKey!);
+    manifestEntries.set(ex.id, { startAlt, endAlt });
+
+    writeFingerprint(exDir, {
+      promptHash,
+      model: MODEL,
+      modelVersion: MODEL_VERSION,
+      generatedAt: new Date().toISOString(),
+    });
+  }
+
+  if (!cli.dryRun) {
+    writeManifest(manifestEntries);
+    if (cli.contactSheet) writeContactSheet(manifestEntries);
+  }
+}
+
+main().catch((err) => {
+  console.error("[gen] fatal:", (err as Error).message);
+  process.exit(1);
+});

--- a/scripts/verify-exercise-illustrations-size.sh
+++ b/scripts/verify-exercise-illustrations-size.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Bundle-gate: verify exercise illustration asset directory stays within budget.
+#
+# R2 plan (BLD-556/BLD-561): target ≤8MB, hard fail >12MB.
+# Wired into pre-push hook and Bundle Gate CI workflow.
+#
+# Why: AI-generated webp illustrations are bundled into the APK. A batch
+# regeneration at a higher quality or a missed transparent-alpha downgrade
+# can silently double the bundle. This gate catches that before merge.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+ASSET_DIR="assets/exercise-illustrations"
+TARGET_BYTES=$((8 * 1024 * 1024))
+HARD_FAIL_BYTES=$((12 * 1024 * 1024))
+
+if [ ! -d "$ASSET_DIR" ]; then
+  echo "[illustration-size] $ASSET_DIR not present — skipping"
+  exit 0
+fi
+
+# Sum only .webp files so non-image artifacts (manifest, README, fingerprints)
+# don't count against the bundle budget.
+total_bytes=0
+while IFS= read -r -d '' f; do
+  size=$(wc -c <"$f")
+  total_bytes=$((total_bytes + size))
+done < <(find "$ASSET_DIR" -type f -name '*.webp' -print0)
+
+human() {
+  awk -v b="$1" 'BEGIN { printf "%.2f MB", b / (1024*1024) }'
+}
+
+echo "[illustration-size] $ASSET_DIR/**/*.webp total: $(human "$total_bytes") (target ≤ $(human "$TARGET_BYTES"), hard fail > $(human "$HARD_FAIL_BYTES"))"
+
+if [ "$total_bytes" -gt "$HARD_FAIL_BYTES" ]; then
+  echo "[illustration-size] FAIL: exercise illustrations exceed hard-fail budget." >&2
+  echo "[illustration-size] Reduce webp quality, drop coverage, or re-encode at 384×384 Q75." >&2
+  exit 1
+fi
+
+if [ "$total_bytes" -gt "$TARGET_BYTES" ]; then
+  echo "[illustration-size] WARN: over target budget but under hard fail — review before merging." >&2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Implements R2 plan for visual exercise illustrations (BLD-556 → BLD-561, GH #332).
Ships the full pipeline, renderer, tests, and bundle gate for the 10-exercise pilot.

**Image generation is deferred to a follow-up commit on this branch.** The generator script (`scripts/generate-exercise-images.ts`) is committed and ready; producing the 10 pilot images requires `OPENAI_API_KEY` in the runner environment (not available to this implementation agent). The manifest is intentionally empty-but-valid — the both-or-neither rule in the resolver keeps every Voltra exercise at text-only rendering until a curator has reviewed generated images.

## Changes

### DB / types
- Additive migration adds `exercises.start_image_uri` / `end_image_uri` via the existing `addColumnIfMissing` 3-file pattern (`lib/db/tables.ts`, `lib/db/migrations.ts`, `lib/db/schema.ts`).
- `Exercise` type in `lib/types.ts` gains optional `start_image_uri` / `end_image_uri`.

### Resolver + manifest
- `assets/exercise-illustrations/resolve.ts` — single source of truth; returns `null` unless BOTH positions resolve (both-or-neither).
- `assets/exercise-illustrations/manifest.generated.ts` — empty-but-valid manifest with `@generated` header.
- `assets/exercise-illustrations/pilot-ids.ts` — 10-exercise selection (4 canonical + 6 prompt-stress, mount × arm coverage).

### Generator
- `scripts/generate-exercise-images.ts` — OpenAI `gpt-image-1` pinned, 384×384 webp Q75 transparent-alpha, fingerprint sidecar idempotency (drift requires `--force-regen`), `--contact-sheet` + `--dry-run` flags, separate text-model call for substantive alt-text.
- `npm run generate:exercise-images` in `package.json`.

### Renderer
- `ExerciseIllustrationCards` — `expo-image` `contentFit="contain"` on a `surfaceAlt` card, `onLayout` container-width breakpoint (≥480px → side-by-side, <480 → stacked), hardcoded EN captions, tap-to-zoom.
- `ExerciseImageZoomModal` — full-screen pinch-zoom via reanimated + gesture-handler (Pinch + Exclusive(DoubleTap, Pan)), swipe-down dismiss, lazy-mount so tests skip gesture construction.
- Wired into both `ExerciseDetailDrawer` (bottom sheet) and `ExerciseDetailPane` (tablet split pane) above numbered steps.
- Custom exercise without images → "Add your own illustration — coming soon" hint.
- `accessibilityLabel` = resolved `startAlt` / `endAlt` (AI-generated; never stub).

### Bundle gate
- `scripts/verify-exercise-illustrations-size.sh` — target ≤8MB, hard fail >12MB.
- Wired into `.husky/pre-push` and `.github/workflows/bundle-gate.yml` in THIS PR (per QD note).

### Tests (3 new files, 18 tests total)
- `__tests__/exercise-illustrations-manifest.test.ts` — shape + deterministic sort + per-pilot completeness.
- `__tests__/exercise-illustrations-resolver.test.ts` — `it.each` over both-or-neither matrix.
- `__tests__/components/ExerciseIllustrationCards.test.tsx` — RTL: 2 images, substantive alt, empty state, onLayout breakpoint.

### Curation
- `assets/exercise-illustrations/CURATION.md` — two-gate (visual + technique) sign-off template; documents OPENAI_API_KEY prerequisite for pilot generation.

## Testing

- `npx tsc --noEmit` — clean.
- `npx jest` — 2130/2131 suites pass; the 1 failure is pre-existing (BLD-258 `circleCheck` size mismatch), unrelated to this PR.
- `scripts/verify-exercise-illustrations-size.sh` — returns 0.00 MB (empty manifest), well under target.

## Deferred

- Pilot image generation (requires `OPENAI_API_KEY`). Once images are committed, the `review--sports-science` pass + CURATION.md sign-offs follow. Plan acceptance criterion 'All 10 pilot images committed' will be satisfied in a follow-up commit on this branch.
- BLD-556-P2 (remaining 46 Voltra), P3 (community), P4 (custom upload UX).

## Issue

Resolves BLD-561 (implements parent BLD-556 R2 plan).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>