### PR TITLE
fix(strava): surface auth-prompt errors + broaden support CTA (BLD-547)

### DIFF
--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -604,13 +604,13 @@ describe("Strava Integration — Friendly Error Mapping (BLD-505)", () => {
         .toMatch(/isn't set up correctly.*contact support/i);
     });
 
-    it("falls back to generic message for unknown errors (no raw API text leaks)", () => {
+    it("falls back to generic retry message for unknown errors (no raw API text leaks)", () => {
       expect(strava.getStravaUserMessage(new Error("Token exchange failed: 500")))
-        .toBe("Something went wrong connecting to Strava.");
+        .toBe("Something went wrong connecting to Strava. Please try again.");
       expect(strava.getStravaUserMessage("some random thing"))
-        .toBe("Something went wrong connecting to Strava.");
+        .toBe("Something went wrong connecting to Strava. Please try again.");
       expect(strava.getStravaUserMessage(new strava.StravaError("unknown", "??")))
-        .toBe("Something went wrong connecting to Strava.");
+        .toBe("Something went wrong connecting to Strava. Please try again.");
     });
   });
 
@@ -626,12 +626,20 @@ describe("Strava Integration — Friendly Error Mapping (BLD-505)", () => {
       expect(typeof action.onPress).toBe("function");
     });
 
+    it("returns a 'Get help' action for unknown errors (BLD-547)", () => {
+      const action = strava.getStravaSupportAction(
+        new strava.StravaError("unknown", "auth prompt errored"),
+      );
+      expect(action).toBeDefined();
+      expect(action.label).toBe("Get help");
+      expect(typeof action.onPress).toBe("function");
+    });
+
     it("returns undefined for non-config errors (no CTA on self-recoverable errors)", () => {
       expect(strava.getStravaSupportAction(new strava.StravaError("network", "x"))).toBeUndefined();
       expect(strava.getStravaSupportAction(new strava.StravaError("auth_expired", "x"))).toBeUndefined();
       expect(strava.getStravaSupportAction(new strava.StravaError("rate_limit", "x"))).toBeUndefined();
       expect(strava.getStravaSupportAction(new strava.StravaError("server", "x"))).toBeUndefined();
-      expect(strava.getStravaSupportAction(new strava.StravaError("unknown", "x"))).toBeUndefined();
       expect(strava.getStravaSupportAction(new Error("plain"))).toBeUndefined();
       expect(strava.getStravaSupportAction("string error")).toBeUndefined();
     });
@@ -727,6 +735,32 @@ describe("Strava Integration — Friendly Error Mapping (BLD-505)", () => {
         expect(msg).toBe("Connection expired. Please try again.");
         expect(msg).not.toMatch(/401|token exchange/i);
       }
+    });
+
+    it("throws StravaError(unknown) when AuthSession prompt returns type='error' (BLD-547)", async () => {
+      AuthSession.AuthRequest.mockImplementation(() => ({
+        promptAsync: jest.fn().mockResolvedValue({
+          type: "error",
+          params: {},
+          error: new Error("deep link routing failed"),
+        }),
+      }));
+      await expect(strava.connectStrava()).rejects.toMatchObject({
+        name: "StravaError",
+        code: "unknown",
+      });
+    });
+
+    it("still returns null (no throw) when user dismisses or cancels the prompt", async () => {
+      AuthSession.AuthRequest.mockImplementation(() => ({
+        promptAsync: jest.fn().mockResolvedValue({ type: "cancel", params: {} }),
+      }));
+      await expect(strava.connectStrava()).resolves.toBeNull();
+
+      AuthSession.AuthRequest.mockImplementation(() => ({
+        promptAsync: jest.fn().mockResolvedValue({ type: "dismiss", params: {} }),
+      }));
+      await expect(strava.connectStrava()).resolves.toBeNull();
     });
   });
 });

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -78,13 +78,13 @@ export function getStravaUserMessage(err: unknown): string {
         return "Strava isn't set up correctly. Please contact support.";
       case "unknown":
       default:
-        return "Something went wrong connecting to Strava.";
+        return "Something went wrong connecting to Strava. Please try again.";
     }
   }
   if (isNetworkError(err)) {
     return "Check your internet and try again.";
   }
