### PR TITLE
fix(dx): make npm install work in headless containers (BLD-741)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ cd cablesnap
 npm install
 ```
 
+The `postinstall` step runs `npx --no-install patch-package` to apply patches
+in `patches/` against `node_modules/`. Two install-time concerns are handled:
+
+1. `patch-package` is declared in `dependencies` (not `devDependencies`) so it
+   is installed even when `NODE_ENV=production` or `npm config omit=dev` —
+   common in headless agent / CI containers. It is invoked only via the
+   `postinstall` hook and is never imported by app code, so it has no impact
+   on the production bundle.
+2. `npx --no-install` resolves the binary directly from `node_modules/.bin/`
+   instead of relying on shell `PATH`, which makes the hook robust to
+   containers that strip `node_modules/.bin` from `PATH`.
+
+If you ever need to skip patches (e.g., a fast lockfile-only install), use
+`npm install --ignore-scripts`.
+
+The `prepare` script (`husky || true`) installs git hooks for local
+contributors but no-ops when `husky` is absent (production / CI / agent
+containers where `devDependencies` are skipped).
+
 ### Development Build (Recommended)
 
 CableSnap uses [expo-dev-client](https://docs.expo.dev/develop/development-builds/introduction/) instead of Expo Go, which enables native module support (e.g., HealthKit integration).

--- a/__tests__/config/install-lifecycle.test.ts
+++ b/__tests__/config/install-lifecycle.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Regression lock: `npm install` must succeed in headless / production
+ * containers (NODE_ENV=production, npm config omit=dev) without requiring
+ * the `--ignore-scripts` workaround.
+ *
+ * Failure mode (BLD-741): `patch-package` was previously a devDependency,
+ * so it was absent in production-mode installs and the `postinstall` hook
+ * crashed. Similarly, `husky` (devDep) crashed the `prepare` hook.
+ *
+ * Invariants:
+ *   1. `patch-package` is declared in `dependencies` so it is always
+ *      installed regardless of NODE_ENV / omit=dev.
+ *   2. `postinstall` invokes `npx --no-install patch-package` — the
+ *      `--no-install` flag forces resolution to `node_modules/.bin/`
+ *      instead of relying on shell PATH.
+ *   3. `prepare` is guarded with `|| true` so missing husky (production)
+ *      does not break the install.
+ *
+ * Refs: BLD-741.
+ */
+import fs from "fs";
+import path from "path";
+
+interface PackageJson {
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+describe("Install lifecycle scripts (BLD-741)", () => {
+  const pkg: PackageJson = JSON.parse(
+    fs.readFileSync(
+      path.resolve(__dirname, "../../package.json"),
+      "utf8",
+    ),
+  );
+
+  it("declares patch-package in dependencies (not devDependencies) so headless installs do not skip it", () => {
+    expect(pkg.dependencies?.["patch-package"]).toBeDefined();
+    expect(pkg.devDependencies?.["patch-package"]).toBeUndefined();
+  });
+
+  it("postinstall hook invokes patch-package via `npx --no-install` to bypass PATH lookup", () => {
+    const postinstall = pkg.scripts?.postinstall ?? "";
+    expect(postinstall).toContain("patch-package");
+    // `npx --no-install` resolves directly from node_modules/.bin and never
+    // attempts a network install — required for offline / locked-down agent
+    // containers.
+    expect(postinstall).toMatch(/npx\s+--no-install\s+patch-package/);
+  });
+
+  it("prepare hook tolerates missing husky in production / agent containers", () => {
+    const prepare = pkg.scripts?.prepare ?? "";
+    // Either `husky || true` (current fix) or any other shell construct that
+    // exits 0 on husky absence is acceptable. We assert the `|| true` guard
+    // explicitly because that is what the documented fix uses; revisit if a
+    // different mechanism is adopted.
+    expect(prepare).toMatch(/husky\s*\|\|\s*true/);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "expo-system-ui": "~55.0.15",
         "expo-web-browser": "~55.0.14",
         "lucide-react-native": "^1.8.0",
+        "patch-package": "^8.0.1",
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-hook-form": "^7.72.1",
@@ -89,7 +90,6 @@
         "jest": "^29.7.0",
         "jest-expo": "~55.0.16",
         "lint-staged": "^16.4.0",
-        "patch-package": "^8.0.1",
         "react-test-renderer": "19.2.0",
         "sharp": "^0.34.5",
         "ts-jest": "^29.4.9",
@@ -6340,7 +6340,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/abab": {
@@ -7254,7 +7253,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7273,7 +7271,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7287,7 +7284,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8230,7 +8226,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -8580,7 +8575,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -8749,7 +8743,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8796,7 +8789,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -10270,7 +10262,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
       "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "micromatch": "^4.0.2"
@@ -10377,7 +10368,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -10392,7 +10382,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -10513,7 +10502,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -10556,7 +10544,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -10686,7 +10673,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10756,7 +10742,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -10785,7 +10770,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11648,7 +11632,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -12806,7 +12789,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
       "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -12845,7 +12827,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -12858,7 +12839,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -12868,7 +12848,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "dev": true,
       "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12904,7 +12883,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
       "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
@@ -13713,7 +13691,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -14268,7 +14245,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -14540,7 +14516,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -14985,7 +14960,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
       "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
@@ -15015,7 +14989,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16686,7 +16659,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -17635,7 +17607,6 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
       "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "screenshots:raw": "playwright test e2e/screenshot-capture.spec.ts --project=store-pixel9 --project=store-fold7",
     "screenshots:frame": "tsx scripts/generate-store-screenshots.ts",
     "screenshots": "npm run screenshots:raw && npm run screenshots:frame",
-    "prepare": "husky",
-    "postinstall": "patch-package"
+    "prepare": "husky || true",
+    "postinstall": "npx --no-install patch-package"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
@@ -80,6 +80,7 @@
     "expo-system-ui": "~55.0.15",
     "expo-web-browser": "~55.0.14",
     "lucide-react-native": "^1.8.0",
+    "patch-package": "^8.0.1",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-hook-form": "^7.72.1",
@@ -118,7 +119,6 @@
     "jest": "^29.7.0",
     "jest-expo": "~55.0.16",
     "lint-staged": "^16.4.0",
-    "patch-package": "^8.0.1",
     "react-test-renderer": "19.2.0",
     "sharp": "^0.34.5",
     "ts-jest": "^29.4.9",


### PR DESCRIPTION
## Summary

Plain \`npm install\` failed in headless agent / CI containers (where \`NODE_ENV=production\` or \`npm config omit=dev\` skip devDependencies) because both the \`postinstall\` hook (\`patch-package\`) and the \`prepare\` hook (\`husky\`) referenced binaries that lived in \`devDependencies\`. Agents had to remember the \`--ignore-scripts\` workaround, and \`patches/\` were silently not applied — meaning any test that depended on a patched dep could misbehave without warning.

## Root cause

Diagnosed by reproducing in this very container:

\`\`\`
> cablesnap@0.26.16 postinstall
> npx --no-install patch-package
npm error npx canceled due to missing packages and no YES option: ["patch-package@8.0.1"]
\`\`\`

So the issue was **not** primarily a \`PATH\` problem (as originally suspected); it was that \`patch-package\` and \`husky\` were never installed at all in production-mode installs. The PATH symptom was a secondary concern.

## Fix (combined Option 1 + Option 2 from the ticket)

| Change | Why |
|---|---|
| Move \`patch-package\` from \`devDependencies\` to \`dependencies\` | So it is installed even when devDeps are omitted. Bundle impact: zero — \`patch-package\` is invoked only via the postinstall hook and is never \`import\`/\`require\`'d from app code (verified via grep). |
| \`postinstall\`: \`patch-package\` → \`npx --no-install patch-package\` | Forces resolution from \`node_modules/.bin/\` instead of relying on shell PATH. \`--no-install\` guarantees no network call. |
| \`prepare\`: \`husky\` → \`husky \|\| true\` | Standard husky-recommended pattern so the hook no-ops gracefully when husky is absent (production / CI / agent containers). |

## Verification

In the headless agent container with \`NODE_ENV=production\`:

\`\`\`
$ rm -rf node_modules
$ npm install --legacy-peer-deps    # NO --ignore-scripts
…
> cablesnap@0.26.16 postinstall
> npx --no-install patch-package
patch-package 8.0.1
Applying patches...
expo-sqlite@55.0.15 ✔
> cablesnap@0.26.16 prepare
> husky || true
sh: 1: husky: not found
added 826 packages   # exit 0
\`\`\`

- \`tsc --noEmit\` clean (exit 0)
- \`npm test\`: 237 suites / 2555 tests pass
- New regression-lock test: \`__tests__/config/install-lifecycle.test.ts\` (3 tests) pins the three invariants so a future devDep move cannot silently regress this.

## Documentation

\`README.md\` "Install" section now explains both fixes and when to use \`--ignore-scripts\` (lockfile-only installs).

## Issue

Resolves BLD-741.