### PR TITLE
feat(exercises): YouTube form-tutorial quick-link (BLD-593)

### DIFF
--- a/__tests__/components/exercises/ExerciseTutorialLink.parity.test.ts
+++ b/__tests__/components/exercises/ExerciseTutorialLink.parity.test.ts
@@ -1,0 +1,40 @@
+/**
+ * BLD-593 — ExerciseTutorialLink integration parity.
+ *
+ * AC: Same behavior ships in both ExerciseDetailPane.tsx AND
+ * ExerciseDetailDrawer.tsx. In the Drawer, the link must be a sibling
+ * of the `instructions` expansion, appearing in BOTH branches of the
+ * `atLeastMedium` layout ternary (otherwise the zero-steps AC fails).
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const paneSrc = readFileSync(
+  resolve(__dirname, "../../../components/exercises/ExerciseDetailPane.tsx"),
+  "utf8",
+);
+const drawerSrc = readFileSync(
+  resolve(__dirname, "../../../components/session/ExerciseDetailDrawer.tsx"),
+  "utf8",
+);
+
+describe("ExerciseTutorialLink — parity across detail surfaces", () => {
+  it("ExerciseDetailPane imports and renders ExerciseTutorialLink", () => {
+    expect(paneSrc).toMatch(
+      /import \{ ExerciseTutorialLink \} from ["']\.\/ExerciseTutorialLink["']/,
+    );
+    expect(paneSrc).toMatch(/<ExerciseTutorialLink\s+exerciseName=\{detail\.name\}/);
+  });
+
+  it("ExerciseDetailDrawer imports and renders ExerciseTutorialLink", () => {
+    expect(drawerSrc).toMatch(
+      /import \{ ExerciseTutorialLink \} from ["']\.\.\/exercises\/ExerciseTutorialLink["']/,
+    );
+    // Must appear in both layout branches — at least two occurrences.
+    const matches = drawerSrc.match(/<ExerciseTutorialLink\b/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+    expect(drawerSrc).toMatch(
+      /<ExerciseTutorialLink\s+exerciseName=\{exercise\.name\}/,
+    );
+  });
+});

--- a/__tests__/components/exercises/ExerciseTutorialLink.test.tsx
+++ b/__tests__/components/exercises/ExerciseTutorialLink.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * BLD-593 — ExerciseTutorialLink component (GH #332 interim).
+ */
+import React from "react";
+import { Alert, Linking } from "react-native";
+import { render, fireEvent } from "@testing-library/react-native";
+import * as Sentry from "@sentry/react-native";
+
+import { ExerciseTutorialLink } from "@/components/exercises/ExerciseTutorialLink";
+import { __resetTutorialLinkLockForTests } from "@/lib/exercise-tutorial-link";
+
+jest.mock("@sentry/react-native", () => ({
+  addBreadcrumb: jest.fn(),
+}));
+
+// Minimal theme colors mock — component only depends on primary + onSurfaceVariant.
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#3B82F6",
+    onSurfaceVariant: "#6B7280",
+    outlineVariant: "#E5E7EB",
+  }),
+}));
+
+describe("ExerciseTutorialLink", () => {
+  beforeEach(() => {
+    __resetTutorialLinkLockForTests();
+    jest.clearAllMocks();
+  });
+
+  it("returns null (renders nothing) when exerciseName is empty", () => {
+    const { toJSON } = render(<ExerciseTutorialLink exerciseName="" />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it("returns null when exerciseName is whitespace-only", () => {
+    const { toJSON } = render(
+      <ExerciseTutorialLink exerciseName={"   \t\n "} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders the Pressable with the exact link label + caption", () => {
+    const { getByText, getByTestId } = render(
+      <ExerciseTutorialLink exerciseName="Cable Row" testID="tut-link" />,
+    );
+    // Link label.
+    expect(getByText("Watch form tutorial ↗")).toBeTruthy();
+    // Disclaimer caption.
+    expect(
+      getByText(
+        /Opens YouTube search in your browser\. External content — not endorsed by CableSnap\./,
+      ),
+    ).toBeTruthy();
+    // Pressable has accessibility role=link and label with exercise name.
+    const pressable = getByTestId("tut-link");
+    expect(pressable.props.accessibilityRole).toBe("link");
+    expect(pressable.props.accessibilityLabel).toContain("Cable Row");
+    expect(pressable.props.accessibilityLabel).toContain(
+      "opens YouTube search in browser",
+    );
+    // The a11y label must NOT include the disclaimer caption (caption is a
+    // sibling Text, not inside the Pressable).
+    expect(pressable.props.accessibilityLabel).not.toMatch(
+      /not endorsed by CableSnap/,
+    );
+    // Tap target >= 44×44.
+    const flat = Array.isArray(pressable.props.style)
+      ? Object.assign({}, ...pressable.props.style)
+      : pressable.props.style;
+    expect(flat.minHeight).toBeGreaterThanOrEqual(44);
+    expect(flat.minWidth).toBeGreaterThanOrEqual(44);
+  });
+
+  it("taps → opens YouTube search URL + emits Sentry open breadcrumb", async () => {
+    jest.spyOn(Linking, "canOpenURL").mockResolvedValue(true);
+    const open = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+    const { getByTestId } = render(
+      <ExerciseTutorialLink exerciseName="Cable Row" testID="tut-link" />,
+    );
+    fireEvent.press(getByTestId("tut-link"));
+    // Flush microtasks.
+    await new Promise((r) => setImmediate(r));
+    expect(open).toHaveBeenCalledWith(
+      "https://www.youtube.com/results?search_query=Cable%20Row%20form%20tutorial",
+    );
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "exercise.tutorial",
+        message: "open",
+      }),
+    );
+  });
+
+  it("failure path: Alert + open_failed breadcrumb when canOpenURL is false", async () => {
+    jest.spyOn(Linking, "canOpenURL").mockResolvedValue(false);
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    const { getByTestId } = render(
+      <ExerciseTutorialLink exerciseName="Cable Row" testID="tut-link" />,
+    );
+    fireEvent.press(getByTestId("tut-link"));
+    await new Promise((r) => setImmediate(r));
+    expect(alertSpy).toHaveBeenCalled();
+    const [title] = alertSpy.mock.calls[0];
+    expect(title).toBe("Couldn't open browser");
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "exercise.tutorial",
+        message: "open_failed",
+      }),
+    );
+  });
+});

