### PR TITLE
feat(session): search-all fallback in substitution sheet (BLD-545)

### DIFF
--- a/__tests__/app/fta-decomposition.test.ts
+++ b/__tests__/app/fta-decomposition.test.ts
@@ -90,8 +90,9 @@ describe("FTA decomposition structural tests", () => {
     ["components/session/SessionListFooter.tsx", "Cancel Workout", "has Cancel Workout action"],
 
     // Batch 5 — SubstitutionSheet decomposition
-    ["components/SubstitutionSheet.tsx", "SubstitutionItem", "imports SubstitutionItem"],
-    ["components/SubstitutionSheet.tsx", "EquipmentFilter", "imports EquipmentFilter"],
+    ["components/SubstitutionSheet.tsx", "SubstitutionSheetBody", "imports SubstitutionSheetBody"],
+    ["components/substitution/SubstitutionSheetBody.tsx", "SubstitutionItem", "body uses SubstitutionItem"],
+    ["components/substitution/SubstitutionSheetBody.tsx", "EquipmentFilter", "body uses EquipmentFilter"],
     ["components/substitution/SubstitutionItem.tsx", "matchColor", "uses matchColor"],
     ["components/substitution/EquipmentFilter.tsx", "Chip", "uses Chip"],
 

--- a/__tests__/lib/exercise-substitution-search.test.ts
+++ b/__tests__/lib/exercise-substitution-search.test.ts
@@ -1,0 +1,223 @@
+import { composeSearchResults, isBlankQuery } from "../../lib/exercise-substitution-search";
+import { findSubstitutions } from "../../lib/exercise-substitutions";
+import type { Exercise } from "../../lib/types";
+
+function makeExercise(overrides: Partial<Exercise> = {}): Exercise {
+  return {
+    id: "ex-1",
+    name: "Bench Press",
+    category: "chest",
+    primary_muscles: ["chest", "triceps"],
+    secondary_muscles: ["shoulders"],
+    equipment: "barbell",
+    instructions: "",
+    difficulty: "intermediate",
+    is_custom: false,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+describe("exercise-substitution-search", () => {
+  describe("isBlankQuery", () => {
+    it("treats empty and whitespace-only strings as blank", () => {
+      expect(isBlankQuery("")).toBe(true);
+      expect(isBlankQuery("   ")).toBe(true);
+      expect(isBlankQuery("\t\n")).toBe(true);
+    });
+    it("treats non-empty strings as non-blank", () => {
+      expect(isBlankQuery("a")).toBe(false);
+      expect(isBlankQuery(" pull ")).toBe(false);
+    });
+  });
+
+  describe("composeSearchResults", () => {
+    const source = makeExercise({ id: "src", name: "Barbell Bench Press" });
+
+    const benchMuscleMatch = makeExercise({
+      id: "bench-db",
+      name: "Dumbbell Bench Press",
+      primary_muscles: ["chest", "triceps"],
+      equipment: "dumbbell",
+    });
+    const dipMuscleMatch = makeExercise({
+      id: "dip",
+      name: "Cable Chest Dip",
+      primary_muscles: ["chest"],
+      equipment: "cable",
+    });
+    const unrelated = makeExercise({
+      id: "squat",
+      name: "Zippy Back Squat",
+      primary_muscles: ["quads"],
+      secondary_muscles: ["glutes"],
+      category: "legs_glutes",
+      equipment: "bodyweight",
+      difficulty: "advanced",
+    });
+    const unrelatedPull = makeExercise({
+      id: "pullup",
+      name: "Pull-Up",
+      primary_muscles: ["lats"],
+      secondary_muscles: ["biceps"],
+      category: "back",
+      equipment: "bodyweight",
+    });
+    const deletedMatch = makeExercise({
+      id: "deleted-pull",
+      name: "Pulldown (deleted)",
+      primary_muscles: ["lats"],
+      equipment: "cable",
+      deleted_at: 1735689600000,
+    });
+
+    const allExercises = [
+      source,
+      benchMuscleMatch,
+      dipMuscleMatch,
+      unrelated,
+      unrelatedPull,
+      deletedMatch,
+    ];
+    const scored = findSubstitutions(source, allExercises);
+
+    it("empty query returns muscle-relevance results with no 'other' section", () => {
+      const res = composeSearchResults({
+        query: "",
+        scored,
+        allExercises,
+        sourceExercise: source,
+        equipmentFilter: null,
+      });
+      expect(res.other).toEqual([]);
+      expect(res.relevance.map((r) => r.exercise.id)).toEqual(
+        scored.map((s) => s.exercise.id)
+      );
+    });
+
+    it("empty query applies equipment filter to relevance", () => {
+      const res = composeSearchResults({
+        query: "   ",
+        scored,
+        allExercises,
+        sourceExercise: source,
+        equipmentFilter: "cable",
+      });
+      expect(res.other).toEqual([]);
+      expect(res.relevance.every((r) => r.exercise.equipment === "cable")).toBe(true);
+    });
+
+    it("name query finds muscle-relevance matches by name and places them in `relevance`", () => {
+      const res = composeSearchResults({
+        query: "bench",
+        scored,
+        allExercises,
+        sourceExercise: source,
+        equipmentFilter: null,
+      });
+      const relevanceIds = res.relevance.map((r) => r.exercise.id);
+      expect(relevanceIds).toContain("bench-db");
+      expect(res.other.every((o) => o.exercise.id !== "bench-db")).toBe(true);
+    });
+
+    it("non-muscle name matches land in `other`, sorted alphabetically", () => {
+      const res = composeSearchResults({
+        query: "zippy",
+        scored,
+        allExercises,
+        sourceExercise: source,
+        equipmentFilter: null,
+      });
+      const relevanceIds = res.relevance.map((r) => r.exercise.id);
+      const otherIds = res.other.map((o) => o.exercise.id);
+      expect(otherIds).toContain("squat");
+      expect(relevanceIds).not.toContain("squat");
+      // alphabetic order
+      const names = res.other.map((o) => o.exercise.name);
+      const sorted = [...names].sort((a, b) => a.localeCompare(b));
+      expect(names).toEqual(sorted);
+    });
+
+    it("query is case-insensitive and substring-based", () => {
+      const res = composeSearchResults({
+        query: "PULL",
+        scored,
+        allExercises,
+        sourceExercise: source,
+        equipmentFilter: null,
+      });
+      const all = [...res.relevance, ...res.other].map((r) => r.exercise.id);
+      expect(all).toContain("pullup");
+    });
+
+    it("excludes source exercise from both sections", () => {
+      const res = composeSearchResults({
+        query: "bench",
+        scored,
+        allExercises,
+        sourceExercise: source,
+        equipmentFilter: null,
+      });
+      const all = [...res.relevance, ...res.other].map((r) => r.exercise.id);
+      expect(all).not.toContain("src");
+    });
+
+    it("excludes deleted exercises from `other`", () => {
+      const res = composeSearchResults({
+        query: "pulldown",
+        scored,
+        allExercises,
+        sourceExercise: source,
+        equipmentFilter: null,
+      });
+      const all = [...res.relevance, ...res.other].map((r) => r.exercise.id);
+      expect(all).not.toContain("deleted-pull");
+    });
+
+    it("applies equipment filter to both sections when query is set", () => {
+      const res = composeSearchResults({
+        query: "bench",
+        scored,
+        allExercises,
+        sourceExercise: source,
+        equipmentFilter: "cable",
+      });
+      const all = [...res.relevance, ...res.other];
+      expect(all.every((r) => r.exercise.equipment === "cable")).toBe(true);
+    });
+
+    it("returns empty sections when no names match", () => {
+      const res = composeSearchResults({
+        query: "zzzunknownzzz",
+        scored,
+        allExercises,
+        sourceExercise: source,
+        equipmentFilter: null,
+      });
+      expect(res.relevance).toEqual([]);
+      expect(res.other).toEqual([]);
+    });
+
+    it("supports the no-muscle-data source path: still returns name matches in `other`", () => {
+      const noMuscleSource = makeExercise({
+        id: "nomuscle",
+        name: "Mystery Exercise",
+        primary_muscles: [],
+        secondary_muscles: [],
+      });
+      // findSubstitutions returns [] when source has no muscles
+      const emptyScored = findSubstitutions(noMuscleSource, allExercises);
+      expect(emptyScored).toEqual([]);
+      const res = composeSearchResults({
+        query: "bench",
+        scored: emptyScored,
+        allExercises,
+        sourceExercise: noMuscleSource,
+        equipmentFilter: null,
+      });
+      expect(res.relevance).toEqual([]);
+      const otherIds = res.other.map((o) => o.exercise.id);
+      expect(otherIds).toContain("bench-db");
+    });
+  });
+});

--- a/components/SubstitutionSheet.tsx
+++ b/components/SubstitutionSheet.tsx
@@ -1,19 +1,19 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Alert, Platform, StyleSheet, View } from "react-native";
-import { Text } from "@/components/ui/text";
+import { Alert, Platform } from "react-native";
 import BottomSheet, {
   BottomSheetBackdrop,
-  BottomSheetFlatList,
 } from "@gorhom/bottom-sheet";
 import type { Exercise, Equipment } from "../lib/types";
-import { MUSCLE_LABELS } from "../lib/types";
+import { findSubstitutions } from "../lib/exercise-substitutions";
 import {
-  findSubstitutions,
-  type SubstitutionScore,
-} from "../lib/exercise-substitutions";
+  composeSearchResults,
+  isBlankQuery,
+} from "../lib/exercise-substitution-search";
 import { useThemeColors } from "@/hooks/useThemeColors";
-import { SubstitutionItem } from "./substitution/SubstitutionItem";
-import { EquipmentFilter } from "./substitution/EquipmentFilter";
+import {
+  SubstitutionSheetBody,
+  type ListRow,
+} from "./substitution/SubstitutionSheetBody";
 
 type Props = {
   sheetRef: React.RefObject<BottomSheet | null>;
@@ -33,16 +33,38 @@ export default function SubstitutionSheet({
   const colors = useThemeColors();
   const snapPoints = useMemo(() => ["50%", "90%"], []);
   const [equipmentFilter, setEquipmentFilter] = useState<Equipment | null>(null);
+  const [query, setQuery] = useState<string>("");
 
   const scored = useMemo(() => {
     if (!sourceExercise) return [];
     return findSubstitutions(sourceExercise, allExercises);
   }, [sourceExercise, allExercises]);
 
-  const filtered = useMemo(() => {
-    if (!equipmentFilter) return scored;
-    return scored.filter((s) => s.exercise.equipment === equipmentFilter);
-  }, [scored, equipmentFilter]);
+  const composed = useMemo(
+    () =>
+      composeSearchResults({
+        query,
+        scored,
+        allExercises,
+        sourceExercise,
+        equipmentFilter,
+      }),
+    [query, scored, allExercises, sourceExercise, equipmentFilter]
+  );
+
+  const rows = useMemo<ListRow[]>(() => {
+    const out: ListRow[] = composed.relevance.map((item) => ({
+      kind: "item" as const,
+      item,
+    }));
+    if (composed.other.length > 0) {
+      out.push({ kind: "header", label: "Other exercises" });
+      for (const item of composed.other) {
+        out.push({ kind: "item", item });
+      }
+    }
+    return out;
+  }, [composed]);
 
   const availableEquipment = useMemo(() => {
     const set = new Set<Equipment>();
@@ -62,14 +84,11 @@ export default function SubstitutionSheet({
         onSelect(exercise);
         sheetRef.current?.close();
         setEquipmentFilter(null);
+        setQuery("");
       };
 
       if (Platform.OS === "web") {
-        if (
-          window.confirm(
-            `Replace ${sourceExercise.name} with ${exercise.name}?`
-          )
-        ) {
+        if (window.confirm(`Replace ${sourceExercise.name} with ${exercise.name}?`)) {
           doSwap();
         }
       } else {
@@ -88,20 +107,31 @@ export default function SubstitutionSheet({
 
   const handleClose = useCallback(() => {
     setEquipmentFilter(null);
+    setQuery("");
     onDismiss();
   }, [onDismiss]);
 
-  const noMuscleData =
+  const noMuscleData = Boolean(
     sourceExercise &&
-    (!sourceExercise.primary_muscles ||
-      sourceExercise.primary_muscles.length === 0);
-
-  const renderItem = useCallback(
-    ({ item }: { item: SubstitutionScore }) => (
-      <SubstitutionItem item={item} onPress={handleSelect} />
-    ),
-    [handleSelect]
+      (!sourceExercise.primary_muscles ||
+        sourceExercise.primary_muscles.length === 0)
   );
+
+  const hasQuery = !isBlankQuery(query);
+  const hasResults = rows.length > 0;
+  const relevanceEmpty = composed.relevance.length === 0;
+
+  let emptyMessage: string | null = null;
+  if (hasQuery && !hasResults) {
+    emptyMessage = `No exercises match "${query.trim()}"`;
+  } else if (!hasQuery && noMuscleData) {
+    emptyMessage = "No muscle data — search for any exercise above.";
+  } else if (!hasQuery && !noMuscleData && scored.length === 0) {
+    emptyMessage =
+      "No alternatives found. Search above or add the exercise manually.";
+  } else if (!hasQuery && !noMuscleData && relevanceEmpty && equipmentFilter) {
+    emptyMessage = "No alternatives with this equipment. Try removing the filter.";
+  }
 
   return (
     <BottomSheet
@@ -123,117 +153,19 @@ export default function SubstitutionSheet({
       handleIndicatorStyle={{ backgroundColor: colors.onSurfaceVariant }}
     >
       {sourceExercise && (
-        <View style={styles.container}>
-          <Text
-            variant="subtitle"
-            style={[styles.header, { color: colors.onSurface }]}
-          >
-            Alternatives for {sourceExercise.name}
-          </Text>
-
-          {sourceExercise.primary_muscles.length > 0 && (
-            <View style={styles.muscleRow}>
-              {sourceExercise.primary_muscles.map((m) => (
-                <View
-                  key={m}
-                  style={[
-                    styles.muscleChip,
-                    { backgroundColor: colors.primaryContainer },
-                  ]}
-                >
-                  <Text variant="caption"
-                    style={[
-                      styles.muscleText,
-                      { color: colors.onPrimaryContainer },
-                    ]}
-                  >
-                    {MUSCLE_LABELS[m]}
-                  </Text>
-                </View>
-              ))}
-            </View>
-          )}
-
-          {noMuscleData ? (
-            <View style={styles.emptyState}>
-              <Text
-                variant="body"
-                style={{ color: colors.onSurfaceVariant, textAlign: "center" }}
-              >
-                No muscle data — cannot suggest alternatives
-              </Text>
-            </View>
-          ) : (
-            <>
-              <EquipmentFilter
-                availableEquipment={availableEquipment}
-                equipmentFilter={equipmentFilter}
-                onFilterChange={setEquipmentFilter}
-              />
-
-              {scored.length === 0 ? (
-                <View style={styles.emptyState}>
-                  <Text
-                    variant="body"
-                    style={{ color: colors.onSurfaceVariant, textAlign: "center" }}
-                  >
-                    No alternatives found. Try adding the exercise manually.
-                  </Text>
-                </View>
-              ) : filtered.length === 0 && equipmentFilter ? (
-                <View style={styles.emptyState}>
-                  <Text
-                    variant="body"
-                    style={{ color: colors.onSurfaceVariant, textAlign: "center" }}
-                  >
-                    No alternatives with this equipment. Try removing the
-                    filter.
-                  </Text>
-                </View>
-              ) : (
-                <BottomSheetFlatList
-                  data={filtered}
-                  keyExtractor={(item) => item.exercise.id}
-                  renderItem={renderItem}
-                  contentContainerStyle={styles.listContent}
-                />
-              )}
-            </>
-          )}
-        </View>
+        <SubstitutionSheetBody
+          sourceExercise={sourceExercise}
+          query={query}
+          setQuery={setQuery}
+          equipmentFilter={equipmentFilter}
+          setEquipmentFilter={setEquipmentFilter}
+          availableEquipment={availableEquipment}
+          rows={rows}
+          emptyMessage={emptyMessage}
+          noMuscleData={noMuscleData}
+          onSelect={handleSelect}
+        />
       )}
     </BottomSheet>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    paddingHorizontal: 16,
-  },
-  header: {
-    fontWeight: "700",
-    marginBottom: 8,
-  },
-  muscleRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 4,
-    marginBottom: 8,
-  },
-  muscleChip: {
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderRadius: 12,
-  },
-  muscleText: {
-    lineHeight: 16,
-  },
-  listContent: {
-    paddingBottom: 32,
-  },
-  emptyState: {
-    paddingVertical: 48,
-    paddingHorizontal: 24,
-  },
-});

--- a/components/substitution/SearchAllInput.tsx
+++ b/components/substitution/SearchAllInput.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Input } from "@/components/ui/input";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+
+type Props = {
+  value: string;
+  onChange: (text: string) => void;
+};
+
+export function SearchAllInput({ value, onChange }: Props) {
+  const colors = useThemeColors();
+  return (
+    <View style={styles.wrap}>
+      <Input
+        type="input"
+        placeholder="Search all exercises…"
+        placeholderTextColor={colors.onSurfaceVariant}
+        value={value}
+        onChangeText={onChange}
+        autoCorrect={false}
+        autoCapitalize="none"
+        accessibilityLabel="Search all exercises"
+        rightComponent={
+          value.length > 0 ? (
+            <Pressable
+              onPress={() => onChange("")}
+              accessibilityRole="button"
+              accessibilityLabel="Clear search"
+              hitSlop={8}
+            >
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                ✕
+              </Text>
+            </Pressable>
+          ) : undefined
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    marginBottom: 8,
+  },
+});

--- a/components/substitution/SubstitutionSheetBody.tsx
+++ b/components/substitution/SubstitutionSheetBody.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { BottomSheetFlatList } from "@gorhom/bottom-sheet";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { MUSCLE_LABELS } from "../../lib/types";
+import type { Exercise, Equipment } from "../../lib/types";
+import type { SubstitutionScore } from "../../lib/exercise-substitutions";
+import { SubstitutionItem } from "./SubstitutionItem";
+import { EquipmentFilter } from "./EquipmentFilter";
+import { SearchAllInput } from "./SearchAllInput";
+
+export type ListRow =
+  | { kind: "item"; item: SubstitutionScore }
+  | { kind: "header"; label: string };
+
+type Props = {
+  sourceExercise: Exercise;
+  query: string;
+  setQuery: (q: string) => void;
+  equipmentFilter: Equipment | null;
+  setEquipmentFilter: (eq: Equipment | null) => void;
+  availableEquipment: Equipment[];
+  rows: ListRow[];
+  emptyMessage: string | null;
+  noMuscleData: boolean;
+  onSelect: (exercise: Exercise) => void;
+};
+
+export function SubstitutionSheetBody(props: Props) {
+  const {
+    sourceExercise,
+    query,
+    setQuery,
+    equipmentFilter,
+    setEquipmentFilter,
+    availableEquipment,
+    rows,
+    emptyMessage,
+    noMuscleData,
+    onSelect,
+  } = props;
+  const colors = useThemeColors();
+
+  const renderItem = ({ item }: { item: ListRow }) => {
+    if (item.kind === "header") {
+      return (
+        <Text
+          variant="caption"
+          style={[styles.sectionHeader, { color: colors.onSurfaceVariant }]}
+        >
+          {item.label}
+        </Text>
+      );
+    }
+    return <SubstitutionItem item={item.item} onPress={onSelect} />;
+  };
+
+  const keyExtractor = (row: ListRow, index: number) =>
+    row.kind === "header" ? `header-${row.label}-${index}` : row.item.exercise.id;
+
+  return (
+    <View style={styles.container}>
+      <Text
+        variant="subtitle"
+        style={[styles.header, { color: colors.onSurface }]}
+      >
+        Alternatives for {sourceExercise.name}
+      </Text>
+
+      {sourceExercise.primary_muscles.length > 0 && (
+        <View style={styles.muscleRow}>
+          {sourceExercise.primary_muscles.map((m) => (
+            <View
+              key={m}
+              style={[
+                styles.muscleChip,
+                { backgroundColor: colors.primaryContainer },
+              ]}
+            >
+              <Text
+                variant="caption"
+                style={[styles.muscleText, { color: colors.onPrimaryContainer }]}
+              >
+                {MUSCLE_LABELS[m]}
+              </Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      <SearchAllInput value={query} onChange={setQuery} />
+
+      {!noMuscleData && (
+        <EquipmentFilter
+          availableEquipment={availableEquipment}
+          equipmentFilter={equipmentFilter}
+          onFilterChange={setEquipmentFilter}
+        />
+      )}
+
+      {emptyMessage ? (
+        <View style={styles.emptyState}>
+          <Text
+            variant="body"
+            style={{ color: colors.onSurfaceVariant, textAlign: "center" }}
+          >
+            {emptyMessage}
+          </Text>
+        </View>
+      ) : (
+        <BottomSheetFlatList
+          data={rows}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          contentContainerStyle={styles.listContent}
+          keyboardShouldPersistTaps="handled"
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingHorizontal: 16 },
+  header: { fontWeight: "700", marginBottom: 8 },
+  muscleRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 4,
+    marginBottom: 8,
+  },
+  muscleChip: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 12,
+  },
+  muscleText: { lineHeight: 16 },
+  listContent: { paddingBottom: 32 },
+  emptyState: { paddingVertical: 48, paddingHorizontal: 24 },
+  sectionHeader: {
+    marginTop: 4,
+    marginBottom: 6,
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+});

--- a/lib/exercise-substitution-search.ts
+++ b/lib/exercise-substitution-search.ts
@@ -1,0 +1,81 @@
+import type { Exercise, Equipment } from "./types";
+import type { SubstitutionScore } from "./exercise-substitutions";
+
+const MAX_SEARCH_RESULTS = 100;
+
+const EMPTY_MATCH = {
+  primaryOverlap: 0,
+  secondaryOverlap: 0,
+  equipmentMatch: 0,
+  categoryMatch: 0,
+  difficultyProx: 0,
+};
+
+export type ComposedResults = {
+  relevance: SubstitutionScore[];
+  other: SubstitutionScore[];
+};
+
+export function isBlankQuery(query: string): boolean {
+  return query.trim().length === 0;
+}
+
+/**
+ * Compose search results for the substitution sheet.
+ *
+ * Empty query → returns the muscle-relevance list filtered by equipment (`other` empty).
+ * Non-empty query → partitions into:
+ *   - `relevance`: muscle-relevance matches whose name contains the query (preserves relevance order)
+ *   - `other`: remaining exercises whose name contains the query, sorted alphabetically
+ * Equipment filter is applied (AND) in both cases. Source exercise and deleted exercises
+ * are always excluded.
+ */
+export function composeSearchResults(params: {
+  query: string;
+  scored: SubstitutionScore[];
+  allExercises: Exercise[];
+  sourceExercise: Exercise | null;
+  equipmentFilter: Equipment | null;
+}): ComposedResults {
+  const { query, scored, allExercises, sourceExercise, equipmentFilter } = params;
+  const blank = isBlankQuery(query);
+  const q = query.trim().toLowerCase();
+
+  const byEquipment = (ex: Exercise) =>
+    !equipmentFilter || ex.equipment === equipmentFilter;
+
+  if (blank) {
+    return {
+      relevance: scored.filter((s) => byEquipment(s.exercise)),
+      other: [],
+    };
+  }
+
+  const relevanceIds = new Set<string>();
+  const relevance: SubstitutionScore[] = [];
+  for (const s of scored) {
+    if (!s.exercise.name.toLowerCase().includes(q)) continue;
+    if (!byEquipment(s.exercise)) continue;
+    relevance.push(s);
+    relevanceIds.add(s.exercise.id);
+  }
+
+  const other: SubstitutionScore[] = [];
+  for (const ex of allExercises) {
+    if (sourceExercise && ex.id === sourceExercise.id) continue;
+    if (ex.deleted_at) continue;
+    if (relevanceIds.has(ex.id)) continue;
+    if (!ex.name.toLowerCase().includes(q)) continue;
+    if (!byEquipment(ex)) continue;
+    other.push({ exercise: ex, score: 0, matchDetails: { ...EMPTY_MATCH } });
+  }
+  other.sort((a, b) => a.exercise.name.localeCompare(b.exercise.name));
+
+  const totalLimit = MAX_SEARCH_RESULTS;
+  const clampedRelevance = relevance.slice(0, totalLimit);
+  const remaining = Math.max(0, totalLimit - clampedRelevance.length);
+  return {
+    relevance: clampedRelevance,
+    other: other.slice(0, remaining),
+  };
+}


### PR DESCRIPTION
## Summary

Adds a 'search all exercises' affordance to the substitution sheet so users can swap to any exercise — not just same-muscle matches. Muscle-relevance ranking remains the default.

Closes GH #331.

## Changes

- `lib/exercise-substitution-search.ts` — pure helper that composes `{ relevance, other }` results given a query + the existing muscle-relevance list.
- `components/SubstitutionSheet.tsx` — adds a `SearchAllInput` above the equipment filter; renders an 'Other exercises' section header for non-relevance name matches; unblocks the no-muscle-data path so users can still search.
- `components/substitution/SubstitutionSheetBody.tsx` — extracted body to keep the main file under the FTA line-limit.
- `components/substitution/SearchAllInput.tsx` — reuses `components/ui/input` with a clear (✕) button.
- Tests: `__tests__/lib/exercise-substitution-search.test.ts` covers empty/non-empty queries, source+deleted exclusion, equipment AND, case-insensitivity, no-muscle-data path, and alphabetic 'other' ordering.
- FTA test updated to reference the new body component file.

## Behaviour

| State | Result |
|---|---|
| Empty query | Identical to prior behaviour — muscle-relevance only, equipment filter applies. |
| Non-empty query | Relevance matches by name first (preserve score order), then name-only matches alphabetically under 'Other exercises'. |
| No-muscle-data source + query | Returns name matches instead of hard-blocking. |
| No matches | 'No exercises match "<query>"'. |
| Equipment filter | Applied (AND) in both sections. |

## Testing

- `npx tsc --noEmit` — passes.
- `npx jest` — 39/39 new+related tests pass (full suite: 1 pre-existing failure in `settings-card-notes` unrelated to this branch).