### PR TITLE
feat(infra): GH Actions workflow for daily UX audit capture (BLD-645)

### DIFF
--- a/.github/workflows/ux-audit.yml
+++ b/.github/workflows/ux-audit.yml
@@ -1,0 +1,109 @@
+name: UX Audit (Daily Visual Capture)
+
+# Daily visual UX audit capture (BLD-481, unblocks BLD-645).
+#
+# Exports the web bundle in dev mode (so the `__TEST_SCENARIO__` seed hook is
+# active) and runs the scenario specs at the `mobile` viewport. Screenshots +
+# JSON metadata land in `.pixelslop/screenshots/scenarios/<scenario>/` and
+# are uploaded as a downloadable artifact for the ux-designer agent to
+# consume via `gh run download`.
+#
+# Why GitHub Actions, not the agent runtime container:
+#   - Container is shared infra and lacks Chromium runtime libs (libnss3,
+#     libxkbcommon0, libgbm1, …). `apt-get` / `sudo` are unavailable.
+#   - `npx playwright install --with-deps chromium` works on ubuntu-latest.
+#   - This workflow mirrors `e2e-update-snapshots.yml`, which already runs
+#     Playwright successfully in CI.
+#
+# Refs: BLD-481 (audit loop), BLD-494 (scenario hook), BLD-631 / BLD-644
+#       (prior attempts), BLD-645 (this workflow).
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Daily at 09:00 UTC — matches BLD-481 spec ("daily 09:00 local"). UTC is
+    # used because GH cron has no timezone support; agent triage absorbs the
+    # offset.
+    - cron: '0 9 * * *'
+
+# Multiple dispatches against the same ref shouldn't pile up.
+concurrency:
+  group: ux-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  capture:
+    name: Capture scenario screenshots
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Export web bundle (dev mode for scenario seed hook)
+        # `--dev --no-minify` keeps `__DEV__=true` so `if (__DEV__)`-gated
+        # scenario hooks (lib/db/test-seed.ts) execute. Static export avoids
+        # Metro cold-start in CI (BLD-517).
+        run: npx expo export -p web --dev --no-minify
+
+      - name: Run scenario captures (mobile viewport)
+        env:
+          CI: 'true'
+          E2E_USE_STATIC: '1'
+        run: |
+          npx playwright test \
+            e2e/scenarios/completed-workout.spec.ts \
+            e2e/scenarios/workout-history.spec.ts \
+            --project=mobile
+
+      - name: Write empty-bundle marker if no screenshots produced
+        # If pauseAndCapture wrote zero files, surface that explicitly in the
+        # artifact instead of silently uploading nothing.
+        if: always()
+        run: |
+          OUT=".pixelslop/screenshots/scenarios"
+          mkdir -p "$OUT"
+          PNG_COUNT=$(find "$OUT" -name '*.png' -type f 2>/dev/null | wc -l)
+          if [ "$PNG_COUNT" -eq 0 ]; then
+            echo "::warning::ux-audit produced zero screenshots — emitting empty-bundle marker"
+            CAPTURED_AT="$(date -u +%FT%TZ)"
+            printf '{"warning":"no screenshots captured","runId":"%s","commitSha":"%s","ref":"%s","capturedAt":"%s"}\n' \
+              "${{ github.run_id }}" "${{ github.sha }}" "${{ github.ref }}" "$CAPTURED_AT" \
+              > "$OUT/_empty-bundle.json"
+          else
+            echo "Captured $PNG_COUNT screenshot(s)."
+          fi
+
+      - name: Upload screenshot bundle
+        # `if: always()` so partial captures still upload when a later spec
+        # fails. Naming includes run id so ux-designer can pin to a run.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ux-audit-${{ github.run_id }}
+          path: .pixelslop/screenshots/scenarios/
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload Playwright report (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ux-audit-playwright-report-${{ github.run_id }}
+          path: playwright-report
+          retention-days: 14

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,86 @@
+# e2e — visual UX audit & Playwright specs
+
+This folder hosts:
+
+- **`*.spec.ts`** — Playwright visual-regression specs (snapshots in `__screenshots__/`).
+- **`scenarios/*.spec.ts`** — semantic UX-audit captures consumed by the
+  ux-designer agent. v1 is mobile-only.
+- **`helpers.ts`** — shared fixtures (skip-onboarding, scenario seeding, …).
+- **`generate-manifest.ts`** — Playwright `globalTeardown` that aggregates
+  scenario metadata.
+
+## Running locally
+
+```bash
+npx expo export -p web --dev --no-minify
+E2E_USE_STATIC=1 npx playwright test e2e/scenarios --project=mobile
+```
+
+Screenshots land in `.pixelslop/screenshots/scenarios/<scenario>/<viewport>.png`,
+each accompanied by `<viewport>.json` metadata (scenario, label, route,
+viewport, commit SHA, captured-at timestamp).
+
+## Daily UX audit (BLD-481 / BLD-645)
+
+The agent runtime container can't run Chromium (missing system libs, no
+`sudo`), so the daily capture runs in **GitHub Actions** instead. See
+[`.github/workflows/ux-audit.yml`](../.github/workflows/ux-audit.yml).
+
+### Trigger
+
+- **Cron**: 09:00 UTC daily.
+- **Manual**: `gh workflow run ux-audit.yml` (or via the Actions UI). Useful
+  for the ux-designer heartbeat to invoke on demand.
+
+### Fetching the artifact
+
+```bash
+# List recent runs
+gh run list --workflow=ux-audit.yml --limit 5
+
+# Pin to a specific run, then download into a local folder
+RUN_ID=$(gh run list --workflow=ux-audit.yml --limit 1 --json databaseId -q '.[0].databaseId')
+gh run download "$RUN_ID" -n "ux-audit-$RUN_ID" -D ./ux-audit-bundle
+```
+
+The bundle layout mirrors `.pixelslop/screenshots/scenarios/`:
+
+```
+ux-audit-bundle/
+  completed-workout/
+    mobile.png
+    mobile.json
+  workout-history/
+    mobile.png
+    mobile.json
+```
+
+If a run captured zero screenshots, the bundle contains a single
+`_empty-bundle.json` marker (commit SHA, run id, timestamp) — surface this
+in the audit comment instead of silently passing.
+
+### Metadata schema
+
+Each `<viewport>.json` is the contract between the spec and the audit agent:
+
+| Field | Meaning |
+|-------|---------|
+| `scenario` | Scenario id (matches folder name). |
+| `label` | Human-readable description of the captured screen. |
+| `route` | Expo Router path that was visited. |
+| `viewport` | Playwright project name (currently always `mobile`). |
+| `viewportSize` | `{ width, height }` in CSS pixels. |
+| `commitSha` | `GITHUB_SHA` at capture time (CEO uses this to backtrack). |
+| `capturedAt` | ISO-8601 UTC timestamp. |
+
+The ux-designer agent attaches the PNG + metadata to any new visual-defect
+issue it files so CEO can reproduce against the exact commit and route.
+
+### Failure modes
+
+- **Spec fails mid-run** — workflow status = failed, but the artifact upload
+  step uses `if: always()` so any partial captures still upload.
+- **Zero screenshots produced** — `_empty-bundle.json` marker is written
+  before upload; workflow logs a `::warning::`.
+- **Playwright HTML report** — uploaded as `ux-audit-playwright-report-<run>`
+  on failure for triage.