--- a/__tests__/lib/exercise-tutorial-link.test.ts
+++ b/__tests__/lib/exercise-tutorial-link.test.ts
@@ -1,0 +1,177 @@
+/**
+ * BLD-593: Exercise form-tutorial quick-link helper (GH #332 interim).
+ */
+import { Alert, Linking } from "react-native";
+import * as Sentry from "@sentry/react-native";
+import {
+  buildTutorialSearchUrl,
+  openTutorialForExercise,
+  __resetTutorialLinkLockForTests,
+} from "../../lib/exercise-tutorial-link";
+
+jest.mock("@sentry/react-native", () => ({
+  addBreadcrumb: jest.fn(),
+}));
+
+describe("buildTutorialSearchUrl", () => {
+  it("returns null for empty string", () => {
+    expect(buildTutorialSearchUrl("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only", () => {
+    expect(buildTutorialSearchUrl("   \t\n ")).toBeNull();
+  });
+
+  it("returns null for non-string input (defensive)", () => {
+    // @ts-expect-error — runtime guard for JS callers
+    expect(buildTutorialSearchUrl(undefined)).toBeNull();
+    // @ts-expect-error — runtime guard for JS callers
+    expect(buildTutorialSearchUrl(null)).toBeNull();
+  });
+
+  it("builds a YouTube search URL for plain names", () => {
+    expect(buildTutorialSearchUrl("Cable Row")).toBe(
+      "https://www.youtube.com/results?search_query=Cable%20Row%20form%20tutorial",
+    );
+  });
+
+  it("trims surrounding whitespace before encoding", () => {
+    expect(buildTutorialSearchUrl("  Pull-up  ")).toBe(
+      "https://www.youtube.com/results?search_query=Pull-up%20form%20tutorial",
+    );
+  });
+
+  it("encodes ampersands, slashes, and special characters", () => {
+    expect(buildTutorialSearchUrl("Barbell Row & Curl")).toBe(
+      "https://www.youtube.com/results?search_query=Barbell%20Row%20%26%20Curl%20form%20tutorial",
+    );
+  });
+
+  it("encodes emoji + unicode", () => {
+    const url = buildTutorialSearchUrl("プッシュアップ 💪");
+    expect(url).not.toBeNull();
+    expect(url).toContain("https://www.youtube.com/results?search_query=");
+    // Decoded payload round-trips back to trimmed input + suffix.
+    const q = new URL(url!).searchParams.get("search_query");
+    expect(q).toBe("プッシュアップ 💪 form tutorial");
+  });
+});
+
+describe("openTutorialForExercise", () => {
+  beforeEach(() => {
+    __resetTutorialLinkLockForTests();
+    jest.clearAllMocks();
+  });
+
+  it("no-ops when name is whitespace-only (no Sentry, no Linking)", async () => {
+    const canOpen = jest.spyOn(Linking, "canOpenURL").mockResolvedValue(true);
+    const open = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+    await openTutorialForExercise("  ");
+    expect(canOpen).not.toHaveBeenCalled();
+    expect(open).not.toHaveBeenCalled();
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled();
+  });
+
+  it("opens the YouTube search URL and records an 'open' breadcrumb on success", async () => {
+    jest.spyOn(Linking, "canOpenURL").mockResolvedValue(true);
+    const open = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+    await openTutorialForExercise("Cable Row");
+    expect(open).toHaveBeenCalledWith(
+      "https://www.youtube.com/results?search_query=Cable%20Row%20form%20tutorial",
+    );
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      category: "exercise.tutorial",
+      message: "open",
+      level: "info",
+      data: { exerciseName: "Cable Row" },
+    });
+  });
+
+  it("shows Alert + records open_failed breadcrumb when canOpenURL is false", async () => {
+    jest.spyOn(Linking, "canOpenURL").mockResolvedValue(false);
+    const open = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    await openTutorialForExercise("Cable Row");
+    expect(open).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalled();
+    const [title, body] = alertSpy.mock.calls[0];
+    expect(title).toBe("Couldn't open browser");
+    expect(body).toContain(
+      "https://www.youtube.com/results?search_query=Cable%20Row%20form%20tutorial",
+    );
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "exercise.tutorial",
+        message: "open_failed",
+        level: "warning",
+        data: expect.objectContaining({ exerciseName: "Cable Row" }),
+      }),
+    );
+  });
+
+  it("shows Alert + open_failed breadcrumb when openURL throws", async () => {
+    jest.spyOn(Linking, "canOpenURL").mockResolvedValue(true);
+    jest.spyOn(Linking, "openURL").mockRejectedValue(new Error("boom"));
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    await openTutorialForExercise("Cable Row");
+    expect(alertSpy).toHaveBeenCalled();
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "open_failed",
+        data: expect.objectContaining({
+          exerciseName: "Cable Row",
+          error: expect.stringContaining("boom"),
+        }),
+      }),
+    );
+  });
+
+  it("honors onError override instead of Alert.alert", async () => {
+    jest.spyOn(Linking, "canOpenURL").mockResolvedValue(false);
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    const onError = jest.fn();
+    await openTutorialForExercise("Cable Row", { onError });
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [, urlArg] = onError.mock.calls[0];
+    expect(urlArg).toBe(
+      "https://www.youtube.com/results?search_query=Cable%20Row%20form%20tutorial",
+    );
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  it("double-tap guard: second call while first in-flight is a no-op", async () => {
+    let resolveOpen: () => void = () => {};
+    jest.spyOn(Linking, "canOpenURL").mockResolvedValue(true);
+    const open = jest
+      .spyOn(Linking, "openURL")
+      .mockImplementation(
+        () => new Promise<void>((res) => {
+          resolveOpen = res;
+        }),
+      );
+
+    const first = openTutorialForExercise("Cable Row");
+    const second = openTutorialForExercise("Cable Row");
+    // Flush microtasks so the first task reaches the Linking.openURL call.
+    await Promise.resolve();
+    await Promise.resolve();
+    // Second should return the same in-flight promise (so only ONE openURL call).
+    expect(open).toHaveBeenCalledTimes(1);
+    resolveOpen();
+    await Promise.all([first, second]);
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets in-flight lock in finally even on error (re-tap works after failure)", async () => {
+    jest.spyOn(Linking, "canOpenURL").mockResolvedValue(true);
+    const open = jest
+      .spyOn(Linking, "openURL")
+      .mockRejectedValueOnce(new Error("first failed"))
+      .mockResolvedValueOnce(undefined);
+    jest.spyOn(Alert, "alert").mockImplementation(() => {});
+
+    await openTutorialForExercise("Cable Row");
+    await openTutorialForExercise("Cable Row");
+    expect(open).toHaveBeenCalledTimes(2);
+  });
+});

