### PR TITLE
feat(BLD-630): anchor workout duration to first completed set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ marker) at release time.
 - Hydration tracking — log water in ml or fl oz from the Nutrition tab; configurable daily goal and preset volumes in Settings.
 - Workout templates now remember the training mode you pick per Voltra exercise; sessions started from the template open in the saved mode automatically.
 
+### Changed
+- Workout duration now starts when you log your first completed set, not the moment you tap Start (BLD-630).
+
 ### Removed
 - Removed the **Eccentric** training mode chip and tempo tracking. Existing eccentric sets in your history are preserved as standard sets; other Voltra modes (Band, Damper, Isokinetic, Isometric, Custom, Rowing) are unchanged.
 

--- a/__tests__/helpers/factories.ts
+++ b/__tests__/helpers/factories.ts
@@ -116,6 +116,7 @@ export function createSession(overrides: Partial<WorkoutSession> = {}): WorkoutS
     template_id: null,
     name: 'Morning Workout',
     started_at: Date.now(),
+    clock_started_at: null,
     completed_at: null,
     duration_seconds: null,
     notes: '',

--- a/__tests__/hooks/useSessionActions-elapsed-clock.test.ts
+++ b/__tests__/hooks/useSessionActions-elapsed-clock.test.ts
@@ -122,7 +122,9 @@ function makeParams(overrides: any = {}) {
     startRest: jest.fn(),
     startRestWithDuration: jest.fn(),
     startRestWithBreakdown: jest.fn(),
-    session: { started_at: Date.now(), name: "Test" },
+    // BLD-630: tests assume an already-anchored session unless they
+    // explicitly override `clock_started_at` to null.
+    session: { started_at: Date.now(), clock_started_at: Date.now(), name: "Test" },
     showToast: jest.fn(),
     showError: jest.fn(),
     ...overrides,
@@ -144,7 +146,7 @@ describe("useSessionActions — elapsed clock AppState pause/resume (BLD-560)", 
   it("starts ticking when mounted in active state", () => {
     const startedAt = Date.now();
     const { result } = renderHook(() =>
-      useSessionActions(makeParams({ session: { started_at: startedAt, name: "T" } })),
+      useSessionActions(makeParams({ session: { started_at: startedAt, clock_started_at: startedAt, name: "T" } })),
     );
     expect(result.current.elapsed).toBe(0);
 
@@ -158,7 +160,7 @@ describe("useSessionActions — elapsed clock AppState pause/resume (BLD-560)", 
   it("pauses the 1Hz interval when app goes to background", () => {
     const startedAt = Date.now();
     const { result } = renderHook(() =>
-      useSessionActions(makeParams({ session: { started_at: startedAt, name: "T" } })),
+      useSessionActions(makeParams({ session: { started_at: startedAt, clock_started_at: startedAt, name: "T" } })),
     );
 
     act(() => { jest.advanceTimersByTime(2000); });
@@ -177,12 +179,12 @@ describe("useSessionActions — elapsed clock AppState pause/resume (BLD-560)", 
     expect(result.current.elapsed).toBe(beforePaused);
   });
 
-  it("recomputes elapsed from session.started_at on resume (no drift)", () => {
+  it("recomputes elapsed from clock_started_at on resume (no drift)", () => {
     const now = Date.now();
     jest.setSystemTime(now);
     const startedAt = now;
     const { result } = renderHook(() =>
-      useSessionActions(makeParams({ session: { started_at: startedAt, name: "T" } })),
+      useSessionActions(makeParams({ session: { started_at: startedAt, clock_started_at: startedAt, name: "T" } })),
     );
 
     // Simulate: user opens app, waits 2s of ticking, backgrounds.
@@ -204,7 +206,7 @@ describe("useSessionActions — elapsed clock AppState pause/resume (BLD-560)", 
       jest.advanceTimersByTime(1000);
     });
 
-    // Elapsed should reflect absolute (now+32s+1s - started_at).
+    // Elapsed should reflect absolute (now+32s+1s - clock_started_at).
     expect(result.current.elapsed).toBeGreaterThanOrEqual(33);
   });
 
@@ -212,7 +214,7 @@ describe("useSessionActions — elapsed clock AppState pause/resume (BLD-560)", 
     mockAppState.currentState = "background";
     const startedAt = Date.now();
     const { result } = renderHook(() =>
-      useSessionActions(makeParams({ session: { started_at: startedAt, name: "T" } })),
+      useSessionActions(makeParams({ session: { started_at: startedAt, clock_started_at: startedAt, name: "T" } })),
     );
 
     // Because start() is guarded, elapsed should remain 0 even as timers
@@ -228,5 +230,120 @@ describe("useSessionActions — elapsed clock AppState pause/resume (BLD-560)", 
       jest.advanceTimersByTime(1000);
     });
     expect(result.current.elapsed).toBeGreaterThan(0);
+  });
+});
+
+describe("useSessionActions — clock anchor on first set completion (BLD-630)", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    mockAppStateListeners = [];
+    mockAppState.currentState = "active";
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("keeps elapsed at 0 while clock_started_at is null (no anchor)", () => {
+    const startedAt = Date.now();
+    const { result } = renderHook(() =>
+      useSessionActions(makeParams({
+        session: { started_at: startedAt, clock_started_at: null, name: "T" },
+      })),
+    );
+    expect(result.current.clockStartedAt).toBeNull();
+    expect(result.current.elapsed).toBe(0);
+
+    // Even after several "wall-clock" ticks, the hook must NOT advance
+    // elapsed because no interval was scheduled (the unanchored guard
+    // returns early).
+    act(() => { jest.advanceTimersByTime(10_000); });
+    expect(result.current.elapsed).toBe(0);
+  });
+
+  it("anchors and starts ticking on first handleCheck (within 1 tick)", async () => {
+    const startedAt = Date.now();
+    const updateGroupSet = jest.fn();
+    const { result, rerender } = renderHook(
+      (props: any) => useSessionActions(props),
+      {
+        initialProps: makeParams({
+          session: { started_at: startedAt, clock_started_at: null, name: "T" },
+          updateGroupSet,
+        }),
+      },
+    );
+
+    expect(result.current.elapsed).toBe(0);
+    expect(result.current.clockStartedAt).toBeNull();
+
+    // Simulate completing a set. The optimistic anchor flips
+    // clockStartedAt synchronously inside handleCheck before awaiting the
+    // DB write, so the next interval tick should advance elapsed.
+    await act(async () => {
+      await result.current.handleCheck({
+        id: "set-1",
+        exercise_id: "ex-1",
+        completed: false,
+        set_type: "normal",
+        weight: null,
+        reps: null,
+      } as any);
+    });
+
+    expect(result.current.clockStartedAt).not.toBeNull();
+    // Force the interval to fire; the elapsed effect was just rescheduled
+    // with a non-null clockStartedAt, which calls update() synchronously
+    // on start. The next tick should produce elapsed >= 1.
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current.elapsed).toBeGreaterThanOrEqual(1);
+
+    // Sanity: completeSet was called exactly once.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { completeSet } = require("../../lib/db") as { completeSet: jest.Mock };
+    expect(completeSet).toHaveBeenCalledWith("set-1");
+
+    rerender(makeParams({
+      session: { started_at: startedAt, clock_started_at: null, name: "T" },
+      updateGroupSet,
+    }));
+  });
+
+  it("does not roll back the anchor when uncompleting the only completed set", async () => {
+    const startedAt = Date.now();
+    const { result } = renderHook(() =>
+      useSessionActions(makeParams({
+        session: { started_at: startedAt, clock_started_at: null, name: "T" },
+      })),
+    );
+
+    // Complete a set → anchor flips on.
+    await act(async () => {
+      await result.current.handleCheck({
+        id: "set-1",
+        exercise_id: "ex-1",
+        completed: false,
+        set_type: "normal",
+        weight: null,
+        reps: null,
+      } as any);
+    });
+    const anchoredAt = result.current.clockStartedAt;
+    expect(anchoredAt).not.toBeNull();
+
+    // Uncomplete the same set. The clock anchor must NOT be cleared —
+    // user mental model is "the clock started when I lifted".
+    await act(async () => {
+      await result.current.handleCheck({
+        id: "set-1",
+        exercise_id: "ex-1",
+        completed: true,
+        set_type: "normal",
+        weight: null,
+        reps: null,
+      } as any);
+    });
+    expect(result.current.clockStartedAt).toBe(anchoredAt);
   });
 });

--- a/__tests__/lib/db.test.ts
+++ b/__tests__/lib/db.test.ts
@@ -64,6 +64,9 @@ const mockDrizzleDb = {
   insert: jest.fn(() => createChainableInsert()),
   update: jest.fn(() => createChainableUpdate()),
   delete: jest.fn(() => createChainableDelete()),
+  // BLD-630: completeSet now issues a raw `db.run(sql`...`)` to anchor
+  // workout_sessions.clock_started_at on first set completion.
+  run: jest.fn(() => Promise.resolve()),
 };
 
 jest.mock("drizzle-orm/expo-sqlite", () => ({
@@ -464,6 +467,9 @@ describe("sets CRUD", () => {
     jest.spyOn(Date, "now").mockReturnValue(9000);
     await db.completeSet("set1");
     expect(mockDrizzleDb.update).toHaveBeenCalled();
+    // BLD-630: completeSet must also fire the session-anchor UPDATE so the
+    // elapsed clock starts on first set completion.
+    expect(mockDrizzleDb.run).toHaveBeenCalled();
     jest.restoreAllMocks();
   });
 

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -111,7 +111,7 @@ export default function ActiveSession() {
   const { celebration, triggerPR, cleanup: cleanupCelebration } = usePRCelebration();
 
   const {
-    elapsed, exerciseNotesOpen, exerciseNotesDraft, halfStep, nextHint, hintTimer,
+    elapsed, clockStartedAt, exerciseNotesOpen, exerciseNotesDraft, halfStep, nextHint, hintTimer,
     handleUpdate, handleCheck, handleAddSet, handleModeChange, handleRPE,
     handleHalfStep, handleHalfStepClear, handleHalfStepOpen, handleDelete,
     handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes,
@@ -297,6 +297,7 @@ export default function ActiveSession() {
             <SessionHeaderToolbar
               rest={rest}
               elapsed={elapsed}
+              clockStarted={clockStartedAt != null}
               estimatedDuration={estimatedDuration}
               breakdown={breakdown}
               onStartRest={handleToolboxStartRest}

--- a/components/session/SessionHeaderToolbar.tsx
+++ b/components/session/SessionHeaderToolbar.tsx
@@ -31,6 +31,13 @@ function presetLabel(seconds: number): string {
 type Props = {
   rest: number;
   elapsed: number;
+  /**
+   * BLD-630: when `false`, the elapsed timer is not yet anchored to a
+   * completed set. The header renders a small "Starts when you log your
+   * first set" caption and the a11y label is updated accordingly. Defaults
+   * to `true` when omitted (preserves harness/test back-compat).
+   */
+  clockStarted?: boolean;
   estimatedDuration?: number | null;
   breakdown?: RestBreakdown;
   onStartRest: (duration: number) => void;
@@ -54,6 +61,7 @@ type Props = {
 function SessionHeaderToolbarInner({
   rest,
   elapsed,
+  clockStarted = true,
   estimatedDuration,
   breakdown,
   onStartRest,
@@ -272,51 +280,15 @@ function SessionHeaderToolbarInner({
         )}
 
         {/* Elapsed time + remaining estimate */}
-        <Pressable
+        <ElapsedDisplay
+          elapsed={elapsed}
+          estimatedDuration={estimatedDuration ?? null}
+          isRestActive={isRestActive}
+          clockStarted={clockStarted}
+          colors={colors}
           onPress={handleElapsedTap}
           onLongPress={handleLongPress}
-          delayLongPress={400}
-          disabled={isRestActive}
-          accessibilityLabel={
-            (() => {
-              const remainingText = formatTimeRemaining(estimatedDuration ?? null, elapsed);
-              const base = `Elapsed time: ${formatTime(elapsed)}`;
-              if (isRestActive) return base;
-              const suffix = ". Tap to start rest timer. Long press for rest settings.";
-              if (remainingText) return `${base}, approximately ${Math.ceil(((estimatedDuration ?? 0) - elapsed) / 60)} minutes remaining${suffix}`;
-              return `${base}${suffix}`;
-            })()
-          }
-          accessibilityRole="button"
-          style={styles.elapsedButton}
-        >
-          <Text
-            variant="body"
-            testID="elapsed-time"
-            style={{
-              color: isRestActive ? colors.onSurfaceVariant : colors.primary,
-              fontSize: fontSizes.sm,
-            }}
-          >
-            {formatTime(elapsed)}
-          </Text>
-          {(() => {
-            const remainingText = formatTimeRemaining(estimatedDuration ?? null, elapsed);
-            if (!remainingText) return null;
-            return (
-              <Text
-                variant="body"
-                testID="elapsed-remaining"
-                style={{
-                  color: colors.onSurfaceVariant,
-                  fontSize: fontSizes.xs,
-                }}
-              >
-                {remainingText}
-              </Text>
-            );
-          })()}
-        </Pressable>
+        />
 
         {/* Wrench / toolbox button */}
         <Pressable
@@ -444,6 +416,88 @@ function RestDurationPicker({
 
 export const SessionHeaderToolbar = React.memo(SessionHeaderToolbarInner);
 
+function ElapsedRemaining({
+  elapsed,
+  estimatedDuration,
+  color,
+}: {
+  elapsed: number;
+  estimatedDuration: number | null;
+  color: string;
+}) {
+  const remainingText = formatTimeRemaining(estimatedDuration, elapsed);
+  if (!remainingText) return null;
+  return (
+    <Text
+      variant="body"
+      testID="elapsed-remaining"
+      style={{ color, fontSize: fontSizes.xs }}
+    >
+      {remainingText}
+    </Text>
+  );
+}
+
+type ElapsedDisplayColors = {
+  primary: string;
+  onSurfaceVariant: string;
+};
+
+function ElapsedDisplay({
+  elapsed,
+  estimatedDuration,
+  isRestActive,
+  clockStarted,
+  colors,
+  onPress,
+  onLongPress,
+}: {
+  elapsed: number;
+  estimatedDuration: number | null;
+  isRestActive: boolean;
+  clockStarted: boolean;
+  colors: ElapsedDisplayColors;
+  onPress: () => void;
+  onLongPress: () => void;
+}) {
+  const a11yLabel = buildElapsedA11yLabel({ elapsed, estimatedDuration, isRestActive, clockStarted });
+  const elapsedColor = isRestActive ? colors.onSurfaceVariant : colors.primary;
+  return (
+    <Pressable
+      onPress={onPress}
+      onLongPress={onLongPress}
+      delayLongPress={400}
+      disabled={isRestActive}
+      accessibilityLabel={a11yLabel}
+      accessibilityRole={clockStarted ? "button" : "timer"}
+      style={styles.elapsedButton}
+    >
+      <Text
+        variant="body"
+        testID="elapsed-time"
+        style={{ color: elapsedColor, fontSize: fontSizes.sm }}
+      >
+        {formatTime(elapsed)}
+      </Text>
+      {clockStarted ? (
+        <ElapsedRemaining
+          elapsed={elapsed}
+          estimatedDuration={estimatedDuration}
+          color={colors.onSurfaceVariant}
+        />
+      ) : (
+        <Text
+          variant="body"
+          testID="elapsed-not-started-caption"
+          style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.xs }}
+        >
+          Starts when you log your first set
+        </Text>
+      )}
+    </Pressable>
+  );
+}
+
 function buildActiveA11yLabel(
   rest: number,
   showRestDone: boolean,
@@ -458,6 +512,30 @@ function buildActiveA11yLabel(
     return `Rest timer: ${min} minutes ${sec} seconds. ${breakdown.reasonAccessible}. Tap to dismiss. Long-press for breakdown.`;
   }
   return base;
+}
+
+function buildElapsedA11yLabel({
+  elapsed,
+  estimatedDuration,
+  isRestActive,
+  clockStarted,
+}: {
+  elapsed: number;
+  estimatedDuration: number | null;
+  isRestActive: boolean;
+  clockStarted: boolean;
+}): string {
+  const base = `Workout timer: ${formatTime(elapsed)}`;
+  // BLD-630: while unanchored, communicate the empty state and skip
+  // rest-timer hints (the primary instruction is "log a set").
+  if (!clockStarted) return `${base}, starts when you log your first set`;
+  if (isRestActive) return base;
+  const suffix = ". Tap to start rest timer. Long press for rest settings.";
+  const remainingText = formatTimeRemaining(estimatedDuration, elapsed);
+  if (remainingText) {
+    return `${base}, approximately ${Math.ceil(((estimatedDuration ?? 0) - elapsed) / 60)} minutes remaining${suffix}`;
+  }
+  return `${base}${suffix}`;
 }
 
 const styles = StyleSheet.create({

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -72,7 +72,7 @@ type Params = {
   startRest: (ctx: string | SetContext) => void;
   startRestWithDuration: (secs: number) => void;
   startRestWithBreakdown: (breakdown: RestBreakdown) => void;
-  session: { started_at: number; name: string } | null;
+  session: { started_at: number; clock_started_at?: number | null; name: string } | null;
   showToast: (msg: string) => void;
   showError: (msg: string) => void;
   triggerPR?: (exerciseName: string, goalAchieved?: boolean) => void;
@@ -99,6 +99,20 @@ export function useSessionActions({
 
   // --- local state ---
   const [elapsed, setElapsed] = useState(0);
+  // BLD-630: optimistic local mirror of `workout_sessions.clock_started_at`.
+  // The DB write inside completeSet is authoritative for persistence/export,
+  // but `useSessionDetail` fetches the session once on `[id]` and never
+  // re-runs, so without a local override the on-screen elapsed timer would
+  // never start ticking. We sync from the prop on session-id change.
+  const [clockStartedAt, setClockStartedAt] = useState<number | null>(
+    session?.clock_started_at ?? null,
+  );
+  useEffect(() => {
+    // Mirror DB anchor into local state when the session prop changes (e.g.
+    // navigating to another session, or a hydration roundtrip after restart).
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- prop sync
+    setClockStartedAt(session?.clock_started_at ?? null);
+  }, [session?.clock_started_at]);
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
   const [exerciseNotesOpen, setExerciseNotesOpen] = useState<Record<string, boolean>>({});
   const [exerciseNotesDraft, setExerciseNotesDraft] = useState<Record<string, string>>({});
@@ -111,15 +125,29 @@ export function useSessionActions({
   const bwPRExerciseSet = useRef<Set<string>>(new Set());
 
   // Session-elapsed clock.
+  // BLD-630: the clock is now anchored to the first completed set, not the
+  // moment the user tapped Start. While `clockStartedAt` is null, elapsed
+  // stays at 0 and the 1Hz interval is not scheduled.
   // BLD-553 battery fix: pause setInterval when app is backgrounded. On some
   // RN runtimes setInterval continues to schedule wake-ups with the screen
   // off, and if it doesn't, React still triggers a render-burst as Date.now()
-  // jumps on resume. We recompute elapsed from session.started_at on resume,
+  // jumps on resume. We recompute elapsed from `clockStartedAt` on resume,
   // so there's no drift.
   useEffect(() => {
     if (!session) return;
+    if (clockStartedAt == null) {
+      // Not yet anchored — show 0:00 and don't run the interval. The "Starts
+      // when you log your first set" caption is rendered in the header.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- clearing elapsed when clock unanchors
+      setElapsed(0);
+      if (timer.current) {
+        clearInterval(timer.current);
+        timer.current = null;
+      }
+      return;
+    }
     const update = () => {
-      setElapsed(Math.floor((Date.now() - session.started_at) / 1000));
+      setElapsed(Math.floor((Date.now() - clockStartedAt) / 1000));
     };
     const start = () => {
       if (timer.current) return;
@@ -157,7 +185,7 @@ export function useSessionActions({
       stop();
       sub.remove();
     };
-  }, [session]);
+  }, [session, clockStartedAt]);
 
   // Cleanup hint timer
   useEffect(() => {
@@ -251,6 +279,10 @@ export function useSessionActions({
 
     const now = Date.now();
     updateGroupSet(set.id, { completed: true, completed_at: now });
+    // BLD-630: anchor the session clock optimistically before the DB write
+    // so the elapsed timer starts ticking within the next render. The DB
+    // update inside `completeSet` is authoritative for persistence/export.
+    setClockStartedAt((prev) => (prev == null ? now : prev));
     await completeSet(set.id);
 
     // BLD-541 R2: invalidate the smart-default cache so the next add-set
@@ -697,6 +729,10 @@ export function useSessionActions({
 
   return {
     elapsed,
+    /** BLD-630: null until the user completes the first set in the session.
+     * Consumers (header) use this to render the "Starts when you log your
+     * first set" caption and the appropriate a11y label. */
+    clockStartedAt,
     exerciseNotesOpen,
     exerciseNotesDraft,
     halfStep,

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -81,6 +81,9 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   // workout_sessions table
   await addColumnIfMissing(database, "workout_sessions", "program_day_id", "TEXT DEFAULT NULL");
   await addColumnIfMissing(database, "workout_sessions", "rating", "INTEGER DEFAULT NULL");
+  // BLD-630: anchor session elapsed clock to first completed set.
+  // NULL = legacy/unanchored — readers fall back to started_at.
+  await addColumnIfMissing(database, "workout_sessions", "clock_started_at", "INTEGER");
 
   // workout_sets table
   await addColumnIfMissing(database, "workout_sets", "rpe", "REAL DEFAULT NULL");

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -60,6 +60,7 @@ export const workoutSessions = sqliteTable("workout_sessions", {
   template_id: text("template_id"),
   name: text("name").notNull(),
   started_at: integer("started_at").notNull(),
+  clock_started_at: integer("clock_started_at"),
   completed_at: integer("completed_at"),
   duration_seconds: integer("duration_seconds"),
   notes: text("notes").default(""),

--- a/lib/db/session-sets.ts
+++ b/lib/db/session-sets.ts
@@ -323,9 +323,19 @@ export async function updateSetDuration(
 
 export async function completeSet(id: string): Promise<void> {
   const db = await getDrizzle();
+  const now = Date.now();
   await db.update(workoutSets)
-    .set({ completed: 1, completed_at: Date.now() })
+    .set({ completed: 1, completed_at: now })
     .where(eq(workoutSets.id, id));
+  // BLD-630: anchor the parent session's elapsed clock on first set
+  // completion only. The `clock_started_at IS NULL` guard makes this a no-op
+  // on subsequent set completions and idempotent under concurrent writers.
+  await db.run(sql`
+    UPDATE workout_sessions
+    SET clock_started_at = ${now}
+    WHERE id = (SELECT session_id FROM workout_sets WHERE id = ${id})
+      AND clock_started_at IS NULL
+  `);
 }
 
 export async function uncompleteSet(id: string): Promise<void> {

--- a/lib/db/session-sets.ts
+++ b/lib/db/session-sets.ts
@@ -327,12 +327,20 @@ export async function completeSet(id: string): Promise<void> {
   await db.update(workoutSets)
     .set({ completed: 1, completed_at: now })
     .where(eq(workoutSets.id, id));
-  // BLD-630: anchor the parent session's elapsed clock on first set
-  // completion only. The `clock_started_at IS NULL` guard makes this a no-op
-  // on subsequent set completions and idempotent under concurrent writers.
+  // BLD-630: anchor the parent session's elapsed clock to the EARLIEST
+  // completed set in the session (not just `now`), so resumed sessions and
+  // pre-existing completed sets — e.g., rows written before this migration
+  // landed, or near-concurrent completions — anchor to the true first
+  // completion. The `clock_started_at IS NULL` guard keeps it idempotent on
+  // subsequent set completions.
   await db.run(sql`
     UPDATE workout_sessions
-    SET clock_started_at = ${now}
+    SET clock_started_at = (
+      SELECT MIN(completed_at)
+      FROM workout_sets
+      WHERE session_id = (SELECT session_id FROM workout_sets WHERE id = ${id})
+        AND completed_at IS NOT NULL
+    )
     WHERE id = (SELECT session_id FROM workout_sets WHERE id = ${id})
       AND clock_started_at IS NULL
   `);

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -146,6 +146,9 @@ export async function startSession(
     template_id: templateId,
     name,
     started_at: now,
+    // BLD-630: not yet anchored — readers fall back to started_at until the
+    // first set in this session is completed.
+    clock_started_at: null,
     completed_at: null,
     duration_seconds: null,
     notes: "",
@@ -159,11 +162,17 @@ export async function completeSession(
 ): Promise<void> {
   const now = Date.now();
   const db = await getDrizzle();
-  const session = await db.select({ started_at: workoutSessions.started_at })
+  const session = await db.select({
+      started_at: workoutSessions.started_at,
+      clock_started_at: workoutSessions.clock_started_at,
+    })
     .from(workoutSessions)
     .where(eq(workoutSessions.id, id))
     .get();
-  const duration = session ? Math.floor((now - session.started_at) / 1000) : 0;
+  // BLD-630: duration is anchored to first-completed-set when available;
+  // fall back to started_at for legacy rows / sessions with no completed sets.
+  const anchor = session ? (session.clock_started_at ?? session.started_at) : 0;
+  const duration = session ? Math.floor((now - anchor) / 1000) : 0;
   await db.update(workoutSessions)
     .set({ completed_at: now, duration_seconds: duration, notes: notes ?? "" })
     .where(eq(workoutSessions.id, id));

--- a/lib/db/tables.ts
+++ b/lib/db/tables.ts
@@ -91,6 +91,7 @@ export async function createCoreTables(database: SQLite.SQLiteDatabase): Promise
       template_id TEXT,
       name TEXT NOT NULL,
       started_at INTEGER NOT NULL,
+      clock_started_at INTEGER DEFAULT NULL,
       completed_at INTEGER,
       duration_seconds INTEGER,
       notes TEXT DEFAULT '',

--- a/lib/health-connect.ts
+++ b/lib/health-connect.ts
@@ -111,6 +111,9 @@ export async function openHealthConnectSettings(): Promise<void> {
 
 interface SessionData {
   started_at: number;
+  /** BLD-630: when set, used as the canonical session start instead of
+   * `started_at` (which marks row creation, often inflated by pre-set idle). */
+  clock_started_at: number | null;
   completed_at: number | null;
   name: string | null;
 }
@@ -124,7 +127,7 @@ function buildExerciseSessionRecord(
   session: SessionData,
   completedSets: SetData[]
 ) {
-  const sessionStartMs = session.started_at;
+  const sessionStartMs = session.clock_started_at ?? session.started_at;
   const sessionEndMs = session.completed_at ?? Date.now();
 
   const exerciseMap = new Map<string, { startTime: string; endTime: string }>();

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -540,7 +540,8 @@ async function uploadActivity(
   const weightUnit = bodySettings.weight_unit as "kg" | "lb";
 
   const description = buildActivityDescription(sets, weightUnit);
-  const startDate = new Date(session.started_at).toISOString();
+  // BLD-630: anchor Strava activity start to first-completed-set.
+  const startDate = new Date(session.clock_started_at ?? session.started_at).toISOString();
   const elapsedTime = session.duration_seconds ?? 0;
 
   const response = await fetch(`${STRAVA_API_BASE}/activities`, {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -210,6 +210,14 @@ export type WorkoutSession = {
   template_id: string | null;
   name: string;
   started_at: number;
+  /**
+   * BLD-630: timestamp at which the session's elapsed clock should start
+   * counting. Set to `Date.now()` the first time any set in the session is
+   * marked complete; `NULL` for legacy/unanchored rows (readers fall back to
+   * `started_at`). Once set, never rolled back — even if all sets are
+   * subsequently uncompleted.
+   */
+  clock_started_at: number | null;
   completed_at: number | null;
   duration_seconds: number | null;
   notes: string;


### PR DESCRIPTION
## Summary

Anchors the session elapsed clock + `duration_seconds` + Strava `start_date` + Health Connect `startTime` to the **first completed set** instead of the moment the user tapped Start. Legacy/unanchored sessions fall back to `started_at`, preserving today's behavior.

Resolves BLD-630.

## Changes

- **DB**: new nullable `workout_sessions.clock_started_at INTEGER` (schema, fresh-install table, idempotent migration via `addColumnIfMissing`).
- **`completeSet`**: single UPDATE-with-subquery anchors the parent session on first completion only (`IS NULL` guard → idempotent).
- **`completeSession`**: duration computed from `clock_started_at ?? started_at`.
- **`useSessionActions`**: optimistic local `clockStartedAt` mirror so the on-screen timer starts ticking immediately on first set complete (`useSessionDetail` doesn't refetch on writes).
- **`SessionHeaderToolbar`**: 'Starts when you log your first set' caption + `accessibilityRole='timer'` while unanchored; 'Workout timer:' a11y prefix.
- **Strava + Health Connect** exports use the anchor for start time.
- **Types**: `WorkoutSession.clock_started_at` + `SessionData.clock_started_at` (`number | null`).
- **CHANGELOG**: Unreleased entry under Changed.

## Testing

- 3 new fake-timer tests in `__tests__/hooks/useSessionActions-elapsed-clock.test.ts` cover: unanchored stay-at-zero, optimistic anchor on first `handleCheck`, no-rollback when uncompleting the only set.
- All 2298 existing tests pass.
- `npx -p typescript tsc --noEmit` clean for the touched files (5 unrelated pre-existing TS errors on main verified via git stash baseline).
- ESLint clean (0 errors / 0 warnings) on all touched files.

## Issue

Resolves BLD-630.