### PR TITLE
fix(session): allow previous-performance label to wrap to 2 lines (GH #328)

### DIFF
--- a/__tests__/components/session/GroupCardHeader-prev-perf-wrap.test.tsx
+++ b/__tests__/components/session/GroupCardHeader-prev-perf-wrap.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * BLD-656: Previous-performance chip text must wrap to up to 2 lines
+ * instead of single-line truncation. On narrow viewports (e.g., Z Fold6
+ * cover screen ~884dp inner width) the previous-performance summary
+ * was being truncated with ellipsis when the available width was
+ * insufficient. This test locks in `numberOfLines={2}` so the change
+ * isn't silently reverted by a future refactor.
+ */
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { GroupCardHeader } from "../../../components/session/GroupCardHeader";
+import type { ExerciseGroup, SetWithMeta } from "../../../components/session/types";
+
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+  const Icon = (props: { name: string; size?: number; color?: string; accessibilityLabel?: string }) =>
+    React.createElement(Text, { ...props }, props.name);
+  return { __esModule: true, default: Icon };
+});
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#6200ee",
+    primaryContainer: "#e8def8",
+    onSurface: "#1c1b1f",
+    onSurfaceVariant: "#49454f",
+    outlineVariant: "#cac4d0",
+    surface: "#fffbfe",
+    surfaceVariant: "#e7e0ec",
+    shadow: "#000000",
+    background: "#fffbfe",
+  }),
+}));
+
+jest.mock("../../../components/TrainingModeSelector", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("../../../components/session/ExerciseNotesPanel", () => ({
+  __esModule: true,
+  ExerciseNotesPanel: () => null,
+}));
+
+function makeGroup(overrides: Partial<ExerciseGroup> = {}): ExerciseGroup {
+  return {
+    exercise_id: "ex-1",
+    name: "Cable Row",
+    training_modes: ["concentric"],
+    is_voltra: false,
+    sets: [],
+    progressionSuggested: false,
+    ...overrides,
+  } as ExerciseGroup;
+}
+
+const baseProps = {
+  group: makeGroup(),
+  modes: {} as Record<string, never>,
+  currentMode: undefined,
+  exerciseNotesOpen: false,
+  exerciseNotesDraft: undefined,
+  firstSet: undefined as SetWithMeta | undefined,
+  onModeChange: jest.fn(),
+  onExerciseNotes: jest.fn(),
+  onExerciseNotesDraftChange: jest.fn(),
+  onToggleExerciseNotes: jest.fn(),
+  onShowDetail: jest.fn(),
+  onSwap: jest.fn(),
+  onDeleteExercise: jest.fn(),
+};
+
+describe("GroupCardHeader — previous-performance wrap (BLD-656)", () => {
+  it("renders the previous-performance text with numberOfLines={2} so it wraps instead of truncating on narrow viewports", () => {
+    const summary = "5 reps · 60 kg · concentric · prior session 2026-04-22";
+    const { getByText } = render(
+      <GroupCardHeader
+        {...baseProps}
+        previousPerformance={summary}
+        onPrefill={jest.fn()}
+      />,
+    );
+
+    const textNode = getByText(summary);
+    expect(textNode.props.numberOfLines).toBe(2);
+  });
+});

--- a/components/session/GroupCardHeader.tsx
+++ b/components/session/GroupCardHeader.tsx
@@ -81,7 +81,7 @@ function GroupCardHeaderInner({ group, currentMode, exerciseNotesOpen, exerciseN
                 accessibilityHint="Tap to refill from previous"
               >
                 <ProgressionIcon suggested={group.progressionSuggested} color={colors.primary} />
-                <Text numberOfLines={1} style={[styles.previousPerf, { color: colors.primary }]}>
+                <Text numberOfLines={2} style={[styles.previousPerf, { color: colors.primary }]}>
                   {previousPerformance}
                 </Text>
                 {/* BLD-551: trailing refresh glyph restores tappability affordance lost in BLD-542. */}


### PR DESCRIPTION
## Summary

On the session screen, exercise group headers display a tappable previous-performance summary (e.g., `5 reps · 60 kg`). It used `numberOfLines={1}` which truncates with ellipsis on narrow inner widths (Z Fold6 cover screen, GitHub #328). Owner asked for wrapping instead. This bumps to `numberOfLines={2}`.

## Changes

- `components/session/GroupCardHeader.tsx`: `numberOfLines={1}` → `numberOfLines={2}` on the previous-performance Text.
- New test `__tests__/components/session/GroupCardHeader-prev-perf-wrap.test.tsx` locks in `numberOfLines={2}` so the fix isn't silently reverted.

## Why this is safe

Parent Pressable already has `flexWrap: 'wrap'` and `minHeight: 36`, so the second line fits within the existing layout. The trailing refresh icon + ProgressionIcon (BLD-551) continue to render inline. Short summaries still render on a single line — `numberOfLines={2}` is a max, not a forced height.

## Testing

- Targeted Jest run: 4/4 pass (new wrap test + BLD-551 affordance tests).
- `tsc --noEmit`: no new errors introduced (pre-existing baseline errors in unrelated files: `notes-panel-readability.acceptance.test.tsx` missing, `useAppInit-web-shared-array-buffer`, `GroupCardHeader-prev-perf-affordance` missing `currentMode`).
- ESLint complexity warning on `GroupCardHeaderInner` is pre-existing on main (verified) and unrelated to this one-character change.

## Issue

Resolves BLD-656 / GitHub #328 (truncation half — auto-prefill half is already shipped via BLD-542 in v0.26.8+).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>