### PR TITLE
fix(session): MountPositionChip label uses fontSizes.xs token (BLD-633)

### DIFF
--- a/__tests__/components/session/MountPositionChip.test.tsx
+++ b/__tests__/components/session/MountPositionChip.test.tsx
@@ -7,9 +7,11 @@
  *  - Chip self-suppresses on `null` AND `undefined` (DB-loaded null vs absent).
  */
 import React from "react";
+import { StyleSheet } from "react-native";
 import { render } from "@testing-library/react-native";
 import { MountPositionChip } from "../../../components/session/MountPositionChip";
 import { MOUNT_POSITION_LABELS, type MountPosition } from "../../../lib/types";
+import { fontSizes } from "../../../constants/design-tokens";
 
 jest.mock("@/hooks/useThemeColors", () => ({
   useThemeColors: () => ({
@@ -43,5 +45,19 @@ describe("MountPositionChip — BLD-596", () => {
   it("renders nothing when mount is undefined", () => {
     const { toJSON } = render(<MountPositionChip mount={undefined} />);
     expect(toJSON()).toBeNull();
+  });
+
+  // BLD-633: token-discipline regression guard. Previous regression class
+  // (BLD-550 on GroupCardHeader.previousPerf, then again here in BLD-596)
+  // hardcoded fontSize:11 / lineHeight:14 — both off the design-token grid
+  // (fontSizes.xs = 12). This assertion locks the chip's label typography to
+  // tokens so a future refactor cannot silently drift back off-grid.
+  it("uses fontSizes.xs token for label typography (BLD-633)", () => {
+    const { getByText } = render(<MountPositionChip mount="high" />);
+    const labelNode = getByText(MOUNT_POSITION_LABELS["high"]);
+    const flat = StyleSheet.flatten(labelNode.props.style) ?? {};
+    expect(flat.fontSize).toBe(fontSizes.xs);
+    expect(flat.fontSize).not.toBe(11);
+    expect(flat.lineHeight).toBe(16);
   });
 });

--- a/components/session/MountPositionChip.tsx
+++ b/components/session/MountPositionChip.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { fontSizes } from "@/constants/design-tokens";
 import { MOUNT_POSITION_LABELS, type MountPosition } from "../../lib/types";
 
 export type MountPositionChipProps = {
@@ -15,8 +16,8 @@ export type MountPositionChipProps = {
  * Uses `!mount` truthiness gate so DB-loaded `null` is treated identically to
  * `undefined`.
  *
- * Visual: rounded pill, surfaceVariant background, 11pt onSurfaceVariant text,
- * 4dp/8dp padding. Target height ≤20dp at 360dp+.
+ * Visual: rounded pill, surfaceVariant background, fontSizes.xs (12pt)
+ * onSurfaceVariant text, 4dp/8dp padding. Target height ≤20dp at 360dp+.
  *
  * Wrapper carries `flexShrink: 0` and a small marginLeft so the title column
  * compresses before the chip; parent `headerRow1` uses `flexWrap: "wrap"` so
@@ -50,8 +51,8 @@ const styles = StyleSheet.create({
     alignSelf: "center",
   },
   label: {
-    fontSize: 11,
-    lineHeight: 14,
+    fontSize: fontSizes.xs,
+    lineHeight: 16,
     fontWeight: "600",
   },
 });


### PR DESCRIPTION
## Summary

Same regression class as BLD-550. The mount-position chip introduced in BLD-596 hardcoded `fontSize: 11 / lineHeight: 14` — both off the design-token grid (`fontSizes.xs = 12`). This is the second time a session chip slipped past plan review with literal 11pt; switch to the token + lineHeight 16 (matches the xs ratio used elsewhere) and lock it with a unit-test assertion.

## Changes

- `components/session/MountPositionChip.tsx`:
  - Import `fontSizes` from `@/constants/design-tokens`.
  - `fontSize: 11` → `fontSizes.xs` (12)
  - `lineHeight: 14` → `16`
  - JSDoc updated (was "11pt", now "fontSizes.xs (12pt)").
- `__tests__/components/session/MountPositionChip.test.tsx`:
  - New regression-guard test asserting label uses `fontSizes.xs` + `lineHeight: 16`. Uses `StyleSheet.flatten` to resolve the wrapped `Text` style stack.

## Testing

- `npx jest __tests__/components/session/MountPositionChip.test.tsx` → 7/7 passed (including new guard).
- `npx tsc --noEmit` clean for touched files.

## Issue

Resolves BLD-633.