### PR TITLE
fix(test): apply patch-package via jest globalSetup (BLD-831)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     'react-native-reanimated': '<rootDir>/__mocks__/react-native-reanimated.js',
   },
   testPathIgnorePatterns: ['/node_modules/', '__tests__/helpers/', '__tests__/fixtures/', '/e2e/'],
+  globalSetup: './jest.global-setup.js',
   setupFiles: ['./jest.setup.js'],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],

--- a/jest.global-setup.js
+++ b/jest.global-setup.js
@@ -1,0 +1,56 @@
+/**
+ * Jest globalSetup — ensure `patch-package` patches are applied before any
+ * test runs.
+ *
+ * Why: `__tests__/lib/expo-sqlite-worker-channel-length.test.ts` (BLD-660 /
+ * BLD-831) reads `node_modules/expo-sqlite/web/WorkerChannel.ts` from disk to
+ * guard the BLD-660 length-prefix patch. The patch is normally applied by the
+ * `postinstall` hook (`patch-package`). Any environment that installs deps
+ * with `--ignore-scripts` (CI cache restores, security-locked installs, the
+ * exact reproduction command in BLD-831) skips postinstall and leaves the
+ * file unpatched, causing a deterministic test failure unrelated to the
+ * codebase under test.
+ *
+ * Running `patch-package` here is idempotent — already-applied patches are a
+ * no-op — and adds <1s to a cold test run. If `patch-package` itself isn't
+ * installed (e.g. a stripped-down node_modules), we silently skip and let the
+ * downstream test fail with its own clear message.
+ */
+
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+
+module.exports = async function globalSetup() {
+  const repoRoot = __dirname;
+  const patchPackageBin = path.join(
+    repoRoot,
+    'node_modules',
+    '.bin',
+    'patch-package',
+  );
+
+  if (!fs.existsSync(patchPackageBin)) {
+    return;
+  }
+
+  const patchesDir = path.join(repoRoot, 'patches');
+  if (!fs.existsSync(patchesDir)) {
+    return;
+  }
+
+  const result = spawnSync(patchPackageBin, [], {
+    cwd: repoRoot,
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    const stderr = (result.stderr || '').trim();
+    const stdout = (result.stdout || '').trim();
+    throw new Error(
+      `[jest globalSetup] patch-package failed (exit ${result.status}):\n` +
+        `${stdout}\n${stderr}`,
+    );
+  }
+};


### PR DESCRIPTION
## Summary

Fix `__tests__/lib/expo-sqlite-worker-channel-length.test.ts` failing on `main` when deps were installed with `--ignore-scripts` (the exact reproduction in BLD-831, plus CI cache restores and security-locked installs).

## Root cause

The test reads `node_modules/expo-sqlite/web/WorkerChannel.ts` from disk and asserts the BLD-660 length-prefix patch is applied. The patch is normally applied by the `postinstall` hook (`patch-package`). When `--ignore-scripts` is used, postinstall is skipped, the file is unpatched, and the assertion deterministically fails.

This is **not** a regression in the codebase — it is a missing safeguard against lifecycle-script-skipping installers.

## Fix

Add a Jest `globalSetup` that runs `patch-package` once before any test starts. The call is idempotent (already-applied patches are a no-op) and adds <1s to a cold test run. If `patch-package` itself isn't installed (stripped-down sandbox), the hook silently returns and lets the downstream test fail with its own clear message.

## Changes

- `jest.global-setup.js` — new file, runs `patch-package` via `spawnSync`.
- `jest.config.js` — wire `globalSetup: './jest.global-setup.js'`.

## Verification

- Manually reverted the `WorkerChannel.ts` patch and ran the test 3 consecutive times — passes deterministically every time (AC: 3 consecutive deterministic runs on `main`).
- Ran the exact issue reproduction: `npm test -- expo-sqlite-worker-channel-length` from an unpatched starting state — 15/15 tests pass.
- `npx tsc --noEmit` clean.

## Issue

Resolves BLD-831