### PR TITLE
feat(session): one-shot flash on rest timer start (BLD-611)

### DIFF
--- a/__tests__/hooks/useRestTimer-flash.test.ts
+++ b/__tests__/hooks/useRestTimer-flash.test.ts
@@ -1,0 +1,166 @@
+/**
+ * BLD-611: rest-start flash trigger tests for useRestTimer.
+ *
+ * Asserts that:
+ * - On rest START (0 → positive), the flash shared value is animated via
+ *   withSequence (one peak + return). End-flash is no longer fired.
+ * - With OS reduce motion ON, a static-tint hold sequence is used instead
+ *   (gentle fade, no opacity flicker, no cycles).
+ * - Tick (positive → smaller positive) does NOT re-trigger the flash.
+ * - End (positive → 0) does NOT trigger the flash (rest-start-only).
+ * - Each rest start in a session fires its own flash.
+ */
+import { renderHook, act } from "@testing-library/react-native";
+
+// Override the global reanimated mock so we can spy on animation primitives.
+const mockWithTiming = jest.fn((v: unknown) => v);
+const mockWithSequence = jest.fn((...args: unknown[]) => { void args; return "SEQ"; });
+const mockWithDelay = jest.fn((_d: number, v: unknown) => v);
+const mockReduceMotion = { value: false };
+
+jest.mock("react-native-reanimated", () => {
+  const actual = jest.requireActual("../../__mocks__/react-native-reanimated");
+  return {
+    ...actual,
+    withTiming: (...args: unknown[]) => mockWithTiming(...args),
+    withSequence: (...args: unknown[]) => mockWithSequence(...args),
+    withDelay: (...args: unknown[]) => mockWithDelay(...(args as [number, unknown])),
+    useReducedMotion: () => mockReduceMotion.value,
+  };
+});
+
+jest.mock("expo-haptics", () => ({
+  notificationAsync: jest.fn().mockResolvedValue(undefined),
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  NotificationFeedbackType: { Warning: "warning" },
+  ImpactFeedbackStyle: { Heavy: "heavy" },
+}));
+
+jest.mock("../../lib/audio", () => ({ play: jest.fn() }));
+
+jest.mock("../../lib/notifications", () => ({
+  isAvailable: () => false,
+  scheduleRestComplete: jest.fn().mockResolvedValue("notif-1"),
+  cancelRestComplete: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../lib/db", () => ({
+  getRestSecondsForExercise: jest.fn().mockResolvedValue(60),
+  getAppSetting: jest.fn().mockResolvedValue("true"),
+  getRestContext: jest.fn(),
+}));
+
+import { useRestTimer } from "../../hooks/useRestTimer";
+
+const defaultOptions = {
+  sessionId: "session-1",
+  colors: { primaryContainer: "#eee", primary: "#333" },
+};
+
+describe("useRestTimer — BLD-611 rest-start flash", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockWithTiming.mockClear();
+    mockWithSequence.mockClear();
+    mockWithDelay.mockClear();
+    mockReduceMotion.value = false;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("fires a single-cycle pulse on rest start (0 → positive)", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    expect(mockWithSequence).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.startRestWithDuration(60);
+    });
+
+    // Single sequence call: rise + fall (no withDelay path).
+    expect(mockWithSequence).toHaveBeenCalledTimes(1);
+    expect(mockWithDelay).not.toHaveBeenCalled();
+
+    // Sequence must contain TWO timing legs (peak then back to baseline).
+    const args = mockWithTiming.mock.calls;
+    // First two timing calls correspond to the two legs of the start-flash.
+    expect(args.length).toBeGreaterThanOrEqual(2);
+    const [v1, opts1] = args[0] as [number, { duration: number }];
+    const [v2, opts2] = args[1] as [number, { duration: number }];
+    expect(v1).toBe(1);
+    expect(v2).toBe(0);
+
+    // WCAG / spec: total ≤ 700 ms, ≥ 300 ms total.
+    const total = opts1.duration + opts2.duration;
+    expect(total).toBeLessThanOrEqual(700);
+    expect(total).toBeGreaterThanOrEqual(300);
+  });
+
+  it("does NOT fire the flash on tick (positive → smaller positive)", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    act(() => {
+      result.current.startRestWithDuration(5);
+    });
+    const seqCallsAfterStart = mockWithSequence.mock.calls.length;
+
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current.rest).toBe(4);
+    expect(mockWithSequence.mock.calls.length).toBe(seqCallsAfterStart);
+
+    act(() => { jest.advanceTimersByTime(1000); });
+    expect(result.current.rest).toBe(3);
+    expect(mockWithSequence.mock.calls.length).toBe(seqCallsAfterStart);
+  });
+
+  it("does NOT fire the flash on rest end (positive → 0)", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    act(() => {
+      result.current.startRestWithDuration(2);
+    });
+    const seqCallsAfterStart = mockWithSequence.mock.calls.length;
+
+    act(() => { jest.advanceTimersByTime(2000); });
+    expect(result.current.rest).toBe(0);
+
+    // No additional flash on the start→end transition.
+    expect(mockWithSequence.mock.calls.length).toBe(seqCallsAfterStart);
+  });
+
+  it("fires a fresh flash on EACH rest start within a session", () => {
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    act(() => { result.current.startRestWithDuration(2); });
+    expect(mockWithSequence).toHaveBeenCalledTimes(1);
+
+    act(() => { jest.advanceTimersByTime(2000); });
+    expect(result.current.rest).toBe(0);
+
+    act(() => { result.current.startRestWithDuration(2); });
+    expect(mockWithSequence).toHaveBeenCalledTimes(2);
+
+    act(() => { jest.advanceTimersByTime(2000); });
+    act(() => { result.current.startRestWithDuration(2); });
+    expect(mockWithSequence).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses static-tint hold (withDelay) when reduce motion is enabled", () => {
+    mockReduceMotion.value = true;
+
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    act(() => {
+      result.current.startRestWithDuration(60);
+    });
+
+    expect(mockWithSequence).toHaveBeenCalledTimes(1);
+    // Reduced-motion branch nests a withDelay → withTiming(0) for the hold.
+    expect(mockWithDelay).toHaveBeenCalledTimes(1);
+    const [delay] = mockWithDelay.mock.calls[0] as [number, unknown];
+    expect(delay).toBeGreaterThanOrEqual(150);
+    expect(delay).toBeLessThanOrEqual(300);
+  });
+});

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -87,7 +87,7 @@ export default function ActiveSession() {
   } = useSessionData({ id, templateId, sourceSessionId });
 
   const {
-    rest, breakdown, startRest, startRestWithDuration, startRestWithBreakdown, dismissRest, restRef,
+    rest, breakdown, restFlashStyle, startRest, startRestWithDuration, startRestWithBreakdown, dismissRest, restRef,
   } = useRestTimer({ sessionId: id, colors });
 
   const {
@@ -299,7 +299,7 @@ export default function ActiveSession() {
               elapsed={elapsed}
               clockStarted={clockStartedAt != null}
               estimatedDuration={estimatedDuration}
-              breakdown={breakdown}
+              breakdown={breakdown} flashStyle={restFlashStyle}
               onStartRest={handleToolboxStartRest}
               onDismissRest={dismissRest}
               onOpenToolbox={handleToolboxOpen}

--- a/components/session/SessionHeaderToolbar.tsx
+++ b/components/session/SessionHeaderToolbar.tsx
@@ -7,6 +7,7 @@ import {
   useWindowDimensions,
   View,
 } from "react-native";
+import Animated, { type AnimatedStyle } from "react-native-reanimated";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { BottomSheetModal } from "@gorhom/bottom-sheet";
 import { router } from "expo-router";
@@ -56,6 +57,12 @@ type Props = {
    * a getAppSetting/setAppSetting race (BLD-537).
    */
   showBreakdownChip?: boolean;
+  /**
+   * BLD-611: Animated style applied to the rest-timer chip wrapper so the
+   * chip can pulse on rest start (driven by useRestTimer.restFlashStyle).
+   * Optional — when omitted, the chip renders without background tint.
+   */
+  flashStyle?: AnimatedStyle;
 };
 
 function SessionHeaderToolbarInner({
@@ -70,6 +77,7 @@ function SessionHeaderToolbarInner({
   pickerRequested,
   onPickerDismissed,
   showBreakdownChip: showBreakdownChipProp,
+  flashStyle,
 }: Props) {
   const colors = useThemeColors();
   const { width: viewportWidth } = useWindowDimensions();
@@ -255,28 +263,33 @@ function SessionHeaderToolbarInner({
         )}
         {/* Rest countdown or "REST DONE ✓" */}
         {(isRestActive || showRestDone) && (
-          <Pressable
-            onPress={handleRestTap}
-            onLongPress={hasAdaptiveBreakdown ? handleRestLongPress : undefined}
-            delayLongPress={400}
-            accessibilityLabel={activeA11yLabel}
-            accessibilityLiveRegion="polite"
-            style={styles.timerButton}
+          <Animated.View
+            style={[styles.timerFlashWrap, flashStyle]}
+            testID="rest-timer-flash-wrap"
           >
-            <Text
-              variant="body"
-              testID="rest-countdown-text"
-              style={{
-                color: colors.primary,
-                fontWeight: "700",
-                fontSize: fontSizes.base,
-              }}
+            <Pressable
+              onPress={handleRestTap}
+              onLongPress={hasAdaptiveBreakdown ? handleRestLongPress : undefined}
+              delayLongPress={400}
+              accessibilityLabel={activeA11yLabel}
+              accessibilityLiveRegion="polite"
+              style={styles.timerButton}
             >
-              {showRestDone
-                ? "REST DONE ✓"
-                : `${String(Math.floor(rest / 60)).padStart(2, "0")}:${String(rest % 60).padStart(2, "0")}`}
-            </Text>
-          </Pressable>
+              <Text
+                variant="body"
+                testID="rest-countdown-text"
+                style={{
+                  color: colors.primary,
+                  fontWeight: "700",
+                  fontSize: fontSizes.base,
+                }}
+              >
+                {showRestDone
+                  ? "REST DONE ✓"
+                  : `${String(Math.floor(rest / 60)).padStart(2, "0")}:${String(rest % 60).padStart(2, "0")}`}
+              </Text>
+            </Pressable>
+          </Animated.View>
         )}
 
         {/* Elapsed time + remaining estimate */}
@@ -552,6 +565,10 @@ const styles = StyleSheet.create({
     minHeight: 48,
     alignItems: "center",
     justifyContent: "center",
+  },
+  timerFlashWrap: {
+    borderRadius: 14,
+    paddingHorizontal: 4,
   },
   elapsedButton: {
     minHeight: 48,

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -4,7 +4,10 @@ import {
   useSharedValue,
   useAnimatedStyle,
   withTiming,
+  withSequence,
+  withDelay,
   interpolateColor,
+  useReducedMotion,
 } from "react-native-reanimated";
 import * as Haptics from "expo-haptics";
 import { play as playAudio } from "../lib/audio";
@@ -20,7 +23,6 @@ import {
   type RestBreakdown,
 } from "../lib/rest";
 import { isAvailable, scheduleRestComplete, cancelRestComplete } from "../lib/notifications";
-import { duration as durationTokens } from "../constants/design-tokens";
 import { sessionBreadcrumb } from "../lib/session-breadcrumbs";
 
 export type SetContext = {
@@ -51,6 +53,7 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
       [colors.primaryContainer, colors.primary],
     ),
   }));
+  const reduceMotion = useReducedMotion();
   const restHapticTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
   const prevRest = useRef(0);
 
@@ -247,11 +250,31 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
           playAudio("complete");
         }
       });
+    }
 
