### PR TITLE
test: centralize lib/audio jest mock to fix focus-effect cleanup crash (BLD-753a)

### DIFF
--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -253,12 +253,10 @@ jest.mock('../../lib/programs', () => ({
   advanceProgram: jest.fn().mockResolvedValue({ wrapped: false }),
 }))
 
-jest.mock('../../lib/audio', () => ({
-  loadSounds: jest.fn().mockResolvedValue(new Map()),
-  play: jest.fn(),
-  setEnabled: jest.fn(),
-  preload: jest.fn().mockResolvedValue(undefined),
-}))
+// BLD-753a: use centralized manual mock at lib/__mocks__/audio.ts.
+// (Latent same-shape bug as the 8 in techlead's list — no `unload` export —
+// fixed proactively to prevent it from surfacing later.)
+jest.mock('../../lib/audio')
 
 jest.mock('../../lib/notifications', () => ({
   requestPermission: jest.fn().mockResolvedValue('granted'),

--- a/__tests__/acceptance/csv-export.acceptance.test.tsx
+++ b/__tests__/acceptance/csv-export.acceptance.test.tsx
@@ -32,7 +32,8 @@ jest.mock('../../lib/errors', () => ({
   clearErrorLog: jest.fn().mockResolvedValue(undefined),
 }))
 jest.mock('../../lib/interactions', () => ({ log: jest.fn() }))
-jest.mock('../../lib/audio', () => ({ play: jest.fn(), setEnabled: jest.fn(), preload: jest.fn() }))
+// BLD-753a: use centralized manual mock at lib/__mocks__/audio.ts
+jest.mock('../../lib/audio')
 jest.mock('expo-notifications', () => ({
   setNotificationHandler: jest.fn(),
   addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),

--- a/__tests__/acceptance/data-management.acceptance.test.tsx
+++ b/__tests__/acceptance/data-management.acceptance.test.tsx
@@ -33,7 +33,8 @@ jest.mock('../../lib/errors', () => ({
   clearErrorLog: jest.fn().mockResolvedValue(undefined),
 }))
 jest.mock('../../lib/interactions', () => ({ log: jest.fn() }))
-jest.mock('../../lib/audio', () => ({ play: jest.fn(), setEnabled: jest.fn(), preload: jest.fn() }))
+// BLD-753a: use centralized manual mock at lib/__mocks__/audio.ts
+jest.mock('../../lib/audio')
 jest.mock('expo-notifications', () => ({
   setNotificationHandler: jest.fn(),
   addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),

--- a/__tests__/acceptance/rpe-notes.test.tsx
+++ b/__tests__/acceptance/rpe-notes.test.tsx
@@ -101,7 +101,8 @@ jest.mock('expo-keep-awake', () => ({
   deactivateKeepAwake: jest.fn(),
   deactivateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined),
 }))
-jest.mock('../../lib/audio', () => ({ play: jest.fn(), setEnabled: jest.fn(), preload: jest.fn() }))
+// BLD-753a: use centralized manual mock at lib/__mocks__/audio.ts
+jest.mock('../../lib/audio')
 jest.mock('victory-native', () => ({
   CartesianChart: 'CartesianChart',
   Line: 'Line',

--- a/__tests__/acceptance/session-add-exercise.acceptance.test.tsx
+++ b/__tests__/acceptance/session-add-exercise.acceptance.test.tsx
@@ -85,7 +85,8 @@ jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache'
 jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
 jest.mock('expo-haptics', () => ({ impactAsync: jest.fn(), notificationAsync: jest.fn(), ImpactFeedbackStyle: { Light: 'light', Heavy: 'heavy' }, NotificationFeedbackType: { Success: 'success', Warning: 'warning' } }))
 jest.mock('expo-keep-awake', () => ({ activateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined), deactivateKeepAwake: jest.fn() }))
-jest.mock('../../lib/audio', () => ({ play: jest.fn(), setEnabled: jest.fn(), preload: jest.fn() }))
+// BLD-753a: use centralized manual mock at lib/__mocks__/audio.ts
+jest.mock('../../lib/audio')
 jest.mock('../../lib/confirm', () => ({ confirmAction: jest.fn() }))
 
 import React from 'react'

--- a/__tests__/acceptance/session-ux.test.tsx
+++ b/__tests__/acceptance/session-ux.test.tsx
@@ -73,7 +73,8 @@ jest.mock('expo-keep-awake', () => ({
   deactivateKeepAwake: jest.fn(),
   deactivateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined),
 }))
-jest.mock('../../lib/audio', () => ({ play: jest.fn(), setEnabled: jest.fn(), preload: jest.fn() }))
+// BLD-753a: use centralized manual mock at lib/__mocks__/audio.ts
+jest.mock('../../lib/audio')
 jest.mock('victory-native', () => ({ CartesianChart: 'CartesianChart', Line: 'Line', Bar: 'Bar' }))
 
 import React from 'react'

--- a/__tests__/acceptance/settings.test.tsx
+++ b/__tests__/acceptance/settings.test.tsx
@@ -38,7 +38,8 @@ jest.mock('../../lib/errors', () => ({
   generateGitHubURL: jest.fn().mockReturnValue('https://github.com'),
 }))
 jest.mock('../../lib/interactions', () => ({ log: jest.fn() }))
-jest.mock('../../lib/audio', () => ({ play: jest.fn(), setEnabled: jest.fn(), preload: jest.fn() }))
+// BLD-753a: use centralized manual mock at lib/__mocks__/audio.ts
+jest.mock('../../lib/audio')
 jest.mock('expo-notifications', () => ({
   setNotificationHandler: jest.fn(),
   addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),

--- a/__tests__/acceptance/supersets.test.tsx
+++ b/__tests__/acceptance/supersets.test.tsx
@@ -115,7 +115,8 @@ jest.mock('expo-keep-awake', () => ({
   deactivateKeepAwake: jest.fn(),
   deactivateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined),
 }))
-jest.mock('../../lib/audio', () => ({ play: jest.fn(), setEnabled: jest.fn(), preload: jest.fn() }))
+// BLD-753a: use centralized manual mock at lib/__mocks__/audio.ts
+jest.mock('../../lib/audio')
 jest.mock('victory-native', () => ({
   CartesianChart: 'CartesianChart',
   Line: 'Line',

--- a/__tests__/acceptance/workout-session.acceptance.test.tsx
+++ b/__tests__/acceptance/workout-session.acceptance.test.tsx
@@ -87,7 +87,8 @@ jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache'
 jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
 jest.mock('expo-haptics', () => ({ impactAsync: jest.fn(), notificationAsync: jest.fn(), ImpactFeedbackStyle: { Light: 'light', Heavy: 'heavy' }, NotificationFeedbackType: { Success: 'success', Warning: 'warning' } }))
 jest.mock('expo-keep-awake', () => ({ useKeepAwake: jest.fn(), activateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined), deactivateKeepAwake: jest.fn(), deactivateKeepAwakeAsync: jest.fn().mockResolvedValue(undefined) }))
-jest.mock('../../lib/audio', () => ({ play: jest.fn(), setEnabled: jest.fn(), preload: jest.fn() }))
+// BLD-753a: use centralized manual mock at lib/__mocks__/audio.ts
+jest.mock('../../lib/audio')
 jest.mock('victory-native', () => ({ CartesianChart: 'CartesianChart', Line: 'Line', Bar: 'Bar' }))
 
 import React from 'react'

--- a/__tests__/lib/audio-mock-completeness.test.ts
+++ b/__tests__/lib/audio-mock-completeness.test.ts
@@ -1,0 +1,23 @@
+// BLD-753a: Guard rail — keep the manual mock at `lib/__mocks__/audio.ts`
+// in sync with the real `lib/audio` public surface. If the real module
+// adds an export that the mock doesn't know about, this test fails so the
+// author updates the mock instead of leaving a latent
+// `TypeError: (0 , _audio.<missing>) is not a function` bomb.
+
+describe("lib/audio mock completeness (BLD-753a)", () => {
+  it("manual mock exports every value-export of the real module", () => {
+    // Use jest.requireActual to bypass the manual mock and get the real shape.
+    const real = jest.requireActual("../../lib/audio") as Record<string, unknown>
+    // The manual mock is what jest substitutes when we do a plain require.
+    jest.mock("../../lib/audio")
+    const mock = require("../../lib/audio") as Record<string, unknown>
+
+    const realKeys = Object.keys(real).sort()
+    const mockKeys = Object.keys(mock).sort()
+    const missing = realKeys.filter((k) => !(k in mock))
+
+    expect(missing).toEqual([])
+    // Defensive: also surface the full diff in the failure message.
+    expect(mockKeys).toEqual(expect.arrayContaining(realKeys))
+  })
+})

--- a/lib/__mocks__/audio.ts
+++ b/lib/__mocks__/audio.ts
@@ -1,0 +1,47 @@
+// Manual jest mock for `lib/audio` (BLD-753a).
+//
+// Why this exists:
+// - The real module owns a Map of expo-audio AudioPlayer instances and a
+//   `useFocusEffect` cleanup (`unloadAudio()`) wired into `useTimerEngine`.
+// - Test files used to inline-mock with `{ play, setEnabled, preload }` only,
+//   which made `unload()` undefined and exploded the focus-effect cleanup with
+//   `TypeError: (0 , _audio.unload) is not a function`. See BLD-753a thread.
+// - Centralizing the mock here mirrors the FULL public surface of `lib/audio`
+//   so future additions to the real module don't silently break tests again.
+//
+// Usage from a test file:
+//   jest.mock("../../lib/audio");           // picks up THIS manual mock
+//   // OR (also works because jest resolves manual mocks via the real module
+//   // path after path-alias resolution):
+//   jest.mock("@/lib/audio");
+//
+// All exports are `jest.fn()` so individual tests can assert calls if needed:
+//   const audio = require("../../lib/audio")
+//   expect(audio.play).toHaveBeenCalledWith("set_complete")
+
+// Keep these in sync with `lib/audio.ts`. The completeness is enforced by
+// `__tests__/lib/audio-mock-completeness.test.ts` (see BLD-753a).
+import type { AudioCategory, TimerCue } from "../audio"
+
+export type { AudioCategory, TimerCue }
+
+// Mirror the const map from the real module so tests that read CUE_CATEGORY
+// (e.g. via `import { CUE_CATEGORY } from "@/lib/audio"`) get a usable value.
+// Values match the real module to avoid surprising any test that imports it.
+export const CUE_CATEGORY: Record<TimerCue, AudioCategory> = {
+  work_start: "timer",
+  rest_start: "timer",
+  tick: "timer",
+  minute: "timer",
+  warning: "timer",
+  complete: "timer",
+  set_complete: "feedback",
+}
+
+// Public function surface — all auto-mocked. Resolve to `undefined` so the
+// promise-returning APIs can be `await`ed without behaviour changes in tests.
+export const preload = jest.fn().mockResolvedValue(undefined)
+export const play = jest.fn().mockResolvedValue(undefined)
+export const unload = jest.fn().mockResolvedValue(undefined)
+export const setEnabled = jest.fn()
+export const isEnabled = jest.fn(() => true)


### PR DESCRIPTION
## Summary

Fixes the Cluster A pre-existing jest failures surfaced by the BLD-742 CI workflow (PR #415, run [25058800818](https://github.com/alankyshum/cablesnap/actions/runs/25058800818)): 9 failures across `__tests__/acceptance/supersets.test.tsx` (7) and `__tests__/acceptance/session-add-exercise.acceptance.test.tsx` (2), plus a latent same-shape bug in 7 sibling files that just hadn't bitten yet.

## Root cause

`useTimerEngine.useFocusEffect` cleanup calls `unloadAudio()` (= `lib/audio.unload`). 8 acceptance test files inline-mocked `lib/audio` with only `{ play, setEnabled, preload }` — `unload` was missing, so the cleanup threw `TypeError: (0 , _audio.unload) is not a function`.

## Changes

- **New:** `lib/__mocks__/audio.ts` — manual mock mirroring the full public surface of `lib/audio` (`play`, `unload`, `preload`, `setEnabled`, `isEnabled`, `CUE_CATEGORY`, plus `TimerCue` / `AudioCategory` type re-exports). All functions are `jest.fn()` (promises resolve to `undefined`).
- **9 acceptance tests:** replace inline `jest.mock('../../lib/audio', () => ({...}))` with bare `jest.mock('../../lib/audio')` so jest picks up the manual mock. Files: supersets, session-add-exercise.acceptance, workout-session.acceptance, settings, session-ux, rpe-notes, data-management.acceptance, csv-export.acceptance, accessibility.acceptance.
- **New:** `__tests__/lib/audio-mock-completeness.test.ts` — guard rail that fails if `lib/audio` adds an export the manual mock doesn't know about. Prevents the latent-bug pattern from recurring.

## Verification

- ✅ `npx jest __tests__/lib/audio-mock-completeness.test.ts` — passes locally.
- ✅ `npx jest __tests__/lib/audio.test.ts` — existing real-module unit tests still pass.
- ⚠️ Acceptance suites can't be exercised in this local container due to an unrelated `@testing-library/react-native` vs React 19 `actImplementation is not a function` issue that does **not** reproduce on CI. The CI logs (linked above) show the exact `_audio.unload is not a function` failure mode this PR fixes, so CI will confirm.

## Scope

Cluster A (lib/audio mock) only. Cluster B (3 `WorkoutHeatmap` failures) is tracked separately as BLD-753b.

## Issue

Resolves [BLD-753](https://paperclip/BLD/issues/BLD-753) (Cluster A).
