### PR TITLE
fix: clarify workout-history streak card labels (BLD-663)

### DIFF
--- a/__tests__/components/history/StreakAndHeatmap-labels.test.tsx
+++ b/__tests__/components/history/StreakAndHeatmap-labels.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import StreakAndHeatmap from "../../../components/history/StreakAndHeatmap";
+import { renderScreen } from "../../helpers/render";
+import type { ThemeColors } from "@/hooks/useThemeColors";
+
+const colors = {
+  primary: "#000",
+  surface: "#fff",
+  onSurface: "#000",
+  onSurfaceVariant: "#666",
+  onBackground: "#000",
+  background: "#fff",
+  error: "#f00",
+} as unknown as ThemeColors;
+
+describe("StreakAndHeatmap stat labels (BLD-663)", () => {
+  function renderStats() {
+    return renderScreen(
+      <StreakAndHeatmap
+        colors={colors}
+        currentStreak={3}
+        longestStreak={7}
+        totalWorkouts={42}
+        heatmapData={new Map()}
+        heatmapLoading={false}
+        heatmapError={false}
+        heatmapExpanded={false}
+        setHeatmapExpanded={() => {}}
+        onDayPress={() => {}}
+      />,
+    );
+  }
+
+  it("uses self-describing labels (current / longest / workouts) instead of two ambiguous 'weeks' labels", () => {
+    const { getByText, queryAllByText } = renderStats();
+    expect(getByText("current")).toBeTruthy();
+    expect(getByText("longest")).toBeTruthy();
+    expect(getByText("workouts")).toBeTruthy();
+    // Regression guard: the streak card must not render two adjacent "weeks" labels.
+    expect(queryAllByText("weeks").length).toBe(0);
+    expect(queryAllByText("total").length).toBe(0);
+  });
+
+  it("preserves accessibilityLabel with units for screen readers", () => {
+    const { getByLabelText } = renderStats();
+    expect(getByLabelText("Current streak: 3 weeks")).toBeTruthy();
+    expect(getByLabelText("Longest streak: 7 weeks")).toBeTruthy();
+    expect(getByLabelText("Total workouts: 42")).toBeTruthy();
+  });
+});

--- a/components/history/StreakAndHeatmap.tsx
+++ b/components/history/StreakAndHeatmap.tsx
@@ -30,17 +30,17 @@ export default function StreakAndHeatmap({
           <View style={styles.streakItem} accessibilityLabel={`Current streak: ${currentStreak} weeks`}>
             <Icon name={Flame} size={20} color={colors.primary} />
             <Text variant="subtitle" style={{ color: colors.onSurface }}>{currentStreak}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>weeks</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>current</Text>
           </View>
           <View style={styles.streakItem} accessibilityLabel={`Longest streak: ${longestStreak} weeks`}>
             <Icon name={Trophy} size={20} color={colors.primary} />
             <Text variant="subtitle" style={{ color: colors.onSurface }}>{longestStreak}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>weeks</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>longest</Text>
           </View>
           <View style={styles.streakItem} accessibilityLabel={`Total workouts: ${totalWorkouts}`}>
             <Icon name={Dumbbell} size={20} color={colors.primary} />
             <Text variant="subtitle" style={{ color: colors.onSurface }}>{totalWorkouts}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>total</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>workouts</Text>
           </View>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary

The Workout History header showed two adjacent metrics both labeled `weeks` (current streak, longest streak), making it impossible to tell them apart at a glance. Replaced ambiguous unit labels with self-describing text.

## Changes

- `components/history/StreakAndHeatmap.tsx`:
  - Flame caption: `weeks` → `current`
  - Trophy caption: `weeks` → `longest`
  - Dumbbells caption: `total` → `workouts`
  - `accessibilityLabel` on each item still includes the unit (`weeks` / `workouts`) so screen-reader UX is unchanged.

## Testing

- New `__tests__/components/history/StreakAndHeatmap-labels.test.tsx` (2 tests):
  - Asserts the three new labels render and that no `weeks` / `total` captions remain (regression guard).
  - Asserts `accessibilityLabel` strings are preserved with units for screen readers.
- `npx jest __tests__/components/history/StreakAndHeatmap-labels.test.tsx` → ✅ 2/2 passing.
- `tsc --noEmit` → no new errors introduced (pre-existing unrelated errors remain).

## Issue

Resolves BLD-663.