--- a/components/exercises/ExerciseDetailPane.tsx
+++ b/components/exercises/ExerciseDetailPane.tsx
@@ -7,6 +7,7 @@ import { CATEGORY_LABELS, type Exercise } from "../../lib/types";
 import { difficultyText, DIFFICULTY_COLORS } from "../../constants/theme";
 import { MuscleMap } from "../../components/MuscleMap";
 import { BodyweightModifierNotice } from "./BodyweightModifierNotice";
+import { ExerciseTutorialLink } from "./ExerciseTutorialLink";
 import { fontSizes } from "@/constants/design-tokens";
 
 export interface ExerciseDetailPaneProps {
@@ -155,6 +156,7 @@ export function ExerciseDetailPane({ detail, colors, profileGender, bottomInset 
                   })}
                 </>
               )}
+              <ExerciseTutorialLink exerciseName={detail.name} testID="exercise-tutorial-link-pane" />
             </>
           }
         />

--- a/components/exercises/ExerciseTutorialLink.tsx
+++ b/components/exercises/ExerciseTutorialLink.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { ExternalLink } from "lucide-react-native";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { fontSizes } from "@/constants/design-tokens";
+import {
+  buildTutorialSearchUrl,
+  openTutorialForExercise,
+} from "@/lib/exercise-tutorial-link";
+
+export interface ExerciseTutorialLinkProps {
+  exerciseName: string;
+  testID?: string;
+}
+
+/**
+ * Renders a "Watch form tutorial ↗" Pressable + sibling disclaimer caption.
+ *
+ * Returns `null` (not an empty View) when the name is empty / whitespace
+ * so no broken link affordance leaks into the UI.
+ */
+export function ExerciseTutorialLink({
+  exerciseName,
+  testID,
+}: ExerciseTutorialLinkProps) {
+  const colors = useThemeColors();
+
+  const url = buildTutorialSearchUrl(exerciseName);
+  if (!url) return null;
+
+  const label = `Watch form tutorial for ${exerciseName.trim()} — opens YouTube search in browser`;
+
+  return (
+    <View style={styles.container}>
+      <Pressable
+        testID={testID}
+        accessibilityRole="link"
+        accessibilityLabel={label}
+        accessibilityHint="Opens external content outside the app"
+        onPress={() => {
+          void openTutorialForExercise(exerciseName);
+        }}
+        style={({ pressed }) => [
+          styles.pressable,
+          { opacity: pressed ? 0.7 : 1 },
+        ]}
+      >
+        <Text
+          variant="body"
+          style={{ color: colors.primary, fontWeight: "600" }}
+        >
+          Watch form tutorial ↗
+        </Text>
+        <ExternalLink size={16} color={colors.primary} />
+      </Pressable>
+      <Text
+        variant="body"
+        style={{
+          color: colors.onSurfaceVariant,
+          fontSize: fontSizes.xs,
+          marginTop: 4,
+        }}
+      >
+        Opens YouTube search in your browser. External content — not endorsed by
+        CableSnap.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 16,
+  },
+  pressable: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    minHeight: 44,
+    minWidth: 44,
+    paddingVertical: 8,
+  },
+});

