### PR TITLE
fix(web): detect missing SharedArrayBuffer and fail gracefully (BLD-565)

### DIFF
--- a/__tests__/app/web-unsupported-layout-gate.test.ts
+++ b/__tests__/app/web-unsupported-layout-gate.test.ts
@@ -1,0 +1,93 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * BLD-565 regression-lock: on an unsupported web host, RootLayout MUST
+ * short-circuit to <WebUnsupportedScreen/> BEFORE mounting the
+ * <QueryProvider> / <Stack> tree. Any descendant of that tree can
+ * reach drizzle-orm/expo-sqlite's sync API and crash with
+ * `ReferenceError: SharedArrayBuffer is not defined`.
+ *
+ * This is a source-scan test (same pattern as
+ * __tests__/hooks/usePRCelebration-regression-lock.test.ts) rather
+ * than a render-time integration test, because the RootLayout module
+ * runs `Sentry.init`, `SplashScreen.preventAutoHideAsync`,
+ * `setupHandler`, `setupConsoleLogBuffer`, and Reanimated flag setup
+ * at import time — all of which are painful to mock and irrelevant to
+ * this particular gate.
+ */
+
+const layoutPath = path.resolve(__dirname, "../../app/_layout.tsx");
+const bannersPath = path.resolve(__dirname, "../../components/LayoutBanners.tsx");
+const layoutSrc = fs.readFileSync(layoutPath, "utf-8");
+const bannersSrc = fs.readFileSync(bannersPath, "utf-8");
+
+describe("RootLayout web-unsupported render gate (BLD-565)", () => {
+  it("destructures webUnsupported from useAppInit", () => {
+    expect(layoutSrc).toMatch(/webUnsupported\s*[},]/);
+  });
+
+  it("imports WebUnsupportedScreen and WEB_UNSUPPORTED_MESSAGE", () => {
+    expect(layoutSrc).toMatch(
+      /from ['"](?:\.\.\/)?components\/WebUnsupportedScreen['"]/
+    );
+    expect(layoutSrc).toMatch(/WEB_UNSUPPORTED_MESSAGE/);
+  });
+
+  it("checks webUnsupported BEFORE rendering QueryProvider/Stack", () => {
+    const gateIdx = layoutSrc.search(/if\s*\(\s*webUnsupported\s*\)/);
+    const providerIdx = layoutSrc.indexOf("<QueryProvider");
+    const stackIdx = layoutSrc.indexOf("<Stack");
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(providerIdx).toBeGreaterThan(-1);
+    expect(stackIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(providerIdx);
+    expect(gateIdx).toBeLessThan(stackIdx);
+  });
+
+  it("the webUnsupported branch returns WebUnsupportedScreen and nothing from the drizzle-reachable tree", () => {
+    // Extract everything from `if (webUnsupported) {` up to the
+    // matching closing `}` via a simple brace-depth walk.
+    const startIdx = layoutSrc.search(/if\s*\(\s*webUnsupported\s*\)\s*\{/);
+    expect(startIdx).toBeGreaterThan(-1);
+    const openBrace = layoutSrc.indexOf("{", startIdx);
+    let depth = 0;
+    let endIdx = openBrace;
+    for (let i = openBrace; i < layoutSrc.length; i++) {
+      if (layoutSrc[i] === "{") depth++;
+      else if (layoutSrc[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          endIdx = i;
+          break;
+        }
+      }
+    }
+    const gateBlock = layoutSrc.slice(openBrace, endIdx + 1);
+    expect(gateBlock).toMatch(/<WebUnsupportedScreen/);
+    // Must NOT mount anything that would let a descendant touch drizzle.
+    expect(gateBlock).not.toMatch(/<QueryProvider/);
+    expect(gateBlock).not.toMatch(/<Stack\b/);
+    expect(gateBlock).not.toMatch(/<LayoutBanners/);
+  });
+});
+
+describe("LayoutBanners web-unsupported Retry suppression (BLD-565)", () => {
+  it("imports WEB_UNSUPPORTED_MESSAGE from lib/web-support", () => {
+    expect(bannersSrc).toMatch(/WEB_UNSUPPORTED_MESSAGE/);
+    expect(bannersSrc).toMatch(/from ['"]@\/lib\/web-support['"]/);
+  });
+
+  it("gates the Retry affordance on error !== WEB_UNSUPPORTED_MESSAGE", () => {
+    expect(bannersSrc).toMatch(/error\s*!==\s*WEB_UNSUPPORTED_MESSAGE/);
+    // The Retry <Text> element must now be rendered behind a JSX
+    // conditional (`{canRetry && (…)}`). We locate the Retry label
+    // literal that occurs inside JSX (between > and <) to avoid
+    // matching the comment-block mentions of the word.
+    const match = bannersSrc.match(/>\s*Retry\s*</);
+    expect(match).not.toBeNull();
+    const retryIdx = match!.index!;
+    const before = bannersSrc.slice(Math.max(0, retryIdx - 400), retryIdx);
+    expect(before).toMatch(/&&\s*\(/);
+  });
+});

--- a/__tests__/hooks/useAppInit-web-shared-array-buffer.test.ts
+++ b/__tests__/hooks/useAppInit-web-shared-array-buffer.test.ts
@@ -1,0 +1,96 @@
+/**
+ * BLD-565 regression-lock: when the web runtime lacks SharedArrayBuffer
+ * or is not cross-origin isolated, useAppInit must short-circuit
+ * BEFORE calling getDatabase() so drizzle-orm/expo-sqlite's sync API
+ * never throws `ReferenceError: SharedArrayBuffer is not defined`.
+ *
+ * This test locks the integration-level behaviour (vs. the unit tests
+ * in __tests__/lib/web-support.test.ts, which only cover the detector).
+ */
+
+import { renderHook } from "@testing-library/react-native";
+
+const mockHideAsync = jest.fn();
+const mockGetDatabase = jest.fn();
+const mockIsMemoryFallback = jest.fn(() => false);
+const mockIsOnboardingComplete = jest.fn(async () => true);
+const mockSetupGlobalHandler = jest.fn();
+const mockDetectWebSharedMemorySupport = jest.fn();
+
+jest.mock("react-native", () => ({
+  Platform: { OS: "web" },
+}));
+
+jest.mock("expo-splash-screen", () => ({
+  hideAsync: (...args: unknown[]) => mockHideAsync(...args),
+}));
+
+jest.mock("../../lib/db", () => ({
+  getDatabase: (...args: unknown[]) => mockGetDatabase(...args),
+  isMemoryFallback: (...args: unknown[]) => mockIsMemoryFallback(...args),
+  isOnboardingComplete: (...args: unknown[]) => mockIsOnboardingComplete(...args),
+}));
+
+jest.mock("../../lib/errors", () => ({
+  setupGlobalHandler: (...args: unknown[]) => mockSetupGlobalHandler(...args),
+}));
+
+jest.mock("../../lib/web-support", () => ({
+  detectWebSharedMemorySupport: (...args: unknown[]) =>
+    mockDetectWebSharedMemorySupport(...args),
+  WEB_UNSUPPORTED_MESSAGE: "MOCK_WEB_UNSUPPORTED_MESSAGE",
+}));
+
+describe("useAppInit — BLD-565 web SharedArrayBuffer short-circuit", () => {
+  beforeEach(() => {
+    mockHideAsync.mockReset();
+    mockGetDatabase.mockReset();
+    mockGetDatabase.mockResolvedValue(undefined);
+    mockIsMemoryFallback.mockReset().mockReturnValue(false);
+    mockIsOnboardingComplete.mockReset().mockResolvedValue(true);
+    mockDetectWebSharedMemorySupport.mockReset();
+  });
+
+  it("short-circuits DB init when SharedArrayBuffer is missing", () => {
+    mockDetectWebSharedMemorySupport.mockReturnValue({
+      supported: false,
+      reason: "missing_shared_array_buffer",
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useAppInit } = require("../../hooks/useAppInit");
+    const { result } = renderHook(() => useAppInit());
+
+    expect(mockGetDatabase).not.toHaveBeenCalled();
+    expect(mockHideAsync).toHaveBeenCalledTimes(1);
+    expect(result.current.error).toBe("MOCK_WEB_UNSUPPORTED_MESSAGE");
+    expect(result.current.ready).toBe(true);
+  });
+
+  it("short-circuits DB init when page is not cross-origin isolated", () => {
+    mockDetectWebSharedMemorySupport.mockReturnValue({
+      supported: false,
+      reason: "not_cross_origin_isolated",
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useAppInit } = require("../../hooks/useAppInit");
+    const { result } = renderHook(() => useAppInit());
+
+    expect(mockGetDatabase).not.toHaveBeenCalled();
+    expect(mockHideAsync).toHaveBeenCalledTimes(1);
+    expect(result.current.error).toBe("MOCK_WEB_UNSUPPORTED_MESSAGE");
+  });
+
+  it("proceeds with DB init when web capability check passes", () => {
+    mockDetectWebSharedMemorySupport.mockReturnValue({ supported: true });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useAppInit } = require("../../hooks/useAppInit");
+    const { result } = renderHook(() => useAppInit());
+
+    expect(mockGetDatabase).toHaveBeenCalledTimes(1);
+    expect(result.current.error).toBeNull();
+    expect(mockHideAsync).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hooks/useAppInit-web-shared-array-buffer.test.ts
+++ b/__tests__/hooks/useAppInit-web-shared-array-buffer.test.ts
@@ -65,6 +65,7 @@ describe("useAppInit — BLD-565 web SharedArrayBuffer short-circuit", () => {
     expect(mockHideAsync).toHaveBeenCalledTimes(1);
     expect(result.current.error).toBe("MOCK_WEB_UNSUPPORTED_MESSAGE");
     expect(result.current.ready).toBe(true);
+    expect(result.current.webUnsupported).toBe(true);
   });
 
   it("short-circuits DB init when page is not cross-origin isolated", () => {
@@ -80,6 +81,7 @@ describe("useAppInit — BLD-565 web SharedArrayBuffer short-circuit", () => {
     expect(mockGetDatabase).not.toHaveBeenCalled();
     expect(mockHideAsync).toHaveBeenCalledTimes(1);
     expect(result.current.error).toBe("MOCK_WEB_UNSUPPORTED_MESSAGE");
+    expect(result.current.webUnsupported).toBe(true);
   });
 
   it("proceeds with DB init when web capability check passes", async () => {
@@ -97,6 +99,7 @@ describe("useAppInit — BLD-565 web SharedArrayBuffer short-circuit", () => {
       expect(result.current.ready).toBe(true);
     });
     expect(result.current.error).toBeNull();
+    expect(result.current.webUnsupported).toBe(false);
     // hideAsync is called once after successful init (not the
     // short-circuit path, which also fires hideAsync immediately).
     expect(mockHideAsync).toHaveBeenCalledTimes(1);

--- a/__tests__/hooks/useAppInit-web-shared-array-buffer.test.ts
+++ b/__tests__/hooks/useAppInit-web-shared-array-buffer.test.ts
@@ -8,7 +8,7 @@
  * in __tests__/lib/web-support.test.ts, which only cover the detector).
  */
 
-import { renderHook } from "@testing-library/react-native";
+import { renderHook, waitFor } from "@testing-library/react-native";
 
 const mockHideAsync = jest.fn();
 const mockGetDatabase = jest.fn();
@@ -82,15 +82,23 @@ describe("useAppInit — BLD-565 web SharedArrayBuffer short-circuit", () => {
     expect(result.current.error).toBe("MOCK_WEB_UNSUPPORTED_MESSAGE");
   });
 
-  it("proceeds with DB init when web capability check passes", () => {
+  it("proceeds with DB init when web capability check passes", async () => {
     mockDetectWebSharedMemorySupport.mockReturnValue({ supported: true });
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { useAppInit } = require("../../hooks/useAppInit");
     const { result } = renderHook(() => useAppInit());
 
-    expect(mockGetDatabase).toHaveBeenCalledTimes(1);
+    // Wait for the async DB-init chain + setState calls to settle so
+    // this test validates post-microtask behaviour (and doesn't emit
+    // act(...) warnings from pending updates).
+    await waitFor(() => {
+      expect(mockGetDatabase).toHaveBeenCalledTimes(1);
+      expect(result.current.ready).toBe(true);
+    });
     expect(result.current.error).toBeNull();
-    expect(mockHideAsync).not.toHaveBeenCalled();
+    // hideAsync is called once after successful init (not the
+    // short-circuit path, which also fires hideAsync immediately).
+    expect(mockHideAsync).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/lib/web-support.test.ts
+++ b/__tests__/lib/web-support.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment node
+ */
+import { detectWebSharedMemorySupport, WEB_UNSUPPORTED_MESSAGE } from "../../lib/web-support";
+
+describe("detectWebSharedMemorySupport", () => {
+  const originalSAB = (globalThis as { SharedArrayBuffer?: unknown }).SharedArrayBuffer;
+  const originalCOI = Object.getOwnPropertyDescriptor(globalThis, "crossOriginIsolated");
+
+  afterEach(() => {
+    if (originalSAB === undefined) {
+      delete (globalThis as { SharedArrayBuffer?: unknown }).SharedArrayBuffer;
+    } else {
+      (globalThis as { SharedArrayBuffer?: unknown }).SharedArrayBuffer = originalSAB;
+    }
+    if (originalCOI) {
+      Object.defineProperty(globalThis, "crossOriginIsolated", originalCOI);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (globalThis as any).crossOriginIsolated;
+    }
+  });
+
+  it("reports missing_shared_array_buffer when SharedArrayBuffer is undefined", () => {
+    delete (globalThis as { SharedArrayBuffer?: unknown }).SharedArrayBuffer;
+    expect(detectWebSharedMemorySupport()).toEqual({
+      supported: false,
+      reason: "missing_shared_array_buffer",
+    });
+  });
+
+  it("reports not_cross_origin_isolated when SAB exists but crossOriginIsolated=false", () => {
+    (globalThis as { SharedArrayBuffer?: unknown }).SharedArrayBuffer = ArrayBuffer;
+    Object.defineProperty(globalThis, "crossOriginIsolated", {
+      value: false,
+      configurable: true,
+      writable: true,
+    });
+    expect(detectWebSharedMemorySupport()).toEqual({
+      supported: false,
+      reason: "not_cross_origin_isolated",
+    });
+  });
+
+  it("reports supported when SAB exists and crossOriginIsolated=true", () => {
+    (globalThis as { SharedArrayBuffer?: unknown }).SharedArrayBuffer = ArrayBuffer;
+    Object.defineProperty(globalThis, "crossOriginIsolated", {
+      value: true,
+      configurable: true,
+      writable: true,
+    });
+    expect(detectWebSharedMemorySupport()).toEqual({ supported: true });
+  });
+
+  it("reports supported when SAB exists and crossOriginIsolated is not defined (native runtimes)", () => {
+    (globalThis as { SharedArrayBuffer?: unknown }).SharedArrayBuffer = ArrayBuffer;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).crossOriginIsolated;
+    expect(detectWebSharedMemorySupport()).toEqual({ supported: true });
+  });
+
+  it("exports a user-facing message that references headers", () => {
+    expect(WEB_UNSUPPORTED_MESSAGE).toMatch(/COOP\/COEP/);
+    expect(WEB_UNSUPPORTED_MESSAGE).toMatch(/iOS or Android/);
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -28,6 +28,8 @@ import { useAppInit } from "../hooks/useAppInit";
 import { SCREEN_CONFIGS } from "../constants/screen-config";
 import { LayoutToastBridge } from "../components/LayoutToastBridge";
 import { LayoutBanners } from "../components/LayoutBanners";
+import { WebUnsupportedScreen } from "../components/WebUnsupportedScreen";
+import { WEB_UNSUPPORTED_MESSAGE } from "../lib/web-support";
 import * as Sentry from '@sentry/react-native';
 
 Sentry.init({
@@ -57,7 +59,7 @@ export default Sentry.wrap(function RootLayout() {
   const scheme = useColorScheme();
   const isDark = scheme === "dark";
   const themeColors = isDark ? Colors.dark : Colors.light;
-  const { banner, setBanner, error, setError, ready, onboarded, setOnboarded } = useAppInit();
+  const { banner, setBanner, error, setError, ready, onboarded, setOnboarded, webUnsupported } = useAppInit();
   const pathname = usePathname();
   const prev = useRef(pathname);
 
@@ -76,6 +78,20 @@ export default Sentry.wrap(function RootLayout() {
   );
 
   if (!ready) return null;
+
+  // BLD-565: on a web host without cross-origin isolation, drizzle's
+  // sync API will throw `ReferenceError: SharedArrayBuffer is not
+  // defined` on the first query.  Render a fullscreen fallback
+  // INSTEAD of the normal tree so that no child effect / event
+  // handler can reach the DB.
+  if (webUnsupported) {
+    return (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <WebUnsupportedScreen message={WEB_UNSUPPORTED_MESSAGE} themeColors={themeColors} />
+        <StatusBar style="auto" />
+      </GestureHandlerRootView>
+    );
+  }
 
   const headerStyle = { backgroundColor: themeColors.card };
 

--- a/components/LayoutBanners.tsx
+++ b/components/LayoutBanners.tsx
@@ -1,6 +1,7 @@
 import { View, Text } from "react-native";
 import { Colors } from "@/theme/colors";
 import { getDatabase } from "@/lib/db";
+import { WEB_UNSUPPORTED_MESSAGE } from "@/lib/web-support";
 
 type Props = {
   banner: boolean;
@@ -11,6 +12,13 @@ type Props = {
 };
 
 export function LayoutBanners({ banner, setBanner, error, setError, themeColors }: Props) {
+  // BLD-565: on a web host without cross-origin isolation the only
+  // surfaced error is WEB_UNSUPPORTED_MESSAGE and a Retry call to
+  // getDatabase() would succeed (DB open is lazy) but the first query
+  // would still crash with `ReferenceError: SharedArrayBuffer is not
+  // defined`.  Suppress the Retry affordance for this specific error
+  // so the user is not led into the crash path.
+  const canRetry = !!error && error !== WEB_UNSUPPORTED_MESSAGE;
   return (
     <>
       {banner && (
@@ -28,9 +36,11 @@ export function LayoutBanners({ banner, setBanner, error, setError, themeColors 
           <Text style={{ color: themeColors.foreground }}>
             ❌ Database error: {error}. Try reloading the app.
           </Text>
-          <Text style={{ color: themeColors.primary, marginTop: 8, fontWeight: "600" }} onPress={() => { setError(null); getDatabase().catch((e) => setError(e?.message ?? "Retry failed")); }}>
-            Retry
-          </Text>
+          {canRetry && (
+            <Text style={{ color: themeColors.primary, marginTop: 8, fontWeight: "600" }} onPress={() => { setError(null); getDatabase().catch((e) => setError(e?.message ?? "Retry failed")); }}>
+              Retry
+            </Text>
+          )}
         </View>
       )}
     </>

--- a/components/WebUnsupportedScreen.tsx
+++ b/components/WebUnsupportedScreen.tsx
@@ -1,0 +1,61 @@
+import { View, Text, StyleSheet } from "react-native";
+import { Colors } from "@/theme/colors";
+
+type Props = {
+  message: string;
+  themeColors: typeof Colors.light;
+};
+
+/**
+ * Fullscreen fallback rendered on web when the host is not
+ * cross-origin isolated (i.e. `SharedArrayBuffer` / `crossOriginIsolated`
+ * are not available).  This is rendered INSTEAD of the normal
+ * <QueryProvider>/<Stack> tree so that no downstream effect, query, or
+ * event handler can reach drizzle-orm/expo-sqlite's sync API and
+ * trigger `ReferenceError: SharedArrayBuffer is not defined`.
+ *
+ * Intentionally:
+ *  - contains no interactive elements that could invoke the DB;
+ *  - does not mount QueryProvider or Stack;
+ *  - does not render LayoutBanners (whose Retry would re-invoke getDatabase).
+ *
+ * See BLD-565.
+ */
+export function WebUnsupportedScreen({ message, themeColors }: Props) {
+  return (
+    <View
+      testID="web-unsupported-screen"
+      style={[styles.container, { backgroundColor: themeColors.background }]}
+    >
+      <View style={[styles.card, { backgroundColor: themeColors.card }]}>
+        <Text style={[styles.title, { color: themeColors.foreground }]}>
+          Web build unavailable
+        </Text>
+        <Text style={[styles.body, { color: themeColors.foreground }]}>{message}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  card: {
+    maxWidth: 560,
+    padding: 24,
+    borderRadius: 12,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "600",
+    marginBottom: 12,
+  },
+  body: {
+    fontSize: 15,
+    lineHeight: 22,
+  },
+});

--- a/hooks/useAppInit.ts
+++ b/hooks/useAppInit.ts
@@ -86,5 +86,5 @@ export function useAppInit() {
     setupGlobalHandler();
   }, [unsupportedWeb]);
 
-  return { banner, setBanner, error, setError, ready, onboarded, setOnboarded };
+  return { banner, setBanner, error, setError, ready, onboarded, setOnboarded, webUnsupported: unsupportedWeb };
 }

--- a/hooks/useAppInit.ts
+++ b/hooks/useAppInit.ts
@@ -3,14 +3,34 @@ import { Platform } from "react-native";
 import * as SplashScreen from "expo-splash-screen";
 import { getDatabase, isMemoryFallback, isOnboardingComplete } from "../lib/db";
 import { setupGlobalHandler } from "../lib/errors";
+import { detectWebSharedMemorySupport, WEB_UNSUPPORTED_MESSAGE } from "../lib/web-support";
+
+// BLD-565: On web, drizzle-orm/expo-sqlite calls prepareSync/executeSync
+// which internally uses `new SharedArrayBuffer(…)`.  Without a
+// cross-origin-isolated host (real COOP + COEP response headers), SAB
+// is undefined and the first query throws
+// `ReferenceError: SharedArrayBuffer is not defined`.  We detect this
+// up-front and skip DB init so the user sees a readable banner instead
+// of a blank screen + uncaught ReferenceError in Sentry.
+function webNeedsUnsupportedFallback(): boolean {
+  if (Platform.OS !== "web") return false;
+  return !detectWebSharedMemorySupport().supported;
+}
 
 export function useAppInit() {
   const [banner, setBanner] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(() =>
+    webNeedsUnsupportedFallback() ? WEB_UNSUPPORTED_MESSAGE : null
+  );
+  const [ready, setReady] = useState<boolean>(() => webNeedsUnsupportedFallback());
   const [onboarded, setOnboarded] = useState(true);
 
   useEffect(() => {
+    if (webNeedsUnsupportedFallback()) {
+      SplashScreen.hideAsync();
+      return;
+    }
+
     getDatabase()
       .then(async () => {
         if (Platform.OS === "web" && isMemoryFallback()) setBanner(true);

--- a/hooks/useAppInit.ts
+++ b/hooks/useAppInit.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Platform } from "react-native";
 import * as SplashScreen from "expo-splash-screen";
 import { getDatabase, isMemoryFallback, isOnboardingComplete } from "../lib/db";
@@ -18,15 +18,20 @@ function webNeedsUnsupportedFallback(): boolean {
 }
 
 export function useAppInit() {
+  // Capability is a property of the JS runtime + document isolation
+  // state; it does not change across re-renders for a given session,
+  // so evaluate once and reuse.
+  const unsupportedWeb = useMemo(() => webNeedsUnsupportedFallback(), []);
+
   const [banner, setBanner] = useState(false);
   const [error, setError] = useState<string | null>(() =>
-    webNeedsUnsupportedFallback() ? WEB_UNSUPPORTED_MESSAGE : null
+    unsupportedWeb ? WEB_UNSUPPORTED_MESSAGE : null
   );
-  const [ready, setReady] = useState<boolean>(() => webNeedsUnsupportedFallback());
+  const [ready, setReady] = useState<boolean>(() => unsupportedWeb);
   const [onboarded, setOnboarded] = useState(true);
 
   useEffect(() => {
-    if (webNeedsUnsupportedFallback()) {
+    if (unsupportedWeb) {
       SplashScreen.hideAsync();
       return;
     }
@@ -79,7 +84,7 @@ export function useAppInit() {
         SplashScreen.hideAsync();
       });
     setupGlobalHandler();
-  }, []);
+  }, [unsupportedWeb]);
 
   return { banner, setBanner, error, setError, ready, onboarded, setOnboarded };
 }

--- a/lib/web-support.ts
+++ b/lib/web-support.ts
@@ -1,0 +1,49 @@
+/**
+ * Web-platform capability detection.
+ *
+ * CableSnap uses `expo-sqlite` on web, which in turn uses a Web Worker
+ * with synchronous message passing backed by `SharedArrayBuffer` +
+ * `Atomics`.  `drizzle-orm/expo-sqlite` calls only the sync worker API
+ * (`prepareSync` / `executeSync` / `getAllSync`), so on the web build
+ * every query requires `SharedArrayBuffer` at runtime.
+ *
+ * `SharedArrayBuffer` is only exposed to pages served with
+ * cross-origin isolation enabled — i.e., COOP: `same-origin` AND
+ * COEP: `require-corp` — delivered via **HTTP response headers**.
+ * `<meta http-equiv="Cross-Origin-Opener-Policy">` does NOT enable
+ * isolation per the HTML spec (only COEP can be set via meta).  On
+ * hosts without real HTTP headers, `SharedArrayBuffer` is `undefined`
+ * and drizzle's first query throws
+ * `ReferenceError: SharedArrayBuffer is not defined`.
+ *
+ * See BLD-565 and Sentry issue
+ *   https://cablesnap.sentry.io/issues/7437437393/
+ * for the original report.
+ */
+
+export type WebSharedMemorySupport = {
+  supported: boolean;
+  /** Stable string we surface to the user + log to Sentry. */
+  reason?: "missing_shared_array_buffer" | "not_cross_origin_isolated";
+};
+
+export function detectWebSharedMemorySupport(): WebSharedMemorySupport {
+  if (typeof globalThis === "undefined") {
+    return { supported: false, reason: "missing_shared_array_buffer" };
+  }
+  if (typeof (globalThis as { SharedArrayBuffer?: unknown }).SharedArrayBuffer === "undefined") {
+    return { supported: false, reason: "missing_shared_array_buffer" };
+  }
+  // `crossOriginIsolated` is only defined in browser-like globals.  When
+  // it IS defined and false, SAB may still be a visible identifier on
+  // some browsers but constructing it throws — treat as unsupported.
+  const coi = (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated;
+  if (typeof coi === "boolean" && coi === false) {
+    return { supported: false, reason: "not_cross_origin_isolated" };
+  }
+  return { supported: true };
+}
+
+export const WEB_UNSUPPORTED_MESSAGE =
+  "This web build requires a cross-origin-isolated host (COOP/COEP HTTP headers). " +
+  "Please use the iOS or Android app, or serve the web bundle with the correct headers.";

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,8 @@
+# BLD-565: expo-sqlite on web needs SharedArrayBuffer, which requires the
+# page to be cross-origin isolated.  Meta tags alone are insufficient —
+# COOP must arrive as an HTTP header.  These rules apply when the `dist/`
+# bundle is served by Netlify, Cloudflare Pages, or any host that honours
+# the `_headers` syntax.
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "_comment": "BLD-565: expo-sqlite on web requires SharedArrayBuffer, which is only available in cross-origin-isolated pages. Meta tags cannot enable isolation — COOP must be an HTTP header. These headers apply when the dist/ bundle is deployed to Vercel.",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes Sentry crash `ReferenceError: SharedArrayBuffer is not defined`
([issue 7437437393](https://cablesnap.sentry.io/issues/7437437393/)).

**Root cause** — detailed in BLD-565 comment: `drizzle-orm/expo-sqlite`
calls only the sync SQLite API on web (`prepareSync` / `executeSync` /
`getAllSync`), and `expo-sqlite`'s web worker channel
(`node_modules/expo-sqlite/web/WorkerChannel.ts:104`) allocates
`new SharedArrayBuffer(…)` inside `invokeWorkerSync`. `SharedArrayBuffer`
is only exposed to pages that are **cross-origin isolated**, which
requires `Cross-Origin-Opener-Policy` + `Cross-Origin-Embedder-Policy`
as **HTTP response headers**. Our `public/index.html` sets them via
`<meta http-equiv>`, which is a no-op for COOP per the HTML spec, so
on any static host that doesn't send the real headers, the first
drizzle query throws on web.

**Mobile is untouched**: verified by exporting iOS + Android Hermes
bundles and grep'ing the bytecode string tables — 0 references to
`SharedArrayBuffer`. The Sentry event is from web traffic.

## Changes

- `lib/web-support.ts` — `detectWebSharedMemorySupport()` helper +
  user-facing message constant.
- `hooks/useAppInit.ts` — on web, short-circuits DB init and surfaces
  a readable banner when the host isn't cross-origin isolated, so the
  first drizzle query never runs and no ReferenceError leaks to Sentry.
- `vercel.json` + `public/_headers` — instruct Vercel / Netlify /
  Cloudflare Pages to send the real COOP + COEP HTTP headers when the
  `dist/` bundle is deployed there.
- `__tests__/lib/web-support.test.ts` — 5 unit tests covering the
  capability-detection matrix (SAB present/absent × `crossOriginIsolated`
  true/false/undefined) plus a guard on the user message.

## Testing

- `npx jest __tests__/lib/web-support.test.ts` → 5 pass
- `npx jest __tests__/hooks/` → 75 pass (no regressions)
- `npx -p typescript tsc --noEmit` → new files clean; pre-existing 3
  errors in `GroupCardHeader-prev-perf-affordance.test.tsx` exist on
  `main` already and are unrelated to this change.
- `npx eslint hooks/useAppInit.ts lib/web-support.ts __tests__/lib/web-support.test.ts` → clean

## Issue

Resolves BLD-565