### PR DESCRIPTION
## What

Adds `.github/workflows/ux-audit.yml` — a `workflow_dispatch` + daily 09:00 UTC cron that exports the web bundle in dev mode, runs the two scenario specs at the `mobile` viewport, and uploads `.pixelslop/screenshots/scenarios/` as a 14-day-retention artifact named `ux-audit-${{ github.run_id }}`.

Also adds `e2e/README.md` documenting how the ux-designer agent fetches the bundle (`gh run download`) and the per-screenshot metadata schema.

## Why this layer

Per BLD-481 / BLD-631 / BLD-644: the agent runtime container lacks Chromium runtime libs (`libnss3`, `libxkbcommon0`, `libgbm1`, …) and `apt-get` / `sudo` are unavailable. `ubuntu-latest` runs `npx playwright install --with-deps chromium` successfully — the existing `e2e-update-snapshots.yml` is the precedent for the same shape.

## Edge cases handled (matches the issue's table)

| Scenario | Behaviour |
|---|---|
| Spec fails mid-run | Artifact upload uses `if: always()` so partial captures still ship; workflow status = failed. |
| `pauseAndCapture` writes 0 files | A pre-upload step writes `_empty-bundle.json` (run id, commit SHA, timestamp) and emits a `::warning::`. |
| Network flake during `npm ci` | `actions/setup-node` cache is enabled (`cache: 'npm'`). |

Playwright HTML report uploaded as `ux-audit-playwright-report-${run_id}` on failure for triage.

## Acceptance criteria

- [x] Workflow file at `.github/workflows/ux-audit.yml`.
- [x] Triggers: `workflow_dispatch` + `schedule: '0 9 * * *'`.
- [x] Steps: checkout → setup-node → `npm ci` → `npx playwright install --with-deps chromium` → dev export → `E2E_USE_STATIC=1 npx playwright test` (the two scenario specs, `--project=mobile`) → upload artifact `ux-audit-${{ github.run_id }}`.
- [x] Artifact retention 14 days.
- [x] `if: always()` upload for partial-capture survival.
- [x] README note in `e2e/README.md` (folder lacked a README; created one).
- [ ] Manual dispatch on `main` runs green — verifiable only after merge (workflow files must be on `main` for cron + reliable dispatch).
- [ ] Cron tick verified — same constraint; verifiable post-merge.

## Out of scope (per issue)

- Wiring ux-designer's heartbeat to invoke the workflow — separate ticket.
- Expanding to all 7 BLD-481 scenarios — start with the existing 2.
- Baking deps into the agent container.

## Refs

BLD-481 (audit loop), BLD-494 (scenario hook DCE contract), BLD-644 (fixture fix on `main` at `5852865`), BLD-645 (this workflow).