### PR TITLE
fix(settings): inline 'permission required' CTA when Health Connect denied (BLD-715)

### DIFF
--- a/__tests__/components/settings/IntegrationsCard.hc-permission.test.tsx
+++ b/__tests__/components/settings/IntegrationsCard.hc-permission.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * BLD-715 — Health Connect toggle permission-denied UX.
+ *
+ * AC2: tapping toggle requests permission (system dialog or its mock here).
+ * AC3: when permission is denied, an inline "permission required" CTA renders
+ *      with an "Open Health Connect settings" button that calls the deep link.
+ * AC4: error path still surfaces (no silent failure) — toast + inline.
+ * AC5: grant + deny mocked paths covered.
+ */
+import React from "react";
+import { Platform } from "react-native";
+import { render, fireEvent, waitFor, act } from "@testing-library/react-native";
+
+// --- Mocks (must precede component import) ---
+jest.mock("@/lib/db", () => ({
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockRequestHCPermission = jest.fn();
+const mockDisableHC = jest.fn().mockResolvedValue(undefined);
+const mockOpenHCSettings = jest.fn().mockResolvedValue(undefined);
+jest.mock("@/lib/health-connect", () => ({
+  __esModule: true,
+  requestHealthConnectPermission: (...a: unknown[]) => mockRequestHCPermission(...a),
+  disableHealthConnect: (...a: unknown[]) => mockDisableHC(...a),
+  openHealthConnectSettings: (...a: unknown[]) => mockOpenHCSettings(...a),
+}));
+
+jest.mock("@/lib/strava", () => ({
+  connectStrava: jest.fn(),
+  disconnect: jest.fn(),
+  getStravaSupportAction: jest.fn(),
+  getStravaUserMessage: jest.fn(),
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+const toastStub = {
+  success: mockToastSuccess,
+  error: mockToastError,
+  info: jest.fn(),
+  warn: jest.fn(),
+  show: jest.fn(),
+  dismiss: jest.fn(),
+} as unknown as ReturnType<typeof import("@/components/ui/bna-toast").useToast>;
+
+import IntegrationsCard from "@/components/settings/IntegrationsCard";
+import type { ThemeColors } from "@/hooks/useThemeColors";
+
+const mockColors: Partial<ThemeColors> = {
+  surface: "#FFFFFF",
+  surfaceVariant: "#F3F4F6",
+  onSurface: "#111827",
+  onSurfaceVariant: "#6B7280",
+  errorContainer: "#FEE2E2",
+  onErrorContainer: "#7F1D1D",
+  error: "#DC2626",
+  primary: "#3B82F6",
+};
+
+beforeAll(() => {
+  Object.defineProperty(Platform, "OS", { configurable: true, get: () => "android" });
+});
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+function renderCard(overrides: Partial<React.ComponentProps<typeof IntegrationsCard>> = {}) {
+  const setHcEnabled = jest.fn();
+  const setHcLoading = jest.fn();
+  const setHcPermissionDenied = jest.fn();
+  const setStravaAthlete = jest.fn();
+  const setStravaLoading = jest.fn();
+  const utils = render(
+    <IntegrationsCard
+      colors={mockColors as ThemeColors}
+      toast={toastStub}
+      stravaAthlete={null}
+      setStravaAthlete={setStravaAthlete}
+      stravaLoading={false}
+      setStravaLoading={setStravaLoading}
+      hcEnabled={false}
+      setHcEnabled={setHcEnabled}
+      hcLoading={false}
+      setHcLoading={setHcLoading}
+      hcPermissionDenied={false}
+      setHcPermissionDenied={setHcPermissionDenied}
+      hcSdkStatus="available"
+      {...overrides}
+    />,
+  );
+  return { ...utils, setHcEnabled, setHcLoading, setHcPermissionDenied };
+}
+
+describe("IntegrationsCard — Health Connect toggle (BLD-715)", () => {
+  it("AC2: tapping toggle ON when permission is granted enables HC and clears denied state", async () => {
+    mockRequestHCPermission.mockResolvedValueOnce(true);
+    const { getByLabelText, setHcEnabled, setHcPermissionDenied } = renderCard();
+
+    const sw = getByLabelText("Sync workouts to Health Connect");
+    await act(async () => {
+      fireEvent(sw, "valueChange", true);
+    });
+
+    await waitFor(() => expect(mockRequestHCPermission).toHaveBeenCalled());
+    expect(setHcEnabled).toHaveBeenCalledWith(true);
+    expect(setHcPermissionDenied).toHaveBeenCalledWith(false);
+    expect(mockToastSuccess).toHaveBeenCalledWith("Health Connect enabled");
+  });
+
+  it("AC3: tapping toggle ON when permission is DENIED sets denied state and surfaces toast", async () => {
+    mockRequestHCPermission.mockResolvedValueOnce(false);
+    const { getByLabelText, setHcEnabled, setHcPermissionDenied } = renderCard();
+
+    const sw = getByLabelText("Sync workouts to Health Connect");
+    await act(async () => {
+      fireEvent(sw, "valueChange", true);
+    });
+
+    await waitFor(() => expect(setHcPermissionDenied).toHaveBeenCalledWith(true));
+    expect(setHcEnabled).toHaveBeenCalledWith(false);
+    expect(mockToastError).toHaveBeenCalledWith("Health Connect permission denied");
+  });
+
+  it("AC3: when hcPermissionDenied is true, inline CTA renders with Open-settings button", () => {
+    const { getByTestId, getByLabelText } = renderCard({
+      hcPermissionDenied: true,
+      hcEnabled: false,
+    });
+
+    expect(getByTestId("hc-permission-denied")).toBeTruthy();
+    expect(getByLabelText("Open Health Connect settings")).toBeTruthy();
+  });
+
+  it("AC3: tapping Open Health Connect settings invokes openHealthConnectSettings deep link", async () => {
+    const { getByLabelText } = renderCard({
+      hcPermissionDenied: true,
+      hcEnabled: false,
+    });
+
+    const btn = getByLabelText("Open Health Connect settings");
+    await act(async () => {
+      fireEvent.press(btn);
+    });
+
+    await waitFor(() => expect(mockOpenHCSettings).toHaveBeenCalled());
+  });
+
+  it("AC4: when requestPermission throws, denied state is set and error toast surfaces", async () => {
+    mockRequestHCPermission.mockRejectedValueOnce(new Error("boom"));
+    const { getByLabelText, setHcPermissionDenied } = renderCard();
+
+    const sw = getByLabelText("Sync workouts to Health Connect");
+    await act(async () => {
+      fireEvent(sw, "valueChange", true);
+    });
+
+    await waitFor(() => expect(setHcPermissionDenied).toHaveBeenCalledWith(true));
+    expect(mockToastError).toHaveBeenCalledWith("Failed to enable Health Connect");
+  });
+
+  it("toggling OFF clears denied state and disables HC", async () => {
+    const { getByLabelText, setHcEnabled, setHcPermissionDenied } = renderCard({
+      hcEnabled: true,
+    });
+
+    const sw = getByLabelText("Sync workouts to Health Connect");
+    await act(async () => {
+      fireEvent(sw, "valueChange", false);
+    });
+
+    await waitFor(() => expect(mockDisableHC).toHaveBeenCalled());
+    expect(setHcEnabled).toHaveBeenCalledWith(false);
+    expect(setHcPermissionDenied).toHaveBeenCalledWith(false);
+  });
+
+  it("inline CTA does NOT render when permission is granted", () => {
+    const { queryByTestId } = renderCard({ hcEnabled: true, hcPermissionDenied: false });
+    expect(queryByTestId("hc-permission-denied")).toBeNull();
+  });
+});

--- a/__tests__/lib/health-connect.test.ts
+++ b/__tests__/lib/health-connect.test.ts
@@ -106,11 +106,14 @@ describe("Health Connect settings integration", () => {
     expect(source).toContain("AccessibilityInfo");
     expect(source).toContain('accessibilityRole="switch"');
     expect(source).toContain('accessibilityLabel="Sync workouts to Health Connect"');
-    // dynamic import
-    expect(source).not.toMatch(/^import.*from.*["'].*health-connect["']/m);
-    expect(source).toContain('await import("../../lib/health-connect")');
-    // shows toast on permission denial
+    // health-connect lib import (BLD-715: switched to static import; lib itself
+    // dynamic-imports the native module, so iOS/web stay safe)
+    expect(source).toMatch(/from\s+["']@\/lib\/health-connect["']/);
+    expect(source).toContain("requestHealthConnectPermission");
+    expect(source).toContain("openHealthConnectSettings");
+    // shows toast on permission denial AND inline CTA
     expect(source).toContain("permission denied");
+    expect(source).toContain("hc-permission-denied");
     // platform gating
     expect(source).toContain('Platform.OS === "android"');
     expect(source).toContain('hcSdkStatus !== "unavailable"');

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -61,6 +61,7 @@ export default function Settings() {
     stravaLoading, setStravaLoading,
     hcEnabled, setHcEnabled,
     hcLoading, setHcLoading,
+    hcPermissionDenied, setHcPermissionDenied,
     hcSdkStatus,
     weeklyGoal, setWeeklyGoal,
   } = useSettingsData();
@@ -139,6 +140,8 @@ export default function Settings() {
           setHcEnabled={setHcEnabled}
           hcLoading={hcLoading}
           setHcLoading={setHcLoading}
+          hcPermissionDenied={hcPermissionDenied}
+          setHcPermissionDenied={setHcPermissionDenied}
           hcSdkStatus={hcSdkStatus}
         />
         <AutoBackupSection colors={colors} toast={toast} />

--- a/components/settings/IntegrationsCard.tsx
+++ b/components/settings/IntegrationsCard.tsx
@@ -4,11 +4,16 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { Activity, HeartPulse } from "lucide-react-native";
+import { Activity, AlertCircle, ExternalLink, HeartPulse } from "lucide-react-native";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { flowCardStyle } from "@/components/ui/FlowContainer";
 import { fontSizes } from "@/constants/design-tokens";
 import { setAppSetting } from "@/lib/db";
+import {
+  disableHealthConnect,
+  openHealthConnectSettings,
+  requestHealthConnectPermission,
+} from "@/lib/health-connect";
 import { connectStrava, disconnect as disconnectStrava, getStravaSupportAction, getStravaUserMessage } from "@/lib/strava";
 import type { ThemeColors } from "@/hooks/useThemeColors";
 import type { useToast } from "@/components/ui/bna-toast";
@@ -24,13 +29,16 @@ type Props = {
   setHcEnabled: (v: boolean) => void;
   hcLoading: boolean;
   setHcLoading: (v: boolean) => void;
+  hcPermissionDenied: boolean;
+  setHcPermissionDenied: (v: boolean) => void;
   hcSdkStatus: "available" | "needs_install" | "needs_update" | "unavailable";
 };
 
 export default function IntegrationsCard({
   colors, toast,
   stravaAthlete, setStravaAthlete, stravaLoading, setStravaLoading,
-  hcEnabled, setHcEnabled, hcLoading, setHcLoading, hcSdkStatus,
+  hcEnabled, setHcEnabled, hcLoading, setHcLoading,
+  hcPermissionDenied, setHcPermissionDenied, hcSdkStatus,
 }: Props) {
   if (Platform.OS === "web") return null;
 
@@ -114,25 +122,30 @@ export default function IntegrationsCard({
                         if (value) {
                           setHcLoading(true);
                           try {
-                            const { requestHealthConnectPermission } = await import("../../lib/health-connect");
                             const granted = await requestHealthConnectPermission();
                             if (granted) {
                               await setAppSetting("health_connect_enabled", "true");
                               setHcEnabled(true);
+                              setHcPermissionDenied(false);
                               toast.success("Health Connect enabled");
                             } else {
                               setHcEnabled(false);
+                              setHcPermissionDenied(true);
                               toast.error("Health Connect permission denied");
-                              AccessibilityInfo.announceForAccessibility("Health Connect permission denied");
+                              AccessibilityInfo.announceForAccessibility("Health Connect permission denied. Open Health Connect settings to grant permission manually.");
                             }
-                          } catch { setHcEnabled(false); toast.error("Failed to enable Health Connect"); }
+                          } catch {
+                            setHcEnabled(false);
+                            setHcPermissionDenied(true);
+                            toast.error("Failed to enable Health Connect");
+                          }
                           finally { setHcLoading(false); }
                         } else {
                           setHcLoading(true);
                           try {
-                            const { disableHealthConnect } = await import("../../lib/health-connect");
                             await disableHealthConnect();
                             setHcEnabled(false);
+                            setHcPermissionDenied(false);
                             toast.success("Health Connect disabled");
                           } catch { toast.error("Failed to disable Health Connect"); }
                           finally { setHcLoading(false); }
@@ -140,7 +153,41 @@ export default function IntegrationsCard({
                       }}
                     />
                   </View>
-                  <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>Completed workouts appear in Google Fit, Samsung Health, and other Health Connect apps.</Text>
+                  {hcPermissionDenied && !hcEnabled ? (
+                    <View
+                      testID="hc-permission-denied"
+                      style={[styles.deniedBlock, { backgroundColor: colors.errorContainer, borderColor: colors.error }]}
+                    >
+                      <View style={styles.deniedHeader}>
+                        <AlertCircle size={16} color={colors.error} />
+                        <Text variant="body" style={{ color: colors.onErrorContainer, fontSize: fontSizes.sm, fontWeight: "600", marginLeft: 6 }}>
+                          Permission required
+                        </Text>
+                      </View>
+                      <Text variant="caption" style={{ color: colors.onErrorContainer, marginTop: 4 }}>
+                        Android did not grant CableSnap permission to write to Health Connect. If you tapped Deny earlier, the system may stop showing the prompt — open Health Connect settings and grant the “Write exercise sessions” permission manually, then come back and try the toggle again.
+                      </Text>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        icon={ExternalLink}
+                        style={{ marginTop: 10, alignSelf: "flex-start", minHeight: 48 }}
+                        onPress={async () => {
+                          try {
+                            await openHealthConnectSettings();
+                          } catch {
+                            toast.error("Could not open Health Connect settings");
+                          }
+                        }}
+                        accessibilityRole="button"
+                        accessibilityLabel="Open Health Connect settings"
+                      >
+                        Open Health Connect settings
+                      </Button>
+                    </View>
+                  ) : (
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>Completed workouts appear in Google Fit, Samsung Health, and other Health Connect apps.</Text>
+                  )}
                 </View>
               ) : (
                 <View>
@@ -175,4 +222,11 @@ export default function IntegrationsCard({
 const styles = StyleSheet.create({
   flowCard: { ...flowCardStyle, maxWidth: undefined, padding: 14 },
   row: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginBottom: 8 },
+  deniedBlock: {
+    marginTop: 8,
+    padding: 10,
+    borderRadius: 8,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  deniedHeader: { flexDirection: "row", alignItems: "center" },
 });

--- a/hooks/useSettingsData.ts
+++ b/hooks/useSettingsData.ts
@@ -31,6 +31,7 @@ export function useSettingsData() {
   const [stravaLoading, setStravaLoading] = useState(false);
   const [hcEnabled, setHcEnabled] = useState(false);
   const [hcLoading, setHcLoading] = useState(false);
+  const [hcPermissionDenied, setHcPermissionDenied] = useState(false);
   const [hcSdkStatus, setHcSdkStatus] = useState<
     'available' | 'needs_install' | 'needs_update' | 'unavailable'
   >('unavailable');
@@ -111,15 +112,18 @@ export function useSettingsData() {
                     set('health_connect_enabled', 'false'),
                   );
                   setHcEnabled(false);
+                  setHcPermissionDenied(true);
                   toast.error('Health Connect permission was revoked');
                   AccessibilityInfo.announceForAccessibility(
                     'Health Connect permission was revoked',
                   );
                 } else {
                   setHcEnabled(true);
+                  setHcPermissionDenied(false);
                 }
               } else {
                 setHcEnabled(false);
+                setHcPermissionDenied(false);
               }
             }
           } catch {
@@ -148,6 +152,7 @@ export function useSettingsData() {
     stravaLoading, setStravaLoading,
     hcEnabled, setHcEnabled,
     hcLoading, setHcLoading,
+    hcPermissionDenied, setHcPermissionDenied,
     hcSdkStatus,
     weeklyGoal, setWeeklyGoal,
   };


### PR DESCRIPTION
## Summary

Fixes the Health Connect toggle "doing nothing" symptom reported in GH #237 (BLD-715). When Android returns no granted permissions — either because the user denied or because the 24-hour request lockout silently rejected the dialog — only an ephemeral toast surfaced. After the toast dismissed, the toggle reset to off with no indication and no path forward, so it appeared inert.

## Repro

1. Open settings → tap Health Connect toggle.
2. Deny permission (or trigger the OS lockout via repeated denials).
3. Before this PR: toast briefly appears, then the row reverts to "Disabled" with no further state. Tapping again repeats the same flash.
4. After this PR: an inline "Permission required" block renders under the row with explanatory copy and an "Open Health Connect settings" button that deep-links to system HC settings, so the user can grant the write-exercise permission manually.

## Changes

- `hooks/useSettingsData.ts` — track `hcPermissionDenied` state; set when the focus check finds HC enabled-but-permission-revoked.
- `components/settings/IntegrationsCard.tsx`:
  - Render an inline error block (testID `hc-permission-denied`) with `AlertCircle` icon, error-container theming, explanatory copy, and an `Open Health Connect settings` button (48dp tap target, calls `openHealthConnectSettings()` deep link from the existing lib).
  - Set `hcPermissionDenied` from the toggle handler on the granted-false, exception, and revoked-on-focus paths; clear it on grant success and on toggle-off.
  - Switch from dynamic to static `lib/health-connect` import so the toggle handler is unit-testable. The lib still dynamic-imports `react-native-health-connect`, so iOS/web stay safe and the existing `Platform.OS === "android"` render guard is unchanged.
- `app/(tabs)/settings.tsx` — wire the new state into `IntegrationsCard`.
- `__tests__/components/settings/IntegrationsCard.hc-permission.test.tsx` — new (7 tests): grant, deny (inline CTA + state), inline-CTA visibility gating, open-settings deep link, exception path, toggle-off, denied-state hidden when granted.
- `__tests__/lib/health-connect.test.ts` — update the source-shape assertions for the new static import.

## Acceptance criteria

- [x] AC1: Reproduced on current main — silent failure mode (toast only, no remediation path) explained in PR description.
- [x] AC2: Toggle still triggers `requestHealthConnectPermission()` (which opens the Android HC permission dialog when the OS allows it).
- [x] AC3: Inline "Permission required" message + "Open Health Connect settings" deep link surface when permission is denied or revoked.
- [x] AC4: Loading (`hcLoading`) + error (toast + inline block) states render — no silent failure.
- [x] AC5: Tests cover grant + deny + exception + open-settings paths (7 new tests).
- [x] AC6: `tsc --noEmit` clean for changed files (10 pre-existing unrelated errors); 232 / 2523 tests pass; no new lint warnings.

## Issue

Resolves BLD-715 (GH #237).