-  return "Something went wrong connecting to Strava.";
+  return "Something went wrong connecting to Strava. Please try again.";
 }
 
 // Public URL users can open when Strava errors are unactionable in-app
@@ -100,9 +100,13 @@ export interface StravaSupportAction {
 
 /**
  * Returns an optional support CTA to pair with a Strava error toast.
- * Only errors the user cannot self-resolve (currently `config`) surface
- * a "Get help" link that opens {@link STRAVA_SUPPORT_URL}. For all other
- * error codes, returns undefined so the toast shows no CTA.
+ * Errors the user cannot self-resolve surface a "Get help" link that opens
+ * {@link STRAVA_SUPPORT_URL}:
+ * - `config`: misconfigured build (client_id / proxy URL missing)
+ * - `unknown`: we have no actionable hint — give the user a way to report it
+ *
+ * For self-recoverable errors (network, rate_limit, server, auth_*) we omit
+ * the CTA — retrying resolves them.
  *
  * TODO(BLD-513): generalize if a second integration needs this — extract
  * a `makeSupportAction(url, label)` factory into `lib/support.ts` and
@@ -111,7 +115,9 @@ export interface StravaSupportAction {
 export function getStravaSupportAction(
   err: unknown,
 ): StravaSupportAction | undefined {
-  if (err instanceof StravaError && err.code === "config") {
+  const isConfig = err instanceof StravaError && err.code === "config";
+  const isUnknown = err instanceof StravaError && err.code === "unknown";
+  if (isConfig || isUnknown) {
     return {
       label: "Get help",
       onPress: () => {
@@ -396,6 +402,23 @@ export async function connectStrava(): Promise<{
   });
 
   if (result.type !== "success" || !result.params.code) {
+    // "error" surfaces issues like Android deep-link routing failures or
+    // a malformed authorization response. Without this branch, the caller
+    // silently received null and no toast was shown — the user saw nothing
+    // or only the spinner stop. (BLD-547 / GH #333)
+    if (result.type === "error") {
+      const promptErr = (result as { error?: Error | null }).error;
+      const message = promptErr?.message || "Strava authorization failed";
+      const wrapped = new StravaError("unknown", message);
+      stravaLog("warn", "strava auth prompt errored", {
+        flow: "strava_connect",
+        step: "auth_prompt_error",
+        resultType: result.type,
+        errorMessage: message,
+      });
+      captureStravaError(wrapped, "strava_connect", "auth_prompt_error", { resultType: result.type });
+      throw wrapped;
+    }
     stravaLog("info", "strava connect user cancelled", {
       flow: "strava_connect",
       step: "user_cancelled",


### PR DESCRIPTION
## Summary

Fixes GH #333 — 'Strava connection failed' with unhelpful (or absent) toast. When `AuthSession.AuthRequest.promptAsync` returned `type === 'error'` (e.g. Android deep-link routing failure on Z Fold6), the old code swallowed it as a null return — the user saw the spinner stop with no feedback.

## Changes

- `lib/strava.ts` — `connectStrava`: throw `StravaError('unknown')` on prompt `type === 'error'`, with Sentry breadcrumb + structured `auth_prompt_error` log for future diagnosis. `cancel` / `dismiss` still return null (no toast, no Sentry noise).
- `lib/strava.ts` — `getStravaUserMessage`: unknown-bucket copy is now 'Something went wrong connecting to Strava. Please try again.' — actionable.
- `lib/strava.ts` — `getStravaSupportAction`: now returns the 'Get help' CTA for `unknown` errors too, not just `config`. Users hitting the generic bucket have a way to file a bug.
- `__tests__/lib/strava.test.ts` — three new cases; existing cases updated for new copy.

## Testing

- `npx jest __tests__/lib/strava.test.ts` → **50/50 pass**
- `tsc --noEmit` clean
- New tests: auth-prompt-error throws unknown; cancel/dismiss still resolve null; support action covers unknown.

## Issue

Resolves BLD-547 / GH #333.