### PR TITLE
fix: avoid duplicate Workout Complete title on summary screen (BLD-684)

### DIFF
--- a/__tests__/acceptance/summary-appbar-title.acceptance.test.tsx
+++ b/__tests__/acceptance/summary-appbar-title.acceptance.test.tsx
@@ -132,6 +132,27 @@ describe('Workout Summary — app-bar title (BLD-684)', () => {
     expect(title).not.toBe('Workout Complete!')
   })
 
+  it.each([
+    ['short label', 'Push'],
+    ['long label', 'Upper Body Hypertrophy Day'],
+  ])('app-bar title differs from hero h1 — %s (%s)', async (_label, name) => {
+    const { session, exercises, sets } = createCompletedWorkoutFixture()
+    mockDb.getSessionById.mockResolvedValue({ ...session, name })
+    mockDb.getSessionSets.mockResolvedValue(sets)
+    mockDb.getExercisesByIds.mockResolvedValue(exercises)
+
+    const screen = renderScreen(<Summary />)
+    await screen.findByText('Workout Complete!')
+
+    const appBarTitle = lastTitle()
+    const heroH1 = 'Workout Complete!'
+    expect(appBarTitle).toBe(name)
+    expect(appBarTitle).not.toBe(heroH1)
+    // Truncation/ellipsis of long titles is delegated to the native header
+    // (no manual width clamp in the screen source) — keep the title string
+    // intact and let the platform handle overflow.
+  })
+
   it('falls back to "Summary" when the session has no name', async () => {
     const { session, exercises, sets } = createCompletedWorkoutFixture()
     const namelessSession = { ...session, name: '   ' }

--- a/__tests__/acceptance/summary-appbar-title.acceptance.test.tsx
+++ b/__tests__/acceptance/summary-appbar-title.acceptance.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Acceptance test for BLD-684:
+ * Completed-workout summary must not duplicate "Workout Complete!" in
+ * both the app-bar title and the hero h1.
+ *
+ * Renders app/session/summary/[id].tsx with a completed-workout fixture
+ * and asserts:
+ *  - The app-bar Stack.Screen `title` is the workout name (session.name),
+ *    not the literal hero string "Workout Complete!".
+ *  - When session.name is missing/blank, falls back to "Summary".
+ */
+
+const mockStackScreenSpy = jest.fn()
+
+jest.mock('../../lib/db', () => ({
+  getSessionById: jest.fn(),
+  getSessionSets: jest.fn().mockResolvedValue([]),
+  getBodySettings: jest.fn().mockResolvedValue({
+    weight_unit: 'kg',
+    measurement_unit: 'cm',
+    sex: 'male',
+    weight_goal: null,
+    body_fat_goal: null,
+  }),
+  getSessionPRs: jest.fn().mockResolvedValue([]),
+  getSessionRepPRs: jest.fn().mockResolvedValue([]),
+  getSessionDurationPRs: jest.fn().mockResolvedValue([]),
+  getSessionWeightIncreases: jest.fn().mockResolvedValue([]),
+  getSessionComparison: jest.fn().mockResolvedValue(null),
+  getSessionSetCount: jest.fn().mockResolvedValue(0),
+  getExercisesByIds: jest.fn().mockResolvedValue({}),
+  buildAchievementContext: jest.fn().mockResolvedValue({}),
+  getEarnedAchievementIds: jest.fn().mockResolvedValue([]),
+  saveEarnedAchievements: jest.fn().mockResolvedValue(undefined),
+  updateSession: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  useLocalSearchParams: () => ({ id: 'sess-completed' }),
+  usePathname: () => '/session/summary/sess-completed',
+  useFocusEffect: jest.fn(),
+  Stack: {
+    Screen: (props: { options?: { title?: string } }) => {
+      mockStackScreenSpy(props)
+      return null
+    },
+  },
+  Redirect: () => null,
+}))
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../lib/layout', () => ({
+  useLayout: () => ({ wide: false, width: 375, scale: 1.0 }),
+}))
+jest.mock('../../lib/errors', () => ({
+  logError: jest.fn(),
+  generateReport: jest.fn().mockResolvedValue('{}'),
+  getRecentErrors: jest.fn().mockResolvedValue([]),
+  generateGitHubURL: jest.fn().mockReturnValue('https://github.com'),
+}))
+jest.mock('../../lib/interactions', () => ({
+  log: jest.fn(),
+  recent: jest.fn().mockResolvedValue([]),
+}))
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+  NotificationFeedbackType: { Success: 'success', Warning: 'warning' },
+}))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+jest.mock('../../lib/units', () => ({
+  toDisplay: (v: number) => v,
+  toKg: (v: number) => v,
+  KG_TO_LB: 2.20462,
+  LB_TO_KG: 0.453592,
+}))
+jest.mock('victory-native', () => ({
+  CartesianChart: 'CartesianChart',
+  Line: 'Line',
+  Bar: 'Bar',
+}))
+jest.mock('../../lib/useProfileGender', () => ({
+  useProfileGender: () => 'male',
+}))
+jest.mock('../../components/MuscleMap', () => {
+  const React = require('react')
+  return {
+    MuscleMap: (props: Record<string, unknown>) =>
+      React.createElement('MuscleMap', props),
+  }
+})
+
+import React from 'react'
+import { renderScreen } from '../helpers/render'
+import { resetIds } from '../helpers/factories'
+import { createCompletedWorkoutFixture } from '../fixtures/completedWorkoutSummary'
+import Summary from '../../app/session/summary/[id]'
+
+const mockDb = require('../../lib/db') as Record<string, jest.Mock>
+
+function lastTitle(): string | undefined {
+  for (let i = mockStackScreenSpy.mock.calls.length - 1; i >= 0; i--) {
+    const props = mockStackScreenSpy.mock.calls[i][0] as { options?: { title?: string } }
+    if (props?.options && 'title' in props.options) return props.options.title
+  }
+  return undefined
+}
+
+describe('Workout Summary — app-bar title (BLD-684)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockStackScreenSpy.mockClear()
+    resetIds()
+  })
+
+  it('app-bar title is the workout name, not the hero "Workout Complete!" string', async () => {
+    const { session, exercises, sets } = createCompletedWorkoutFixture()
+    mockDb.getSessionById.mockResolvedValue(session)
+    mockDb.getSessionSets.mockResolvedValue(sets)
+    mockDb.getExercisesByIds.mockResolvedValue(exercises)
+
+    const screen = renderScreen(<Summary />)
+
+    // Wait for the loaded screen (hero renders after session resolves).
+    await screen.findByText('Workout Complete!')
+
+    const title = lastTitle()
+    expect(title).toBe(session.name)
+    expect(title).not.toBe('Workout Complete!')
+  })
+
+  it('falls back to "Summary" when the session has no name', async () => {
+    const { session, exercises, sets } = createCompletedWorkoutFixture()
+    const namelessSession = { ...session, name: '   ' }
+    mockDb.getSessionById.mockResolvedValue(namelessSession)
+    mockDb.getSessionSets.mockResolvedValue(sets)
+    mockDb.getExercisesByIds.mockResolvedValue(exercises)
+
+    const screen = renderScreen(<Summary />)
+    await screen.findByText('Workout Complete!')
+
+    expect(lastTitle()).toBe('Summary')
+  })
+})

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -124,7 +124,7 @@ function Summary() {
 
   return (
     <>
-      <Stack.Screen options={{ title: "Workout Complete!" }} />
+      <Stack.Screen options={{ title: session.name?.trim() || "Summary" }} />
       <FlatList
         data={listData}
         keyExtractor={(s) => s.key}


### PR DESCRIPTION
## Summary


Applies CEO-scoped Option A: app-bar title now shows `session.name` (the workout label, e.g. "Upper Body"), falling back to "Summary" when blank.

## Changes

- `app/session/summary/[id].tsx`: Stack.Screen options.title bound to `session.name?.trim() || "Summary"` (loaded path). Fallback path already showed "Summary".

## Testing

- New acceptance suite: 2/2 pass
- Sibling summary suites (`workout-summary`, `summary-backhandler`): 7/7 pass — no regressions
- TypeScript: no new errors introduced (pre-existing failures in unrelated test files)

## Issue

Resolves BLD-684