### PR TITLE
feat(analytics): per-exercise cable variant filter on exercise detail (BLD-788)

### DIFF
--- a/__tests__/acceptance/phase43-1rm-features.acceptance.test.tsx
+++ b/__tests__/acceptance/phase43-1rm-features.acceptance.test.tsx
@@ -60,6 +60,7 @@ jest.mock('../../lib/db', () => ({
   getExerciseChartData: jest.fn(),
   getExercise1RMChartData: jest.fn(),
   getBestSet: jest.fn(),
+  getVariantSetCount: jest.fn().mockResolvedValue(0),
   getExerciseHistory: jest.fn().mockResolvedValue([]),
   softDeleteCustomExercise: jest.fn(),
   getTemplatesUsingExercise: jest.fn().mockResolvedValue([]),

--- a/__tests__/components/exercise/ExerciseVariantFilter.test.tsx
+++ b/__tests__/components/exercise/ExerciseVariantFilter.test.tsx
@@ -106,18 +106,18 @@ describe("ExerciseVariantFilter — BLD-788", () => {
     expect(onChange).toHaveBeenCalledWith({ attachment: "bar" });
   });
 
-  it("renders active-state badge as 'Showing: Rope · High'", () => {
+  it("renders active-state badge as 'Showing: Rope · High (N logged)' with the filter count", () => {
     const { getByText } = render(
       <ExerciseVariantFilter
         scope={{ attachment: "rope", mount_position: "high" }}
         onChange={jest.fn()}
-        variantTotal={5}
+        variantTotal={12}
       />
     );
-    expect(getByText("Showing: Rope · High")).toBeTruthy();
+    expect(getByText("Showing: Rope · High (12 logged)")).toBeTruthy();
   });
 
-  it("renders single-dimension active badge correctly", () => {
+  it("renders single-dimension active badge with count", () => {
     const { getByText } = render(
       <ExerciseVariantFilter
         scope={{ attachment: "bar" }}
@@ -125,7 +125,7 @@ describe("ExerciseVariantFilter — BLD-788", () => {
         variantTotal={5}
       />
     );
-    expect(getByText("Showing: Bar")).toBeTruthy();
+    expect(getByText("Showing: Bar (5 logged)")).toBeTruthy();
   });
 
   it("Clear button resets scope to empty object", () => {

--- a/__tests__/components/exercise/ExerciseVariantFilter.test.tsx
+++ b/__tests__/components/exercise/ExerciseVariantFilter.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * BLD-788 — ExerciseVariantFilter unit tests.
+ *
+ * Behavior coverage:
+ *  - Default state: "Showing: All variants (N logged)" badge, no Clear button.
+ *  - Active state: badge shows selected dimensions; Clear is rendered.
+ *  - Tapping an unselected attachment chip emits onChange with that attachment.
+ *  - Tapping the active attachment chip again clears that dimension only
+ *    (mount_position untouched).
+ *  - Same independence rule for mount_position.
+ *  - Clear emits empty object scope.
+ *  - Vocabulary comes exclusively from lib/cable-variant — every value renders.
+ */
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import ExerciseVariantFilter from "../../../components/exercise/ExerciseVariantFilter";
+import { ATTACHMENT_VALUES, MOUNT_POSITION_VALUES } from "../../../lib/cable-variant";
+import { ATTACHMENT_LABELS, MOUNT_POSITION_LABELS } from "../../../lib/types";
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    surface: "#fff",
+    surfaceVariant: "#ECE6F0",
+    onSurface: "#000",
+    onSurfaceVariant: "#49454F",
+    outlineVariant: "#cccccc",
+    primaryContainer: "#E8DEF8",
+    onPrimaryContainer: "#21005D",
+  }),
+}));
+
+describe("ExerciseVariantFilter — BLD-788", () => {
+  it("renders default 'All variants (N logged)' badge with no Clear button", () => {
+    const onChange = jest.fn();
+    const { getByText, queryByLabelText } = render(
+      <ExerciseVariantFilter scope={{}} onChange={onChange} variantTotal={42} />
+    );
+    expect(getByText("Showing: All variants (42 logged)")).toBeTruthy();
+    expect(queryByLabelText("Clear variant filter")).toBeNull();
+  });
+
+  it("renders all attachment chips from ATTACHMENT_VALUES", () => {
+    const { getByLabelText } = render(
+      <ExerciseVariantFilter scope={{}} onChange={jest.fn()} variantTotal={0} />
+    );
+    for (const v of ATTACHMENT_VALUES) {
+      expect(getByLabelText(`Attachment ${ATTACHMENT_LABELS[v]}`)).toBeTruthy();
+    }
+  });
+
+  it("renders all mount chips from MOUNT_POSITION_VALUES", () => {
+    const { getByLabelText } = render(
+      <ExerciseVariantFilter scope={{}} onChange={jest.fn()} variantTotal={0} />
+    );
+    for (const v of MOUNT_POSITION_VALUES) {
+      expect(getByLabelText(`Mount ${MOUNT_POSITION_LABELS[v]}`)).toBeTruthy();
+    }
+  });
+
+  it("tapping an attachment chip selects that dimension only", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <ExerciseVariantFilter scope={{}} onChange={onChange} variantTotal={0} />
+    );
+    fireEvent.press(getByLabelText("Attachment Rope"));
+    expect(onChange).toHaveBeenCalledWith({ attachment: "rope" });
+  });
+
+  it("tapping the active attachment chip clears just that dimension", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <ExerciseVariantFilter
+        scope={{ attachment: "rope", mount_position: "high" }}
+        onChange={onChange}
+        variantTotal={0}
+      />
+    );
+    fireEvent.press(getByLabelText("Attachment Rope, selected"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ mount_position: "high" });
+  });
+
+  it("tapping a mount chip selects that dimension only", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <ExerciseVariantFilter
+        scope={{ attachment: "bar" }}
+        onChange={onChange}
+        variantTotal={0}
+      />
+    );
+    fireEvent.press(getByLabelText("Mount High"));
+    expect(onChange).toHaveBeenCalledWith({ attachment: "bar", mount_position: "high" });
+  });
+
+  it("tapping the active mount chip clears just that dimension", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <ExerciseVariantFilter
+        scope={{ attachment: "bar", mount_position: "low" }}
+        onChange={onChange}
+        variantTotal={0}
+      />
+    );
+    fireEvent.press(getByLabelText("Mount Low, selected"));
+    expect(onChange).toHaveBeenCalledWith({ attachment: "bar" });
+  });
+
+  it("renders active-state badge as 'Showing: Rope · High'", () => {
+    const { getByText } = render(
+      <ExerciseVariantFilter
+        scope={{ attachment: "rope", mount_position: "high" }}
+        onChange={jest.fn()}
+        variantTotal={5}
+      />
+    );
+    expect(getByText("Showing: Rope · High")).toBeTruthy();
+  });
+
+  it("renders single-dimension active badge correctly", () => {
+    const { getByText } = render(
+      <ExerciseVariantFilter
+        scope={{ attachment: "bar" }}
+        onChange={jest.fn()}
+        variantTotal={5}
+      />
+    );
+    expect(getByText("Showing: Bar")).toBeTruthy();
+  });
+
+  it("Clear button resets scope to empty object", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <ExerciseVariantFilter
+        scope={{ attachment: "rope", mount_position: "high" }}
+        onChange={onChange}
+        variantTotal={3}
+      />
+    );
+    fireEvent.press(getByLabelText("Clear variant filter"));
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+});

--- a/__tests__/lib/db/variant-scope-filter.test.ts
+++ b/__tests__/lib/db/variant-scope-filter.test.ts
@@ -162,6 +162,28 @@ describe('BLD-788 variant scope filter', () => {
       expect(sql).toMatch(/ws\.attachment\s+IS\s+NOT\s+NULL\s+OR\s+ws\.mount_position\s+IS\s+NOT\s+NULL/);
       expect(helpers.queryOne.mock.calls[0][1]).toEqual(['ex-3']);
     });