--- a/components/session/ExerciseDetailDrawer.tsx
+++ b/components/session/ExerciseDetailDrawer.tsx
@@ -9,6 +9,7 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { CATEGORY_LABELS, ATTACHMENT_LABELS } from "../../lib/types";
 import { difficultyText, DIFFICULTY_COLORS } from "../../constants/theme";
 import { ExerciseDrawerStats } from "./ExerciseDrawerStats";
+import { ExerciseTutorialLink } from "../exercises/ExerciseTutorialLink";
 import type { Exercise } from "../../lib/types";
 import { fontSizes } from "@/constants/design-tokens";
 
@@ -134,6 +135,10 @@ export function ExerciseDetailDrawerContent({ exercise, unit }: Props) {
                 </View>
                 <View style={styles.detailColRight}>
                   {instructions}
+                  <ExerciseTutorialLink
+                    exerciseName={exercise.name}
+                    testID="exercise-tutorial-link-drawer-wide"
+                  />
                 </View>
               </View>
               <MuscleMap
@@ -147,6 +152,10 @@ export function ExerciseDetailDrawerContent({ exercise, unit }: Props) {
             <>
               {musclesAndMeta}
               {instructions}
+              <ExerciseTutorialLink
+                exerciseName={exercise.name}
+                testID="exercise-tutorial-link-drawer"
+              />
             </>
           )}
         </>

