### PR TITLE
fix(settings): don't flag HC permission-denied on persistence failures (BLD-715 follow-up)

### DIFF
--- a/__tests__/components/settings/IntegrationsCard.hc-permission.test.tsx
+++ b/__tests__/components/settings/IntegrationsCard.hc-permission.test.tsx
@@ -174,6 +174,26 @@ describe("IntegrationsCard — Health Connect toggle (BLD-715)", () => {
     expect(setHcPermissionDenied).toHaveBeenCalledWith(false);
   });
 
+  it("persistence failure on granted branch does NOT mark permission denied (techlead nit follow-up)", async () => {
+    mockRequestHCPermission.mockResolvedValueOnce(true);
+    const dbMod = jest.requireMock("@/lib/db") as { setAppSetting: jest.Mock };
+    dbMod.setAppSetting.mockRejectedValueOnce(new Error("db write failed"));
+    const { getByLabelText, setHcEnabled, setHcPermissionDenied } = renderCard();
+
+    const sw = getByLabelText("Sync workouts to Health Connect");
+    await act(async () => {
+      fireEvent(sw, "valueChange", true);
+    });
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledWith("Failed to enable Health Connect"));
+    expect(setHcEnabled).toHaveBeenCalledWith(false);
+    // Critical: permission was actually granted; do not surface the misleading CTA
+    const deniedCalls = setHcPermissionDenied.mock.calls.filter(([v]) => v === true);
+    expect(deniedCalls).toEqual([]);
+    // restore default behavior for subsequent tests
+    dbMod.setAppSetting.mockResolvedValue(undefined);
+  });
+
   it("inline CTA does NOT render when permission is granted", () => {
     const { queryByTestId } = renderCard({ hcEnabled: true, hcPermissionDenied: false });
     expect(queryByTestId("hc-permission-denied")).toBeNull();

--- a/components/settings/IntegrationsCard.tsx
+++ b/components/settings/IntegrationsCard.tsx
@@ -121,9 +121,19 @@ export default function IntegrationsCard({
                       onValueChange={async (value) => {
                         if (value) {
                           setHcLoading(true);
+                          let granted = false;
+                          let permissionRequestFailed = false;
                           try {
-                            const granted = await requestHealthConnectPermission();
-                            if (granted) {
+                            granted = await requestHealthConnectPermission();
+                          } catch {
+                            permissionRequestFailed = true;
+                          }
+                          try {
+                            if (permissionRequestFailed) {
+                              setHcEnabled(false);
+                              setHcPermissionDenied(true);
+                              toast.error("Failed to enable Health Connect");
+                            } else if (granted) {
                               await setAppSetting("health_connect_enabled", "true");
                               setHcEnabled(true);
                               setHcPermissionDenied(false);
@@ -135,8 +145,9 @@ export default function IntegrationsCard({
                               AccessibilityInfo.announceForAccessibility("Health Connect permission denied. Open Health Connect settings to grant permission manually.");
                             }
                           } catch {
+                            // Persistence failure on the granted branch — permission is fine,
+                            // so don't surface the "permission required" CTA. Just toast.
                             setHcEnabled(false);
-                            setHcPermissionDenied(true);
                             toast.error("Failed to enable Health Connect");
                           }
                           finally { setHcLoading(false); }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #405 (BLD-715). Addresses techlead's non-blocking nit: the bare `catch` in the Health Connect toggle handler set `hcPermissionDenied(true)` for ALL exceptions, including `setAppSetting` persistence failures on the **granted** branch — which surfaced a misleading 'Permission required' CTA after the user had actually granted permission.

## Changes

- `components/settings/IntegrationsCard.tsx`: split the request-permission try block from the result-handling try block. Only `requestHealthConnectPermission()` failures now mark permission denied; persistence failures (`setAppSetting`) on the granted branch toast a generic enable-failure without the inline CTA.
- `__tests__/components/settings/IntegrationsCard.hc-permission.test.tsx`: regression test asserting that `setAppSetting` rejection on the granted branch never sets `hcPermissionDenied(true)`.

## Testing

- `./node_modules/.bin/jest __tests__/components/settings/IntegrationsCard.hc-permission.test.tsx` — 8/8 pass (1 new).
- `./node_modules/.bin/tsc --noEmit` — 0 errors.

## Issue

Follows up on BLD-715 (PR #405 merged 2026-04-27 17:48Z). Techlead nit referenced in approval comment 7228f9cd.