### PR TITLE
fix(history): disambiguate heatmap weekday labels (BLD-686)

### DIFF
--- a/__tests__/components/WorkoutHeatmap.test.tsx
+++ b/__tests__/components/WorkoutHeatmap.test.tsx
@@ -29,12 +29,17 @@ describe("WorkoutHeatmap", () => {
     expect(queryByText("Start working out to see your consistency here!")).toBeNull();
   });
 
-  it("renders day labels", () => {
-    const { getAllByText } = renderScreen(
+  it("renders unambiguous weekday labels (BLD-686: GitHub-style Mon/Wed/Fri only)", () => {
+    const { getAllByText, queryAllByText } = renderScreen(
       <WorkoutHeatmap data={emptyData} />
     );
-    expect(getAllByText("M").length).toBeGreaterThanOrEqual(1);
-    expect(getAllByText("S").length).toBeGreaterThanOrEqual(1);
+    // Only Mon/Wed/Fri rows show labels — Tue/Thu/Sat/Sun are blank to avoid T/T and S/S collisions.
+    expect(getAllByText("Mon").length).toBeGreaterThanOrEqual(1);
+    expect(getAllByText("Wed").length).toBeGreaterThanOrEqual(1);
+    expect(getAllByText("Fri").length).toBeGreaterThanOrEqual(1);
+    // Regression guard: never reintroduce ambiguous single-letter labels.
+    expect(queryAllByText("T").length).toBe(0);
+    expect(queryAllByText("S").length).toBe(0);
   });
 
   it("renders accessibility labels on cells", () => {

--- a/components/WorkoutHeatmap.tsx
+++ b/components/WorkoutHeatmap.tsx
@@ -21,7 +21,9 @@ type HeatmapProps = {
   totalAllTime?: number;
 };
 
-const DAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"] as const;
+// GitHub-style: only Mon/Wed/Fri labeled to avoid T/T and S/S ambiguity (BLD-686).
+// rowIdx 0=Mon, 1=Tue, 2=Wed, 3=Thu, 4=Fri, 5=Sat, 6=Sun
+const DAY_LABELS = ["Mon", "", "Wed", "", "Fri", "", ""] as const;
 
 function getMondayOfWeek(date: Date): Date {
   const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
@@ -101,7 +103,8 @@ export default function WorkoutHeatmap({ data, weeks = 16, onDayPress, totalAllT
     return g;
   }, [data, weeks]);
 
-  const labelWidth = 18;
+  // BLD-686: bumped from 18 to 22 to accommodate 3-letter weekday labels (Mon/Wed/Fri).
+  const labelWidth = 22;
   const gap = 2;
   const availableWidth = layout.width - layout.horizontalPadding * 2 - labelWidth - gap;
   const cellSize = Math.max(14, Math.min(24, Math.floor((availableWidth - gap * (weeks - 1)) / weeks)));


### PR DESCRIPTION
## Summary

The Last 16 Weeks heatmap on the History screen used single-letter weekday labels (`M T W T F S S`) with two ambiguous pairs (T = Tue or Thu, S = Sat or Sun). Users could not tell which row mapped to which day, defeating the purpose of a calendar heatmap.

This PR adopts GitHub-style labels: only **Mon / Wed / Fri** are rendered; **Tue / Thu / Sat / Sun** rows stay blank. Same width characteristics, zero ambiguity.

## Changes

- `components/WorkoutHeatmap.tsx`
  - `DAY_LABELS` is now `["Mon", "", "Wed", "", "Fri", "", ""]`
  - `labelWidth` bumped from `18` to `22` to fit the 3-letter labels at 390dp
- `__tests__/components/WorkoutHeatmap.test.tsx`
  - Replaced the single-letter-label test with one that asserts `Mon`/`Wed`/`Fri` are present and guards against regression to ambiguous `T`/`S` labels.

## Acceptance criteria

- [x] Rendered labels: Mon / blank / Wed / blank / Fri / blank / blank
- [x] No two non-empty labels collide
- [x] Existing typography tokens preserved (`fontSizes.xs`, `colors.onSurfaceVariant`)
- [x] Test updated; regression guard for old labels in place
- [x] tsc clean for `WorkoutHeatmap.tsx` and its test

## Verification

- `npx tsc --noEmit` produces no errors for `components/WorkoutHeatmap.tsx` or its test (pre-existing TS errors in other files are unrelated).
- Jest test suite for `WorkoutHeatmap` fails on `origin/main` AND on this branch with the same `actImplementation is not a function` error from `@testing-library/react-native` — pre-existing test infra issue, not caused by this change.

## Issue

Resolves BLD-686.