### PR TITLE
feat(BLD-622): remove eccentric_overload training mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The `<!-- versionCode: N -->` marker is optional but required for F-Droid
 sidecar emission. The `publish-release` skill prepends a new section (with
 marker) at release time.
 
+## Unreleased
+
+- Removed the **Eccentric** training mode chip and tempo tracking. Existing eccentric sets in your history are preserved as standard sets; other Voltra modes (Band, Damper, Isokinetic, Isometric, Custom, Rowing) are unchanged.
+
 ## v0.26.8 — 2026-04-24
 <!-- versionCode: 57 -->
 - Set-completion now confirms with a subtle haptic + audio cue — toggle separately from timer sounds in Settings → Preferences.

--- a/__tests__/components/TrainingModeSelector.test.tsx
+++ b/__tests__/components/TrainingModeSelector.test.tsx
@@ -8,7 +8,7 @@ const announce = jest.fn()
 jest.spyOn(AccessibilityInfo, 'announceForAccessibility').mockImplementation(announce)
 
 describe('TrainingModeSelector', () => {
-  const modes = ['weight', 'eccentric_overload', 'band'] as const
+  const modes = ['weight', 'damper', 'band'] as const
   const defaults = {
     modes: [...modes],
     selected: 'weight' as const,
@@ -21,14 +21,14 @@ describe('TrainingModeSelector', () => {
   it('renders chip for each mode', () => {
     const { getByText } = renderScreen(<TrainingModeSelector {...defaults} />)
     expect(getByText('Standard')).toBeTruthy()
-    expect(getByText('Eccentric')).toBeTruthy()
+    expect(getByText('Damper')).toBeTruthy()
     expect(getByText('Band')).toBeTruthy()
   })
 
   it('calls onSelect when a chip is pressed', () => {
     const { getByText } = renderScreen(<TrainingModeSelector {...defaults} />)
-    fireEvent.press(getByText('Eccentric'))
-    expect(defaults.onSelect).toHaveBeenCalledWith('eccentric_overload')
+    fireEvent.press(getByText('Damper'))
+    expect(defaults.onSelect).toHaveBeenCalledWith('damper')
   })
 
   it('announces mode change for accessibility', () => {
@@ -48,9 +48,9 @@ describe('TrainingModeSelector', () => {
     )
   })
 
-  it('does NOT show tempo field when eccentric mode is selected (tempo removed)', () => {
+  it('does NOT show tempo field for any mode (tempo input removed)', () => {
     const { queryByPlaceholderText } = renderScreen(
-      <TrainingModeSelector {...defaults} selected="eccentric_overload" />
+      <TrainingModeSelector {...defaults} selected="damper" />
     )
     expect(queryByPlaceholderText(/Tempo/)).toBeNull()
   })

--- a/__tests__/components/session/GroupCardHeader.memo.test.tsx
+++ b/__tests__/components/session/GroupCardHeader.memo.test.tsx
@@ -133,7 +133,7 @@ describe("GroupCardHeader — React.memo subscription-slice (BLD-560)", () => {
       act(() => {
         setter!((prev) => ({
           ...prev,
-          "ex-2": i % 2 === 0 ? "eccentric_overload" : "weight",
+          "ex-2": i % 2 === 0 ? "band" : "weight",
         }));
       });
     }
@@ -161,7 +161,7 @@ describe("GroupCardHeader — React.memo subscription-slice (BLD-560)", () => {
     ).toBe(1);
 
     act(() => {
-      setter!((prev) => ({ ...prev, "ex-1": "eccentric_overload" }));
+      setter!((prev) => ({ ...prev, "ex-1": "band" }));
     });
 
     expect(

--- a/__tests__/components/session/mount-transition-gating.test.tsx
+++ b/__tests__/components/session/mount-transition-gating.test.tsx
@@ -179,7 +179,7 @@ describe("BLD-596 — chip does not regress GroupCardHeader memoisation", () => 
       act(() => {
         setter!((prev) => ({
           ...prev,
-          "ex-2": i % 2 === 0 ? "eccentric_overload" : "weight",
+          "ex-2": i % 2 === 0 ? "band" : "weight",
         }));
       });
     }

--- a/__tests__/lib/db/import-export.test.ts
+++ b/__tests__/lib/db/import-export.test.ts
@@ -555,3 +555,82 @@ describe("estimateExportSize", () => {
     expect(label).toBeTruthy();
   });
 });
+
+// ---- BLD-622: eccentric_overload removal hardening ----
+
+describe("importData — workout_sets training_mode coercion (BLD-622)", () => {
+  function captureWorkoutSetsInserts() {
+    const inserts: { sql: string; params: unknown[] }[] = [];
+    mockDb.runAsync.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes("INSERT OR IGNORE INTO workout_sets")) {
+        inserts.push({ sql, params: params ?? [] });
+      }
+      return { changes: 1 };
+    });
+    return inserts;
+  }
+
+  // SQL columns: id, session_id, exercise_id, set_number, weight, reps, completed,
+  //              completed_at, rpe, notes, link_id, round, training_mode, tempo,
+  //              set_type, duration_seconds, bodyweight_modifier_kg
+  // training_mode is the 13th param (index 12).
+  const TRAINING_MODE_PARAM_INDEX = 12;
+
+  const baseRow = (overrides: Record<string, unknown> = {}) => ({
+    id: "ws1",
+    session_id: "s1",
+    exercise_id: "e1",
+    set_number: 1,
+    weight: 100,
+    reps: 8,
+    completed: 1,
+    completed_at: 2,
+    ...overrides,
+  });
+
+  it("coerces legacy 'eccentric_overload' training_mode to null on import", async () => {
+    const inserts = captureWorkoutSetsInserts();
+    await importData({
+      version: 6,
+      data: {
+        workout_sets: [baseRow({ training_mode: "eccentric_overload" })],
+      },
+    });
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].params[TRAINING_MODE_PARAM_INDEX]).toBeNull();
+  });
+
+  it("preserves valid training_mode values (e.g. 'damper') unchanged", async () => {
+    const inserts = captureWorkoutSetsInserts();
+    await importData({
+      version: 6,
+      data: {
+        workout_sets: [baseRow({ training_mode: "damper" })],
+      },
+    });
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0].params[TRAINING_MODE_PARAM_INDEX]).toBe("damper");
+  });
+
+  it("coerces unknown training_mode strings to null (defense-in-depth)", async () => {
+    const inserts = captureWorkoutSetsInserts();
+    await importData({
+      version: 6,
+      data: {
+        workout_sets: [baseRow({ training_mode: "totally_made_up" })],
+      },
+    });
+    expect(inserts[0].params[TRAINING_MODE_PARAM_INDEX]).toBeNull();
+  });
+
+  it("preserves null training_mode as null", async () => {
+    const inserts = captureWorkoutSetsInserts();
+    await importData({
+      version: 6,
+      data: {
+        workout_sets: [baseRow({ training_mode: null })],
+      },
+    });
+    expect(inserts[0].params[TRAINING_MODE_PARAM_INDEX]).toBeNull();
+  });
+});

--- a/__tests__/lib/db/migrations-eccentric-cleanup.test.ts
+++ b/__tests__/lib/db/migrations-eccentric-cleanup.test.ts
@@ -1,0 +1,52 @@
+import { stripEccentricFromTrainingModesJSON } from "../../../lib/db/migrations";
+
+describe("stripEccentricFromTrainingModesJSON (BLD-622)", () => {
+  it("returns null for input that does not contain eccentric_overload (skips row)", () => {
+    expect(stripEccentricFromTrainingModesJSON('["weight","band"]')).toBeNull();
+    expect(stripEccentricFromTrainingModesJSON('["weight"]')).toBeNull();
+    expect(stripEccentricFromTrainingModesJSON("")).toBeNull();
+    expect(stripEccentricFromTrainingModesJSON(null)).toBeNull();
+    expect(stripEccentricFromTrainingModesJSON(undefined)).toBeNull();
+  });
+
+  it("strips eccentric_overload when it is the only mode → defaults to ['weight']", () => {
+    expect(stripEccentricFromTrainingModesJSON('["eccentric_overload"]')).toBe('["weight"]');
+  });
+
+  it("strips eccentric_overload at leading position", () => {
+    expect(stripEccentricFromTrainingModesJSON('["eccentric_overload","weight","band"]'))
+      .toBe('["weight","band"]');
+  });
+
+  it("strips eccentric_overload at middle position", () => {
+    expect(stripEccentricFromTrainingModesJSON('["weight","eccentric_overload","band"]'))
+      .toBe('["weight","band"]');
+  });
+
+  it("strips eccentric_overload at trailing position", () => {
+    expect(stripEccentricFromTrainingModesJSON('["weight","band","eccentric_overload"]'))
+      .toBe('["weight","band"]');
+  });
+
+  it("strips multiple occurrences of eccentric_overload", () => {
+    expect(stripEccentricFromTrainingModesJSON('["eccentric_overload","weight","eccentric_overload"]'))
+      .toBe('["weight"]');
+  });
+
+  it("falls back to ['weight'] for malformed JSON containing the substring", () => {
+    expect(stripEccentricFromTrainingModesJSON('["eccentric_overload"'))
+      .toBe('["weight"]');
+  });
+
+  it("falls back to ['weight'] when JSON is not an array", () => {
+    expect(stripEccentricFromTrainingModesJSON('"eccentric_overload"'))
+      .toBe('["weight"]');
+    expect(stripEccentricFromTrainingModesJSON('{"mode":"eccentric_overload"}'))
+      .toBe('["weight"]');
+  });
+
+  it("preserves whitespace-formatted JSON arrays correctly (re-serializes compactly)", () => {
+    expect(stripEccentricFromTrainingModesJSON('[ "weight", "eccentric_overload", "band" ]'))
+      .toBe('["weight","band"]');
+  });
+});

--- a/__tests__/lib/training-mode.test.ts
+++ b/__tests__/lib/training-mode.test.ts
@@ -4,7 +4,7 @@ import { createSet } from '../helpers/factories'
 
 describe('TrainingMode types and labels', () => {
   const ALL_MODES: TrainingMode[] = [
-    'weight', 'eccentric_overload', 'band', 'damper',
+    'weight', 'band', 'damper',
     'isokinetic', 'isometric', 'custom_curves', 'rowing',
   ]
 
@@ -23,6 +23,12 @@ describe('TrainingMode types and labels', () => {
     }
   })
 
+  it('eccentric_overload mode has been removed (BLD-622)', () => {
+    expect(ALL_MODES).not.toContain('eccentric_overload' as TrainingMode)
+    // @ts-expect-error — eccentric_overload no longer in TrainingMode union
+    expect(TRAINING_MODE_LABELS['eccentric_overload']).toBeUndefined()
+  })
+
   it('WorkoutSet factory defaults training_mode and tempo to null', () => {
     const set = createSet()
     expect(set.training_mode).toBeNull()
@@ -30,8 +36,8 @@ describe('TrainingMode types and labels', () => {
   })
 
   it('WorkoutSet can be created with training_mode', () => {
-    const set = createSet({ training_mode: 'eccentric_overload', tempo: '3-1-5-1' })
-    expect(set.training_mode).toBe('eccentric_overload')
+    const set = createSet({ training_mode: 'band', tempo: '3-1-5-1' })
+    expect(set.training_mode).toBe('band')
     expect(set.tempo).toBe('3-1-5-1')
   })
 

--- a/__tests__/lib/training-mode.test.ts
+++ b/__tests__/lib/training-mode.test.ts
@@ -1,4 +1,4 @@
-import { TRAINING_MODE_LABELS } from '../../lib/types'
+import { TRAINING_MODE_LABELS, VALID_TRAINING_MODES, coerceTrainingMode } from '../../lib/types'
 import type { TrainingMode } from '../../lib/types'
 import { createSet } from '../helpers/factories'
 
@@ -25,8 +25,7 @@ describe('TrainingMode types and labels', () => {
 
   it('eccentric_overload mode has been removed (BLD-622)', () => {
     expect(ALL_MODES).not.toContain('eccentric_overload' as TrainingMode)
-    // @ts-expect-error — eccentric_overload no longer in TrainingMode union
-    expect(TRAINING_MODE_LABELS['eccentric_overload']).toBeUndefined()
+    expect((TRAINING_MODE_LABELS as Record<string, unknown>)['eccentric_overload']).toBeUndefined()
   })
 
   it('WorkoutSet factory defaults training_mode and tempo to null', () => {
@@ -44,5 +43,29 @@ describe('TrainingMode types and labels', () => {
   it('legacy sets with null training_mode are valid', () => {
     const set = createSet({ training_mode: null })
     expect(set.training_mode).toBeNull()
+  })
+})
+
+describe('coerceTrainingMode (BLD-622 read-side guard)', () => {
+  it('passes through every valid mode', () => {
+    for (const mode of VALID_TRAINING_MODES) {
+      expect(coerceTrainingMode(mode)).toBe(mode)
+    }
+  })
+
+  it('coerces removed eccentric_overload to null', () => {
+    expect(coerceTrainingMode('eccentric_overload')).toBeNull()
+  })
+
+  it('coerces unknown / bogus strings to null', () => {
+    expect(coerceTrainingMode('made_up')).toBeNull()
+    expect(coerceTrainingMode('')).toBeNull()
+  })
+
+  it('coerces null / undefined / non-strings to null', () => {
+    expect(coerceTrainingMode(null)).toBeNull()
+    expect(coerceTrainingMode(undefined)).toBeNull()
+    expect(coerceTrainingMode(42)).toBeNull()
+    expect(coerceTrainingMode({})).toBeNull()
   })
 })

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -13,6 +13,7 @@ import type {
   MealTemplate,
   MealTemplateItem,
 } from "../types";
+import { coerceTrainingMode } from "../types";
 import { getDatabase, withTransaction } from "./helpers";
 
 // --------------- Backup Format Types ---------------
@@ -454,9 +455,13 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
     }
     case "workout_sets": {
       const setType = row.set_type ?? (row.is_warmup ? "warmup" : "normal");
+      // BLD-622: coerce removed/unknown training_mode values (e.g. legacy
+      // 'eccentric_overload') to null on import so backups predating the
+      // removal cannot reintroduce the dropped mode into a freshly migrated DB.
+      const trainingMode = coerceTrainingMode(row.training_mode);
       const r = await database.runAsync(
         "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, training_mode, tempo, set_type, duration_seconds, bodyweight_modifier_kg) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        [row.id, row.session_id, row.exercise_id, row.set_number, row.weight, row.reps, row.completed, row.completed_at, row.set_rpe ?? row.rpe ?? null, row.set_notes ?? row.notes ?? "", row.link_id ?? null, row.round ?? null, row.training_mode ?? null, row.tempo ?? null, setType, row.duration_seconds ?? null, row.bodyweight_modifier_kg ?? null]
+        [row.id, row.session_id, row.exercise_id, row.set_number, row.weight, row.reps, row.completed, row.completed_at, row.set_rpe ?? row.rpe ?? null, row.set_notes ?? row.notes ?? "", row.link_id ?? null, row.round ?? null, trainingMode, row.tempo ?? null, setType, row.duration_seconds ?? null, row.bodyweight_modifier_kg ?? null]
       );
       return r.changes > 0;
     }

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -2,6 +2,42 @@ import * as SQLite from "expo-sqlite";
 import { createCoreTables, createExtensionTables, addColumnIfMissing, hasColumn } from "./tables";
 import { createScheduleAndIndexes } from "./table-migrations";
 
+/**
+ * BLD-622: Strip the removed "eccentric_overload" value from
+ * exercises.training_modes JSON arrays. Pure-string entry point so it can be
+ * unit-tested without an SQLite mock.
+ *
+ * Behaviour:
+ * - Valid JSON array → filter out "eccentric_overload"; if the result is
+ *   empty, return '["weight"]' as a safe default (every exercise must have at
+ *   least one mode).
+ * - Malformed JSON or non-array → return '["weight"]' fallback.
+ * - Returns null if the input contains no "eccentric_overload" reference (so
+ *   callers can skip the row entirely and avoid pointless writes).
+ */
+export function stripEccentricFromTrainingModesJSON(raw: string | null | undefined): string | null {
+  if (typeof raw !== "string" || !raw.includes("eccentric_overload")) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return '["weight"]';
+    const filtered = parsed.filter((m) => m !== "eccentric_overload");
+    return filtered.length === 0 ? '["weight"]' : JSON.stringify(filtered);
+  } catch {
+    return '["weight"]';
+  }
+}
+
+async function sanitizeExercisesTrainingModes(database: SQLite.SQLiteDatabase): Promise<void> {
+  const rows = await database.getAllAsync<{ id: string; training_modes: string | null }>(
+    `SELECT id, training_modes FROM exercises WHERE training_modes LIKE '%eccentric_overload%'`
+  );
+  for (const row of rows) {
+    const next = stripEccentricFromTrainingModesJSON(row.training_modes);
+    if (next === null) continue;
+    await database.runAsync(`UPDATE exercises SET training_modes = ? WHERE id = ?`, [next, row.id]);
+  }
+}
+
 async function addPerformanceIndexes(database: SQLite.SQLiteDatabase): Promise<void> {
   await database.execAsync(`
     CREATE INDEX IF NOT EXISTS idx_workout_sets_exercise ON workout_sets(exercise_id);
@@ -79,17 +115,16 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   // BLD-622: Eccentric training mode removed entirely. Sanitize legacy values.
   // - workout_sets.training_mode='eccentric_overload' → NULL (treated as standard set)
   // - template_exercises.training_mode='eccentric_overload' → NULL
-  // - exercises.training_modes JSON array: drop "eccentric_overload" entry
   await database.execAsync(`
     UPDATE workout_sets SET training_mode = NULL WHERE training_mode = 'eccentric_overload';
     UPDATE template_exercises SET training_mode = NULL WHERE training_mode = 'eccentric_overload';
-    UPDATE exercises
-      SET training_modes = REPLACE(REPLACE(REPLACE(training_modes,
-        '"eccentric_overload",', ''),
-        ',"eccentric_overload"', ''),
-        '"eccentric_overload"', '')
-      WHERE training_modes LIKE '%eccentric_overload%';
   `);
+  // - exercises.training_modes JSON array: drop "eccentric_overload" entries via
+  //   JS-side parse/filter/serialize. SQL chained REPLACE was fragile (couldn't
+  //   robustly handle whitespace, escaping, or middle positions in malformed
+  //   arrays). The JS path is explicit, contract-locked by unit tests, and falls
+  //   back to '["weight"]' if a row's JSON is corrupt.
+  await sanitizeExercisesTrainingModes(database);
 
   // Phase 66: strength goals table
   await database.execAsync(`

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -76,6 +76,21 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   // body_settings table
   await addColumnIfMissing(database, "body_settings", "sex", "TEXT NOT NULL DEFAULT 'male'");
 
+  // BLD-622: Eccentric training mode removed entirely. Sanitize legacy values.
+  // - workout_sets.training_mode='eccentric_overload' → NULL (treated as standard set)
+  // - template_exercises.training_mode='eccentric_overload' → NULL
+  // - exercises.training_modes JSON array: drop "eccentric_overload" entry
+  await database.execAsync(`
+    UPDATE workout_sets SET training_mode = NULL WHERE training_mode = 'eccentric_overload';
+    UPDATE template_exercises SET training_mode = NULL WHERE training_mode = 'eccentric_overload';
+    UPDATE exercises
+      SET training_modes = REPLACE(REPLACE(REPLACE(training_modes,
+        '"eccentric_overload",', ''),
+        ',"eccentric_overload"', ''),
+        '"eccentric_overload"', '')
+      WHERE training_modes LIKE '%eccentric_overload%';
+  `);
+
   // Phase 66: strength goals table
   await database.execAsync(`
     CREATE TABLE IF NOT EXISTS strength_goals (

--- a/lib/db/session-sets.ts
+++ b/lib/db/session-sets.ts
@@ -2,6 +2,7 @@
 import { eq, ne, sql, and, inArray, isNotNull, avg, count, max, asc, desc } from "drizzle-orm";
 import { alias } from "drizzle-orm/sqlite-core";
 import type { WorkoutSet, TrainingMode, SetType } from "../types";
+import { coerceTrainingMode } from "../types";
 import { categorize, type ExerciseCategory } from "../rest";
 import { uuid } from "../uuid";
 import { getDrizzle, withTransaction, getDatabase } from "./helpers";
@@ -56,7 +57,7 @@ export async function getSessionSets(
     notes: r.notes ?? "",
     link_id: r.link_id ?? null,
     round: r.round ?? null,
-    training_mode: (r.training_mode as TrainingMode) ?? null,
+    training_mode: coerceTrainingMode(r.training_mode),
     tempo: r.tempo ?? null,
     swapped_from_exercise_id: r.swapped_from_exercise_id ?? null,
     set_type: (r.set_type as SetType) ?? "normal",
@@ -108,7 +109,7 @@ export async function getSourceSessionSets(
     weight: r.weight,
     reps: r.reps,
     link_id: r.link_id,
-    training_mode: r.training_mode,
+    training_mode: coerceTrainingMode(r.training_mode),
     tempo: r.tempo,
     exercise_exists: r.exercise_exists != null,
     set_type: (r.set_type as SetType) ?? "normal",

--- a/lib/seed.ts
+++ b/lib/seed.ts
@@ -69,7 +69,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to high mount on rack.\n2. Stand facing the Voltra, arms extended overhead.\n3. Pull cable down and back toward hips in a sweeping arc.\n4. Engage core to stabilize throughout the pull.\n5. Return to start with controlled tempo.",
       mount_position: "high",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "One-arm Chest Fly with Rotation",
@@ -80,7 +80,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to mid mount on rack.\n2. Stand sideways to the Voltra, arm extended to the side.\n3. Sweep arm across body while rotating torso.\n4. Focus on oblique engagement through the rotation.\n5. Return slowly, resisting the cable pull.",
       mount_position: "mid",
       attachment: "handle",
-      training_modes: ["weight", "band", "eccentric_overload"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "One-arm Chest Press with Rotational Lunge",
@@ -102,7 +102,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to mid mount on rack.\n2. Stand with back to Voltra, staggered stance.\n3. Press cable forward with one arm.\n4. Rotate spine through the press for full range of motion.\n5. Return slowly, controlling the rotation.",
       mount_position: "mid",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Squat with Rotational Force",
@@ -137,7 +137,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Stand facing the Voltra, arm at your side.\n3. Curl the handle upward, keeping elbow pinned to your side.\n4. Squeeze bicep at the top of the movement.\n5. Lower slowly with control.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band", "isokinetic"],
+      training_modes: ["weight", "band", "isokinetic"],
     }),
     voltra({
       name: "Biceps Curls",
@@ -148,7 +148,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to floor mount.\n2. Stand upright, gripping handle with underhand grip.\n3. Curl the cable up toward your shoulder.\n4. Keep upper arm stationary throughout.\n5. Lower with a controlled eccentric phase.",
       mount_position: "floor",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Hammer Curl",
@@ -159,7 +159,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach rope to low mount on rack.\n2. Stand facing the Voltra, neutral grip on rope.\n3. Curl upward with thumbs pointing to the ceiling.\n4. Keep elbows close to your body.\n5. Lower slowly to full extension.",
       mount_position: "low",
       attachment: "rope",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "High Pulley Overhead Triceps Extension",
@@ -170,7 +170,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach rope to high mount on rack.\n2. Face away from Voltra, lean slightly forward.\n3. Extend arms overhead, straightening elbows.\n4. Squeeze triceps at full extension.\n5. Return slowly behind head, feeling the stretch.",
       mount_position: "high",
       attachment: "rope",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Lying Triceps Extension",
@@ -181,7 +181,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Lie supine with head toward the Voltra.\n3. Grip handle overhead with arms extended.\n4. Bend elbows to lower handle behind head.\n5. Extend arms back to start, squeezing triceps.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Seated One-arm Concentration Curl",
@@ -192,7 +192,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Sit on a bench, brace elbow against inner thigh.\n3. Curl cable upward with strict form.\n4. Squeeze at the top, then lower with control.\n5. Complete all reps before switching arms.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Single-arm Biceps Curls",
@@ -203,7 +203,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Stand sideways to Voltra, gripping handle in far hand.\n3. Curl handle up toward shoulder.\n4. Maintain upright posture, no swinging.\n5. Lower slowly and repeat.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Triceps Push-down",
@@ -214,7 +214,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach bar to high mount on rack.\n2. Stand facing the Voltra, grip bar with overhand grip.\n3. Push bar down by extending elbows.\n4. Keep upper arms pinned to your sides.\n5. Return slowly to start position.",
       mount_position: "high",
       attachment: "bar",
-      training_modes: ["weight", "eccentric_overload", "band", "isokinetic"],
+      training_modes: ["weight", "band", "isokinetic"],
     }),
     voltra({
       name: "Wrist Curl",
@@ -238,7 +238,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach bar to high mount on rack.\n2. Sit or kneel below the Voltra.\n3. Grip bar wide, pull down to upper chest.\n4. Squeeze shoulder blades together at the bottom.\n5. Return bar overhead with controlled tempo.",
       mount_position: "high",
       attachment: "bar",
-      training_modes: ["weight", "eccentric_overload", "band", "isokinetic"],
+      training_modes: ["weight", "band", "isokinetic"],
     }),
     voltra({
       name: "Close Grip Lat Pull-down",
@@ -249,7 +249,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach bar to high mount on rack.\n2. Sit or kneel below the Voltra.\n3. Grip bar with narrow, neutral grip.\n4. Pull down to upper chest, elbows driving back.\n5. Return to start with control, feeling the lat stretch.",
       mount_position: "high",
       attachment: "bar",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Seated Cable Row",
@@ -260,7 +260,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Sit on floor or bench facing the Voltra.\n3. Pull handles toward your torso, squeezing shoulder blades.\n4. Keep chest up and back straight.\n5. Extend arms forward slowly to return.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band", "rowing"],
+      training_modes: ["weight", "band", "rowing"],
     }),
     voltra({
       name: "Single-arm Lat Pull-down",
@@ -271,7 +271,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to high mount on rack.\n2. Kneel or sit below the Voltra.\n3. Pull handle down with one arm to shoulder level.\n4. Focus on lat contraction, elbow driving down.\n5. Return with control and switch arms.",
       mount_position: "high",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Single-arm Row on Bench",
@@ -282,7 +282,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Place one knee and hand on bench for support.\n3. Row cable upward, pulling elbow past your torso.\n4. Squeeze at the top, then lower slowly.\n5. Complete all reps before switching sides.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Spinal Extension",
@@ -304,7 +304,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Stand upright holding handle at sides.\n3. Shrug shoulders straight up toward ears.\n4. Hold briefly at the top, squeezing traps.\n5. Lower shoulders slowly and repeat.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Straight Arm Lat Pull-down",
@@ -315,7 +315,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach bar to high mount on rack.\n2. Stand facing the Voltra, arms extended overhead.\n3. Pull bar down in an arc to thighs, keeping arms straight.\n4. Squeeze lats hard at the bottom.\n5. Return to start position with control.",
       mount_position: "high",
       attachment: "bar",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Supinated Seated Cable Row",
@@ -326,7 +326,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Sit facing the Voltra, palms facing up.\n3. Pull handle toward lower chest with supinated grip.\n4. Squeeze shoulder blades, emphasizing lower lats.\n5. Extend arms slowly to return.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band", "rowing"],
+      training_modes: ["weight", "band", "rowing"],
     }),
 
     // ── Chest (9) ────────────────────────────────────────────
@@ -339,7 +339,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Lie on bench positioned next to the Voltra.\n3. With slight elbow bend, sweep arm across body.\n4. Squeeze chest at the top of the movement.\n5. Lower slowly, feeling the chest stretch.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Crossover Fly",
@@ -350,7 +350,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to high mount on rack.\n2. Stand with back to Voltra, staggered stance.\n3. Bring arms together in front of chest in a hugging motion.\n4. Squeeze chest at the midline.\n5. Return slowly, arms out to sides.",
       mount_position: "high",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Decline Flys",
@@ -361,7 +361,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to high mount on rack.\n2. Stand facing away, hands at shoulder height.\n3. Press arms downward and together in a sweeping arc.\n4. Focus on lower chest contraction.\n5. Return to start with control.",
       mount_position: "high",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Incline Chest Press",
@@ -372,7 +372,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Sit on incline bench facing away from Voltra.\n3. Press cables upward and forward at incline angle.\n4. Squeeze chest at full extension.\n5. Lower slowly to chest level.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "One-arm Upper Chest Fly",
@@ -383,7 +383,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Stand sideways to Voltra, cable arm low.\n3. Sweep arm upward and across, targeting upper chest.\n4. Squeeze at the top of the arc.\n5. Return slowly and complete all reps before switching.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Single-arm Chest Press",
@@ -394,7 +394,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to mid mount on rack.\n2. Stand with back to Voltra, staggered stance.\n3. Press cable forward with one arm at chest height.\n4. Extend fully, squeezing the chest.\n5. Return slowly and switch arms after set.",
       mount_position: "mid",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Standing Chest Press (Bar)",
@@ -405,7 +405,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach bar to mid mount on rack.\n2. Stand with back to Voltra, grip bar at chest width.\n3. Press bar forward until arms fully extend.\n4. Keep core braced for stability.\n5. Return to chest level with control.",
       mount_position: "mid",
       attachment: "bar",
-      training_modes: ["weight", "eccentric_overload", "band", "isokinetic"],
+      training_modes: ["weight", "band", "isokinetic"],
     }),
     voltra({
       name: "Standing Chest Press (Handle)",
@@ -416,7 +416,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to mid mount on rack.\n2. Stand with back to Voltra, handle at chest.\n3. Press handle forward in a straight line.\n4. Squeeze chest at full extension.\n5. Return handle to chest with controlled tempo.",
       mount_position: "mid",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Standing Decline Chest Fly",
@@ -427,7 +427,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to high mount on rack.\n2. Stand facing away from Voltra.\n3. With slight elbow bend, bring arms downward and together.\n4. Focus on lower chest squeeze at the bottom.\n5. Return to start position slowly.",
       mount_position: "high",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
 
     // ── Legs & Glutes (9) ────────────────────────────────────
@@ -451,7 +451,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach bar to floor mount.\n2. Stand over the cable, feet hip-width.\n3. Hinge at hips, grip bar with straight arms.\n4. Drive through heels, extending hips to standing.\n5. Lower with control, pushing hips back.",
       mount_position: "floor",
       attachment: "bar",
-      training_modes: ["weight", "eccentric_overload", "band", "isokinetic"],
+      training_modes: ["weight", "band", "isokinetic"],
     }),
     voltra({
       name: "Goblet Squat",
@@ -618,7 +618,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach bar to low mount on rack.\n2. Stand facing the Voltra, grip bar shoulder-width.\n3. Pull bar up along your body to chin height.\n4. Lead with elbows, keeping bar close to body.\n5. Lower to full arm extension with control.",
       mount_position: "low",
       attachment: "bar",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Upright Shoulder External Rotation",
@@ -642,7 +642,7 @@ export function seedExercises(): Exercise[] {
       instructions: "1. Attach handle to low mount on rack.\n2. Stand with back to Voltra, handle at shoulder height.\n3. Press cable overhead until arms are fully extended.\n4. Keep core braced and avoid arching the lower back.\n5. Lower slowly to shoulder level with control.",
       mount_position: "low",
       attachment: "handle",
-      training_modes: ["weight", "eccentric_overload", "band"],
+      training_modes: ["weight", "band"],
     }),
     voltra({
       name: "Kneeling Cable Crunch",

--- a/lib/starter-templates.ts
+++ b/lib/starter-templates.ts
@@ -119,11 +119,11 @@ export const STARTER_TEMPLATES: StarterTemplate[] = [
     difficulty: "advanced",
     duration: "~45 min",
     exercises: [
-      { id: "starter-te-7a-chest-press", exercise_id: "voltra-035", target_sets: 5, target_reps: "6, 10-12", rest_seconds: 30, training_mode: "eccentric_overload" },
-      { id: "starter-te-7a-triceps-pushdown", exercise_id: "voltra-017", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30, training_mode: "eccentric_overload" },
+      { id: "starter-te-7a-chest-press", exercise_id: "voltra-035", target_sets: 5, target_reps: "6, 10-12", rest_seconds: 30 },
+      { id: "starter-te-7a-triceps-pushdown", exercise_id: "voltra-017", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30 },
       { id: "starter-te-7a-bent-over-row", exercise_id: "mw-bb-001", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30 },
-      { id: "starter-te-7a-overhead-press", exercise_id: "voltra-055", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30, training_mode: "eccentric_overload" },
-      { id: "starter-te-7a-decline-fly", exercise_id: "voltra-036", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30, training_mode: "eccentric_overload" },
+      { id: "starter-te-7a-overhead-press", exercise_id: "voltra-055", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30 },
+      { id: "starter-te-7a-decline-fly", exercise_id: "voltra-036", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30 },
     ],
   },
   {
@@ -133,10 +133,10 @@ export const STARTER_TEMPLATES: StarterTemplate[] = [
     duration: "~45 min",
     exercises: [
       { id: "starter-te-7b-push-up", exercise_id: "mw-bw-001", target_sets: 5, target_reps: "6, 10", rest_seconds: 30 },
-      { id: "starter-te-7b-supinated-row", exercise_id: "voltra-027", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30, training_mode: "eccentric_overload" },
-      { id: "starter-te-7b-kneeling-crunch", exercise_id: "voltra-056", target_sets: 5, target_reps: "6, 10-12", rest_seconds: 30, training_mode: "eccentric_overload" },
-      { id: "starter-te-7b-goblet-squat", exercise_id: "voltra-039", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30, training_mode: "eccentric_overload" },
-      { id: "starter-te-7b-face-pulls", exercise_id: "voltra-046", target_sets: 5, target_reps: "6, 10-12", rest_seconds: 30, training_mode: "eccentric_overload" },
+      { id: "starter-te-7b-supinated-row", exercise_id: "voltra-027", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30 },
+      { id: "starter-te-7b-kneeling-crunch", exercise_id: "voltra-056", target_sets: 5, target_reps: "6, 10-12", rest_seconds: 30 },
+      { id: "starter-te-7b-goblet-squat", exercise_id: "voltra-039", target_sets: 5, target_reps: "6, 6-8", rest_seconds: 30 },
+      { id: "starter-te-7b-face-pulls", exercise_id: "voltra-046", target_sets: 5, target_reps: "6, 10-12", rest_seconds: 30 },
     ],
   },
 ];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -46,6 +46,27 @@ export type TrainingMode =
   | "custom_curves"
   | "rowing";
 
+/**
+ * Defense-in-depth set of valid TrainingMode values for runtime validation
+ * at every DB read/write boundary. Any unknown value (including the removed
+ * "eccentric_overload" — see BLD-622) is coerced to null by `coerceTrainingMode`.
+ */
+export const VALID_TRAINING_MODES: ReadonlySet<TrainingMode> = new Set<TrainingMode>([
+  "weight",
+  "band",
+  "damper",
+  "isokinetic",
+  "isometric",
+  "custom_curves",
+  "rowing",
+]);
+
+/** Returns the value if it's a valid TrainingMode, otherwise null. */
+export function coerceTrainingMode(value: unknown): TrainingMode | null {
+  if (typeof value !== "string") return null;
+  return VALID_TRAINING_MODES.has(value as TrainingMode) ? (value as TrainingMode) : null;
+}
+
 export type Category =
   | "abs_core"
   | "arms"

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,7 +39,6 @@ export type Attachment =
 
 export type TrainingMode =
   | "weight"
-  | "eccentric_overload"
   | "band"
   | "damper"
   | "isokinetic"
@@ -230,7 +229,6 @@ export type WorkoutSet = {
 
 export const TRAINING_MODE_LABELS: Record<TrainingMode, { label: string; short: string; description: string }> = {
   weight: { label: "Standard", short: "STD", description: "Normal cable weight resistance — standard lifting" },
-  eccentric_overload: { label: "Eccentric", short: "ECC", description: "Heavier resistance on the lowering phase for muscle growth" },
   band: { label: "Band", short: "BND", description: "Resistance band attached for variable tension" },
   damper: { label: "Damper", short: "DMP", description: "Damper provides smooth, constant resistance" },
   isokinetic: { label: "Isokinetic", short: "ISO", description: "Machine controls speed — constant velocity throughout" },


### PR DESCRIPTION
## Summary

Removes the **Eccentric** training mode (`eccentric_overload`) entirely from CableSnap. Cable-based exercises theoretically support eccentric overload, but maintaining it across every exercise complicates the data model — simpler to drop the mode and let users log eccentric work as standard sets.

Other Voltra modes (Standard, Band, Damper, Isokinetic, Isometric, Custom, Rowing) are unchanged.

## Changes

- `lib/types.ts` — drop `eccentric_overload` from `TrainingMode` union and `TRAINING_MODE_LABELS`.
- `lib/seed.ts` — strip the value from every voltra exercise's `training_modes` array.
- `lib/starter-templates.ts` — remove `training_mode: 'eccentric_overload'` on Founder's Favourite A/B starter rows (target sets default to standard).
- `lib/db/migrations.ts` — idempotent cleanup migration:
  - `UPDATE workout_sets SET training_mode = NULL WHERE training_mode = 'eccentric_overload'`
  - same for `template_exercises`
  - REPLACE the value out of `exercises.training_modes` JSON arrays
- Tests updated; new regression test in `__tests__/lib/training-mode.test.ts` asserts the mode is gone from `TrainingMode` and from `TRAINING_MODE_LABELS`.
- CHANGELOG: Unreleased note.

## Testing

- `npx -p typescript tsc --noEmit` clean (pre-existing errors in `GroupCardHeader-prev-perf-affordance.test.tsx` + `useAppInit-web-shared-array-buffer.test.ts` unchanged).
- `npx jest` — **2293/2293 tests pass**, 202 suites green.
- ESLint baseline unchanged.

## Migration safety

Existing users with `training_mode = 'eccentric_overload'` rows in their local SQLite database get the value silently nulled on app upgrade — sets remain fully visible, just rendered as standard sets. No data loss.

## Issue

Resolves BLD-622