### PR TITLE
fix(session): default adaptive-rest chip OFF; fix breakdown sheet anchor (BLD-616)

### DIFF
--- a/__mocks__/@gorhom/bottom-sheet.js
+++ b/__mocks__/@gorhom/bottom-sheet.js
@@ -14,6 +14,25 @@ const BottomSheet = React.forwardRef(({ children, ...props }, ref) => {
 
 BottomSheet.displayName = 'BottomSheet';
 
+const BottomSheetModal = React.forwardRef(({ children, ...props }, ref) => {
+  React.useImperativeHandle(ref, () => ({
+    present: jest.fn(),
+    dismiss: jest.fn(),
+    snapToIndex: jest.fn(),
+    snapToPosition: jest.fn(),
+    expand: jest.fn(),
+    collapse: jest.fn(),
+    close: jest.fn(),
+    forceClose: jest.fn(),
+  }));
+  return React.createElement('View', { testID: 'bottom-sheet-modal', ...props }, children);
+});
+
+BottomSheetModal.displayName = 'BottomSheetModal';
+
+const BottomSheetModalProvider = ({ children }) =>
+  React.createElement(React.Fragment, null, children);
+
 const BottomSheetFlatList = React.forwardRef((props, ref) =>
   React.createElement('FlatList', { ...props, ref })
 );
@@ -28,6 +47,8 @@ const BottomSheetBackdrop = (props) =>
 module.exports = {
   __esModule: true,
   default: BottomSheet,
+  BottomSheetModal,
+  BottomSheetModalProvider,
   BottomSheetFlatList,
   BottomSheetScrollView,
   BottomSheetBackdrop,

--- a/__tests__/components/session/SessionHeaderToolbar.test.tsx
+++ b/__tests__/components/session/SessionHeaderToolbar.test.tsx
@@ -298,4 +298,83 @@ describe("SessionHeaderToolbar", () => {
     );
     expect(queryByText("REST DONE ✓")).toBeNull();
   });
+
+  // BLD-616: default-OFF chip behaviour. With no `rest_show_breakdown` value
+  // persisted, the toolbar must NOT render the adaptive chip during a rest —
+  // even when an adaptive breakdown is available. Covers the AC-1 fresh-install
+  // path and the pre-hydration flash gap (initial useState must be `false`).
+  it("does NOT render adaptive chip on fresh install with no rest_show_breakdown setting", async () => {
+    mockGetAppSetting.mockResolvedValue(null);
+    const breakdown = {
+      totalSeconds: 130,
+      baseSeconds: 90,
+      factors: [{ label: "Heavy", multiplier: 1.2, deltaSeconds: 0 }],
+      isDefault: false,
+      reasonShort: "Heavy",
+      reasonAccessible: "Heavy set",
+    };
+
+    const { queryByTestId } = render(
+      <SessionHeaderToolbar {...defaultProps} rest={130} breakdown={breakdown} />
+    );
+
+    // No flash on first paint.
+    expect(queryByTestId("adaptive-chip")).toBeNull();
+
+    // After async getAppSetting resolves with null, chip remains hidden.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryByTestId("adaptive-chip")).toBeNull();
+  });
+
+  // BLD-616: chip renders only when setting is explicitly "true".
+  it("renders adaptive chip when rest_show_breakdown setting is explicitly 'true'", async () => {
+    mockGetAppSetting.mockImplementation(async (key: string) => {
+      if (key === "rest_show_breakdown") return "true";
+      return null;
+    });
+    const breakdown = {
+      totalSeconds: 130,
+      baseSeconds: 90,
+      factors: [{ label: "Heavy", multiplier: 1.2, deltaSeconds: 0 }],
+      isDefault: false,
+      reasonShort: "Heavy",
+      reasonAccessible: "Heavy set",
+    };
+
+    const { queryByTestId } = render(
+      <SessionHeaderToolbar {...defaultProps} rest={130} breakdown={breakdown} />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryByTestId("adaptive-chip")).toBeTruthy();
+  });
+
+  // BLD-616: chip stays hidden when user explicitly disabled it.
+  it("does NOT render adaptive chip when rest_show_breakdown is 'false'", async () => {
+    mockGetAppSetting.mockImplementation(async (key: string) => {
+      if (key === "rest_show_breakdown") return "false";
+      return null;
+    });
+    const breakdown = {
+      totalSeconds: 130,
+      baseSeconds: 90,
+      factors: [{ label: "Heavy", multiplier: 1.2, deltaSeconds: 0 }],
+      isDefault: false,
+      reasonShort: "Heavy",
+      reasonAccessible: "Heavy set",
+    };
+
+    const { queryByTestId } = render(
+      <SessionHeaderToolbar {...defaultProps} rest={130} breakdown={breakdown} />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(queryByTestId("adaptive-chip")).toBeNull();
+  });
 });

--- a/app/__test__/rest-toolbar.tsx
+++ b/app/__test__/rest-toolbar.tsx
@@ -104,11 +104,11 @@ export default function RestToolbarHarness() {
   if (Platform.OS !== "web") return null;
   if (!seed) return null;
 
-  // Resolve chip visibility synchronously from the seed. Default: true (chip
-  // shown) — matches the production default when `rest_show_breakdown` is
-  // unset. Only the literal string "false" hides the chip, matching
-  // `SessionHeaderToolbar`'s `v !== "false"` convention.
-  const showBreakdownChip = seed.settings?.rest_show_breakdown !== "false";
+  // Resolve chip visibility synchronously from the seed. Default OFF (BLD-616)
+  // — only the literal string "true" shows the chip, matching
+  // `SessionHeaderToolbar`'s `v === "true"` convention. Tests that exercise
+  // chip-visible states must set `rest_show_breakdown: "true"` explicitly.
+  const showBreakdownChip = seed.settings?.rest_show_breakdown === "true";
 
   return (
     <View>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,6 +8,7 @@ import "react-native-reanimated";
 };
 
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Redirect, Stack, usePathname } from "expo-router";
 import { StatusBar } from "expo-status-bar";
@@ -105,6 +106,7 @@ export default Sentry.wrap(function RootLayout() {
       <ThemePreferenceProvider>
       <BNAThemeProvider>
         <ToastProvider>
+          <BottomSheetModalProvider>
           <LayoutToastBridge />
           {!onboarded && !pathname.startsWith("/onboarding") && (
             <Redirect href="/onboarding/welcome" />
@@ -128,6 +130,7 @@ export default Sentry.wrap(function RootLayout() {
             ))}
           </Stack>
           <StatusBar style="auto" />
+          </BottomSheetModalProvider>
         </ToastProvider>
       </BNAThemeProvider>
       </ThemePreferenceProvider>

--- a/components/session/RestBreakdownSheet.tsx
+++ b/components/session/RestBreakdownSheet.tsx
@@ -1,6 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
-import BottomSheet, { BottomSheetBackdrop, BottomSheetScrollView } from "@gorhom/bottom-sheet";
+import {
+  BottomSheetBackdrop,
+  BottomSheetModal,
+  BottomSheetScrollView,
+} from "@gorhom/bottom-sheet";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { useThemeColors } from "@/hooks/useThemeColors";
@@ -9,7 +13,7 @@ import { getAppSetting, setAppSetting } from "../../lib/db";
 import type { RestBreakdown } from "../../lib/rest";
 
 type Props = {
-  sheetRef: React.RefObject<BottomSheet | null>;
+  sheetRef: React.RefObject<BottomSheetModal | null>;
   breakdown: RestBreakdown;
   remainingSeconds: number;
   onAddTime: (delta: number) => void;
@@ -77,13 +81,12 @@ export function RestBreakdownSheet({
   );
 
   return (
-    <BottomSheet
+    <BottomSheetModal
       ref={sheetRef}
-      index={-1}
       snapPoints={snapPoints}
       enablePanDownToClose
       enableDynamicSizing={false}
-      onClose={onDismiss}
+      onDismiss={onDismiss}
       onChange={handleChange}
       backdropComponent={(props) => (
         <BottomSheetBackdrop {...props} disappearsOnIndex={-1} appearsOnIndex={0} pressBehavior="close" />
@@ -187,7 +190,7 @@ export function RestBreakdownSheet({
           />
         ) : null}
       </BottomSheetScrollView>
-    </BottomSheet>
+    </BottomSheetModal>
   );
 }
 

--- a/components/session/SessionHeaderToolbar.tsx
+++ b/components/session/SessionHeaderToolbar.tsx
@@ -8,7 +8,7 @@ import {
   View,
 } from "react-native";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
-import BottomSheet from "@gorhom/bottom-sheet";
+import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { router } from "expo-router";
 import { Text } from "@/components/ui/text";
 import { Chip } from "@/components/ui/chip";
@@ -68,14 +68,16 @@ function SessionHeaderToolbarInner({
   const [pickerVisible, setPickerVisible] = useState(false);
   const [showRestDone, setShowRestDone] = useState(false);
   // When the prop is supplied (harness / future lifted-state consumer), use it
-  // as the source of truth. Otherwise, fall back to the internal DB-read state
-  // initialized to `true` (matches pre-BLD-537 behavior).
-  const [showBreakdownChipState, setShowBreakdownChip] = useState(true);
+  // as the source of truth. Otherwise, fall back to the internal DB-read state.
+  // Initial value is `false` so the chip never flashes during the async
+  // `getAppSetting("rest_show_breakdown")` window for fresh installs (BLD-616
+  // — default OFF).
+  const [showBreakdownChipState, setShowBreakdownChip] = useState(false);
   const showBreakdownChip =
     showBreakdownChipProp !== undefined ? showBreakdownChipProp : showBreakdownChipState;
   const prevRestRef = useRef(0);
   const restDoneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const breakdownSheetRef = useRef<BottomSheet>(null);
+  const breakdownSheetRef = useRef<BottomSheetModal>(null);
 
   // Settings state for the picker modal
   const [vibrateSetting, setVibrateSetting] = useState(true);
@@ -116,7 +118,7 @@ function SessionHeaderToolbarInner({
   }, [onDismissRest]);
 
   const handleRestLongPress = useCallback(() => {
-    breakdownSheetRef.current?.snapToIndex(0);
+    breakdownSheetRef.current?.present();
   }, []);
 
   const handleBreakdownDismiss = useCallback(() => {
@@ -131,11 +133,11 @@ function SessionHeaderToolbarInner({
   }, [rest, onStartRest, onDismissRest]);
 
   const handleBreakdownCut = useCallback(() => {
-    breakdownSheetRef.current?.close();
+    breakdownSheetRef.current?.dismiss();
     onDismissRest();
   }, [onDismissRest]);
 
-  // Load rest_show_breakdown setting (default on via !== "false").
+  // Load rest_show_breakdown setting (default OFF — explicit "true" required).
   // Loaded once on mount — users toggle this in Settings before a session, so
   // re-reading per tick of `rest` is a waste (SQLite hit every second). If the
   // user flips the toggle mid-session, it will take effect on the next session.
@@ -147,7 +149,7 @@ function SessionHeaderToolbarInner({
     if (showBreakdownChipProp !== undefined) return;
     let cancelled = false;
     getAppSetting("rest_show_breakdown").then((v) => {
-      if (!cancelled) setShowBreakdownChip(v !== "false");
+      if (!cancelled) setShowBreakdownChip(v === "true");
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [showBreakdownChipProp]);
@@ -198,7 +200,7 @@ function SessionHeaderToolbarInner({
   }, []);
 
   const handleEditAdaptiveRules = useCallback(() => {
-    breakdownSheetRef.current?.close();
+    breakdownSheetRef.current?.dismiss();
     router.push("/(tabs)/settings");
   }, []);
 
@@ -229,6 +231,13 @@ function SessionHeaderToolbarInner({
               selected={false}
               onPress={handleRestLongPress}
               compact
+              icon={
+                <MaterialCommunityIcons
+                  name="information-outline"
+                  size={14}
+                  color={colors.onSurfaceVariant}
+                />
+              }
               accessibilityLabel={`Adaptive rest reason: ${chipLabel}. Tap to see breakdown.`}
               accessibilityRole="button"
             >

--- a/components/settings/PreferencesCard.tsx
+++ b/components/settings/PreferencesCard.tsx
@@ -28,9 +28,11 @@ export default function PreferencesCard({
 }: Props) {
   const [soundTooltipVisible, setSoundTooltipVisible] = useState(false);
 
-  // Intelligent Rest Timer (BLD-531) settings — default-on via `setting !== "false"`.
+  // Intelligent Rest Timer (BLD-531) settings — adaptive rest defaults ON
+  // (`!== "false"`). Breakdown chip defaults OFF (BLD-616) — explicit "true"
+  // required, so initial state is `false` to avoid a hydration flash.
   const [adaptiveRest, setAdaptiveRest] = useState(true);
-  const [showBreakdown, setShowBreakdown] = useState(true);
+  const [showBreakdown, setShowBreakdown] = useState(false);
   const [restAfterWarmup, setRestAfterWarmup] = useState(false);
 
   // BLD-559: set-completion confirmation feedback — haptic default ON,
@@ -56,7 +58,7 @@ export default function PreferencesCard({
     ]).then(([adaptive, show, warmup, scHaptic, scAudio]) => {
       if (cancelled) return;
       setAdaptiveRest(adaptive !== "false");
-      setShowBreakdown(show !== "false");
+      setShowBreakdown(show === "true");
       setRestAfterWarmup(warmup === "true");
       setSetCompleteHapticState(scHaptic !== "false");
       setSetCompleteAudioState(scAudio === "true");

--- a/e2e/scenarios/adaptive-rest.spec.ts
+++ b/e2e/scenarios/adaptive-rest.spec.ts
@@ -60,6 +60,7 @@ const STATES: StateCase[] = [
         reasonShort: "Heavy · RPE 9",
         reasonAccessible: "Heavy set, RPE 9",
       },
+      settings: { rest_show_breakdown: "true" },
     },
   },
   {
@@ -75,7 +76,7 @@ const STATES: StateCase[] = [
         reasonShort: "Warmup",
         reasonAccessible: "Warmup set",
       },
-      settings: { rest_after_warmup_enabled: "true" },
+      settings: { rest_after_warmup_enabled: "true", rest_show_breakdown: "true" },
     },
   },
   {
@@ -91,6 +92,7 @@ const STATES: StateCase[] = [
         reasonShort: "Drop-set",
         reasonAccessible: "Drop-set",
       },
+      settings: { rest_show_breakdown: "true" },
     },
   },
   {
@@ -106,6 +108,7 @@ const STATES: StateCase[] = [
         reasonShort: "",
         reasonAccessible: "",
       },
+      settings: { rest_show_breakdown: "true" },
     },
   },
   {
@@ -144,6 +147,7 @@ const STATES: StateCase[] = [
         reasonShort: "Failure",
         reasonAccessible: "Failure set",
       },
+      settings: { rest_show_breakdown: "true" },
     },
   },
   {
@@ -167,6 +171,7 @@ const STATES: StateCase[] = [
         reasonShort: "Heavy · RPE 9 · Cable",
         reasonAccessible: "Heavy set, RPE 9, cable",
       },
+      settings: { rest_show_breakdown: "true" },
     },
   },
 ];
@@ -211,10 +216,10 @@ test.describe("@scenario adaptive-rest", () => {
       await expect(toolbar).toBeVisible({ timeout: 5_000 });
 
       // Async-resolve guard: the toolbar's useEffect reads `rest_show_breakdown`
-      // via `getAppSetting` (components/session/SessionHeaderToolbar.tsx:125-131).
-      // It starts with `showBreakdownChip=true`, flips to the persisted value
-      // on microtask resolve. Harness flips `data-test-ready` synchronously
-      // with first mount (app/__test__/rest-toolbar.tsx:89-93), so for the
+      // via `getAppSetting` (components/session/SessionHeaderToolbar.tsx).
+      // Default is OFF (BLD-616) — chip only renders when the setting is
+      // explicitly "true". Harness flips `data-test-ready` synchronously
+      // with first mount (app/__test__/rest-toolbar.tsx), so for the
       // "chip MUST NOT render" states (S4 isDefault=true, S5 setting=false)
       // we must wait for the chip to NOT be present before screenshotting.
       // This gates on the `adaptive-chip` testID on the chip-wrap View.


### PR DESCRIPTION
## Summary

Fixes the ghost cable badge reported in BLD-616: an adaptive-rest reason chip rendered to the left of the rest timer for users who had not opted in, and tapping it opened a slide-up sheet that anchored to the toolbar's tiny region inside the Stack header (the cramped sheet bug).

## Changes

- **Default-OFF for `rest_show_breakdown`** — chip now requires the setting to be explicitly persisted as `"true"`. Both read sites updated identically (`SessionHeaderToolbar.tsx`, `PreferencesCard.tsx`); existing users with `"true"` keep the chip.
- **Pre-hydration flash removed** — initial `useState` for the chip flag is `false`, so a fresh install never flashes the chip while `getAppSetting` resolves.
- **Modal hoist** — `RestBreakdownSheet` converted from `BottomSheet` to `BottomSheetModal`, with `BottomSheetModalProvider` added at the root layout. The sheet now portals to the screen root and presents flush to the bottom regardless of where it is mounted.
- **Info icon on chip** — `information-outline` icon makes the chip's affordance obvious for opted-in users.
- **Test seeds updated** — `app/__test__/rest-toolbar.tsx` harness and `e2e/scenarios/adaptive-rest.spec.ts` now seed `rest_show_breakdown: "true"` for chip-visible scenarios.
- **Mocks extended** — `__mocks__/@gorhom/bottom-sheet.js` adds `BottomSheetModal` + `BottomSheetModalProvider`.
- **New unit tests** — fresh-install no-chip (AC-1), explicit `"true"` renders chip, explicit `"false"` hides chip.

## Testing

- `npx -p typescript tsc --noEmit` — clean for changed files (only pre-existing unrelated errors remain).
- `npx jest` — **2295/2295 passing**, including 18/18 in `SessionHeaderToolbar.test.tsx`.

## Issue

Resolves BLD-616