### PR TITLE
fix: improve in-session exercise notes readability (BLD-651, GH #330)

### DIFF
--- a/__tests__/acceptance/notes-panel-readability.acceptance.test.tsx
+++ b/__tests__/acceptance/notes-panel-readability.acceptance.test.tsx
@@ -1,9 +1,16 @@
 /**
- * BLD-544 (GH #330): In-session workout notes textarea — taller + higher contrast.
+ * BLD-651 (GH #330): In-session workout notes textarea — readability bump.
+ *
+ * Builds on the original BLD-544 contrast pass; this round increases the
+ * visible area, font size, and switches to the outline variant so the
+ * textarea is clearly visible on dark theme (the original GH #330 bug).
  *
  * Acceptance:
- * - minHeight bumped from 48 → ~96 (≈3 lines)
- * - fontSize bumped from fontSizes.sm → fontSizes.base or larger
+ * - minHeight ≥ 140dp (≈5 lines, up from 96/3 lines)
+ * - rows={5} so the textarea renders 5 visible lines without scrolling
+ * - variant="outline" so the field has a real, theme-coloured border on
+ *   both light and dark themes (filled variant has border==card → invisible)
+ * - fontSize ≥ fontSizes.lg (18) for easier reading & typing on small/foldable phones
  * - Explicit theme text color (colors.onSurface) + placeholderTextColor
  *   (colors.onSurfaceVariant) for WCAG AA contrast
  * - textAlignVertical="top" so Android multiline starts top-left
@@ -11,23 +18,27 @@
 import fs from "fs";
 import path from "path";
 
-describe("ExerciseNotesPanel — taller + higher contrast (BLD-544, GH #330)", () => {
+describe("ExerciseNotesPanel — taller + higher contrast (BLD-651, GH #330)", () => {
   const src = fs.readFileSync(
     path.resolve(__dirname, "../../components/session/ExerciseNotesPanel.tsx"),
     "utf-8"
   );
 
-  it("textarea minHeight is at least 96dp (≈3 lines)", () => {
+  it("textarea minHeight is at least 140dp (≈5 lines)", () => {
     const m = src.match(/minHeight:\s*(\d+)/);
     expect(m).not.toBeNull();
-    expect(Number(m![1])).toBeGreaterThanOrEqual(96);
+    expect(Number(m![1])).toBeGreaterThanOrEqual(140);
   });
 
-  it("textarea fontSize is at least fontSizes.base (16) for legibility", () => {
+  it("textarea fontSize is at least fontSizes.lg (18) for legibility", () => {
     const m = src.match(/input:\s*\{[^}]*fontSize:\s*fontSizes\.(\w+)/);
     expect(m).not.toBeNull();
     const fontSizeMap: Record<string, number> = { xs: 12, sm: 14, base: 16, lg: 18, xl: 20 };
-    expect(fontSizeMap[m![1]] ?? 0).toBeGreaterThanOrEqual(16);
+    expect(fontSizeMap[m![1]] ?? 0).toBeGreaterThanOrEqual(18);
+  });
+
+  it("uses variant='outline' so border is visible on both themes", () => {
+    expect(src).toMatch(/variant="outline"/);
   });
 
   it("placeholder text color is explicitly set from theme (AA contrast)", () => {
@@ -42,9 +53,9 @@ describe("ExerciseNotesPanel — taller + higher contrast (BLD-544, GH #330)", (
     expect(src).toMatch(/textAlignVertical="top"/);
   });
 
-  it("uses Input type='textarea' (rows-based sizing, not single-line input)", () => {
+  it("uses Input type='textarea' with rows={5}", () => {
     expect(src).toMatch(/type="textarea"/);
-    expect(src).toMatch(/rows=\{3\}/);
+    expect(src).toMatch(/rows=\{5\}/);
   });
 
   it("does not touch the post-session summary notes file", () => {

--- a/components/session/ExerciseNotesPanel.tsx
+++ b/components/session/ExerciseNotesPanel.tsx
@@ -18,7 +18,8 @@ export function ExerciseNotesPanel({ exerciseId, value, onDraftChange, onSave }:
     <View style={styles.container}>
       <Input
         type="textarea"
-        rows={3}
+        variant="outline"
+        rows={5}
         placeholder="Add exercise notes..."
         placeholderTextColor={colors.onSurfaceVariant}
         value={value}
@@ -38,5 +39,5 @@ export function ExerciseNotesPanel({ exerciseId, value, onDraftChange, onSave }:
 
 const styles = StyleSheet.create({
   container: { paddingHorizontal: 8, paddingBottom: 8, paddingTop: 4 },
-  input: { fontSize: fontSizes.base, minHeight: 96 },
+  input: { fontSize: fontSizes.lg, lineHeight: 24, minHeight: 140 },
 });


### PR DESCRIPTION
## Summary

Fixes [GH #330](https://github.com/alankyshum/cablesnap/issues/330): in-session exercise notes are hard to view & type. The textarea was 3 rows tall (96dp), used the `filled` variant whose border equals the card colour (i.e. invisible), and used `fontSizes.base` (16). On dark theme + foldable layouts the field was nearly impossible to spot, focus, or type into.

## Changes

`components/session/ExerciseNotesPanel.tsx`:
- Switch to `variant="outline"` so the textarea has a real, theme-coloured border on both light and dark themes.
- `rows={3}` → `rows={5}` and `minHeight: 96` → `minHeight: 140` so multi-line notes are visible without scrolling.
- `fontSize: fontSizes.base` (16) → `fontSizes.lg` (18) with `lineHeight: 24` for easier reading & typing on small/foldable phones.
- Placeholder colour, text colour, `textAlignVertical="top"`, counter, `onDraftChange`/`onSave`/`maxLength`, and `accessibilityLabel` all unchanged.

## Tests

Renamed `__tests__/acceptance/notes-panel-contrast.acceptance.test.tsx` → `notes-panel-readability.acceptance.test.tsx` and updated the assertions to the new BLD-651 acceptance criteria (minHeight ≥ 140, fontSize ≥ `lg`, `variant='outline'`, `rows={5}`, plus all preserved invariants). All 8 cases pass locally.

## QD review

Followed the QD plan-review correction (`fontSizes.lg` not `fontSizes.md` — `md` does not exist on the font scale).

## Issue

Closes #330
Resolves BLD-651