### PR TITLE
fix(scripts): surface 4xx/5xx error bodies on clip.sh writes (BLD-846)

### DIFF
--- a/scripts/__tests__/clip-error-surfacing.test.ts
+++ b/scripts/__tests__/clip-error-surfacing.test.ts
@@ -1,0 +1,259 @@
+/**
+ * @jest-environment node
+ *
+ * BLD-846 — Tests for clip.sh error surfacing.
+ *
+ * Bug background:
+ *   The original `/skills/scripts/clip.sh` used `curl -sf` for write
+ *   endpoints. With `-f`, curl exits non-zero on HTTP errors but the
+ *   response body (containing the structured API error like
+ *   "Issue is checked out by another agent") is silently discarded.
+ *   Combined with downstream pipelines that didn't reliably surface
+ *   the exit code, this swallowed real failures (BLD-743 incident:
+ *   knowledge-curator's status flip 409'd against a CEO-locked issue
+ *   and the agent thought it succeeded).
+ *
+ * Acceptance criteria (from BLD-846):
+ *   1. On 4xx/5xx response, clip.sh writes the response body to stderr.
+ *   2. On 409 specifically, the structured error body (e.g.
+ *      `{"error":"Issue is checked out by another agent","holderRunId":"..."}`)
+ *      is preserved verbatim so callers can read who holds the lock.
+ *   3. Exit code is non-zero so callers using `set -e` see the failure.
+ *   4. No regression on 2xx — current happy-path output unchanged.
+ *
+ * Test strategy:
+ *   We spin up a tiny http server on a random port that responds with
+ *   scripted status codes + bodies, point clip.sh at it via
+ *   PAPERCLIP_API_BASE, and invoke real subcommands. This validates
+ *   the end-to-end behaviour through the actual `api()` helper without
+ *   mocking curl.
+ */
+import { spawn } from 'child_process';
+import * as http from 'http';
+import * as path from 'path';
+import { AddressInfo } from 'net';
+
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+
+const SCRIPT = path.resolve(__dirname, '..', 'clip.sh');
+
+function startMockServer(handler: Handler): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(handler);
+    // Aggressively short timeouts so a stuck/keep-alive connection from curl
+    // can't hang the test runner.
+    server.keepAliveTimeout = 100;
+    server.headersTimeout = 500;
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () =>
+          new Promise<void>((res) => {
+            // closeAllConnections is required on Node 18+ to drop sockets
+            // that curl left in keep-alive — without it close() blocks
+            // until they time out.
+            (server as unknown as { closeAllConnections?: () => void }).closeAllConnections?.();
+            server.close(() => res());
+          }),
+      });
+    });
+  });
+}
+
+function runClip(
+  args: string[],
+  apiBase: string,
+  extraEnv: Record<string, string> = {},
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [SCRIPT, ...args], {
+      env: {
+        ...process.env,
+        PAPERCLIP_API_BASE: apiBase,
+        PAPERCLIP_AGENT_API_KEY: 'test-key',
+        CLIP_COMPANY: '00000000-0000-0000-0000-000000000001',
+        CLIP_AGENT: '00000000-0000-0000-0000-000000000002',
+        ...extraEnv,
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => (stdout += c.toString()));
+    child.stderr.on('data', (c) => (stderr += c.toString()));
+    child.on('error', reject);
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+describe('clip.sh — BLD-846 error surfacing', () => {
+  describe('happy path (2xx) — must not regress', () => {
+    it('comment-issue 201 prints body to stdout, exits 0, stderr empty', async () => {
+      const server = await startMockServer((req, res) => {
+        let body = '';
+        req.on('data', (c) => (body += c));
+        req.on('end', () => {
+          expect(req.method).toBe('POST');
+          expect(req.url).toBe('/api/issues/abc/comments');
+          // Echo back a created-comment shape
+          res.writeHead(201, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ id: 'cm-1', body: JSON.parse(body).body }));
+        });
+      });
+      try {
+        const r = await runClip(['comment-issue', 'abc', '--body', 'hello'], server.url);
+        expect(r.status).toBe(0);
+        expect(r.stderr).toBe('');
+        // jq pretty-prints the body
+        expect(r.stdout).toContain('"id"');
+        expect(r.stdout).toContain('cm-1');
+        expect(r.stdout).toContain('hello');
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('get-issue 200 returns body on stdout, no stderr noise', async () => {
+      const server = await startMockServer((_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ identifier: 'BLD-1', status: 'todo' }));
+      });
+      try {
+        const r = await runClip(['get-issue', 'BLD-1'], server.url);
+        expect(r.status).toBe(0);
+        expect(r.stderr).toBe('');
+        expect(r.stdout).toContain('BLD-1');
+        expect(r.stdout).toContain('todo');
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
+  describe('409 — the BLD-743 regression case', () => {
+    it('comment-issue 409 surfaces holderRunId on stderr and exits non-zero', async () => {
+      const errorBody = {
+        error: 'Issue is checked out by another agent',
+        holderRunId: 'run-owned-by-ceo-12345',
+        holderAgentId: 'agent-ceo',
+      };
+      const server = await startMockServer((_req, res) => {
+        res.writeHead(409, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(errorBody));
+      });
+      try {
+        const r = await runClip(['comment-issue', 'BLD-743', '--body', 'kc note'], server.url);
+        expect(r.status).not.toBe(0);
+        // Body must be preserved verbatim on stderr.
+        expect(r.stderr).toContain('Issue is checked out by another agent');
+        expect(r.stderr).toContain('run-owned-by-ceo-12345');
+        expect(r.stderr).toContain('agent-ceo');
+        // Status code must be visible too.
+        expect(r.stderr).toContain('409');
+        // Stdout MUST NOT contain the body — agents that pipe stdout
+        // (e.g. into jq) should not see the error as if it were data.
+        expect(r.stdout).not.toContain('Issue is checked out');
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('update-issue 409 also surfaces error body and non-zero exit', async () => {
+      const server = await startMockServer((_req, res) => {
+        res.writeHead(409, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'locked', holderRunId: 'r-9' }));
+      });
+      try {
+        const r = await runClip(['update-issue', 'BLD-743', '--status', 'done'], server.url);
+        expect(r.status).not.toBe(0);
+        expect(r.stderr).toContain('locked');
+        expect(r.stderr).toContain('r-9');
+        expect(r.stderr).toContain('409');
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
+  describe('other 4xx / 5xx', () => {
+    it('400 bad request surfaces validation error body on stderr', async () => {
+      const server = await startMockServer((_req, res) => {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'priority must be one of urgent|high|...' }));
+      });
+      try {
+        const r = await runClip(['create-issue', '--title', 't', '--priority', 'bogus'], server.url);
+        expect(r.status).not.toBe(0);
+        expect(r.stderr).toContain('priority must be one of');
+        expect(r.stderr).toContain('400');
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('500 internal error surfaces body and exits non-zero', async () => {
+      const server = await startMockServer((_req, res) => {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('internal kaboom');
+      });
+      try {
+        const r = await runClip(['get-issue', 'BLD-1'], server.url);
+        expect(r.status).not.toBe(0);
+        expect(r.stderr).toContain('internal kaboom');
+        expect(r.stderr).toContain('500');
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('401 unauthorized — empty body still surfaces a useful message', async () => {
+      const server = await startMockServer((_req, res) => {
+        res.writeHead(401);
+        res.end();
+      });
+      try {
+        const r = await runClip(['get-issue', 'BLD-1'], server.url);
+        expect(r.status).not.toBe(0);
+        expect(r.stderr).toContain('401');
+        // Empty body marker so agents know the server returned nothing.
+        expect(r.stderr).toContain('empty response body');
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
+  describe('exit code propagation', () => {
+    it('the failure is detectable under `set -e`', async () => {
+      const server = await startMockServer((_req, res) => {
+        res.writeHead(409, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'locked' }));
+      });
+      try {
+        // Run the script in a parent shell with `set -e` and verify the
+        // outer shell aborts. Use spawn (not spawnSync) so the mock
+        // server's event loop isn't blocked while curl waits.
+        const r = await new Promise<{ status: number | null }>((resolve, reject) => {
+          const child = spawn('bash', ['-c', `set -e; bash "${SCRIPT}" comment-issue x --body y`], {
+            env: {
+              ...process.env,
+              PAPERCLIP_API_BASE: server.url,
+              PAPERCLIP_AGENT_API_KEY: 'test-key',
+              CLIP_COMPANY: 'c',
+              CLIP_AGENT: 'a',
+            },
+          });
+          // Drain pipes so the child can exit.
+          child.stdout.resume();
+          child.stderr.resume();
+          child.on('error', reject);
+          child.on('close', (status) => resolve({ status }));
+        });
+        expect(r.status).not.toBe(0);
+      } finally {
+        await server.close();
+      }
+    });
+  });
+});

--- a/scripts/clip.sh
+++ b/scripts/clip.sh
@@ -1,0 +1,466 @@
+#!/usr/bin/env bash
+# clip.sh — Paperclip API helper for container use
+# Adapted from Claude skill tool--paperclip for use inside Paperclip container
+# Usage: clip.sh <command> [options]
+#
+# BLD-846 (2026-04-29): Surface 4xx/5xx error bodies on stderr.
+# ----------------------------------------------------------------
+# Previously this script used `curl -sf` for write endpoints. With `-f`,
+# curl exits non-zero on HTTP errors but discards the response body. That
+# silently swallowed real errors like "Issue is checked out by another
+# agent" (409) — agents thought their writes succeeded when they did not
+# (see BLD-743 incident, BLD-846 root-cause issue).
+#
+# This version captures both body and HTTP status code, prints the body to
+# stderr on non-2xx (so agents see the structured error), and exits
+# non-zero so callers using `set -e` or explicit checks can react.
+# Happy-path output (2xx) is unchanged.
+#
+# This file lives in the CableSnap repo as the source of truth. The host
+# bind-mounted copy at /skills/scripts/clip.sh should be updated to match.
+# Until that happens, agents can invoke this version directly via
+# `./scripts/clip.sh` from /projects/cablesnap.
+set -euo pipefail
+
+# --- Config (container-aware) ---
+# Inside the container, use localhost since we're in the same process
+API_BASE="${PAPERCLIP_API_BASE:-http://localhost:3100}"
+API_KEY="${PAPERCLIP_API_KEY:-${PAPERCLIP_AGENT_API_KEY:-}}"
+COMPANY="${CLIP_COMPANY:-${PAPERCLIP_COMPANY_ID:-}}"
+AGENT="${CLIP_AGENT:-${PAPERCLIP_AGENT_ID:-}}"
+
+if [[ -z "$API_KEY" ]]; then
+  echo "ERROR: PAPERCLIP_API_KEY (or PAPERCLIP_AGENT_API_KEY) not set" >&2
+  exit 1
+fi
+
+# --- Helpers ---
+
+# api: invoke the Paperclip HTTP API and surface error bodies.
+#
+# Usage: api METHOD PATH [extra curl args...]
+#
+# On 2xx: prints the response body to stdout, exits 0.
+# On non-2xx: prints the response body to stderr (with an
+#   "ERROR <status>" prefix line), exits 1. The structured error body
+#   (e.g. {"error":"Issue is checked out by another agent","holderRunId":...})
+#   is preserved verbatim so callers can grep / jq it.
+# On curl transport failure (network down, DNS, etc.): prints curl's
+#   stderr message and exits with curl's non-zero status.
+#
+# Implementation notes:
+#   - We append `\n<HTTP_STATUS>` to the response body using `-w` and split
+#     on the last newline. This avoids a temp-file dance and works with any
+#     body content (including bodies that already end with newlines).
+#   - We do NOT use `-f` because `-f` discards the body — exactly the bug
+#     this function is fixing.
+#   - We use `--connect-timeout` to avoid hangs against a dead API.
+api() {
+  local method="$1" path="$2"; shift 2
+  local url="${API_BASE}/api${path}"
+  local response status body
+  local curl_status=0
+
+  # Capture body+status. `-w` appends "<newline><http_code>" to the body.
+  response=$(curl -sS -X "$method" \
+    --connect-timeout 10 \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -w $'\n%{http_code}' \
+    "$@" "$url") || curl_status=$?
+
+  if [[ $curl_status -ne 0 ]]; then
+    # Transport failure (curl wrote its own error to stderr via -sS).
+    # `response` may be partial or empty; surface what we have.
+    if [[ -n "$response" ]]; then
+      printf '%s\n' "$response" >&2
+    fi
+    return "$curl_status"
+  fi
+
+  # Split: status is the last line, body is everything before it.
+  status="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+
+  # Defensive: if response had no body and curl emitted only the code,
+  # `body` will equal `status`. Treat that as empty body.
+  if [[ "$body" == "$status" ]]; then
+    body=""
+  fi
+
+  if [[ "$status" =~ ^2[0-9][0-9]$ ]]; then
+    if [[ -n "$body" ]]; then
+      printf '%s\n' "$body"
+    fi
+    return 0
+  fi
+
+  # Non-2xx: surface structured error to stderr.
+  printf 'ERROR %s %s %s\n' "$status" "$method" "$path" >&2
+  if [[ -n "$body" ]]; then
+    printf '%s\n' "$body" >&2
+  else
+    printf '(empty response body)\n' >&2
+  fi
+  return 1
+}
+
+api_get()    { api GET "$1"; }
+api_post()   { api POST "$1" -d "$2"; }
+api_patch()  { api PATCH "$1" -d "$2"; }
+api_delete() { api DELETE "$1"; }
+
+jq_or_cat() { if command -v jq &>/dev/null; then jq "$@"; else cat; fi; }
+
+# --- Commands ---
+cmd="${1:-help}"; shift || true
+
+case "$cmd" in
+  # === Issues ===
+  list-issues)
+    query=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --status)       query="${query:+$query&}status=$2"; shift 2;;
+        --assignee)     query="${query:+$query&}assigneeAgentId=$2"; shift 2;;
+        --project)      query="${query:+$query&}projectId=$2"; shift 2;;
+        --label)        query="${query:+$query&}labelId=$2"; shift 2;;
+        --search|-q)    query="${query:+$query&}q=$2"; shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_get "/companies/$COMPANY/issues${query:+?$query}" | jq_or_cat '.[] | {identifier, title, status, priority}' 2>/dev/null || api_get "/companies/$COMPANY/issues${query:+?$query}"
+    ;;
+
+  get-issue)
+    api_get "/issues/$1" | jq_or_cat '.'
+    ;;
+
+  create-issue)
+    body="{}"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --title)             body=$(echo "$body" | jq --arg v "$2" '. + {title: $v}'); shift 2;;
+        --description)       body=$(echo "$body" | jq --arg v "$2" '. + {description: $v}'); shift 2;;
+        --status)            body=$(echo "$body" | jq --arg v "$2" '. + {status: $v}'); shift 2;;
+        --priority)          body=$(echo "$body" | jq --arg v "$2" '. + {priority: $v}'); shift 2;;
+        --assignee-agent-id) body=$(echo "$body" | jq --arg v "$2" '. + {assigneeAgentId: $v}'); shift 2;;
+        --project-id)        body=$(echo "$body" | jq --arg v "$2" '. + {projectId: $v}'); shift 2;;
+        --goal-id)           body=$(echo "$body" | jq --arg v "$2" '. + {goalId: $v}'); shift 2;;
+        --parent-id)         body=$(echo "$body" | jq --arg v "$2" '. + {parentId: $v}'); shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_post "/companies/$COMPANY/issues" "$body" | jq_or_cat '.'
+    ;;
+
+  update-issue)
+    issue_id="$1"; shift
+    body="{}"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --title)             body=$(echo "$body" | jq --arg v "$2" '. + {title: $v}'); shift 2;;
+        --description)       body=$(echo "$body" | jq --arg v "$2" '. + {description: $v}'); shift 2;;
+        --status)            body=$(echo "$body" | jq --arg v "$2" '. + {status: $v}'); shift 2;;
+        --priority)          body=$(echo "$body" | jq --arg v "$2" '. + {priority: $v}'); shift 2;;
+        --assignee-agent-id) body=$(echo "$body" | jq --arg v "$2" '. + {assigneeAgentId: $v}'); shift 2;;
+        --project-id)        body=$(echo "$body" | jq --arg v "$2" '. + {projectId: $v}'); shift 2;;
+        --goal-id)           body=$(echo "$body" | jq --arg v "$2" '. + {goalId: $v}'); shift 2;;
+        --comment)           body=$(echo "$body" | jq --arg v "$2" '. + {comment: $v}'); shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_patch "/issues/$issue_id" "$body" | jq_or_cat '.'
+    ;;
+
+  comment-issue)
+    issue_id="$1"; shift
+    body=""
+    reopen="false"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --body)   body="$2"; shift 2;;
+        --reopen) reopen="true"; shift;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_post "/issues/$issue_id/comments" "{\"body\":$(echo "$body" | jq -Rs '.'),\"reopen\":$reopen}" | jq_or_cat '.'
+    ;;
+
+  checkout-issue)
+    issue_id="$1"; shift
+    run_id="${1:-$(python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo "manual-$(date +%s)")}"
+    # Route through api() so 4xx/5xx bodies surface (BLD-846).
+    api POST "/issues/$issue_id/checkout" \
+      -H "X-Paperclip-Run-Id: $run_id" \
+      -d "{\"agentId\":\"$AGENT\"}" | jq_or_cat '.'
+    echo "Run ID: $run_id" >&2
+    ;;
+
+  release-issue)
+    api_post "/issues/$1/release" "{}" | jq_or_cat '.'
+    ;;
+
+  # === Goals ===
+  list-goals)
+    api_get "/companies/$COMPANY/goals" | jq_or_cat '.'
+    ;;
+
+  create-goal)
+    body="{}"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --title)       body=$(echo "$body" | jq --arg v "$2" '. + {title: $v}'); shift 2;;
+        --description) body=$(echo "$body" | jq --arg v "$2" '. + {description: $v}'); shift 2;;
+        --level)       body=$(echo "$body" | jq --arg v "$2" '. + {level: $v}'); shift 2;;
+        --status)      body=$(echo "$body" | jq --arg v "$2" '. + {status: $v}'); shift 2;;
+        --parent-id)   body=$(echo "$body" | jq --arg v "$2" '. + {parentId: $v}'); shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_post "/companies/$COMPANY/goals" "$body" | jq_or_cat '.'
+    ;;
+
+  update-goal)
+    goal_id="$1"; shift
+    body="{}"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --title)       body=$(echo "$body" | jq --arg v "$2" '. + {title: $v}'); shift 2;;
+        --description) body=$(echo "$body" | jq --arg v "$2" '. + {description: $v}'); shift 2;;
+        --status)      body=$(echo "$body" | jq --arg v "$2" '. + {status: $v}'); shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_patch "/goals/$goal_id" "$body" | jq_or_cat '.'
+    ;;
+
+  # === Projects ===
+  list-projects)
+    api_get "/companies/$COMPANY/projects" | jq_or_cat '.'
+    ;;
+
+  create-project)
+    body="{}"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --name)        body=$(echo "$body" | jq --arg v "$2" '. + {name: $v}'); shift 2;;
+        --description) body=$(echo "$body" | jq --arg v "$2" '. + {description: $v}'); shift 2;;
+        --status)      body=$(echo "$body" | jq --arg v "$2" '. + {status: $v}'); shift 2;;
+        --lead-agent)  body=$(echo "$body" | jq --arg v "$2" '. + {leadAgentId: $v}'); shift 2;;
+        --goal-id)     body=$(echo "$body" | jq --arg v "$2" '. + {goalId: $v}'); shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_post "/companies/$COMPANY/projects" "$body" | jq_or_cat '.'
+    ;;
+
+  update-project)
+    project_id="$1"; shift
+    body="{}"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --name)        body=$(echo "$body" | jq --arg v "$2" '. + {name: $v}'); shift 2;;
+        --description) body=$(echo "$body" | jq --arg v "$2" '. + {description: $v}'); shift 2;;
+        --status)      body=$(echo "$body" | jq --arg v "$2" '. + {status: $v}'); shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_patch "/projects/$project_id" "$body" | jq_or_cat '.'
+    ;;
+
+  # === Labels ===
+  list-labels)
+    api_get "/companies/$COMPANY/labels" | jq_or_cat '.'
+    ;;
+
+  create-label)
+    name=""; color=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --name)  name="$2"; shift 2;;
+        --color) color="$2"; shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_post "/companies/$COMPANY/labels" "{\"name\":\"$name\",\"color\":\"$color\"}" | jq_or_cat '.'
+    ;;
+
+  # === Agents ===
+  create-agent)
+    # ENFORCED: All agents MUST use copilot_local adapter with command "copilot"
+    body='{"adapterType":"copilot_local"}'
+    config='{"command":"copilot","cwd":"/projects/travel-planner"}'
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --name)                body=$(echo "$body" | jq --arg v "$2" '. + {name: $v}'); shift 2;;
+        --role)                body=$(echo "$body" | jq --arg v "$2" '. + {role: $v}'); shift 2;;
+        --model)               config=$(echo "$config" | jq --arg v "$2" '. + {model: $v}'); shift 2;;
+        --instructions-file)   config=$(echo "$config" | jq --arg v "$2" '. + {instructionsFilePath: $v}'); shift 2;;
+        --prompt-template)     config=$(echo "$config" | jq --arg v "$2" '. + {promptTemplate: $v}'); shift 2;;
+        --cwd)                 config=$(echo "$config" | jq --arg v "$2" '. + {cwd: $v}'); shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    body=$(echo "$body" | jq --argjson c "$config" '. + {adapterConfig: $c}')
+    echo "Creating agent with copilot_local adapter (enforced):" >&2
+    echo "$body" | jq '.' >&2
+    api_post "/companies/$COMPANY/agents" "$body" | jq_or_cat '.'
+    ;;
+
+  list-agents)
+    api_get "/companies/$COMPANY/agents" | jq_or_cat '.'
+    ;;
+
+  get-me)
+    api_get "/agents/me" | jq_or_cat '.'
+    ;;
+
+  get-agent)
+    api_get "/agents/$1" | jq_or_cat '.'
+    ;;
+
+  wake-agent)
+    reason="${1:-manual wakeup}"
+    api_post "/agents/$AGENT/wakeup" "{\"source\":\"cli\",\"reason\":$(echo "$reason" | jq -Rs '.')}" | jq_or_cat '.'
+    ;;
+
+  # === Dashboard & Activity ===
+  dashboard)
+    api_get "/companies/$COMPANY/dashboard" | jq_or_cat '.'
+    ;;
+
+  activity)
+    query=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --agent-id)    query="${query:+$query&}agentId=$2"; shift 2;;
+        --entity-type) query="${query:+$query&}entityType=$2"; shift 2;;
+        --entity-id)   query="${query:+$query&}entityId=$2"; shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_get "/companies/$COMPANY/activity${query:+?$query}" | jq_or_cat '.'
+    ;;
+
+  badges)
+    api_get "/companies/$COMPANY/sidebar-badges" | jq_or_cat '.'
+    ;;
+
+  # === Approvals ===
+  list-approvals)
+    status="${1:-}"
+    api_get "/companies/$COMPANY/approvals${status:+?status=$status}" | jq_or_cat '.'
+    ;;
+
+  create-approval)
+    body="{}"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --type)    body=$(echo "$body" | jq --arg v "$2" '. + {type: $v}'); shift 2;;
+        --payload) body=$(echo "$body" | jq --argjson v "$2" '. + {payload: $v}'); shift 2;;
+        --agent)   body=$(echo "$body" | jq --arg v "$2" '. + {requestedByAgentId: $v}'); shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_post "/companies/$COMPANY/approvals" "$body" | jq_or_cat '.'
+    ;;
+
+  comment-approval)
+    approval_id="$1"; shift
+    body=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --body) body="$2"; shift 2;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+      esac
+    done
+    api_post "/approvals/$approval_id/comments" "{\"body\":$(echo "$body" | jq -Rs '.')}" | jq_or_cat '.'
+    ;;
+
+  # === Heartbeats ===
+  list-runs)
+    limit="${1:-20}"
+    api_get "/companies/$COMPANY/heartbeat-runs?limit=$limit" | jq_or_cat '.'
+    ;;
+
+  live-runs)
+    api_get "/companies/$COMPANY/live-runs" | jq_or_cat '.'
+    ;;
+
+  # === Health ===
+  health)
+    api_get "/health" | jq_or_cat '.'
+    ;;
+
+  # === Help ===
+  help|--help|-h|"")
+    cat <<'HELP'
+clip.sh — Paperclip API helper (container edition)
+
+ISSUES:
+  list-issues [--status S] [--assignee ID] [--project ID] [--label ID] [-q TEXT]
+  get-issue <ID>              Get issue by identifier (ZJ-17) or UUID
+  create-issue --title T [--description D] [--status S] [--priority P] [--goal-id G]
+  update-issue <ID> [--title T] [--status S] [--priority P] [--comment C]
+  comment-issue <ID> --body TEXT [--reopen]
+  checkout-issue <ID> [run-id]
+  release-issue <ID>
+
+GOALS:
+  list-goals
+  create-goal --title T [--level L] [--status S] [--description D]
+  update-goal <ID> [--title T] [--status S]
+
+PROJECTS:
+  list-projects
+  create-project --name N [--description D] [--status S] [--lead-agent ID]
+  update-project <ID> [--name N] [--status S]
+
+LABELS:
+  list-labels
+  create-label --name N --color C
+
+AGENTS:
+  create-agent --name N --model M [--role R] [--instructions-file /skills/AGENTS-X.md]
+               Always uses copilot_local adapter (enforced, not overridable)
+  list-agents | get-me | get-agent <ID> | wake-agent [reason]
+
+DASHBOARD:
+  dashboard | activity [--agent-id ID] | badges
+
+APPROVALS:
+  list-approvals [status] | create-approval --type T --payload JSON
+  comment-approval <ID> --body TEXT
+
+HEARTBEATS:
+  list-runs [limit] | live-runs
+
+OTHER:
+  health | help
+
+ERROR HANDLING (BLD-846):
+  Non-2xx HTTP responses are surfaced to stderr with the structured
+  error body, and the process exits with status 1 (transport errors
+  use curl's exit code). Use `set -e` or check $? to detect failures.
+
+  Example (409 from comment-issue when issue is locked):
+    $ scripts/clip.sh comment-issue BLD-743 --body "..."
+    ERROR 409 POST /issues/.../comments
+    {"error":"Issue is checked out by another agent","holderRunId":"..."}
+    $ echo $?
+    1
+
+ENVIRONMENT:
+  PAPERCLIP_API_BASE         API base URL (default: http://localhost:3100)
+  PAPERCLIP_AGENT_API_KEY    Agent API key (required)
+  CLIP_COMPANY               Company UUID
+  CLIP_AGENT                 Agent UUID
+HELP
+    ;;
+
+  *)
+    echo "Unknown command: $cmd. Run 'clip.sh help' for usage." >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

The bind-mounted `/skills/scripts/clip.sh` used `curl -sf` for write endpoints. With `-f`, curl exits non-zero on HTTP errors but the response body (containing the structured API error like `Issue is checked out by another agent`) is silently discarded. Combined with downstream pipelines that didn't reliably surface the exit code, this swallowed real failures — most recently in BLD-743 where knowledge-curator's status flip 409'd against a CEO-locked issue and the agent thought it succeeded.

## Changes

- New `scripts/clip.sh` in the cablesnap repo (mirroring the `scripts/memory-cli` precedent from BLD-746). The `api()` helper now:
  - Captures both response body and HTTP status code via `curl -w '\n%{http_code}'`.
  - On **2xx**: prints body to stdout, exits 0 — no behaviour change for the happy path.
  - On **4xx/5xx**: prints `ERROR <code> <method> <path>` + the response body to stderr, exits 1. The structured error (e.g. `{"error":...,"holderRunId":...}`) is preserved verbatim so callers can grep / jq it.
  - On **transport failure**: surfaces curl's stderr message and curl's exit code.
- Also routes the previously-raw `curl -sf` inside `checkout-issue` through `api()` so its 409s surface the same way.
- New test `scripts/__tests__/clip-error-surfacing.test.ts` (8 cases, ~2s, hermetic via in-process mock HTTP server).

## Acceptance criteria

| Criterion | Covered by |
|---|---|
| 4xx/5xx response body written to stderr | `400 / 500` tests |
| 409 structured error surfaced (holderRunId visible) | `comment-issue 409` + `update-issue 409` tests |
| Non-zero exit code, detectable under `set -e` | `exit code propagation` test |
| No regression on 2xx | `comment-issue 201` + `get-issue 200` tests |
| Test harness | new Jest spec, runs against an in-process `http.createServer` |

## Testing

```
$ ./node_modules/.bin/jest scripts/__tests__/clip-error-surfacing.test.ts
PASS scripts/__tests__/clip-error-surfacing.test.ts (8 passed, 1.8s)
```

Manual verification against a Python mock server confirmed:
- 409 → stderr contains `{"error":"Issue is checked out by another agent","holderRunId":"r-1"}`, exit code 1
- 201 → stdout contains the response body, exit code 0
- 401 with empty body → stderr contains `401` + `(empty response body)`, exit code 1

`tsc --noEmit` and `eslint` pass on the new test file.

## Deployment note

The host-side bind-mount at `/skills/scripts/clip.sh` is read-only from within agent containers; this PR ships the fix in-tree so it can be reviewed, tested, and committed to source control. The platform operator still needs to update the host-side dotfiles copy so it propagates to all agent containers (same situation as the BLD-746 `memory-cli` shim — that PR established this pattern).

Until the host-side update lands, agents working in `/projects/cablesnap` can call `./scripts/clip.sh ...` directly to pick up the fix.

## Issue

Resolves BLD-846. Related: BLD-743 (incident), BLD-824 (root-cause checkout-lock issue), BLD-746 (memory-cli precedent), BLD-847 (KC read-only path that depends on correct error surfacing).
