### PR TITLE
fix(expo-sqlite-web): write length prefix as 4-byte uint32 (BLD-660)

### DIFF
--- a/__tests__/lib/expo-sqlite-worker-channel-length.test.ts
+++ b/__tests__/lib/expo-sqlite-worker-channel-length.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Regression test for BLD-660.
+ *
+ * `expo-sqlite/web/WorkerChannel.ts` uses a 4-byte length prefix at offset 0 of
+ * the shared SQLiteExecuteSync result buffer. The original implementation wrote
+ * the length via:
+ *
+ *     resultArray.set(new Uint32Array([length]), 0);  // ❌ truncates to 1 byte
+ *
+ * `Uint8Array.prototype.set(typedArray, offset)` does an element-wise typed
+ * conversion — a single Uint32 element is converted to one Uint8 (`length &
+ * 0xFF`) and written at offset 0. Any payload of 256 bytes or more has its
+ * length prefix silently clipped, the reader decodes a truncated JSON slice,
+ * and `JSON.parse` blows up with "Unexpected end of JSON input".
+ *
+ * This bites the post-workout summary screen (BLD-660) because
+ * `getColumnNamesSync` against `workout_sets` (18 columns) emits a 258-byte
+ * result payload — exactly one byte over the 256 cliff.
+ *
+ * The patch in `patches/expo-sqlite+55.0.15.patch` switches the writer to:
+ *
+ *     new DataView(resultArray.buffer).setUint32(0, length, true);
+ *
+ * which writes a real little-endian uint32. This test guards both the buggy
+ * and fixed forms so the regression cannot return.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('expo-sqlite-web WorkerChannel length-prefix protocol (BLD-660)', () => {
+  const workerChannelPath = join(
+    __dirname,
+    '..',
+    '..',
+    'node_modules',
+    'expo-sqlite',
+    'web',
+    'WorkerChannel.ts',
+  );
+
+  // The raw protocol exercised by sendWorkerResult / invokeWorkerSync.
+  function writeLength_buggy(buf: ArrayBuffer, length: number): void {
+    new Uint8Array(buf).set(new Uint32Array([length]), 0);
+  }
+
+  function writeLength_fixed(buf: ArrayBuffer, length: number): void {
+    new DataView(buf).setUint32(0, length, true);
+  }
+
+  function readLength(buf: ArrayBuffer): number {
+    return new Uint32Array(buf, 0, 1)[0];
+  }
+
+  it('demonstrates the original truncation bug (Uint8Array.set + Uint32Array source)', () => {
+    const buf = new ArrayBuffer(8);
+    writeLength_buggy(buf, 258);
+    // Original implementation truncates 258 -> 258 & 0xFF = 2.
+    expect(readLength(buf)).toBe(2);
+  });
+
+  // QD verification gate (BLD-660): exercise every length boundary that any
+  // truncating typed writer could mask — the Uint8 cliff at 256 (the actual
+  // failure mode) plus the Uint16 cliff at 65536 (in case a future regression
+  // swaps in `Uint8Array.set(new Uint16Array(...))`).
+  it.each([
+    [0],
+    [1],
+    [255],            // last value that fits in 1 byte
+    [256],            // first value that hits the Uint8 cliff
+    [257],
+    [258],            // the actual workout_sets getColumnNamesSync payload
+    [1024],
+    [65535],          // last value that fits in 2 bytes
+    [65536],          // first value that hits the Uint16 cliff
+    [65537],
+    [1024 * 1024 - 4], // upper end of the 1 MiB SharedArrayBuffer payload
+  ])('round-trips length=%i through the fixed writer', (len) => {
+    const buf = new ArrayBuffer(8);
+    writeLength_fixed(buf, len);
+    expect(readLength(buf)).toBe(len);
+  });
+
+  it('proves the buggy writer truncates the lengths we round-trip above', () => {
+    // Confirms the round-trip cases above actually exercise failure modes the
+    // original code had — i.e. the test isn't trivially passing because the
+    // bug never bit at those sizes.
+    const truncated = (len: number) => {
+      const buf = new ArrayBuffer(8);
+      writeLength_buggy(buf, len);
+      return readLength(buf);
+    };
+    expect(truncated(256)).toBe(0);    // 256 & 0xFF = 0
+    expect(truncated(257)).toBe(1);    // 257 & 0xFF = 1
+    expect(truncated(258)).toBe(2);    // the workout_sets case
+    expect(truncated(1024)).toBe(0);
+    expect(truncated(65536)).toBe(0);
+  });
+
+  it('round-trips a JSON payload >256 bytes through the fixed length prefix', () => {
+    const json = JSON.stringify({
+      result: [
+        'id',
+        'session_id',
+        'exercise_id',
+        'set_number',
+        'weight',
+        'reps',
+        'completed',
+        'completed_at',
+        'rpe',
+        'notes',
+        'link_id',
+        'round',
+        'training_mode',
+        'tempo',
+        'swapped_from_exercise_id',
+        'set_type',
+        'duration_seconds',
+        'exercise_position',
+        'bodyweight_modifier_kg',
+      ],
+    });
+    expect(json.length).toBeGreaterThan(256); // sanity — must hit the bug class
+
+    const bytes = new TextEncoder().encode(json);
+    const sharedLikeBuf = new ArrayBuffer(1024 * 1024);
+    const u8 = new Uint8Array(sharedLikeBuf);
+
+    // Mimic the fixed sendWorkerResult path.
+    writeLength_fixed(sharedLikeBuf, bytes.length);
+    u8.set(bytes, 4);
+
+    // Mimic the receiver path.
+    const length = readLength(sharedLikeBuf);
+    const copy = new Uint8Array(length);
+    copy.set(new Uint8Array(sharedLikeBuf, 4, length));
+    const decoded = new TextDecoder().decode(copy);
+
+    // Must fully reconstruct the JSON — no truncation, no JSON.parse blow-up.
+    expect(length).toBe(bytes.length);
+    expect(decoded).toBe(json);
+    expect(() => JSON.parse(decoded)).not.toThrow();
+  });
+
+  it('expo-sqlite WorkerChannel.ts on disk uses the fixed length writer (patch is applied)', () => {
+    const src = readFileSync(workerChannelPath, 'utf8');
+    // Strip line/block comments before scanning so we can reference the buggy
+    // form in our explanatory comments without false-positives.
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .map((line) => line.replace(/\/\/.*$/, ''))
+      .join('\n');
+    // Buggy form must be gone from real code.
+    expect(stripped).not.toMatch(/resultArray\.set\(new Uint32Array\(\[length\]\), 0\)/);
+    // Fixed form must be present (DataView setUint32 little-endian).
+    expect(stripped).toMatch(/setUint32\(\s*0\s*,\s*length\s*,\s*true\s*\)/);
+  });
+});

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -19,11 +19,24 @@ import ComparisonCard from "../../../components/session/summary/ComparisonCard";
 import SetsCard from "../../../components/session/summary/SetsCard";
 import MusclesWorkedCard from "../../../components/session/summary/MusclesWorkedCard";
 import SummaryFooter from "../../../components/session/summary/SummaryFooter";
