### PR TITLE
fix(history): seed timestamps in ms so heatmap/streak/dotMap populate (BLD-662)

### DIFF
--- a/__tests__/components/WorkoutHeatmap.test.tsx
+++ b/__tests__/components/WorkoutHeatmap.test.tsx
@@ -81,4 +81,30 @@ describe("WorkoutHeatmap", () => {
     // Legend shows 3+ and the cell with count 3 also shows 3+
     expect(getAllByText("3+").length).toBeGreaterThanOrEqual(2);
   });
+
+  // BLD-662: when totalAllTime > 0 but the visible window is empty, the
+  // copy must NOT contradict the stat card ("X total" + "start working out").
+  it("uses 'no workouts in last N weeks' copy when totalAllTime > 0 and data empty", () => {
+    const { getByText, queryByText } = renderScreen(
+      <WorkoutHeatmap data={emptyData} totalAllTime={5} weeks={16} />
+    );
+    expect(getByText("No completed workouts in the last 16 weeks")).toBeTruthy();
+    expect(queryByText("Start working out to see your consistency here!")).toBeNull();
+  });
+
+  it("uses 'start working out' copy when totalAllTime is 0 (true new user)", () => {
+    const { getByText } = renderScreen(
+      <WorkoutHeatmap data={emptyData} totalAllTime={0} />
+    );
+    expect(getByText("Start working out to see your consistency here!")).toBeTruthy();
+  });
+
+  it("does not show empty state when data has workouts (regardless of totalAllTime)", () => {
+    const data = new Map([["2026-04-14", 1]]);
+    const { queryByText } = renderScreen(
+      <WorkoutHeatmap data={data} totalAllTime={5} />
+    );
+    expect(queryByText(/No completed workouts/)).toBeNull();
+    expect(queryByText("Start working out to see your consistency here!")).toBeNull();
+  });
 });

--- a/__tests__/lib/db/test-seed-timestamps.test.ts
+++ b/__tests__/lib/db/test-seed-timestamps.test.ts
@@ -1,0 +1,120 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * BLD-662 regression: scenario seed must write `started_at` / `completed_at`
+ * in MILLISECONDS to match production (`lib/db/sessions.ts:134` writes
+ * `Date.now()`). When seconds were used the heatmap / streak / dotMap
+ * aggregations filtered every seeded row out (timestamps mapped to year 1970
+ * via `date(started_at / 1000, 'unixepoch')`).
+ *
+ * `duration_seconds` stays in SECONDS (column is `*_seconds`).
+ */
+
+const inserts: Array<{ sql: string; params: unknown[] }> = [];
+
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  runAsync: jest.fn().mockImplementation(async (sql: string, params: unknown[]) => {
+    inserts.push({ sql, params });
+    return { changes: 1 };
+  }),
+};
+
+jest.mock("../../../lib/db/helpers", () => ({
+  getDatabase: jest.fn().mockResolvedValue(mockDb),
+}));
+
+jest.mock("react-native", () => ({ Platform: { OS: "web" } }));
+
+describe("test-seed timestamps (BLD-662)", () => {
+  const realDev = (globalThis as any).__DEV__;
+  const originalWindow = (globalThis as any).window;
+  const originalDocument = (globalThis as any).document;
+
+  beforeEach(() => {
+    inserts.length = 0;
+    jest.clearAllMocks();
+    (globalThis as any).__DEV__ = true;
+    (globalThis as any).document = { body: { dataset: {} } };
+  });
+
+  afterAll(() => {
+    (globalThis as any).__DEV__ = realDev;
+    (globalThis as any).window = originalWindow;
+    (globalThis as any).document = originalDocument;
+  });
+
+  // 2026-01-01T00:00:00Z in ms = 1767225600000; in s = 1767225600.
+  // The threshold (1e12) cleanly separates ms from s for any year > 2001.
+  const isMillisecondTimestamp = (n: number) => n > 1e12;
+
+  test("seedWorkoutHistory inserts started_at / completed_at as milliseconds", async () => {
+    (globalThis as any).window = { __TEST_SCENARIO__: "workout-history" };
+    const { seedScenario } = require("../../../lib/db/test-seed");
+    await seedScenario();
+
+    const sessionInserts = inserts.filter((i) => i.sql.includes("INSERT INTO workout_sessions"));
+    expect(sessionInserts).toHaveLength(5);
+
+    for (const ins of sessionInserts) {
+      // Schema: (id, template_id, name, started_at, completed_at, duration_seconds, notes, rating)
+      const startedAt = ins.params[3] as number;
+      const completedAt = ins.params[4] as number;
+      const durationSeconds = ins.params[5] as number;
+
+      expect(isMillisecondTimestamp(startedAt)).toBe(true);
+      expect(isMillisecondTimestamp(completedAt)).toBe(true);
+      expect(completedAt).toBeGreaterThan(startedAt);
+
+      // duration_seconds column must remain in seconds (≤ ~1 hour each here).
+      expect(durationSeconds).toBeGreaterThan(0);
+      expect(durationSeconds).toBeLessThan(60 * 60 * 24); // < 1 day
+      // It should equal (completedAt - startedAt) / 1000 (within 1s rounding)
+      expect(Math.abs(durationSeconds * 1000 - (completedAt - startedAt))).toBeLessThanOrEqual(1000);
+    }
+  });
+
+  test("seedWorkoutHistory sessions land within the last 16 weeks (heatmap window)", async () => {
+    (globalThis as any).window = { __TEST_SCENARIO__: "workout-history" };
+    const { seedScenario } = require("../../../lib/db/test-seed");
+    await seedScenario();
+
+    const now = Date.now();
+    const sixteenWeeksMs = 16 * 7 * 24 * 60 * 60 * 1000;
+    const sessionInserts = inserts.filter((i) => i.sql.includes("INSERT INTO workout_sessions"));
+
+    for (const ins of sessionInserts) {
+      const startedAt = ins.params[3] as number;
+      // Within last 16 weeks AND not in the future
+      expect(now - startedAt).toBeLessThan(sixteenWeeksMs);
+      expect(startedAt).toBeLessThanOrEqual(now);
+    }
+  });
+
+  test("seedCompletedWorkout inserts started_at / completed_at as milliseconds", async () => {
+    (globalThis as any).window = { __TEST_SCENARIO__: "completed-workout" };
+    const { seedScenario } = require("../../../lib/db/test-seed");
+    await seedScenario();
+
+    const sessionInserts = inserts.filter((i) => i.sql.includes("INSERT INTO workout_sessions"));
+    expect(sessionInserts).toHaveLength(1);
+
+    const startedAt = sessionInserts[0].params[3] as number;
+    const completedAt = sessionInserts[0].params[4] as number;
+    const durationSeconds = sessionInserts[0].params[5] as number;
+
+    expect(isMillisecondTimestamp(startedAt)).toBe(true);
+    expect(isMillisecondTimestamp(completedAt)).toBe(true);
+    // 1h workout = 3540 seconds (60min - 1min), NOT 3540000.
+    expect(durationSeconds).toBeGreaterThan(60);
+    expect(durationSeconds).toBeLessThan(60 * 60 * 24);
+
+    // workout_sets.completed_at should also be ms.
+    const setInserts = inserts.filter((i) => i.sql.includes("INSERT INTO workout_sets"));
+    expect(setInserts.length).toBeGreaterThan(0);
+    for (const ins of setInserts) {
+      // (id, session_id, exercise_id, set_number, weight, reps, completed_at, exercise_position)
+      const setCompletedAt = ins.params[6] as number;
+      expect(isMillisecondTimestamp(setCompletedAt)).toBe(true);
+    }
+  });
+});

