### PR TITLE
fix(e2e): destructure fixtures in beforeAll for Playwright 1.59 (BLD-644)

### DIFF
--- a/e2e/scenarios/completed-workout.spec.ts
+++ b/e2e/scenarios/completed-workout.spec.ts
@@ -25,7 +25,8 @@ const OUT_DIR = path.resolve(
 
 test.describe("@scenario completed-workout", () => {
   // v1 mobile only — skip on other Playwright projects to keep vision cost bounded.
-  test.beforeAll((_args, testInfo) => {
+  // eslint-disable-next-line no-empty-pattern -- Playwright 1.59 requires destructured fixtures arg
+  test.beforeAll(({}, testInfo) => {
     test.skip(
       testInfo.project.name !== "mobile",
       "v1: mobile viewport only (TL#4)",

--- a/e2e/scenarios/workout-history.spec.ts
+++ b/e2e/scenarios/workout-history.spec.ts
@@ -19,7 +19,8 @@ const OUT_DIR = path.resolve(
 );
 
 test.describe("@scenario workout-history", () => {
-  test.beforeAll((_args, testInfo) => {
+  // eslint-disable-next-line no-empty-pattern -- Playwright 1.59 requires destructured fixtures arg
+  test.beforeAll(({}, testInfo) => {
     test.skip(
       testInfo.project.name !== "mobile",
       "v1: mobile viewport only (TL#4)",


### PR DESCRIPTION
## Summary

Fixes Blocker 1 of [BLD-644](BLD-644): scenario specs failed to load under Playwright 1.59 because `test.beforeAll((_args, testInfo) => ...)` violates the new static fixture-detection check ("First argument must use the object destructuring pattern: _args").

## Changes

- `e2e/scenarios/completed-workout.spec.ts`: `(_args, testInfo)` → `({}, testInfo)` with eslint-disable for `no-empty-pattern`.
- `e2e/scenarios/workout-history.spec.ts`: same fix.

## Testing

```
npx playwright test --list e2e/scenarios/
# Total: 63 tests in 3 files (was: parse error)
```

ESLint clean on both files. Pre-existing `tsc` errors in unrelated test files are untouched.

## Scope

Blocker 2 (container missing Chromium runtime libs) is tracked separately in BLD-645. This PR is the trivial 2-line fix from BLD-644.

## Issue

Resolves Blocker 1 of BLD-644.