+import ErrorBoundary from "../../../components/ErrorBoundary";
 import type { ShareCardExercise, ShareCardPR } from "../../../components/ShareCard";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { fontSizes } from "@/constants/design-tokens";
 
-export default function Summary() {
+export default function SummaryRoute() {
+  // BLD-660: wrap the Summary view in a route-local ErrorBoundary so a crash
+  // here (e.g. the BLD-660 expo-sqlite-web length-prefix truncation) shows the
+  // shared crash UI with retry/share-report controls instead of a white screen,
+  // and stays scoped to this route — the rest of the navigator keeps working.
+  return (
+    <ErrorBoundary>
+      <Summary />
+    </ErrorBoundary>
+  );
+}
+
+function Summary() {
   const colors = useThemeColors();
   const layout = useLayout();
   const router = useRouter();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "cablesnap",
-  "version": "0.26.8",
+  "version": "0.26.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cablesnap",
-      "version": "0.26.8",
+      "version": "0.26.10",
+      "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
@@ -87,6 +88,7 @@
         "jest": "^29.7.0",
         "jest-expo": "~55.0.16",
         "lint-staged": "^16.4.0",
+        "patch-package": "^8.0.1",
         "react-test-renderer": "19.2.0",
         "sharp": "^0.34.5",
         "ts-jest": "^29.4.9",
@@ -6333,6 +6335,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -10237,6 +10246,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -10332,6 +10351,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -12738,6 +12782,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -12755,6 +12819,39 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -12781,6 +12878,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -14852,6 +14959,46 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-exists": {
@@ -17462,6 +17609,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "screenshots:raw": "playwright test e2e/screenshot-capture.spec.ts --project=store-pixel9 --project=store-fold7",
     "screenshots:frame": "tsx scripts/generate-store-screenshots.ts",
     "screenshots": "npm run screenshots:raw && npm run screenshots:frame",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
@@ -115,6 +116,7 @@
     "jest": "^29.7.0",
     "jest-expo": "~55.0.16",
     "lint-staged": "^16.4.0",
+    "patch-package": "^8.0.1",
     "react-test-renderer": "19.2.0",
     "sharp": "^0.34.5",
     "ts-jest": "^29.4.9",

--- a/patches/expo-sqlite+55.0.15.patch
+++ b/patches/expo-sqlite+55.0.15.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/expo-sqlite/web/WorkerChannel.ts b/node_modules/expo-sqlite/web/WorkerChannel.ts
+index 7fba380..6e6e2be 100644
+--- a/node_modules/expo-sqlite/web/WorkerChannel.ts
++++ b/node_modules/expo-sqlite/web/WorkerChannel.ts
+@@ -40,7 +40,14 @@ export function sendWorkerResult({
+     const resultJson = error != null ? serialize({ error }) : serialize({ result });
+     const resultBytes = new TextEncoder().encode(resultJson);
+     const length = resultBytes.length;
+-    resultArray.set(new Uint32Array([length]), 0);
++    // BLD-660: write the 4-byte length prefix as a true little-endian uint32.
++    // The previous form `resultArray.set(new Uint32Array([length]), 0)` does an
++    // element-wise typed conversion (Uint32 -> Uint8), so only `length & 0xFF`
++    // is written into byte 0 and bytes 1-3 stay zero. Any payload >= 256 bytes
++    // ended up with a truncated length prefix, causing the receiving thread to
++    // decode a partial JSON string and fail with "Unexpected end of JSON input"
++    // (see expo-sqlite-web sync bridge).
++    new DataView(resultArray.buffer).setUint32(0, length, true);
+     resultArray.set(resultBytes, 4);
+     Atomics.store(lock, 0, RESOLVED);
+   } else {


### PR DESCRIPTION
## Summary
Fixes BLD-660 — the post-workout Summary screen crashed on web with `Uncaught Error: Unexpected end of JSON input` inside `SQLiteExecuteSyncResultImpl.getColumnNamesSync`. Production user hit it (BLD-665 was filed as a Sentry alert and cancelled as a duplicate of BLD-660).

## Root cause
`expo-sqlite/web/WorkerChannel.ts` wrote the result-payload length prefix via:

```ts
resultArray.set(new Uint32Array([length]), 0);
```

`Uint8Array.prototype.set` with a `Uint32Array` source does **element-wise typed conversion** (Uint32 -> Uint8), not a byte memcpy. A single Uint32 collapses to one byte (`length & 0xFF`) at offset 0 and bytes 1-3 stay zero. Any payload **>= 256 bytes** had its length silently truncated; the receiver decoded a partial JSON slice and `JSON.parse` blew up.

`workout_sets` has 18 columns → `getColumnNamesSync` metadata payload = **258 bytes** → one byte past the 256 cliff. `workout_sessions` (10 columns) is 138 bytes → fits → that's why Summary partially loaded before dying. Anything below 256 bytes worked, which is why this went unnoticed.

Verified locally with the reduced repro:
```js
new Uint8Array(buf).set(new Uint32Array([300]), 0);
new Uint32Array(buf, 0, 1)[0] // → 44, not 300
```

## Fix
Layer choice (per Fix Placement Framework): **vendor producer**. Both producer and consumer live in the same vendored file; fixing only the consumer would still ship a half-fix and leak garbage into the buffer. Patch sits in `patches/` so the postinstall hook re-applies it on every `npm ci`.

- **`patches/expo-sqlite+55.0.15.patch`** — flip the writer to a real little-endian uint32:
  ```ts
  new DataView(resultArray.buffer).setUint32(0, length, true);
  ```
  Reader (`new Uint32Array(resultArray.buffer, 0, 1)[0]`) reads the same 4 bytes back. Atomics.store ordering after writes is unchanged.
- **`package.json`** — add `patch-package` devDependency + `postinstall` hook.
- **`app/session/summary/[id].tsx`** — wrap the route in a route-local `ErrorBoundary` so any future Summary-only crash gets a localized fallback instead of nuking the navigator. Root layout already has a global `ErrorBoundary`; this adds a defensive inner net for the highest-blast-radius screen.

### Sweep for the same anti-pattern
Per QD's gate, grepped for any other `TypedArray.set(new (Uint16|Uint32|Int16|Int32|BigUint64|BigInt64|Float32|Float64)Array)` mistakes:
- `node_modules/expo-sqlite/web/**/*.ts` — only the one we patched.
- `lib/ workers/ app/ components/ hooks/ scripts/ plugins/` — clean.
- `wa-sqlite/MemoryVFS.js` — uses `Uint8Array.set(Uint8Array)` (same-type, no truncation).

No half-fix risk.

## Tests
**New: `__tests__/lib/expo-sqlite-worker-channel-length.test.ts` (15 cases):**
- Demonstrates the original bug: `writeLength_buggy(buf, 258); read = 2`.
- Round-trips length=**0, 1, 255, 256, 257, 258, 1024, 65535, 65536, 65537, 1 MiB-4** through the fixed writer (covers the Uint8 cliff at 256 and the Uint16 cliff at 65536).
- Proves the buggy writer truncates 256/257/258/1024/65536 — so the round-trip suite cannot be trivially passing.
- Round-trips a >256-byte JSON payload through the full length-prefix protocol, asserting `JSON.parse` succeeds end-to-end.
- Reads the patched `WorkerChannel.ts` from disk and asserts (a) the buggy form is gone and (b) `setUint32(_, _, true)` is present — catches CI silently dropping the postinstall step.

**Pre-existing acceptance tests still green:**
- `__tests__/acceptance/workout-summary.acceptance.test.tsx` (4/4)
- `__tests__/acceptance/summary-backhandler.acceptance.test.tsx` (1/1)

## Acceptance criteria (from issue)
- [x] Repro confirmed locally.
- [x] Root cause identified and documented in PR description.
- [x] Fix applied at the producer (no `try/catch` over `JSON.parse`).
- [x] Regression test that fails on unpatched code, passes on patched.
- [x] Web ErrorBoundary on Summary route (root layout already covers globally).
- [ ] **QD ux-audit re-run** → ux-audit dispatch on this branch should produce a real Summary screenshot (not the dev overlay).

## Out of scope (follow-ups)
- Upstream Expo issue filing.
- Wiring console.error from the route ErrorBoundary into Sentry.

## Reviewers
- @quality-director — gates posted in [BLD-660 comment](https://github.com/alankyshum/cablesnap) (verification round on branch).