-      // eslint-disable-next-line react-hooks/immutability
-      restFlash.value = 1;
-      // eslint-disable-next-line react-hooks/immutability
-      restFlash.value = withTiming(0, { duration: durationTokens.slow });
+    // BLD-611: one-shot start-flash on rest start (0 → positive). Single
+    // attention pulse on the timer chip in the session header. Honors OS
+    // Reduce Motion via a static tint hold (no opacity flicker, no cycles).
+    // Constraints: total ≤ 700 ms, single cycle ≥ 300 ms, accent palette only
+    // (interpolates primaryContainer ↔ primary). WCAG 2.3.1 (no strobe).
+    if (prevRest.current === 0 && rest > 0) {
+      if (reduceMotion) {
+        // Static tint hold: brief fade-in to peak, hold ~200 ms, fade back.
+        // No flicker — symmetric ease via withTiming endpoints.
+        // eslint-disable-next-line react-hooks/immutability
+        restFlash.value = withSequence(
+          withTiming(1, { duration: 100 }),
+          withDelay(200, withTiming(0, { duration: 100 })),
+        );
+      } else {
+        // Single pulse: rise to peak, return to baseline. ~650 ms total,
+        // one cycle, ≥300 ms total — within WCAG flash budget.
+        // eslint-disable-next-line react-hooks/immutability
+        restFlash.value = withSequence(
+          withTiming(1, { duration: 300 }),
+          withTiming(0, { duration: 350 }),
+        );
+      }
     }
 
     if (rest > 0 && rest <= 3) {
@@ -263,7 +286,7 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
     }
 
     prevRest.current = rest;