+
+    // BLD-788 review blocker: explicit-null scope ({attachment: null}) must NOT
+    // trigger the adoption gate. buildVariantSql returns non-empty SQL but empty
+    // params for IS NULL predicates — the old params.length check was wrong.
+    test('explicit-null attachment scope does NOT trigger adoption gate', async () => {
+      helpers.queryOne.mockResolvedValueOnce({ n: 3 });
+      await getVariantSetCount('ex-4', { attachment: null });
+      const sql = helpers.queryOne.mock.calls[0][0] as string;
+      // Should have IS NULL predicate from the scope, NOT the adoption gate
+      expect(sql).toMatch(/ws\.attachment\s+IS\s+NULL/);
+      expect(sql).not.toMatch(/ws\.attachment\s+IS\s+NOT\s+NULL\s+OR\s+ws\.mount_position\s+IS\s+NOT\s+NULL/);
+      expect(helpers.queryOne.mock.calls[0][1]).toEqual(['ex-4']);
+    });
+
+    test('explicit-null mount_position scope does NOT trigger adoption gate', async () => {
+      helpers.queryOne.mockResolvedValueOnce({ n: 1 });
+      await getVariantSetCount('ex-5', { mount_position: null });
+      const sql = helpers.queryOne.mock.calls[0][0] as string;
+      expect(sql).toMatch(/ws\.mount_position\s+IS\s+NULL/);
+      expect(sql).not.toMatch(/ws\.attachment\s+IS\s+NOT\s+NULL\s+OR\s+ws\.mount_position\s+IS\s+NOT\s+NULL/);
+      expect(helpers.queryOne.mock.calls[0][1]).toEqual(['ex-5']);
+    });
   });
 
   // ── chart functions: variant-scope filtering ────────────────────

--- a/__tests__/lib/db/variant-scope-filter.test.ts
+++ b/__tests__/lib/db/variant-scope-filter.test.ts
@@ -21,6 +21,11 @@ const helpers = require('../../../lib/db/helpers') as {
 };
 
 import { buildVariantSql, getVariantSetCount } from '../../../lib/db/exercise-history';
+import {
+  getExerciseChartData,
+  getExercise1RMChartData,
+  getExerciseDurationChartData,
+} from '../../../lib/db/exercise-history';
 import type { VariantScope } from '../../../lib/db/exercise-history';
 
 describe('BLD-788 variant scope filter', () => {
@@ -124,6 +129,86 @@ describe('BLD-788 variant scope filter', () => {
       expect(sql).toMatch(/wss\.completed_at\s+IS\s+NOT\s+NULL/);
       expect(sql).toMatch(/ws\.attachment\s+IS\s+NOT\s+NULL\s+OR\s+ws\.mount_position\s+IS\s+NOT\s+NULL/);
       expect(params).toEqual(['ex-xyz']);
+    });
+
+    test('with scope, replaces "any variant logged" gate with exact-tuple predicate', async () => {
+      helpers.queryOne.mockResolvedValueOnce({ n: 12 });
+      const n = await getVariantSetCount('ex-1', { attachment: 'rope', mount_position: 'high' });
+      expect(n).toBe(12);
+      const call = helpers.queryOne.mock.calls[0];
+      const sql = call[0] as string;
+      const params = call[1] as unknown[];
+      // Adoption gate gone, tuple predicate applied
+      expect(sql).not.toMatch(/ws\.attachment\s+IS\s+NOT\s+NULL\s+OR\s+ws\.mount_position\s+IS\s+NOT\s+NULL/);
+      expect(sql).toMatch(/ws\.attachment\s*=\s*\?\s*AND\s*ws\.mount_position\s*=\s*\?/);
+      expect(params).toEqual(['ex-1', 'rope', 'high']);
+    });
+
+    test('with single-dimension scope, gates on attachment only', async () => {
+      helpers.queryOne.mockResolvedValueOnce({ n: 5 });
+      await getVariantSetCount('ex-2', { attachment: 'bar' });
+      const sql = helpers.queryOne.mock.calls[0][0] as string;
+      const params = helpers.queryOne.mock.calls[0][1] as unknown[];
+      expect(sql).toMatch(/ws\.attachment\s*=\s*\?/);
+      expect(sql).not.toMatch(/ws\.mount_position\s*=/);
+      expect(params).toEqual(['ex-2', 'bar']);
+    });
+
+    test('empty-object scope is equivalent to undefined scope (default badge)', async () => {
+      helpers.queryOne.mockResolvedValueOnce({ n: 42 });
+      await getVariantSetCount('ex-3', {});
+      const sql = helpers.queryOne.mock.calls[0][0] as string;
+      // Adoption gate present (empty scope → default "any variant logged" count)
+      expect(sql).toMatch(/ws\.attachment\s+IS\s+NOT\s+NULL\s+OR\s+ws\.mount_position\s+IS\s+NOT\s+NULL/);
+      expect(helpers.queryOne.mock.calls[0][1]).toEqual(['ex-3']);
+    });
+  });
+
+  // ── chart functions: variant-scope filtering ────────────────────
+
+  describe('chart functions accept VariantScope', () => {
+    beforeEach(() => helpers.query.mockResolvedValue([]));
+
+    test('getExerciseChartData empty scope → no variant fragment, original params', async () => {
+      await getExerciseChartData('ex-1');
+      const [sql, params] = helpers.query.mock.calls[0];
+      expect(sql as string).not.toMatch(/ws\.attachment\s*=\s*\?/);
+      expect(sql as string).not.toMatch(/ws\.mount_position\s*=\s*\?/);
+      expect(params).toEqual(['ex-1', 20]);
+    });
+
+    test('getExerciseChartData tuple scope → splices fragment + threads params', async () => {
+      await getExerciseChartData('ex-1', 20, { attachment: 'rope', mount_position: 'high' });
+      const [sql, params] = helpers.query.mock.calls[0];
+      expect(sql as string).toMatch(/ws\.attachment\s*=\s*\?\s*AND\s*ws\.mount_position\s*=\s*\?/);
+      // exercise_id, attachment param, mount param, limit — in that order
+      expect(params).toEqual(['ex-1', 'rope', 'high', 20]);
+    });
+
+    test('getExercise1RMChartData single-dimension scope', async () => {
+      await getExercise1RMChartData('ex-1', 20, { attachment: 'bar' });
+      const [sql, params] = helpers.query.mock.calls[0];
+      expect(sql as string).toMatch(/ws\.attachment\s*=\s*\?/);
+      expect(sql as string).not.toMatch(/ws\.mount_position\s*=/);
+      expect(params).toEqual(['ex-1', 'bar', 20]);
+    });
+
+    test('getExerciseDurationChartData NULL scope → IS NULL predicate', async () => {
+      await getExerciseDurationChartData('ex-1', 20, { mount_position: null });
+      const [sql, params] = helpers.query.mock.calls[0];
+      expect(sql as string).toMatch(/ws\.mount_position\s+IS\s+NULL/);
+      // No mount param bound — only exerciseId + limit
+      expect(params).toEqual(['ex-1', 20]);
+    });
+
+    test('getExerciseChartData fallback (reps) query also receives scope', async () => {
+      // First call returns empty → triggers the fallback reps query
+      helpers.query.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      await getExerciseChartData('ex-1', 20, { attachment: 'rope' });
+      expect(helpers.query.mock.calls.length).toBe(2);
+      const [sql, params] = helpers.query.mock.calls[1];
+      expect(sql as string).toMatch(/ws\.attachment\s*=\s*\?/);
+      expect(params).toEqual(['ex-1', 'rope', 20]);
     });
   });
 });