--- a/lib/exercise-tutorial-link.ts
+++ b/lib/exercise-tutorial-link.ts
@@ -1,0 +1,91 @@
+import { Alert, Linking } from "react-native";
+import * as Sentry from "@sentry/react-native";
+
+/**
+ * Build a YouTube search URL for "<exercise name> form tutorial".
+ * Returns null for empty / whitespace-only names.
+ */
+export function buildTutorialSearchUrl(name: string): string | null {
+  if (typeof name !== "string") return null;
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return null;
+  const query = `${trimmed} form tutorial`;
+  return `https://www.youtube.com/results?search_query=${encodeURIComponent(query)}`;
+}
+
+function tutorialBreadcrumb(
+  message: "open" | "open_failed",
+  data: Record<string, unknown>,
+): void {
+  Sentry.addBreadcrumb({
+    category: "exercise.tutorial",
+    message,
+    level: message === "open_failed" ? "warning" : "info",
+    data,
+  });
+}
+
+// Module-level in-flight guard. Single source of truth across all consumers
+// (ExerciseDetailPane + ExerciseDetailDrawer). Resets in finally.
+let inFlight: Promise<void> | null = null;
+
+export interface OpenTutorialOptions {
+  onError?: (error: unknown, url: string) => void;
+}
+
+/**
+ * Open a YouTube search for `"<name> form tutorial"` in the system browser.
+ *
+ * - Guarded by a module-level Promise so double-tap (and parallel taps
+ *   from Pane + Drawer) is a no-op.
+ * - Emits a Sentry breadcrumb on success (`exercise.tutorial` / `open`)
+ *   and on failure (`exercise.tutorial` / `open_failed`).
+ * - Shows an Alert with the URL for manual copy when `canOpenURL` returns
+ *   false or `openURL` throws. Override via `opts.onError`.
+ */
+export async function openTutorialForExercise(
+  name: string,
+  opts: OpenTutorialOptions = {},
+): Promise<void> {
+  if (inFlight) return inFlight;
+
+  const url = buildTutorialSearchUrl(name);
+  if (!url) return;
+
+  const exerciseName = name.trim();
+
+  const task = (async () => {
+    try {
+      const canOpen = await Linking.canOpenURL(url);
+      if (!canOpen) {
+        throw new Error("Linking.canOpenURL returned false");
+      }
+      await Linking.openURL(url);
+      tutorialBreadcrumb("open", { exerciseName });
+    } catch (e) {
+      tutorialBreadcrumb("open_failed", {
+        exerciseName,
+        error: String(e),
+      });
+      if (opts.onError) {
+        opts.onError(e, url);
+      } else {
+        Alert.alert(
+          "Couldn't open browser",
+          `Copy this link to search manually:\n\n${url}`,
+        );
+      }
+    }
+  })();
+
+  inFlight = task.finally(() => {
+    inFlight = null;
+  });
+
+  return inFlight;
+}
+
+// Test-only helper to reset the in-flight lock between tests.
+export function __resetTutorialLinkLockForTests(): void {
+  inFlight = null;
+}