-  }, [rest, restFlash]);
+  }, [rest, restFlash, reduceMotion]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary

One-shot visual pulse on the rest-timer chip in `SessionHeaderToolbar` when a new rest begins (set complete → rest 0 → positive). Repurposes the existing-but-unused `restFlash` shared value in `useRestTimer` and wires `restFlashStyle` through a new optional `flashStyle` prop. No layout changes.

## Approach

**Approach 1 from the scope** — repurposed the existing shared value rather than adding a new one. The end-flash trigger had no consumers, so moving it to start is a net simplification.

## Changes

- `hooks/useRestTimer.ts`: trigger `restFlash` on rest start (`prevRest === 0 && rest > 0`) instead of end. Added `useReducedMotion` branch.
- `components/session/SessionHeaderToolbar.tsx`: new optional `flashStyle?: AnimatedStyle` prop. Timer chip is wrapped in an `Animated.View` so the pulse renders on the chip wrapper without affecting layout.
- `app/session/[id].tsx`: pass `restFlashStyle` from the hook into the toolbar.
- `__tests__/hooks/useRestTimer-flash.test.ts`: 5 tests covering start fires, tick does not, end does not, multiple starts each fire, reduce-motion uses static-tint hold.

## Animation spec compliance

| Constraint | Implementation |
|---|---|
| Total ≤ 700 ms | 300 + 350 = 650 ms |
| Single cycle ≥ 300 ms | 650 ms total, one peak then return |
| Accent palette only | `primaryContainer ↔ primary` interpolation |
| Reduced motion | `withSequence(withTiming(1,100), withDelay(200, withTiming(0,100)))` static hold |
| Start-only trigger | gated by `prevRest === 0 && rest > 0` |
| No layout shift | `Animated.View` wrapper, no scale/translate |

## Testing

- New: `__tests__/hooks/useRestTimer-flash.test.ts` (5 tests, all pass)
- Regression: `useRestTimer`, `SessionHeaderToolbar`, `SessionHeaderToolbar-edit-rules` — 35 tests pass, no failures
- Pre-push: full audit passes (npm test 2406 pass)
- ESLint: clean on changed files
- TypeScript: no new errors in changed files

## Issue

Resolves BLD-611