### PR TITLE
test: relax circleCheck==actionBtn equality to ≥44dp floor (BLD-581)

### DIFF
--- a/__tests__/acceptance/settings-card-notes.acceptance.test.tsx
+++ b/__tests__/acceptance/settings-card-notes.acceptance.test.tsx
@@ -45,13 +45,16 @@ describe("Session notes/delete button touch targets (BLD-258, GitHub #126)", () 
     expect(sessionSource).toContain("width: 36");
   });
 
-  it("circleCheck is consistent size with action buttons", () => {
-    // Both circleCheck and actionBtn should match in size (44dp post-BLD-558 for glove use).
+  it("circleCheck and actionBtn each meet ≥44dp touch target (BLD-258 floor, BLD-579 raised circleCheck to 48)", () => {
+    // BLD-258 established the 44dp glove-use floor for both controls.
+    // BLD-579 intentionally enlarged the primary affirmative circleCheck to 48dp while
+    // leaving secondary action buttons (notes, delete) at 44dp. Assert per-element
+    // minimums so the floor is still enforced without pinning strict equality.
     const circleCheckMatch = sessionSource.match(/circleCheck:\s*\{[^}]*width:\s*(\d+)/);
     const actionBtnMatch = sessionSource.match(/actionBtn:\s*\{[^}]*width:\s*(\d+)/);
     expect(circleCheckMatch).not.toBeNull();
     expect(actionBtnMatch).not.toBeNull();
-    expect(circleCheckMatch![1]).toBe(actionBtnMatch![1]);
+    expect(Number(circleCheckMatch![1])).toBeGreaterThanOrEqual(44);
     expect(Number(actionBtnMatch![1])).toBeGreaterThanOrEqual(44);
   });
 


### PR DESCRIPTION
## Summary

Relaxes the stale BLD-258 strict-equality assertion between `circleCheck` and `actionBtn` widths to per-element ≥44dp minimums. BLD-579 (PR #359) intentionally bumped `circleCheck` to 48dp while leaving secondary action buttons at the 44dp glove-use floor — the equality assertion is no longer valid, but the intent (both ≥44dp) still is.

## Changes

- `__tests__/acceptance/settings-card-notes.acceptance.test.tsx`: replace `toBe(actionBtnMatch)` with `toBeGreaterThanOrEqual(44)` on both widths; update test name/comment to cite BLD-258 (floor) and BLD-579 (48dp primary).

## Testing

- `npx jest __tests__/acceptance/settings-card-notes.acceptance.test.tsx` → 7 passed (previously 6 passed, 1 failed).

## Issue

Resolves BLD-581.