### PR TITLE
fix(history): add 'streak' noun to history metric labels (BLD-685)

### DIFF
--- a/__tests__/components/history/StreakAndHeatmap-labels.test.tsx
+++ b/__tests__/components/history/StreakAndHeatmap-labels.test.tsx
@@ -13,7 +13,7 @@ const colors = {
   error: "#f00",
 } as unknown as ThemeColors;
 
-describe("StreakAndHeatmap stat labels (BLD-663)", () => {
+describe("StreakAndHeatmap stat labels (BLD-663, BLD-685)", () => {
   function renderStats() {
     return renderScreen(
       <StreakAndHeatmap
@@ -31,14 +31,16 @@ describe("StreakAndHeatmap stat labels (BLD-663)", () => {
     );
   }
 
-  it("uses self-describing labels (current / longest / workouts) instead of two ambiguous 'weeks' labels", () => {
+  it("uses self-describing streak-noun labels (BLD-685: 'current streak' / 'longest streak' / 'workouts')", () => {
     const { getByText, queryAllByText } = renderStats();
-    expect(getByText("current")).toBeTruthy();
-    expect(getByText("longest")).toBeTruthy();
+    expect(getByText("current streak")).toBeTruthy();
+    expect(getByText("longest streak")).toBeTruthy();
     expect(getByText("workouts")).toBeTruthy();
-    // Regression guard: the streak card must not render two adjacent "weeks" labels.
+    // Regression guards: never regress to BLD-663 ("weeks"/"total") or to bare adjectives without the "streak" noun (BLD-685).
     expect(queryAllByText("weeks").length).toBe(0);
     expect(queryAllByText("total").length).toBe(0);
+    expect(queryAllByText("current").length).toBe(0);
+    expect(queryAllByText("longest").length).toBe(0);
   });
 
   it("preserves accessibilityLabel with units for screen readers", () => {

--- a/components/history/StreakAndHeatmap.tsx
+++ b/components/history/StreakAndHeatmap.tsx
@@ -30,12 +30,12 @@ export default function StreakAndHeatmap({
           <View style={styles.streakItem} accessibilityLabel={`Current streak: ${currentStreak} weeks`}>
             <Icon name={Flame} size={20} color={colors.primary} />
             <Text variant="subtitle" style={{ color: colors.onSurface }}>{currentStreak}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>current</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>current streak</Text>
           </View>
           <View style={styles.streakItem} accessibilityLabel={`Longest streak: ${longestStreak} weeks`}>
             <Icon name={Trophy} size={20} color={colors.primary} />
             <Text variant="subtitle" style={{ color: colors.onSurface }}>{longestStreak}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>longest</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>longest streak</Text>
           </View>
           <View style={styles.streakItem} accessibilityLabel={`Total workouts: ${totalWorkouts}`}>
             <Icon name={Dumbbell} size={20} color={colors.primary} />


### PR DESCRIPTION
## Summary

The Workout History streak metrics row showed 'current' / 'longest' as bare adjectives with no noun. Per BLD-685 daily UX audit, change visible labels to 'current streak' / 'longest streak' (matches GitHub / Duolingo / Strava convention). 'workouts' label is unchanged.

## Changes

- `components/history/StreakAndHeatmap.tsx` — visible captions now read 'current streak' / 'longest streak' / 'workouts'.
- `__tests__/components/history/StreakAndHeatmap-labels.test.tsx` — updated assertions; regression guard extended to forbid bare 'current' / 'longest' (in addition to existing 'weeks' / 'total' guards).

## Layout

The streakRow uses `justifyContent: space-around` with three unconstrained `streakItem` views. At 390dp the slightly longer captions still fit on a single line in the caption typography token (no truncation). `accessibilityLabel` already includes the unit ('weeks') for screen readers and is unchanged.

## Testing

- Targeted suite passes: `./node_modules/.bin/jest __tests__/components/history/StreakAndHeatmap-labels.test.tsx` — 2/2 ✓
- `tsc --noEmit` introduces no new errors (pre-existing errors on `main` are unrelated to this change).

## Issue

Resolves BLD-685.