--- a/components/WorkoutHeatmap.tsx
+++ b/components/WorkoutHeatmap.tsx
@@ -11,6 +11,14 @@ type HeatmapProps = {
   data: Map<string, number>;
   weeks?: number;
   onDayPress?: (date: string) => void;
+  /**
+   * Total all-time completed workouts. Used only to disambiguate the empty-state
+   * copy: when `data` is empty AND `totalAllTime > 0`, we know the heatmap is
+   * empty because nothing landed in the visible window — not because the user
+   * has never worked out. Defaults to 0 (treats empty data as "no workouts ever").
+   * BLD-662.
+   */
+  totalAllTime?: number;
 };
 
 const DAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"] as const;
@@ -79,7 +87,7 @@ function buildGrid(weeks: number): CellData[][] {
   return grid;
 }
 
-export default function WorkoutHeatmap({ data, weeks = 16, onDayPress }: HeatmapProps) {
+export default function WorkoutHeatmap({ data, weeks = 16, onDayPress, totalAllTime = 0 }: HeatmapProps) {
   const colors = useThemeColors();
   const layout = useLayout();
 
@@ -202,7 +210,9 @@ export default function WorkoutHeatmap({ data, weeks = 16, onDayPress }: Heatmap
       {!hasAnyWorkout && (
         <View style={styles.emptyState}>
           <Text variant="caption" style={{ color: colors.onSurfaceVariant, textAlign: "center" }}>
-            Start working out to see your consistency here!
+            {totalAllTime > 0
+              ? `No completed workouts in the last ${weeks} weeks`
+              : "Start working out to see your consistency here!"}
           </Text>
         </View>
       )}

--- a/components/history/StreakAndHeatmap.tsx
+++ b/components/history/StreakAndHeatmap.tsx
@@ -60,7 +60,7 @@ export default function StreakAndHeatmap({
               <Text variant="caption" style={{ color: colors.error }}>Unable to load heatmap data. Pull down to retry.</Text>
             </View>
           ) : (
-            <WorkoutHeatmap data={heatmapData} weeks={16} onDayPress={onDayPress} />
+            <WorkoutHeatmap data={heatmapData} weeks={16} onDayPress={onDayPress} totalAllTime={totalWorkouts} />
           )
         )}
       </View>

--- a/lib/db/test-seed.ts
+++ b/lib/db/test-seed.ts
@@ -88,9 +88,14 @@ export async function seedScenario(): Promise<void> {
 export async function seedCompletedWorkout(
   db: Awaited<ReturnType<typeof getDatabase>>,
 ): Promise<void> {
-  const now = Math.floor(Date.now() / 1000);
-  const started = now - 60 * 60; // 1h ago
-  const completed = now - 60; // finished 1 minute ago
+  // BLD-662: timestamps MUST be milliseconds — production writes
+  // `started_at: Date.now()` (lib/db/sessions.ts:134) and history queries
+  // (`getSessionCountsByDay`, `getAllCompletedSessionWeeks`,
+  // `getSessionsByMonth`) all assume ms. Seeding seconds caused the heatmap
+  // / streak / dotMap aggregations to filter every seeded row out.
+  const now = Date.now();
+  const started = now - 60 * 60 * 1000; // 1h ago
+  const completed = now - 60 * 1000; // finished 1 minute ago
 
   await db.runAsync(
     `INSERT INTO workout_sessions
@@ -102,7 +107,7 @@ export async function seedCompletedWorkout(
       "Upper Body",
       started,
       completed,
-      completed - started,
+      Math.floor((completed - started) / 1000),
       "",
       4,
     ],
@@ -149,14 +154,15 @@ export async function seedCompletedWorkout(
 export async function seedWorkoutHistory(
   db: Awaited<ReturnType<typeof getDatabase>>,
 ): Promise<void> {
-  const now = Math.floor(Date.now() / 1000);
+  // BLD-662: milliseconds, see seedCompletedWorkout above.
+  const now = Date.now();
   const names = ["Upper Body", "Lower Body", "Push Day", "Pull Day", "Legs"];
 
   for (let i = 0; i < names.length; i += 1) {
     const daysAgo = i + 1;
-    const started = now - daysAgo * 24 * 60 * 60;
-    const duration = 45 * 60 + i * 5 * 60; // 45–65 minutes
-    const completed = started + duration;
+    const started = now - daysAgo * 24 * 60 * 60 * 1000;
+    const duration = 45 * 60 + i * 5 * 60; // 45–65 minutes (seconds — duration_seconds column)
+    const completed = started + duration * 1000;
 
     await db.runAsync(
       `INSERT INTO workout_sessions


### PR DESCRIPTION
## Summary
Fixes the BLD-659 audit finding where the Workout History screen showed **5 total** workouts but an **empty 16-week heatmap** + 'No workouts this month' calendar — provably contradictory state under the seeded `workout-history` scenario.

## Root cause
`lib/db/test-seed.ts` wrote `workout_sessions.started_at` and `completed_at` as **unix seconds** (`Math.floor(Date.now()/1000)`), but production writes **milliseconds** (`lib/db/sessions.ts:134` — `Date.now()`). The history aggregations all assume ms:

- `getSessionCountsByDay`: `gte(started_at, startTs)` where `startTs` is ms
- `getSessionsByMonth`: `new Date(...).getTime()` (ms)
- `getAllCompletedSessionWeeks`: `Date.now() - 2 * 365 * 24 * 60 * 60 * 1000` (ms)
- Heatmap SQL: `date(started_at / 1000, 'unixepoch')` — divides by 1000 again, mapping seeded rows to **year 1970**

`getTotalSessionCount()` was the only widget that worked because it has no time filter — only `completed_at IS NOT NULL`.

## Changes
- **`lib/db/test-seed.ts`** — write `started_at` / `completed_at` in **ms** for both scenarios; `duration_seconds` stays in seconds (column is `*_seconds`); `workout_sets.completed_at` also ms.
- **`components/WorkoutHeatmap.tsx`** — new `totalAllTime` prop. When the visible 16-week window is empty but `totalAllTime > 0`, show *'No completed workouts in the last N weeks'* instead of the contradictory *'Start working out…'* onboarding copy. Defensive UX: any future query mismatch won't ship contradictory text.
- **`components/history/StreakAndHeatmap.tsx`** — pass `totalWorkouts` through to the heatmap.

## Tests
- **`__tests__/lib/db/test-seed-timestamps.test.ts`** (new, 3 tests) — asserts every seeded session has `started_at`/`completed_at` > 1e12 (ms threshold), `duration_seconds` < 1 day, sessions land within the last 16 weeks, and `workout_sets.completed_at` is also ms.
- **`__tests__/components/WorkoutHeatmap.test.tsx`** — new cases for the `totalAllTime > 0` vs `== 0` empty-state copy branches.

Full suite: **2414 / 2414 passing**, tsc no new errors.

## Issue
Resolves BLD-662.