### PR TITLE
test(heatmap): unblock WorkoutHeatmap suite under NODE_ENV=production (BLD-763)

### DIFF
--- a/__tests__/components/WorkoutHeatmap.test.tsx
+++ b/__tests__/components/WorkoutHeatmap.test.tsx
@@ -83,20 +83,31 @@ describe("WorkoutHeatmap", () => {
     const { getAllByText } = renderScreen(
       <WorkoutHeatmap data={data} />
     );
-    // Legend shows 3+ and the cell with count 3 also shows 3+
-    expect(getAllByText("3+").length).toBeGreaterThanOrEqual(2);
+    // BLD-732: numeric labels are intentionally hidden from a11y (the
+    // parent Pressable already announces the count via accessibilityLabel).
+    // They exist purely as a visual non-color cue, so we must opt into
+    // hidden elements to assert they render. Legend shows '3+' and the
+    // body cell with count 3 also shows '3+'. (BLD-763.)
+    expect(
+      getAllByText("3+", { includeHiddenElements: true }).length
+    ).toBeGreaterThanOrEqual(2);
   });
 
   // BLD-732: numeric labels are the non-color cue. Each step must render
   // its count inside the cell so deuteranopia/protanopia users can still
-  // distinguish 1 / 2 / 3+.
+  // distinguish 1 / 2 / 3+. The labels are marked
+  // `accessibilityElementsHidden` because the parent Pressable announces
+  // the count via accessibilityLabel — so the queries below must opt into
+  // hidden elements to find them. (BLD-763.)
   it("renders numeric '1' label for cells with exactly 1 workout (BLD-732)", () => {
     const data = new Map([["2026-04-14", 1]]);
     const { getAllByText } = renderScreen(
       <WorkoutHeatmap data={data} />
     );
     // Legend shows '1' and the body cell with count 1 also shows '1'.
-    expect(getAllByText("1").length).toBeGreaterThanOrEqual(2);
+    expect(
+      getAllByText("1", { includeHiddenElements: true }).length
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it("renders numeric '2' label for cells with exactly 2 workouts (BLD-732)", () => {
@@ -105,7 +116,9 @@ describe("WorkoutHeatmap", () => {
       <WorkoutHeatmap data={data} />
     );
     // Legend shows '2' and the body cell with count 2 also shows '2'.
-    expect(getAllByText("2").length).toBeGreaterThanOrEqual(2);
+    expect(
+      getAllByText("2", { includeHiddenElements: true }).length
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it("does not render a numeric label for cells with zero workouts (BLD-732)", () => {
@@ -113,7 +126,10 @@ describe("WorkoutHeatmap", () => {
       <WorkoutHeatmap data={emptyData} />
     );
     // Step-0 cells stay unlabelled — the empty fill is the cue.
-    expect(queryByText("0")).toBeNull();
+    // Use `includeHiddenElements` because the legend's labels are hidden
+    // from a11y (BLD-763); we need to assert no '0' exists anywhere,
+    // visible OR hidden.
+    expect(queryByText("0", { includeHiddenElements: true })).toBeNull();
   });
 
   it("legend exposes a screen-reader summary of all four steps (BLD-732)", () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,20 @@
+// BLD-763: Force NODE_ENV=test regardless of parent shell.
+//
+// React 19 only exports `React.act` from the development build
+// (`react/cjs/react.development.js`); the production build omits it, and
+// `react-test-renderer` captures `var act = React.act` at module-load time.
+// If `NODE_ENV` is `production` when jest spawns its workers (which can
+// happen when the parent shell exports it — common in agent/CI harness
+// containers), `act` is permanently `undefined` inside the test runtime
+// and `@testing-library/react-native`'s render() throws
+// "TypeError: actImplementation is not a function" on every render() call.
+//
+// Jest only auto-sets NODE_ENV=test when it is null
+// (see `jest-cli/bin/jest.js`), so we have to force it ourselves here.
+// This must run before any test file or preset requires `react` /
+// `react-test-renderer`.
+process.env.NODE_ENV = 'test';
+
 module.exports = {
   preset: 'jest-expo',
   testTimeout: 10000,


### PR DESCRIPTION
## Summary

Diagnoses and fixes the 3 failing WorkoutHeatmap text-rendering tests called out in BLD-763 (Cluster B). The ticket framed this as "Text being stripped from Pressable in tests"; the real diagnosis turned out to be two independent upstream issues, neither in the product code:

1. **`act` was undefined** because `NODE_ENV=production` leaked from the parent shell into jest workers. React 19 only exports `React.act` from the dev build, and `react-test-renderer` captures it at module-load time, so `@testing-library/react-native`'s `render()` threw `TypeError: actImplementation is not a function` on **all 16** tests in the suite. Forcing `process.env.NODE_ENV = 'test'` at the top of `jest.config.js` makes this deterministic across local / agent / CI environments.
2. **`getAllByText` correctly skips a11y-hidden subtrees.** The BLD-732 numeric cell labels are wrapped with `accessibilityElementsHidden` so screen readers don't double-announce the count (the parent `Pressable` already announces "Tuesday, April 14, 1 workout"). The 3 BLD-732 assertions just need to opt into `{ includeHiddenElements: true }` to verify the visual non-color cue.

No `WorkoutHeatmap.tsx` changes — the component was verifiably correct, as the ticket called out.

## Verification

```
node_modules/.bin/jest __tests__/components/WorkoutHeatmap.test.tsx
# Tests: 16 passed, 16 total
```

Full suite: 233/236 suites pass. The 3 remaining failures are out-of-scope and tracked elsewhere:
- `session-add-exercise.acceptance.test.tsx`, `supersets.test.tsx` -> BLD-753a (lib/audio mock, claudecoder)
- `expo-sqlite-worker-channel-length.test.ts` -> BLD-660 patch-detection, unrelated

## Diff scope

- `jest.config.js`: 1 effective LOC (+ comment block explaining why)
- `__tests__/components/WorkoutHeatmap.test.tsx`: 4 tests opt into `includeHiddenElements`. No new tests added; no tests skipped.

## Notes for reviewers

- The fuller diagnosis is in the BLD-763 issue thread (root-cause walkthrough with file/line refs).
- After this lands, BLD-742's CI workflow can flip its jest job to blocking (combined with BLD-753a closing).
- The accessibility contract for BLD-732 remains covered by the dedicated `accessibilityLabel` assertions on lines 45-60 (cell) and 119-126 (legend summary). We didn't weaken a11y coverage, only the over-strict visual-text assertions.