### PR TITLE
fix(progress): wrap Muscles segment in shared scroll container (BLD-702)

### DIFF
--- a/__tests__/acceptance/muscle-volume.test.tsx
+++ b/__tests__/acceptance/muscle-volume.test.tsx
@@ -202,6 +202,24 @@ describe('MuscleVolumeSegment — Loading', () => {
   })
 })
 
+// --- Scroll Container (BLD-702) ---
+
+describe('MuscleVolumeSegment — Scroll Container', () => {
+  it('renders content inside a scrollable container so users can reach overflow content', async () => {
+    const { findByTestId } = renderScreen(<MuscleVolumeSegment />)
+    // The shared scroll container pattern (matches Nutrition/Monthly Progress subtabs)
+    // is required so all content is reachable on phone-sized layouts.
+    expect(await findByTestId('muscle-volume-scroll')).toBeTruthy()
+  })
+
+  it('keeps the scroll container present in the empty state', async () => {
+    mockGetMuscleVolumeForWeek.mockResolvedValue([])
+    const { findByTestId, findByText } = renderScreen(<MuscleVolumeSegment />)
+    expect(await findByText('No workouts this week. Complete a session to see muscle volume.')).toBeTruthy()
+    expect(await findByTestId('muscle-volume-scroll')).toBeTruthy()
+  })
+})
+
 // --- Error State ---
 
 describe('MuscleVolumeSegment — Error', () => {

--- a/components/MuscleVolumeSegment.tsx
+++ b/components/MuscleVolumeSegment.tsx
@@ -133,7 +133,7 @@ export default function MuscleVolumeSegment() {
     <View style={styles.flex}>
       <ScrollView
         style={styles.flex}
-        contentContainerStyle={[styles.scrollContent, { paddingBottom: tabBarHeight + 16 }]}
+        contentContainerStyle={{ paddingBottom: tabBarHeight + 16 }}
         testID="muscle-volume-scroll"
       >
       {/* Week Selector */}
@@ -278,7 +278,6 @@ export default function MuscleVolumeSegment() {
 
 const styles = StyleSheet.create({
   flex: { flex: 1 },
-  scrollContent: { paddingBottom: 16 },
   center: { flex: 1, justifyContent: "center", alignItems: "center", padding: 32 },
   weekRow: { flexDirection: "row", alignItems: "center", marginBottom: 8, paddingHorizontal: 4 },
   chevron: { minWidth: 48, minHeight: 48 },

--- a/components/MuscleVolumeSegment.tsx
+++ b/components/MuscleVolumeSegment.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { Pressable, StyleSheet, View, FlatList } from "react-native";
+import { Pressable, ScrollView, StyleSheet, View, FlatList } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -7,6 +7,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { ChevronLeft, ChevronRight, SlidersHorizontal } from "lucide-react-native";
 import { MUSCLE_LABELS } from "../lib/types";
 import { useLayout } from "../lib/layout";
+import { useFloatingTabBarHeight } from "./FloatingTabBar";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useMuscleVolume } from "@/hooks/useMuscleVolume";
 import type { VolumeRow } from "@/hooks/useMuscleVolume";
@@ -63,6 +64,7 @@ const MuscleRow = React.memo(function MuscleRow({
 export default function MuscleVolumeSegment() {
   const colors = useThemeColors();
   const layout = useLayout();
+  const tabBarHeight = useFloatingTabBarHeight();
   const {
     offset, setOffset, data, trend, selected, selectMuscle,
     loading, error, load, monday, maxSets, hasEnoughTrend, reduced, formatRange,
@@ -128,7 +130,12 @@ export default function MuscleVolumeSegment() {
   }
 
   return (
-    <View>
+    <View style={styles.flex}>
+      <ScrollView
+        style={styles.flex}
+        contentContainerStyle={[styles.scrollContent, { paddingBottom: tabBarHeight + 16 }]}
+        testID="muscle-volume-scroll"
+      >
       {/* Week Selector */}
       <View style={styles.weekRow}>
         <Button variant="ghost" size="icon" icon={ChevronLeft} onPress={() => setOffset(offset - 1)} accessibilityLabel="Previous week" style={styles.chevron} />
@@ -256,6 +263,7 @@ export default function MuscleVolumeSegment() {
           </Card>
         </>
       )}
+      </ScrollView>
       <VolumeLandmarksSheet
         visible={sheetVisible}
         onClose={() => setSheetVisible(false)}
@@ -269,6 +277,8 @@ export default function MuscleVolumeSegment() {
 }
 
 const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  scrollContent: { paddingBottom: 16 },
   center: { flex: 1, justifyContent: "center", alignItems: "center", padding: 32 },
   weekRow: { flexDirection: "row", alignItems: "center", marginBottom: 8, paddingHorizontal: 4 },
   chevron: { minWidth: 48, minHeight: 48 },


### PR DESCRIPTION
## Summary

Fixes BLD-702 — the Progress > Muscles subtab rendered all content inside a plain `<View>`, so phone-sized layouts could not scroll to the muscle group details list (or other content) below the fold.

## Changes

- `components/MuscleVolumeSegment.tsx`: wrap the success-path body in a `ScrollView` matching the pattern used by `NutritionSegment` / `MonthlyReportSegment` — `style={{flex:1}}` + `contentContainerStyle` with `paddingBottom: tabBarHeight + 16` from `useFloatingTabBarHeight()`.
- The nested `FlatList` keeps `scrollEnabled={false}`, so virtualization is unaffected.
- The `VolumeLandmarksSheet` modal stays outside the ScrollView.
- Loading / error states keep their existing centered `View` (small content, no scroll needed).
- `__tests__/acceptance/muscle-volume.test.tsx`: 2 regression tests asserting the `muscle-volume-scroll` testID is present in success + empty states.

## Testing

- `npm test -- __tests__/acceptance/muscle-volume.test.tsx` → **17 passed (15 existing + 2 new)**.
- `tsc --noEmit` shows no new errors in changed files (10 pre-existing TS errors in unrelated test files, untouched).

## Acceptance Criteria

- [x] Progress > Muscles uses the same scroll container pattern as Nutrition / Monthly.
- [x] Users can scroll to all content below the fold on phone-sized layouts.
- [x] Other Progress subtabs are unchanged (no files outside MuscleVolumeSegment + its test touched).
- [x] Scroll behaviour explicitly tested (testID assertions in muscle-volume.test.tsx).

## Issue

Resolves BLD-702