### PR TITLE
fix(session): align MountTransitionHint spacing to design tokens (BLD-634)

### DIFF
--- a/components/session/MountTransitionHint.tsx
+++ b/components/session/MountTransitionHint.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { spacing } from "@/constants/design-tokens";
 import { MOUNT_POSITION_LABELS, type MountPosition } from "../../lib/types";
 
 export type MountTransitionHintProps = {
@@ -77,9 +78,9 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 6,
-    paddingVertical: 8,
-    paddingHorizontal: 4,
+    gap: spacing.xs,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.xs,
   },
   text: {
     fontSize: 12,


### PR DESCRIPTION
## Summary

Polish fix from BLD-631 visual UX audit. The cable-switch transition hint introduced in BLD-596 used three spacing literals that drifted off the 4px grid. Replaced with `spacing.xs` / `spacing.sm` tokens.

## Changes

- `components/session/MountTransitionHint.tsx`:
  - Import `spacing` from `@/constants/design-tokens`.
  - `gap: 6` → `spacing.xs` (4)
  - `paddingVertical: 8` → `spacing.sm` (8, same value, now tokenised)
  - `paddingHorizontal: 4` → `spacing.xs` (4, same value, now tokenised)

## Testing

- `npx tsc --noEmit` clean for the touched file (pre-existing errors elsewhere are unrelated).
- `npx jest __tests__/components/session/MountTransitionHint.test.tsx __tests__/components/session/mount-transition-gating.test.tsx` → 11/11 passed.

## Issue

Resolves BLD-634.