--- a/__tests__/lib/db/variant-scope-filter.test.ts
+++ b/__tests__/lib/db/variant-scope-filter.test.ts
@@ -1,0 +1,129 @@
+/**
+ * BLD-788: variant scope filter — data-layer tests.
+ *
+ * Covers `buildVariantSql` (pure function — exercises every undefined / null /
+ * value branch on both dimensions) and `getVariantSetCount` (mocked
+ * `queryOne`). Behavioral integration of the filter inside `getExerciseRecords`
+ * is covered indirectly through `buildVariantSql`'s SQL output — every
+ * variant-aware code path consumes the same fragment.
+ */
+
+jest.mock('../../../lib/db/helpers', () => ({
+  getDrizzle: jest.fn(),
+  query: jest.fn(),
+  queryOne: jest.fn(),
+}));
+
+const helpers = require('../../../lib/db/helpers') as {
+  getDrizzle: jest.Mock;
+  query: jest.Mock;
+  queryOne: jest.Mock;
+};
+
+import { buildVariantSql, getVariantSetCount } from '../../../lib/db/exercise-history';
+import type { VariantScope } from '../../../lib/db/exercise-history';
+
+describe('BLD-788 variant scope filter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── buildVariantSql ─────────────────────────────────────────────
+
+  describe('buildVariantSql', () => {
+    test.each<[string, VariantScope | undefined, string, (string | null)[]]>([
+      ['undefined scope → empty fragment', undefined, '', []],
+      ['empty object → empty fragment', {}, '', []],
+      [
+        'attachment value only → AND ws.attachment = ?',
+        { attachment: 'rope' },
+        ' AND ws.attachment = ?',
+        ['rope'],
+      ],
+      [
+        'attachment NULL → AND ws.attachment IS NULL',
+        { attachment: null },
+        ' AND ws.attachment IS NULL',
+        [],
+      ],
+      [
+        'mount value only → AND ws.mount_position = ?',
+        { mount_position: 'high' },
+        ' AND ws.mount_position = ?',
+        ['high'],
+      ],
+      [
+        'mount NULL → AND ws.mount_position IS NULL',
+        { mount_position: null },
+        ' AND ws.mount_position IS NULL',
+        [],
+      ],
+      [
+        'both values → both ANDed in declaration order',
+        { attachment: 'rope', mount_position: 'high' },
+        ' AND ws.attachment = ? AND ws.mount_position = ?',
+        ['rope', 'high'],
+      ],
+      [
+        'attachment value + mount NULL → mixed predicate',
+        { attachment: 'bar', mount_position: null },
+        ' AND ws.attachment = ? AND ws.mount_position IS NULL',
+        ['bar'],
+      ],
+      [
+        'attachment NULL + mount value → mixed predicate',
+        { attachment: null, mount_position: 'low' },
+        ' AND ws.attachment IS NULL AND ws.mount_position = ?',
+        ['low'],
+      ],
+    ])('%s', (_label, scope, expectedSql, expectedParams) => {
+      const result = buildVariantSql(scope);
+      expect(result.sql).toBe(expectedSql);
+      expect(result.params).toEqual(expectedParams);
+    });
+
+    test('explicit-undefined dimension is treated as no filter', () => {
+      const result = buildVariantSql({ attachment: undefined, mount_position: undefined });
+      expect(result.sql).toBe('');
+      expect(result.params).toEqual([]);
+    });
+  });
+
+  // ── getVariantSetCount ──────────────────────────────────────────
+
+  describe('getVariantSetCount', () => {
+    test('returns row count when present', async () => {
+      helpers.queryOne.mockResolvedValueOnce({ n: 12 });
+      const n = await getVariantSetCount('ex-123');
+      expect(n).toBe(12);
+    });
+
+    test('returns 0 when query returns null/undefined', async () => {
+      helpers.queryOne.mockResolvedValueOnce(undefined);
+      expect(await getVariantSetCount('ex-1')).toBe(0);
+    });
+
+    test('returns 0 when n is null', async () => {
+      helpers.queryOne.mockResolvedValueOnce({ n: null });
+      expect(await getVariantSetCount('ex-1')).toBe(0);
+    });
+
+    test('coerces string-numeric SQL output via Number()', async () => {
+      helpers.queryOne.mockResolvedValueOnce({ n: '7' as unknown as number });
+      expect(await getVariantSetCount('ex-1')).toBe(7);
+    });
+
+    test('SQL gates on completed=1, non-warmup, completed_at NOT NULL', async () => {
+      helpers.queryOne.mockResolvedValueOnce({ n: 0 });
+      await getVariantSetCount('ex-xyz');
+      const call = helpers.queryOne.mock.calls[0];
+      const sql = call[0] as string;
+      const params = call[1] as unknown[];
+      expect(sql).toMatch(/ws\.completed\s*=\s*1/);
+      expect(sql).toMatch(/ws\.set_type\s*!=\s*'warmup'/);
+      expect(sql).toMatch(/wss\.completed_at\s+IS\s+NOT\s+NULL/);
+      expect(sql).toMatch(/ws\.attachment\s+IS\s+NOT\s+NULL\s+OR\s+ws\.mount_position\s+IS\s+NOT\s+NULL/);
+      expect(params).toEqual(['ex-xyz']);
+    });
+  });
+});

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -33,6 +33,8 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { useExerciseDetail, MAX_ITEMS } from "@/hooks/useExerciseDetail";
 import ExerciseRecordsCard from "@/components/exercise/ExerciseRecordsCard";
 import ExerciseChartCard from "@/components/exercise/ExerciseChartCard";
+import ExerciseVariantFilter from "@/components/exercise/ExerciseVariantFilter";
+import { isCableExercise } from "@/lib/cable-variant";
 import StrengthLevelBadge from "@/components/exercise/StrengthLevelBadge";
 import { useStrengthLevel } from "@/hooks/useStrengthLevel";
 import { useStrengthGoal } from "@/hooks/useStrengthGoals";
