### PR TITLE
ci: flip typecheck to blocking (BLD-764)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ name: CI
 #
 # Job split rationale (Option C): typecheck and jest run as separate jobs so
 # each can be independently marked non-blocking via `continue-on-error: true`
-# until the pre-existing failures on `main` are cleaned up.
-# - typecheck: 10 pre-existing TS errors → see BLD-747.
+# until the pre-existing failures on `main` are cleaned up. Typecheck flipped
+# back to blocking in BLD-764 once the pre-existing TS errors were cleared.
 # - jest: 12 pre-existing test failures across 3 suites (supersets,
-#   session-add-exercise, WorkoutHeatmap) → see BLD-753.
-# Both jobs flip back to blocking once their respective cleanup tickets land.
+#   session-add-exercise, WorkoutHeatmap) → see BLD-753. Flips to blocking
+#   once those failures are fixed.
 
 on:
   pull_request: {}
@@ -35,11 +35,6 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # TODO(BLD-747): flip to blocking (remove `continue-on-error`) after the
-    # 10 pre-existing typecheck errors discovered by this workflow's first
-    # run on PR #415 are cleaned up. Until then, typecheck failures surface
-    # as warnings on the PR but do not block merge.
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Flips the `typecheck` job in `.github/workflows/ci.yml` from non-blocking to blocking. Pre-existing TS errors were cleared by PR #422 (BLD-747), so the gate is now safe to enforce.

## Changes

- Remove `continue-on-error: true` from the `typecheck` job
- Remove the `TODO(BLD-747)` comment block above it
- Update the header rationale comment to note typecheck is now blocking; only jest remains non-blocking (BLD-753)

Jest job is untouched — that flip is BLD-753's territory.

## Testing

- `npm run typecheck` passes clean on `main` (verified pre-flight)
- After merge, CI will enforce typecheck as a blocking gate on every PR

## Issue

Resolves BLD-764. Builds on BLD-742 (PR #415, ci.yml) and BLD-747 (PR #422, errors cleared).