### PR TITLE
fix(e2e): COOP/COEP headers on static server so scenario seed runs (BLD-658)

### DIFF
--- a/e2e/serve-coop-coep.json
+++ b/e2e/serve-coop-coep.json
@@ -1,0 +1,12 @@
+{
+  "headers": [
+    {
+      "source": "**/*",
+      "headers": [
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        { "key": "Cross-Origin-Embedder-Policy", "value": "require-corp" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" }
+      ]
+    }
+  ]
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
     // config sets COOP/COEP/CORP headers; the absolute path is required
     // because `serve --config` resolves relative to the served folder.
     command: process.env.E2E_USE_STATIC
-      ? `npx --yes serve -s dist -l 8081 -c ${path.resolve(__dirname, "e2e/serve-coop-coep.json")}`
+      ? `npx --yes serve -s dist -l 8081 -c '${path.resolve(__dirname, "e2e/serve-coop-coep.json")}'`
       : "npx expo start --web --port 8081",
     url: "http://localhost:8081",
     reuseExistingServer: !process.env.CI,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "@playwright/test";
+import * as path from "path";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -58,8 +59,15 @@ export default defineConfig({
     // bundle via `npx serve -s dist` instead of the Metro dev server. The
     // dev server's cold-start bundling time on a fresh CI runner exceeds
     // Playwright's per-test timeout and leaves the page blank (see BLD-517).
+    //
+    // BLD-658: scenario specs need `crossOriginIsolated === true` so the
+    // expo-sqlite Web Worker can use SharedArrayBuffer; otherwise
+    // `useAppInit` short-circuits via `webNeedsUnsupportedFallback` and the
+    // scenario seed never runs (no `data-test-ready` flag). The serve
+    // config sets COOP/COEP/CORP headers; the absolute path is required
+    // because `serve --config` resolves relative to the served folder.
     command: process.env.E2E_USE_STATIC
-      ? "npx --yes serve -s dist -l 8081"
+      ? `npx --yes serve -s dist -l 8081 -c ${path.resolve(__dirname, "e2e/serve-coop-coep.json")}`
       : "npx expo start --web --port 8081",
     url: "http://localhost:8081",
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
## Root cause

The first `ux-audit.yml` dispatch (BLD-645 [run 24938877962](https://github.com/alankyshum/cablesnap/actions/runs/24938877962)) failed at `expect(body[data-test-ready=true]).toBeVisible({ timeout: 15000 })`. The chain:

```
npx serve -s dist                            (no COOP/COEP headers)
  → Chromium: crossOriginIsolated = false
  → detectWebSharedMemorySupport().supported = false   (lib/web-support.ts:30)
  → useAppInit short-circuits via webNeedsUnsupportedFallback()  (BLD-565 guard)
  → getDatabase() never runs
  → seedScenario() never runs
  → document.body.dataset.testReady never set
  → Playwright locator times out
```

This is in the **test-infra layer**, not the workflow (BLD-645's plumbing was already green) and not the seed hook (`__DEV__` IS substituted to `true` under `expo export --dev`; the seed module ships as a separate async chunk and the dynamic import resolves correctly — verified by grepping the dev export).

## Fix

Serve the static bundle with cross-origin-isolation headers when `E2E_USE_STATIC=1`:

- New `e2e/serve-coop-coep.json`:
  - `Cross-Origin-Opener-Policy: same-origin`
  - `Cross-Origin-Embedder-Policy: require-corp`
  - `Cross-Origin-Resource-Policy: same-origin` *(needed on every same-origin subresource under COEP require-corp)*
- `playwright.config.ts` webServer command becomes `npx --yes serve -s dist -l 8081 -c \${absPath}`. The absolute path is mandatory — `serve --config` resolves the path **relative to the served folder** (`./dist`), not cwd.

## Verified locally

```
$ curl -I http://localhost:8081/_expo/static/js/web/entry-*.js
HTTP/1.1 200 OK
Cross-Origin-Opener-Policy: same-origin
Cross-Origin-Embedder-Policy: require-corp
Cross-Origin-Resource-Policy: same-origin
```

`bash scripts/verify-scenario-hook-not-in-bundle.sh` still passes — this fix is purely test-infra, no production-bundle leakage.

A live Playwright run can't be exercised in the agent container (Chromium runtime libs unavailable — same BLD-644 blocker that motivated GH Actions in the first place). Final verification is the post-merge `ux-audit.yml` dispatch.

## Hypotheses ruled out (per BLD-658 ranking)

1. ❌ `__DEV__` substitution — bundle entry literally has `__DEV__=true,...`.
2. ✅ **`webNeedsUnsupportedFallback` short-circuit** — root cause, this PR.
3. ❌ Onboarding race — wouldn't matter; hook runs in `getDatabase().then()` before `setReady`.
4. ❌ Tree-shaking — `SUPPORTED_SCENARIOS` literal present in `test-seed-*.js` chunk.

## Acceptance (post-merge)

- [ ] `gh workflow run ux-audit.yml --ref main` produces ≥2 PNGs + matching `mobile.json` files (no empty-bundle marker).
- [ ] Both scenario specs pass without retry.
- [x] `scripts/verify-scenario-hook-not-in-bundle.sh` clean.
- [x] No native-platform regression — change is web-only test infra.

Closes BLD-658.

## Refs

BLD-645 (parent), BLD-481 (audit loop), BLD-565 (SAB/COOP guard origin), BLD-644 (fixture-syntax fix), BLD-494 (scenario hook DCE contract).