--- a/scripts/audit-tests.sh
+++ b/scripts/audit-tests.sh
@@ -16,8 +16,8 @@ PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_DIR="$PROJECT_ROOT/__tests__"
 
 # ─── Configuration ───────────────────────────────────────────────
-MAX_TESTS="${MAX_TESTS:-1800}"                          # hard ceiling — fail if exceeded
-WARN_TESTS="${WARN_TESTS:-1600}"                        # warning threshold
+MAX_TESTS="${MAX_TESTS:-2100}"                          # hard ceiling — fail if exceeded
+WARN_TESTS="${WARN_TESTS:-2000}"                        # warning threshold
 RUNTIME_BUDGET_SECONDS="${RUNTIME_BUDGET_SECONDS:-150}" # wall-time ceiling for `npm test`
 RUNTIME_WARN_SECONDS="${RUNTIME_WARN_SECONDS:-120}"     # warning threshold
 # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Interim affordance for GH #332 ("plain-text instructions aren't helpful") while BLD-556/561 visual illustrations remain blocked. Adds a single "Watch form tutorial ↗" link below instruction steps in both `ExerciseDetailPane` and `ExerciseDetailDrawer`; tapping opens a YouTube search for `"<exercise name> form tutorial"` in the system browser.

Classification: Behavior-Design = NO. Psychologist N/A per PLAN-BLD-592.md.

## Changes

- `lib/exercise-tutorial-link.ts` — pure helper (`buildTutorialSearchUrl`, `openTutorialForExercise`) with module-level in-flight Promise singleton for double-tap guard and Sentry breadcrumbs (`category: 'exercise.tutorial'`, message `open` / `open_failed`, payload `{ exerciseName }` only).
- `components/exercises/ExerciseTutorialLink.tsx` — shared Pressable + sibling disclaimer caption; returns `null` (not empty View) when name is whitespace; `accessibilityRole="link"`, 44×44 min tap target, label omits "button/link" (RN appends role).
- `components/exercises/ExerciseDetailPane.tsx` — renders link below the instruction-steps block (also when `steps.length === 0`).
- `components/session/ExerciseDetailDrawer.tsx` — renders link as SIBLING of the `instructions` expansion in both wide + narrow branches (OUTSIDE the `steps.length > 0` ternary), satisfying AC #2.
- `scripts/audit-tests.sh` — raise MAX_TESTS 1800→2100 / WARN 1600→2000 per PLAN-BLD-592 CEO directive #9 (do NOT `HUSKY=0`-bypass; raise threshold).

## Testing

- 21 new tests (helper unit + RTL + Pane/Drawer parity guard), all pass.
- Full jest suite: **2275/2275 passing** in 115s.
- `tsc --noEmit` clean for all BLD-593 files (5 pre-existing errors on main untouched).
- Pre-push `audit-tests.sh` now passes.

## Acceptance criteria

All 11 criteria from PLAN-BLD-592.md §Acceptance Criteria satisfied (covered by the 21 tests). Folded in all 9 CEO-combined QD+TL nits.

## Issue

Resolves BLD-593. Source: GitHub alankyshum/cablesnap#332. Parent plan: BLD-592.