### PR TITLE
feat(session): restore tappability affordance on previous-performance chip (BLD-551)

### DIFF
--- a/__tests__/components/session/GroupCardHeader-prev-perf-affordance.test.tsx
+++ b/__tests__/components/session/GroupCardHeader-prev-perf-affordance.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * BLD-551: Previous-performance chip must retain a visual tappability
+ * affordance. BLD-542 removed the trailing `arrow-collapse-down` icon,
+ * leaving the chip reading as a static label for sighted users without
+ * screen readers. This test locks in the restored trailing glyph
+ * (`refresh`) so a future refactor doesn't silently drop it again.
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { GroupCardHeader } from "../../../components/session/GroupCardHeader";
+import type { ExerciseGroup, SetWithMeta } from "../../../components/session/types";
+
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+  const Icon = (props: { name: string; size?: number; color?: string; accessibilityLabel?: string }) =>
+    React.createElement(Text, { ...props }, props.name);
+  return { __esModule: true, default: Icon };
+});
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#6200ee",
+    primaryContainer: "#e8def8",
+    onSurface: "#1c1b1f",
+    onSurfaceVariant: "#49454f",
+    outlineVariant: "#cac4d0",
+    surface: "#fffbfe",
+    surfaceVariant: "#e7e0ec",
+    shadow: "#000000",
+    background: "#fffbfe",
+  }),
+}));
+
+jest.mock("../../../components/TrainingModeSelector", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("../../../components/session/ExerciseNotesPanel", () => ({
+  __esModule: true,
+  ExerciseNotesPanel: () => null,
+}));
+
+function makeGroup(overrides: Partial<ExerciseGroup> = {}): ExerciseGroup {
+  return {
+    exercise_id: "ex-1",
+    name: "Cable Row",
+    training_modes: ["concentric"],
+    is_voltra: false,
+    sets: [],
+    progressionSuggested: false,
+    ...overrides,
+  } as ExerciseGroup;
+}
+
+const baseProps = {
+  group: makeGroup(),
+  modes: {} as Record<string, never>,
+  exerciseNotesOpen: false,
+  exerciseNotesDraft: undefined,
+  firstSet: undefined as SetWithMeta | undefined,
+  onModeChange: jest.fn(),
+  onExerciseNotes: jest.fn(),
+  onExerciseNotesDraftChange: jest.fn(),
+  onToggleExerciseNotes: jest.fn(),
+  onShowDetail: jest.fn(),
+  onSwap: jest.fn(),
+  onDeleteExercise: jest.fn(),
+};
+
+describe("GroupCardHeader — previous-performance affordance (BLD-551)", () => {
+  it("renders a trailing refresh glyph when previousPerformance is present", () => {
+    const { UNSAFE_getAllByProps } = render(
+      <GroupCardHeader
+        {...baseProps}
+        previousPerformance="5 reps · 60 kg"
+        onPrefill={jest.fn()}
+      />,
+    );
+
+    const icons = UNSAFE_getAllByProps({ name: "refresh" });
+    expect(icons.length).toBeGreaterThan(0);
+    const icon = icons[0];
+    // Size must be in the 12–14px affordance range per BLD-551 scope.
+    const size: number = icon.props.size;
+    expect(size).toBeGreaterThanOrEqual(12);
+    expect(size).toBeLessThanOrEqual(14);
+    // Color must match the primary token (same as text) for visual coherence.
+    expect(icon.props.color).toBe("#6200ee");
+  });
+
+  it("does not render the refresh glyph when previousPerformance is absent", () => {
+    const { UNSAFE_queryAllByProps } = render(
+      <GroupCardHeader {...baseProps} previousPerformance={null} />,
+    );
+    expect(UNSAFE_queryAllByProps({ name: "refresh" }).length).toBe(0);
+  });
+
+  it("still fires onPrefill on tap (no regression on BLD-449)", () => {
+    const onPrefill = jest.fn();
+    const { getByLabelText } = render(
+      <GroupCardHeader
+        {...baseProps}
+        previousPerformance="5 reps · 60 kg"
+        onPrefill={onPrefill}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("5 reps · 60 kg"));
+    expect(onPrefill).toHaveBeenCalledWith("ex-1");
+  });
+});

--- a/components/session/GroupCardHeader.tsx
+++ b/components/session/GroupCardHeader.tsx
@@ -65,6 +65,14 @@ export function GroupCardHeader({ group, modes, exerciseNotesOpen, exerciseNotes
                 <Text numberOfLines={1} style={[styles.previousPerf, { color: colors.primary }]}>
                   {previousPerformance}
                 </Text>
+                {/* BLD-551: trailing refresh glyph restores tappability affordance lost in BLD-542. */}
+                <MaterialCommunityIcons
+                  name="refresh"
+                  size={14}
+                  color={colors.primary}
+                  accessibilityElementsHidden
+                  importantForAccessibility="no"
+                />
               </Pressable>
             )}
           </View>


### PR DESCRIPTION
## Summary

Restores the visual tappability affordance on the previous-performance chip in the session screen. BLD-542 removed the trailing `arrow-collapse-down` icon and made the chip read as a static label for sighted users without screen readers — a soft regression on BLD-449.

## Changes

- `components/session/GroupCardHeader.tsx`: adds a trailing 14px `refresh` glyph (primary color) after the previous-performance text inside the existing Pressable.
  - Icon is decorative (`accessibilityElementsHidden` / `importantForAccessibility=no`) so it doesn't duplicate the existing `accessibilityLabel`/`accessibilityHint` for screen readers.
  - No change to text size, `hitSlop`, `minHeight`, or `onPrefill` wiring.
- `__tests__/components/session/GroupCardHeader-prev-perf-affordance.test.tsx`: locks in (1) icon presence when previousPerformance is set, (2) size 12–14px + primary color, (3) no icon when previousPerformance is absent, (4) tap still fires onPrefill (no regression on BLD-449).

## Why `refresh` (not `arrow-collapse-down`)

Per scope: auto-prefill now runs silently on session load. The semantic is "auto-prefill happened; tap to refill again" — `refresh` conveys that better than the original down-arrow (which implied the first prefill).

## Testing

- `npx jest __tests__/components/session/` — **36 passed** (3 new + 33 existing).
- `npx tsc --noEmit` — zero errors.
- `npx eslint` on changed files — clean.
- Full `npm test` — 1 failing suite (`settings-card-notes.acceptance.test.tsx`) verified to be **pre-existing on `origin/main`**, unrelated to this change.

## Issue

Resolves BLD-551.