@@ -155,13 +157,24 @@ export default function ExerciseDetail() {
 
       <FlowContainer gap={16}>
         <ExerciseRecordsCard colors={colors} records={d.records} recordsLoading={d.recordsLoading} recordsError={d.recordsError}
-          best={d.best} bw={d.bw} unit={d.unit} exerciseId={id} loadRecords={d.loadRecords}
+          best={d.best} bw={d.bw} unit={d.unit} exerciseId={id}
+          loadRecords={(eid) => d.loadRecords(eid, d.variantScope)}
+          variantFilterActive={d.variantScope.attachment !== undefined || d.variantScope.mount_position !== undefined}
           style={layout.atLeastMedium ? { ...flowCardStyle, maxWidth: 560 } : undefined} />
         <ExerciseChartCard colors={colors} bw={d.bw} unit={d.unit} chart={d.chart} chart1RM={d.chart1RM}
           activeChart={d.activeChart} chartMode={d.chartMode} setChartMode={d.setChartMode}
           chartLoading={d.chartLoading} chartError={d.chartError} exerciseId={id} exerciseName={exercise.name} loadChart={d.loadChart}
           style={layout.atLeastMedium ? { ...flowCardStyle, maxWidth: 560 } : undefined} />
       </FlowContainer>
+
+      {/* BLD-788: cable variant analytics filter — only renders for cable exercises. */}
+      {isCableExercise(exercise) && (
+        <ExerciseVariantFilter
+          scope={d.variantScope}
+          onChange={d.setVariantScope}
+          variantTotal={d.variantTotal}
+        />
+      )}
 
       {strengthLevel && (
         <StrengthLevelBadge

--- a/app/exercise/[id].tsx
+++ b/app/exercise/[id].tsx
@@ -163,7 +163,7 @@ export default function ExerciseDetail() {
           style={layout.atLeastMedium ? { ...flowCardStyle, maxWidth: 560 } : undefined} />
         <ExerciseChartCard colors={colors} bw={d.bw} unit={d.unit} chart={d.chart} chart1RM={d.chart1RM}
           activeChart={d.activeChart} chartMode={d.chartMode} setChartMode={d.setChartMode}
-          chartLoading={d.chartLoading} chartError={d.chartError} exerciseId={id} exerciseName={exercise.name} loadChart={d.loadChart}
+          chartLoading={d.chartLoading} chartError={d.chartError} exerciseId={id} exerciseName={exercise.name} loadChart={(eid) => d.loadChart(eid, d.variantScope)}
           style={layout.atLeastMedium ? { ...flowCardStyle, maxWidth: 560 } : undefined} />
       </FlowContainer>
 

--- a/components/exercise/ExerciseRecordsCard.tsx
+++ b/components/exercise/ExerciseRecordsCard.tsx
@@ -19,11 +19,36 @@ type Props = {
   exerciseId: string | undefined;
   loadRecords: (id: string) => void;
   style?: object;
+  /**
+   * BLD-788: when true, the "no data" empty state shows the variant-filter-
+   * specific message and CTA instead of the generic onboarding text.
+   */
+  variantFilterActive?: boolean;
 };
 
+function RecordsEmptyState({ colors, variantFilterActive }: { colors: ThemeColors; variantFilterActive?: boolean }) {
+  if (variantFilterActive) {
+    return (
+      <View accessibilityLabel="No sets logged with this variant yet. Log this variant in your next session.">
+        <Text variant="body" style={{ color: colors.onSurfaceVariant, marginBottom: 4 }}>
+          No sets logged with this variant yet
+        </Text>
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+          Log this variant in your next session.
+        </Text>
+      </View>
+    );
+  }
+  return (
+    <Text variant="body" style={{ color: colors.onSurfaceVariant }}>No workout data yet — start a session to build your history</Text>
+  );
+}
+
+// BLD-541 (pre-existing) + BLD-788 empty-state branch tip complexity over 15.
+// eslint-disable-next-line complexity
 export default function ExerciseRecordsCard({
   colors, records, recordsLoading, recordsError, best, bw, unit,
-  exerciseId, loadRecords, style,
+  exerciseId, loadRecords, style, variantFilterActive,
 }: Props) {
   const router = useRouter();
 
@@ -39,7 +64,7 @@ export default function ExerciseRecordsCard({
             <Button variant="ghost" onPress={() => exerciseId && loadRecords(exerciseId)} label="Retry" />
           </View>
         ) : records && records.total_sessions === 0 ? (
-          <Text variant="body" style={{ color: colors.onSurfaceVariant }}>No workout data yet — start a session to build your history</Text>
+          <RecordsEmptyState colors={colors} variantFilterActive={variantFilterActive} />
         ) : records ? (
           <>
             <View style={styles.statsRow}>

--- a/components/exercise/ExerciseVariantFilter.tsx
+++ b/components/exercise/ExerciseVariantFilter.tsx
@@ -65,7 +65,7 @@ function formatBadge(scope: VariantScope, variantTotal: number): string {
   if (scope.mount_position !== undefined) {
     parts.push(scope.mount_position === null ? "(no mount)" : MOUNT_POSITION_LABELS[scope.mount_position]);
   }
-  return `Showing: ${parts.join(" · ")}`;
+  return `Showing: ${parts.join(" · ")} (${variantTotal} logged)`;
 }
 
 export default function ExerciseVariantFilter({

--- a/components/exercise/ExerciseVariantFilter.tsx
+++ b/components/exercise/ExerciseVariantFilter.tsx
@@ -1,0 +1,258 @@
+/**
+ * BLD-788: per-exercise cable variant analytics filter.
+ *
+ * Renders only when the parent exercise is a cable exercise (gating is the
+ * caller's responsibility — pass `null` to hide). Lets the user scope the
+ * exercise's records / chart / best-set queries to a tuple
+ * `(attachment, mount_position)`.
+ *
+ * Each dimension is independent — selecting only an attachment leaves
+ * mount_position unscoped (and vice versa). Tap an active chip again to clear
+ * that dimension.
+ *
+ * State is component-local (lifted into `useExerciseDetail` via
+ * `setVariantScope`); never persisted across cold-start.
+ *
+ * Read-only filter — never writes to `workout_sets`. No streaks, no
+ * gamification, no notifications (Behavior-Design Classification: NO).
+ *
+ * Vocabulary source: `lib/cable-variant.ts` (no hardcoded enum literals — see
+ * `scripts/audit-vocab.sh`).
+ */
+
+import React, { useCallback } from "react";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { fontSizes } from "@/constants/design-tokens";
+import {
+  ATTACHMENT_VALUES,
+  MOUNT_POSITION_VALUES,
+} from "@/lib/cable-variant";
+import {
+  ATTACHMENT_LABELS,
+  MOUNT_POSITION_LABELS,
+  type Attachment,
+  type MountPosition,
+} from "@/lib/types";
+import type { VariantScope } from "@/lib/db";
+
+export type ExerciseVariantFilterProps = {
+  /** Active filter state. `{}` = "All variants". */
+  scope: VariantScope;
+  /** Setter; merge-replace the scope. */
+  onChange: (next: VariantScope) => void;
+  /**
+   * Total count of completed, non-warmup sets for this exercise that have
+   * any variant field populated (attachment OR mount_position not null).
+   * Used for the "All variants (N logged)" badge.
+   */
+  variantTotal: number;
+};
+
+function isFilterActive(scope: VariantScope): boolean {
+  return scope.attachment !== undefined || scope.mount_position !== undefined;
+}
+
+function formatBadge(scope: VariantScope, variantTotal: number): string {
+  if (!isFilterActive(scope)) {
+    return `Showing: All variants (${variantTotal} logged)`;
+  }
+  const parts: string[] = [];
+  if (scope.attachment !== undefined) {
+    parts.push(scope.attachment === null ? "(no attachment)" : ATTACHMENT_LABELS[scope.attachment]);
+  }
+  if (scope.mount_position !== undefined) {
+    parts.push(scope.mount_position === null ? "(no mount)" : MOUNT_POSITION_LABELS[scope.mount_position]);
+  }
+  return `Showing: ${parts.join(" · ")}`;
+}
+
+export default function ExerciseVariantFilter({
+  scope,
+  onChange,
+  variantTotal,
+}: ExerciseVariantFilterProps) {
+  const colors = useThemeColors();
+  const active = isFilterActive(scope);
+
+  const toggleAttachment = useCallback(
+    (value: Attachment) => {
+      if (scope.attachment === value) {
+        const next: VariantScope = { ...scope };
+        delete next.attachment;
+        onChange(next);
+      } else {
+        onChange({ ...scope, attachment: value });
+      }
+    },
+    [scope, onChange]
+  );
+
+  const toggleMount = useCallback(
+    (value: MountPosition) => {
+      if (scope.mount_position === value) {
+        const next: VariantScope = { ...scope };
+        delete next.mount_position;
+        onChange(next);
+      } else {
+        onChange({ ...scope, mount_position: value });
+      }
+    },
+    [scope, onChange]
+  );
+
+  const clear = useCallback(() => onChange({}), [onChange]);
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: colors.surface, borderColor: colors.outlineVariant }]}
+      accessibilityLabel="Cable variant filter"
+    >
+      <View style={styles.headerRow}>
+        <Text
+          variant="body"
+          style={[styles.badge, { color: colors.onSurface }]}
+          accessibilityRole="header"
+          accessibilityLabel={formatBadge(scope, variantTotal)}
+        >
+          {formatBadge(scope, variantTotal)}
+        </Text>
+        {active && (
+          <Pressable
+            onPress={clear}
+            accessibilityRole="button"
+            accessibilityLabel="Clear variant filter"
+            style={({ pressed }) => [
+              styles.clearBtn,
+              { backgroundColor: colors.surfaceVariant, opacity: pressed ? 0.7 : 1 },
+            ]}
+          >
+            <Text style={[styles.clearLabel, { color: colors.onSurfaceVariant }]}>Clear</Text>
+          </Pressable>
+        )}
+      </View>
+
+      <Text style={[styles.dimensionLabel, { color: colors.onSurfaceVariant }]}>Attachment</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.chipRow}
+      >
+        {ATTACHMENT_VALUES.map((v) => {
+          const selected = scope.attachment === v;
+          return (
+            <Pressable
+              key={v}
+              onPress={() => toggleAttachment(v)}
+              accessibilityRole="button"
+              accessibilityState={{ selected }}
+              accessibilityLabel={`Attachment ${ATTACHMENT_LABELS[v]}${selected ? ", selected" : ""}`}
+              style={({ pressed }) => [
+                styles.chip,
+                {
+                  backgroundColor: selected ? colors.primaryContainer : colors.surfaceVariant,
+                  opacity: pressed ? 0.7 : 1,
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.chipLabel,
+                  { color: selected ? colors.onPrimaryContainer : colors.onSurfaceVariant },
+                ]}
+              >
+                {ATTACHMENT_LABELS[v]}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+
+      <Text style={[styles.dimensionLabel, { color: colors.onSurfaceVariant }]}>Mount</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.chipRow}
+      >
+        {MOUNT_POSITION_VALUES.map((v) => {
+          const selected = scope.mount_position === v;
+          return (
+            <Pressable
+              key={v}
+              onPress={() => toggleMount(v)}
+              accessibilityRole="button"
+              accessibilityState={{ selected }}
+              accessibilityLabel={`Mount ${MOUNT_POSITION_LABELS[v]}${selected ? ", selected" : ""}`}
+              style={({ pressed }) => [
+                styles.chip,
+                {
+                  backgroundColor: selected ? colors.primaryContainer : colors.surfaceVariant,
+                  opacity: pressed ? 0.7 : 1,
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.chipLabel,
+                  { color: selected ? colors.onPrimaryContainer : colors.onSurfaceVariant },
+                ]}
+              >
+                {MOUNT_POSITION_LABELS[v]}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    padding: 12,
+    marginVertical: 8,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 8,
+  },
+  badge: {
+    flex: 1,
+    fontSize: fontSizes.sm,
+    fontWeight: "600",
+  },
+  clearBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    marginLeft: 8,
+  },
+  clearLabel: {
+    fontSize: fontSizes.xs,
+    fontWeight: "600",
+  },
+  dimensionLabel: {
+    fontSize: fontSizes.xs,
+    marginTop: 6,
+    marginBottom: 4,
+  },
+  chipRow: {
+    paddingVertical: 2,
+    gap: 6,
+  },
+  chip: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    marginRight: 6,
+  },
+  chipLabel: {
+    fontSize: fontSizes.xs,
+    fontWeight: "600",
+  },
+});

--- a/hooks/useExerciseDetail.ts
+++ b/hooks/useExerciseDetail.ts
@@ -8,8 +8,10 @@ import {
   getExercise1RMChartData,
   getBodySettings,
   getBestSet,
+  getVariantSetCount,
   type ExerciseSession,
   type ExerciseRecords as Records,
+  type VariantScope,
 } from "@/lib/db";
 import type { Exercise } from "@/lib/types";
 
@@ -39,12 +41,31 @@ export function useExerciseDetail(id: string | undefined) {
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
 
-  const loadRecords = useCallback(async (eid: string) => {
+  // BLD-788: per-exercise variant filter scope. Component-local; never persisted.
+  // Empty object = "All variants" (default, current behavior).
+  const [variantScope, setVariantScopeState] = useState<VariantScope>({});
+  const [variantTotal, setVariantTotal] = useState<number>(0);
+
+  const loadRecords = useCallback(async (eid: string, scope?: VariantScope) => {
     setRecordsLoading(true); setRecordsError(false);
-    try { const [r, b] = await Promise.all([getExerciseRecords(eid), getBestSet(eid)]); setRecords(r); setBest(b); }
-    catch { setRecordsError(true); }
+    try {
+      const [r, b] = await Promise.all([getExerciseRecords(eid, scope), getBestSet(eid, scope)]);
+      setRecords(r);
+      setBest(b);
+    } catch { setRecordsError(true); }
     finally { setRecordsLoading(false); }
   }, []);
+
+  // Setter wrapper: state change + immediate records reload — event-driven so we
+  // don't trigger ESLint's react-hooks/set-state-in-effect on a useEffect+setState
+  // cascade. The reload here is the user's intent, not a passive sync.
+  const setVariantScope = useCallback(
+    (next: VariantScope) => {
+      setVariantScopeState(next);
+      if (id) loadRecords(id, next);
+    },
+    [id, loadRecords]
+  );
 
   const loadChart = useCallback(async (eid: string) => {
     setChartLoading(true); setChartError(false);
@@ -64,7 +85,13 @@ export function useExerciseDetail(id: string | undefined) {
     if (!id) return;
     getExerciseById(id).then(setExercise);
     getBodySettings().then((s) => setUnit(s.weight_unit));
-    loadRecords(id); loadChart(id); loadHistory(id);
+    loadRecords(id, variantScope);
+    loadChart(id);
+    loadHistory(id);
+    getVariantSetCount(id).then(setVariantTotal).catch(() => setVariantTotal(0));
+    // variantScope intentionally omitted — setVariantScope handles in-screen
+    // changes; focus-effect only re-runs on screen re-entry.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, loadRecords, loadChart, loadHistory]));
 
   const loadMore = useCallback(async () => {
@@ -87,5 +114,6 @@ export function useExerciseDetail(id: string | undefined) {
     history, historyLoading, historyError, loadingMore, hasMore,
     loadRecords, loadChart, loadHistory, loadMore,
     bw, activeChart,
+    variantScope, setVariantScope, variantTotal,
   };
 }

--- a/hooks/useExerciseDetail.ts
+++ b/hooks/useExerciseDetail.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useFocusEffect } from "expo-router";
 import {
   getExerciseById,
@@ -45,6 +45,10 @@ export function useExerciseDetail(id: string | undefined) {
   // Empty object = "All variants" (default, current behavior).
   const [variantScope, setVariantScopeState] = useState<VariantScope>({});
   const [variantTotal, setVariantTotal] = useState<number>(0);
+  // Ref mirror so useFocusEffect always reads the latest scope on re-entry
+  // without re-creating the callback (which would re-trigger the effect on
+  // every scope change, causing unnecessary reloads on blur→return).
+  const variantScopeRef = useRef<VariantScope>(variantScope);
 
   const loadRecords = useCallback(async (eid: string, scope?: VariantScope) => {
     setRecordsLoading(true); setRecordsError(false);
@@ -85,6 +89,7 @@ export function useExerciseDetail(id: string | undefined) {
   // the exercise-detail screen stay consistent (BLD-788 review feedback).
   const setVariantScope = useCallback(
     (next: VariantScope) => {
+      variantScopeRef.current = next;
       setVariantScopeState(next);
       if (id) {
         loadRecords(id, next);
@@ -104,16 +109,16 @@ export function useExerciseDetail(id: string | undefined) {
 
   useFocusEffect(useCallback(() => {
     if (!id) return;
+    const scope = variantScopeRef.current;
     getExerciseById(id).then(setExercise);
     getBodySettings().then((s) => setUnit(s.weight_unit));
-    loadRecords(id, variantScope);
-    loadChart(id, variantScope);
+    loadRecords(id, scope);
+    loadChart(id, scope);
     loadHistory(id);
-    // Default-state badge: count of any-variant-logged sets on this exercise.
-    // Active-state badge count is updated through setVariantScope.
-    loadVariantTotal(id);
-    // variantScope intentionally omitted — setVariantScope handles in-screen
-    // changes; focus-effect only re-runs on screen re-entry.
+    // Badge count scoped to the active filter (or default "any variant" when
+    // scope is empty). Uses the ref so blur→return always reloads with the
+    // user's last-selected filter, not the stale initial closure value.
+    loadVariantTotal(id, scope);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, loadRecords, loadChart, loadHistory, loadVariantTotal]));
 

--- a/hooks/useExerciseDetail.ts
+++ b/hooks/useExerciseDetail.ts
@@ -56,23 +56,44 @@ export function useExerciseDetail(id: string | undefined) {
     finally { setRecordsLoading(false); }
   }, []);
 
-  // Setter wrapper: state change + immediate records reload — event-driven so we
-  // don't trigger ESLint's react-hooks/set-state-in-effect on a useEffect+setState
-  // cascade. The reload here is the user's intent, not a passive sync.
-  const setVariantScope = useCallback(
-    (next: VariantScope) => {
-      setVariantScopeState(next);
-      if (id) loadRecords(id, next);
-    },
-    [id, loadRecords]
-  );
-
-  const loadChart = useCallback(async (eid: string) => {
+  const loadChart = useCallback(async (eid: string, scope?: VariantScope) => {
     setChartLoading(true); setChartError(false);
-    try { const [c, c1rm] = await Promise.all([getExerciseChartData(eid), getExercise1RMChartData(eid)]); setChart(c); setChart1RM(c1rm); }
+    try {
+      const [c, c1rm] = await Promise.all([
+        getExerciseChartData(eid, undefined, scope),
+        getExercise1RMChartData(eid, undefined, scope),
+      ]);
+      setChart(c); setChart1RM(c1rm);
+    }
     catch { setChartError(true); }
     finally { setChartLoading(false); }
   }, []);
+
+  // BLD-788: load the badge count. When `scope` is non-empty, returns the
+  // count for the active filter ("Showing: Rope · High (12 logged)"); when
+  // empty, returns the global "any variant logged" count for the default
+  // badge ("All variants (42 logged)").
+  const loadVariantTotal = useCallback(async (eid: string, scope?: VariantScope) => {
+    try { setVariantTotal(await getVariantSetCount(eid, scope)); }
+    catch { setVariantTotal(0); }
+  }, []);
+
+  // Setter wrapper: state change + immediate reloads — event-driven so we
+  // don't trigger ESLint's react-hooks/set-state-in-effect on a useEffect+setState
+  // cascade. The reloads here are the user's intent, not a passive sync.
+  // Both records AND chart must reload on scope change so the two cards on
+  // the exercise-detail screen stay consistent (BLD-788 review feedback).
+  const setVariantScope = useCallback(
+    (next: VariantScope) => {
+      setVariantScopeState(next);
+      if (id) {
+        loadRecords(id, next);
+        loadChart(id, next);
+        loadVariantTotal(id, next);
+      }
+    },
+    [id, loadRecords, loadChart, loadVariantTotal]
+  );
 
   const loadHistory = useCallback(async (eid: string) => {
     setHistoryLoading(true); setHistoryError(false);
@@ -86,13 +107,15 @@ export function useExerciseDetail(id: string | undefined) {
     getExerciseById(id).then(setExercise);
     getBodySettings().then((s) => setUnit(s.weight_unit));
     loadRecords(id, variantScope);
-    loadChart(id);
+    loadChart(id, variantScope);
     loadHistory(id);
-    getVariantSetCount(id).then(setVariantTotal).catch(() => setVariantTotal(0));
+    // Default-state badge: count of any-variant-logged sets on this exercise.
+    // Active-state badge count is updated through setVariantScope.
+    loadVariantTotal(id);
     // variantScope intentionally omitted — setVariantScope handles in-screen
     // changes; focus-effect only re-runs on screen re-entry.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, loadRecords, loadChart, loadHistory]));
+  }, [id, loadRecords, loadChart, loadHistory, loadVariantTotal]));
 
   const loadMore = useCallback(async () => {
     if (!id || loadingMore || !hasMore || history.length >= MAX_ITEMS) return;

--- a/lib/db/exercise-history.ts
+++ b/lib/db/exercise-history.ts
@@ -158,9 +158,23 @@ function variantDrizzleConditions(scope?: VariantScope) {
  * field populated (used for the "All variants (N logged)" header badge).
  *
  * Counts completed, non-warmup sets in completed sessions where attachment
- * or mount_position is non-null. Independent of the active filter.
+ * or mount_position is non-null.
+ *
+ * When `scope` is supplied, counts sets matching the active filter exactly
+ * (used for the "Showing: Rope · High (12 logged)" active-state badge).
+ * When `scope` is omitted or empty, returns the global "any variant"
+ * count for the default-state badge.
  */
-export async function getVariantSetCount(exerciseId: string): Promise<number> {
+export async function getVariantSetCount(
+  exerciseId: string,
+  scope?: VariantScope,
+): Promise<number> {
+  const variantSql = buildVariantSql(scope);
+  // When scope is empty, retain the original "any variant logged" gate so the
+  // default badge still reports total variant adoption on this exercise.
+  const adoptionGate = variantSql.params.length === 0 || variantSql.sql === ""
+    ? " AND (ws.attachment IS NOT NULL OR ws.mount_position IS NOT NULL)"
+    : "";
   const row = await queryOne<{ n: number | null }>(
     `SELECT COUNT(*) AS n
        FROM workout_sets ws
@@ -168,9 +182,8 @@ export async function getVariantSetCount(exerciseId: string): Promise<number> {
       WHERE ws.exercise_id = ?
         AND ws.completed = 1
         AND ws.set_type != 'warmup'
-        AND wss.completed_at IS NOT NULL
-        AND (ws.attachment IS NOT NULL OR ws.mount_position IS NOT NULL)`,
-    [exerciseId]
+        AND wss.completed_at IS NOT NULL${adoptionGate}${variantSql.sql}`,
+    [exerciseId, ...variantSql.params]
   );
   return Number(row?.n ?? 0);
 }
@@ -244,6 +257,10 @@ export async function getExerciseRecords(
     ),
 
     db
+      // is_bodyweight is an exercise-level property: does this exercise have
+      // ANY weighted history at all? Intentionally unscoped by VariantScope —
+      // a cable row stays a non-bodyweight exercise even when the active
+      // filter selects a tuple with zero weighted sets.
       .select({ val: sql<number>`EXISTS(SELECT 1 FROM workout_sets WHERE exercise_id = ${exerciseId} AND completed = 1 AND weight > 0)` })
       .from(workoutSets)
       .limit(1)
@@ -279,8 +296,10 @@ export async function getExerciseRecords(
 
 export async function getExercise1RMChartData(
   exerciseId: string,
-  limit: number = 20
+  limit: number = 20,
+  scope?: VariantScope
 ): Promise<{ date: number; value: number }[]> {
+  const v = buildVariantSql(scope);
   // Nested subquery (inner SELECT + ORDER + LIMIT, outer re-order) — use raw sql
   return query<{ date: number; value: number }>(
     `SELECT * FROM (
@@ -295,19 +314,21 @@ export async function getExercise1RMChartData(
          AND ws.reps IS NOT NULL
          AND ws.reps > 0
          AND ws.set_type != 'warmup'
-         AND wss.completed_at IS NOT NULL
+         AND wss.completed_at IS NOT NULL${v.sql}
        GROUP BY wss.id
        ORDER BY wss.started_at DESC
        LIMIT ?
      ) ORDER BY date ASC`,
-    [exerciseId, limit]
+    [exerciseId, ...v.params, limit]
   );
 }
 
 export async function getExerciseChartData(
   exerciseId: string,
-  limit: number = 20
+  limit: number = 20,
+  scope?: VariantScope
 ): Promise<{ date: number; value: number }[]> {
+  const v = buildVariantSql(scope);
   const rows = await query<{ date: number; value: number }>(
     `SELECT * FROM (
        SELECT wss.started_at AS date,
@@ -319,12 +340,12 @@ export async function getExerciseChartData(
          AND ws.weight IS NOT NULL
          AND ws.weight > 0
          AND ws.set_type != 'warmup'
-         AND wss.completed_at IS NOT NULL
+         AND wss.completed_at IS NOT NULL${v.sql}
        GROUP BY wss.id
        ORDER BY wss.started_at DESC
        LIMIT ?
      ) ORDER BY date ASC`,
-    [exerciseId, limit]
+    [exerciseId, ...v.params, limit]
   );
 
   if (rows.length > 0) return rows;
@@ -338,19 +359,21 @@ export async function getExerciseChartData(
        WHERE ws.exercise_id = ?
          AND ws.completed = 1
          AND wss.completed_at IS NOT NULL
-         AND ws.set_type != 'warmup'
+         AND ws.set_type != 'warmup'${v.sql}
        GROUP BY wss.id
        ORDER BY wss.started_at DESC
        LIMIT ?
      ) ORDER BY date ASC`,
-    [exerciseId, limit]
+    [exerciseId, ...v.params, limit]
   );
 }
 
 export async function getExerciseDurationChartData(
   exerciseId: string,
-  limit: number = 20
+  limit: number = 20,
+  scope?: VariantScope
 ): Promise<{ date: number; value: number }[]> {
+  const v = buildVariantSql(scope);
   return query<{ date: number; value: number }>(
     `SELECT * FROM (
        SELECT wss.started_at AS date,
@@ -362,12 +385,12 @@ export async function getExerciseDurationChartData(
          AND ws.duration_seconds IS NOT NULL
          AND ws.duration_seconds > 0
          AND ws.set_type != 'warmup'
-         AND wss.completed_at IS NOT NULL
+         AND wss.completed_at IS NOT NULL${v.sql}
        GROUP BY wss.id
        ORDER BY wss.started_at DESC
        LIMIT ?
      ) ORDER BY date ASC`,
-    [exerciseId, limit]
+    [exerciseId, ...v.params, limit]
   );
 }
 

--- a/lib/db/exercise-history.ts
+++ b/lib/db/exercise-history.ts
@@ -170,9 +170,13 @@ export async function getVariantSetCount(
   scope?: VariantScope,
 ): Promise<number> {
   const variantSql = buildVariantSql(scope);
-  // When scope is empty, retain the original "any variant logged" gate so the
-  // default badge still reports total variant adoption on this exercise.
-  const adoptionGate = variantSql.params.length === 0 || variantSql.sql === ""
+  // When scope is genuinely empty (no constrained dimensions), retain the
+  // original "any variant logged" gate so the default badge reports total
+  // variant adoption. We check sql === "" rather than params.length === 0
+  // because explicit-null scopes like {attachment: null} produce non-empty SQL
+  // ("AND ws.attachment IS NULL") but empty params — using params.length would
+  // incorrectly trigger the adoption gate for a legitimate filter.
+  const adoptionGate = variantSql.sql === ""
     ? " AND (ws.attachment IS NOT NULL OR ws.mount_position IS NOT NULL)"
     : "";
   const row = await queryOne<{ n: number | null }>(

--- a/lib/db/exercise-history.ts
+++ b/lib/db/exercise-history.ts
@@ -2,7 +2,25 @@ import { eq, ne, and, sql, desc, asc, isNotNull, isNull, inArray, max, sum, coun
 import { query, queryOne, getDrizzle } from "./helpers";
 import { workoutSets, workoutSessions, exercises } from "./schema";
 import { mapRow } from "./exercises";
-import type { Exercise } from "../types";
+import type { Exercise, Attachment, MountPosition } from "../types";
+
+/**
+ * BLD-788: variant scope for analytics queries.
+ *
+ * Each field is independent:
+ *   - `attachment === undefined` → no constraint on attachment dimension.
+ *   - `attachment === null`      → match rows where attachment IS NULL.
+ *   - `attachment === <value>`   → match rows where attachment = <value>.
+ *
+ * Same shape for `mount_position`. The default ("All variants") passes an
+ * empty object — both fields undefined.
+ *
+ * Read-only filter; never mutates `workout_sets`.
+ */
+export type VariantScope = {
+  attachment?: Attachment | null;
+  mount_position?: MountPosition | null;
+};
 
 export type ExerciseSession = {
   session_id: string;
@@ -81,14 +99,95 @@ export async function getExerciseHistory(
   }));
 }
 
-export async function getExerciseRecords(exerciseId: string): Promise<ExerciseRecords> {
+/**
+ * BLD-788: build the variant SQL fragment for raw queries.
+ *
+ * Returns `{ sql: " AND ws.attachment = ? AND ws.mount_position IS NULL", params: [...] }`.
+ * Empty fragment (`""`, `[]`) when `scope` is undefined or has no dimensions set.
+ *
+ * Caller is responsible for placing the fragment in a position where the
+ * `ws` alias is bound to `workout_sets`.
+ */
+export function buildVariantSql(scope?: VariantScope): { sql: string; params: (string | null)[] } {
+  if (!scope) return { sql: "", params: [] };
+  const parts: string[] = [];
+  const params: (string | null)[] = [];
+
+  if (scope.attachment !== undefined) {
+    if (scope.attachment === null) {
+      parts.push("ws.attachment IS NULL");
+    } else {
+      parts.push("ws.attachment = ?");
+      params.push(scope.attachment);
+    }
+  }
+  if (scope.mount_position !== undefined) {
+    if (scope.mount_position === null) {
+      parts.push("ws.mount_position IS NULL");
+    } else {
+      parts.push("ws.mount_position = ?");
+      params.push(scope.mount_position);
+    }
+  }
+  if (parts.length === 0) return { sql: "", params: [] };
+  return { sql: " AND " + parts.join(" AND "), params };
+}
+
+/**
+ * BLD-788: Drizzle-flavored variant predicate. Returns SQL fragments to AND
+ * into a Drizzle `where()` chain. Returns `[]` when scope is empty.
+ */
+function variantDrizzleConditions(scope?: VariantScope) {
+  const conds: ReturnType<typeof eq | typeof isNull>[] = [];
+  if (!scope) return conds;
+  if (scope.attachment !== undefined) {
+    conds.push(scope.attachment === null
+      ? isNull(workoutSets.attachment)
+      : eq(workoutSets.attachment, scope.attachment));
+  }
+  if (scope.mount_position !== undefined) {
+    conds.push(scope.mount_position === null
+      ? isNull(workoutSets.mount_position)
+      : eq(workoutSets.mount_position, scope.mount_position));
+  }
+  return conds;
+}
+
+/**
+ * BLD-788: count of sets on a given exercise that have at least one variant
+ * field populated (used for the "All variants (N logged)" header badge).
+ *
+ * Counts completed, non-warmup sets in completed sessions where attachment
+ * or mount_position is non-null. Independent of the active filter.
+ */
+export async function getVariantSetCount(exerciseId: string): Promise<number> {
+  const row = await queryOne<{ n: number | null }>(
+    `SELECT COUNT(*) AS n
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+      WHERE ws.exercise_id = ?
+        AND ws.completed = 1
+        AND ws.set_type != 'warmup'
+        AND wss.completed_at IS NOT NULL
+        AND (ws.attachment IS NOT NULL OR ws.mount_position IS NOT NULL)`,
+    [exerciseId]
+  );
+  return Number(row?.n ?? 0);
+}
+
+export async function getExerciseRecords(
+  exerciseId: string,
+  scope?: VariantScope
+): Promise<ExerciseRecords> {
   const db = await getDrizzle();
+  const variantConds = variantDrizzleConditions(scope);
 
   const baseWhere = and(
     eq(workoutSets.exercise_id, exerciseId),
     eq(workoutSets.completed, 1),
     ne(workoutSets.set_type, 'warmup'),
-    isNotNull(workoutSessions.completed_at)
+    isNotNull(workoutSessions.completed_at),
+    ...variantConds
   );
 
   // Simple aggregates via Drizzle
@@ -123,24 +222,25 @@ export async function getExerciseRecords(exerciseId: string): Promise<ExerciseRe
   ]);
 
   // Computed aggregates via sql``
+  const variantSql = buildVariantSql(scope);
   const [vol, rm, weighted, bwBests] = await Promise.all([
     queryOne<{ val: number | null }>(
       `SELECT MAX(sv) AS val FROM (
          SELECT SUM(ws.weight * ws.reps) AS sv
          FROM workout_sets ws
          JOIN workout_sessions wss ON ws.session_id = wss.id
-         WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.set_type != 'warmup' AND wss.completed_at IS NOT NULL
+         WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.set_type != 'warmup' AND wss.completed_at IS NOT NULL${variantSql.sql}
          GROUP BY wss.id
        )`,
-      [exerciseId]
+      [exerciseId, ...variantSql.params]
     ),
 
     queryOne<{ val: number | null }>(
       `SELECT MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS val
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
-       WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.set_type != 'warmup' AND ws.weight > 0 AND ws.reps > 0 AND ws.reps <= 12 AND wss.completed_at IS NOT NULL`,
-      [exerciseId]
+       WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.set_type != 'warmup' AND ws.weight > 0 AND ws.reps > 0 AND ws.reps <= 12 AND wss.completed_at IS NOT NULL${variantSql.sql}`,
+      [exerciseId, ...variantSql.params]
     ),
 
     db
@@ -159,8 +259,8 @@ export async function getExerciseRecords(exerciseId: string): Promise<ExerciseRe
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.set_type != 'warmup'
-         AND ws.bodyweight_modifier_kg IS NOT NULL AND wss.completed_at IS NOT NULL`,
-      [exerciseId]
+         AND ws.bodyweight_modifier_kg IS NOT NULL AND wss.completed_at IS NOT NULL${variantSql.sql}`,
+      [exerciseId, ...variantSql.params]
     ),
   ]);
 
@@ -405,8 +505,10 @@ export async function getRecentExerciseSetsBatch(
 
 export async function getBestSet(
   exerciseId: string,
+  scope?: VariantScope,
 ): Promise<{ weight: number; reps: number; bodyweight_modifier_kg: number | null } | null> {
   const db = await getDrizzle();
+  const variantConds = variantDrizzleConditions(scope);
   const rows = await db
     .select({
       weight: workoutSets.weight,
@@ -423,7 +525,8 @@ export async function getBestSet(
         sql`${workoutSets.weight} > 0`,
         sql`${workoutSets.reps} > 0`,
         sql`${workoutSets.reps} <= 12`,
-        isNotNull(workoutSessions.completed_at)
+        isNotNull(workoutSessions.completed_at),
+        ...variantConds
       )
     )
     .orderBy(sql`${workoutSets.weight} * (1.0 + ${workoutSets.reps} / 30.0) DESC`)

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -116,7 +116,8 @@ export {
 export type { RestContext } from "./sessions";
 export type { SessionEditPayload, SessionEditSetPatch } from "./sessions";
 export type { ExerciseCategory, RestInputs, RestFactor, RestBreakdown } from "../rest";
-export type { ExerciseSession, ExerciseRecords, SourceSessionSet } from "./sessions";
+export type { ExerciseSession, ExerciseRecords, SourceSessionSet, VariantScope } from "./sessions";
+export { getVariantSetCount, buildVariantSql } from "./sessions";
 export type { E1RMTrendRow, WeeklyE1RMRow, SessionRPERow, SessionRatingRow } from "./sessions";
 
 export {

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -73,8 +73,10 @@ export {
   getRecentExerciseSets,
   getRecentExerciseSetsBatch,
   getBestSet,
+  getVariantSetCount,
+  buildVariantSql,
 } from "./exercise-history";
-export type { ExerciseSession, ExerciseRecords } from "./exercise-history";
+export type { ExerciseSession, ExerciseRecords, VariantScope } from "./exercise-history";
 
 // ---- Duration Estimates ----
 


### PR DESCRIPTION
## Summary

Implements the per-exercise variant filter slice of BLD-788 (BLD-771 slice 4). On any cable exercise detail screen, users can now scope the records card and best-set query to a specific (attachment, mount_position) tuple — answering the question "how is my rope-low cable row progressing vs. bar-high cable row?" that motivated per-set variant logging in PR #426.

## Scope decision

The original plan had a contradiction (AC #203 = global PR Dashboard tuple filter, AC #205 = per-exercise badge "N logged on this exercise"). CEO confirmed the resolution via comment on BLD-788: per-exercise tuple filter on the exercise detail screen as the primary surface. The lightweight global toggle on PR Dashboard / Strength Overview is deferred to a follow-up — this PR ships the high-value half.

## Changes

**Data layer** (commit `263bc90a`):
- New `VariantScope` type, `buildVariantSql()`, and `variantDrizzleConditions()` helpers in `lib/db/exercise-history.ts`.
- `getExerciseRecords(exerciseId, scope?)` and `getBestSet(exerciseId, scope?)` accept optional scope; default behavior unchanged.
- New `getVariantSetCount(exerciseId)` returns the count of completed non-warmup sets that have ANY variant populated.
- Re-exports surfaced via `lib/db/sessions.ts` and `lib/db/index.ts`.

**UI** (commit `94594e2c`):
- New `<ExerciseVariantFilter>` component: chip rows for attachment + mount_position, header badge, Clear button.
- Filter UI gated by `isCableExercise(exercise)` — non-cable exercises see no filter.
- `useExerciseDetail` hook exposes `variantScope` / `setVariantScope` / `variantTotal`.
- `<ExerciseRecordsCard>` shows a variant-aware empty state when filter active and zero matches.
- Vocabulary sourced from `lib/cable-variant.ts` exports — no hardcoded literals.
- Filter state is component-local, never persisted.

**Tests** (commits `b6e6cd53`, latest):
- `__tests__/lib/db/variant-scope-filter.test.ts` — 15 tests covering scope permutations + `getVariantSetCount`.
- `__tests__/components/exercise/ExerciseVariantFilter.test.tsx` — 10 RTL tests covering vocab-source guard, independent-dimension toggle, badge formats, Clear behavior.
- `__tests__/acceptance/phase43-1rm-features.acceptance.test.tsx` — added new export to lib/db mock.

## Acceptance Criteria Coverage

- [x] Tuple match: filter (attachment=rope, mount_position=high) → only matching sets.
- [x] Independent attribute filter: rope-only matches all rope sets regardless of mount.
- [x] Empty state with CTA when filter selects a no-match variant.
- [x] Header badge default: "Showing: All variants (N logged)".
- [x] Header badge active: "Showing: Rope · High".
- [x] Filter hidden for non-cable exercises.
- [x] Vocab consistency — all imports from `lib/cable-variant.ts`.

## Testing

- 25 new tests pass.
- Full suite: 2711 / 2711 pass.
- TypeScript: zero errors.
- ESLint: zero warnings on changed files.

## Out of scope (deferred)

- Lightweight global "Cable-variant only" toggle on PR Dashboard + Strength Overview.
- Dual-cable attachments.
- BLD-770 grip variants.

## Issue

Resolves BLD-788.
