### PR TITLE
fix: render workout-history calendar in 7 columns at all widths (BLD-661)

### DIFF
--- a/__tests__/components/history/CalendarGrid-7col-layout.test.tsx
+++ b/__tests__/components/history/CalendarGrid-7col-layout.test.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { Gesture } from "react-native-gesture-handler";
+import { useSharedValue, useAnimatedStyle } from "react-native-reanimated";
+import CalendarGrid from "../../../components/history/CalendarGrid";
+import { renderScreen } from "../../helpers/render";
+import { DAYS } from "../../../lib/format";
+import type { ThemeColors } from "@/hooks/useThemeColors";
+
+const colors = {
+  primary: "#000",
+  surface: "#fff",
+  onSurface: "#000",
+  onSurfaceVariant: "#666",
+  onBackground: "#000",
+  background: "#fff",
+  error: "#f00",
+} as unknown as ThemeColors;
+
+function CalendarHarness({ cellSize }: { cellSize: number }) {
+  const sv = useSharedValue(0);
+  const animatedCalendarStyle = useAnimatedStyle(() => ({ transform: [{ translateX: sv.value }] }));
+  const swipeGesture = Gesture.Pan();
+  const ref = React.useRef(null);
+  return (
+    <CalendarGrid
+      colors={colors}
+      year={2026}
+      month={3}
+      dotMap={new Map()}
+      scheduleMap={new Map()}
+      selected={null}
+      animatedCalendarStyle={animatedCalendarStyle}
+      swipeGesture={swipeGesture}
+      cellSize={cellSize}
+      scale={1}
+      onPrevMonth={() => {}}
+      onNextMonth={() => {}}
+      onTapDay={() => {}}
+      selectedCellRef={ref}
+      monthSummary={{ count: 0, totalHours: 0 }}
+    />
+  );
+}
+
+const PERCENT_WIDTH = `${100 / 7}%`;
+
+function flattenWidth(style: unknown): unknown {
+  const arr = Array.isArray(style) ? style.flat(Infinity) : [style];
+  let result: unknown = undefined;
+  for (const s of arr) {
+    if (s && typeof s === "object" && "width" in (s as object)) {
+      result = (s as { width: unknown }).width;
+    }
+  }
+  return result;
+}
+
+type RNNode = { props: { style?: unknown }; parent: RNNode | null };
+
+function findAncestorWithWidth(node: RNNode | null): unknown {
+  let cur: RNNode | null = node;
+  while (cur) {
+    const w = flattenWidth(cur.props?.style);
+    if (w !== undefined) return w;
+    cur = cur.parent;
+  }
+  return undefined;
+}
+
+describe("CalendarGrid 7-column layout (BLD-661)", () => {
+  it("renders all 7 weekday header labels (no wrap to a 6+1 layout)", () => {
+    const { getByText } = renderScreen(<CalendarHarness cellSize={48} />);
+    for (const label of DAYS) {
+      expect(getByText(label)).toBeTruthy();
+    }
+  });
+
+  it("uses percent-based column widths so 7 cells always fit one row", () => {
+    const { getByText } = renderScreen(<CalendarHarness cellSize={48} />);
+    for (const label of DAYS) {
+      const width = findAncestorWithWidth(getByText(label) as unknown as RNNode);
+      expect(width).toBe(PERCENT_WIDTH);
+    }
+  });
+
+  it("date Pressables also use percent-based widths (so day cells align under their weekday header)", () => {
+    const { getByText } = renderScreen(<CalendarHarness cellSize={48} />);
+    // April 2026 has 30 days. Sample a representative spread of dates.
+    for (const day of ["1", "5", "15", "20", "30"]) {
+      const width = findAncestorWithWidth(getByText(day) as unknown as RNNode);
+      expect(width).toBe(PERCENT_WIDTH);
+    }
+  });
+});

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -21,7 +21,7 @@ function HistoryScreen() {
   const h = useHistoryData();
   const renderSession = useSessionRenderer({ colors });
 
-  const cellSize = Math.max(MIN_TOUCH_TARGET, Math.floor(layout.width / 7) - 4);
+  const cellSize = Math.max(MIN_TOUCH_TARGET, Math.floor((layout.width - layout.horizontalPadding * 2) / 7));
 
   return (
     <FlatList

--- a/components/history/CalendarGrid.tsx
+++ b/components/history/CalendarGrid.tsx
@@ -14,6 +14,7 @@ import type { AnimatedStyle } from "react-native-reanimated";
 import type { ViewStyle } from "react-native";
 
 const MIN_TOUCH_TARGET = 48;
+const COLUMN_WIDTH_PCT = `${100 / 7}%` as `${number}%`;
 
 type Props = {
   colors: ThemeColors;
@@ -72,7 +73,7 @@ export default function CalendarGrid({
     return (
       <Pressable key={key} ref={isSel ? selectedCellRef : undefined} onPress={() => onTapDay(key)} accessibilityLabel={label} accessibilityRole="button"
         style={[styles.cell, {
-          width: cellSize, height: cellSize, borderRadius: cellSize / 2,
+          width: COLUMN_WIDTH_PCT, height: cellSize, borderRadius: cellSize / 2,
           borderWidth: isToday ? 2 : 0, borderColor: isToday ? colors.primary : "transparent",
           backgroundColor: cellBg,
         }]}>
@@ -96,7 +97,7 @@ export default function CalendarGrid({
   };
 
   const cells: React.ReactNode[] = [];
-  for (let i = 0; i < offset; i++) cells.push(<View key={`pad-${i}`} style={{ width: cellSize, height: cellSize }} />);
+  for (let i = 0; i < offset; i++) cells.push(<View key={`pad-${i}`} style={{ width: COLUMN_WIDTH_PCT, height: cellSize }} />);
   for (let d = 1; d <= total; d++) cells.push(renderDay(d));
 
   return (
@@ -118,7 +119,7 @@ export default function CalendarGrid({
 
       <View style={styles.grid}>
         {DAYS.map((d) => (
-          <View key={d} style={[styles.cell, { width: cellSize, height: 28 }]}>
+          <View key={d} style={[styles.cell, { width: COLUMN_WIDTH_PCT, height: 28 }]}>
             <Text variant="caption" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.xs * scale }}>{d}</Text>
           </View>
         ))}
@@ -134,8 +135,8 @@ export default function CalendarGrid({
 const styles = StyleSheet.create({
   monthNav: { flexDirection: "row", justifyContent: "center", alignItems: "center", marginBottom: 8 },
   monthSummary: { textAlign: "center", marginBottom: spacing.sm },
-  grid: { flexDirection: "row", flexWrap: "wrap", justifyContent: "flex-start", paddingHorizontal: 2 },
-  cell: { alignItems: "center", justifyContent: "center", marginVertical: 2, marginHorizontal: 2, minHeight: MIN_TOUCH_TARGET },
+  grid: { flexDirection: "row", flexWrap: "wrap", justifyContent: "flex-start" },
+  cell: { alignItems: "center", justifyContent: "center", marginVertical: 2, minHeight: MIN_TOUCH_TARGET },
   dots: { flexDirection: "row", gap: 3, position: "absolute", bottom: 4 },
   dot: { width: 5, height: 5, borderRadius: radii.sm },
   countBadge: { minWidth: 18, height: 18, borderRadius: 9, alignItems: "center", justifyContent: "center", paddingHorizontal: 2 },


### PR DESCRIPTION
## Summary
Workout-history calendar grid wraps to 6 columns at 390dp because cellSize math floored to MIN_TOUCH_TARGET (48px), making 7 cells exceed the row width. The 7th cell wrapped to a new row, shifting every date one column left of its true weekday (April 1 2026 — a Wednesday — appeared under Mon).

Fix: use percent-based widths ( 100/7% ) for weekday header cells, leading offset pad cells, and date Pressables. 7 always fit on a single row regardless of viewport. Touch-target floor still applies via cellSize height + base style minHeight.

## Changes
- `app/history.tsx` — `cellSize` now subtracts `horizontalPadding * 2` before dividing by 7, so the 48px floor only triggers on truly tiny viewports.
- `components/history/CalendarGrid.tsx` — `COLUMN_WIDTH_PCT = '${100/7}%'` applied to header cells, pad cells, and date Pressables. Removed redundant `paddingHorizontal` and per-cell `marginHorizontal` that were eating row width.

## Testing
- New regression test `__tests__/components/history/CalendarGrid-7col-layout.test.tsx` with 3 cases:
  1. All 7 weekday labels render
  2. Each weekday header cell uses percent width
  3. Date Pressables (sampled across the month) use percent width
- All 31 history-related tests pass: `__tests__/calendar.test.ts`, `StreakAndHeatmap-labels.test.tsx`, `CalendarGrid-7col-layout.test.tsx`
- TS errors in changed files: 0 (other pre-existing TS errors on main are unrelated)

## Issue
Resolves BLD-661 (audit BLD-659).