### PR TITLE
feat(progress): scrollable underline tabs (BLD-849)

### DIFF
--- a/__tests__/components/ui/scrollable-tabs.test.tsx
+++ b/__tests__/components/ui/scrollable-tabs.test.tsx
@@ -6,6 +6,7 @@
  * onValueChange, and the active tab's accessibility state flips.
  */
 import React from "react";
+import { ScrollView, View } from "react-native";
 import { fireEvent, render } from "@testing-library/react-native";
 
 jest.mock("@/hooks/useColor", () => ({
@@ -32,16 +33,17 @@ jest.mock("expo-haptics", () => ({
 
 import * as Haptics from "expo-haptics";
 import { ScrollableTabs } from "../../../components/ui/scrollable-tabs";
+import type { ScrollableTabsButton } from "../../../components/ui/scrollable-tabs";
 
 const impactAsyncMock = Haptics.impactAsync as jest.Mock;
 
-const FIVE_TABS = [
+const FIVE_TABS: readonly ScrollableTabsButton[] = [
   { value: "workouts", label: "Workouts", accessibilityLabel: "Workouts progress" },
   { value: "body", label: "Body", accessibilityLabel: "Body metrics" },
   { value: "muscles", label: "Muscles", accessibilityLabel: "Muscle volume analysis" },
   { value: "nutrition", label: "Nutrition", accessibilityLabel: "Nutrition trends" },
   { value: "monthly", label: "Monthly", accessibilityLabel: "Monthly training report" },
-] as const;
+];
 
 beforeEach(() => {
   impactAsyncMock.mockClear();
@@ -53,7 +55,7 @@ describe("ScrollableTabs (BLD-849)", () => {
       <ScrollableTabs
         value="workouts"
         onValueChange={() => {}}
-        buttons={FIVE_TABS as any}
+        buttons={FIVE_TABS}
       />,
     );
     // Every label must be rendered as text exactly as supplied.
@@ -68,7 +70,7 @@ describe("ScrollableTabs (BLD-849)", () => {
       <ScrollableTabs
         value="workouts"
         onValueChange={onValueChange}
-        buttons={FIVE_TABS as any}
+        buttons={FIVE_TABS}
       />,
     );
     fireEvent.press(getByText("Body"));
@@ -82,7 +84,7 @@ describe("ScrollableTabs (BLD-849)", () => {
       <ScrollableTabs
         value="workouts"
         onValueChange={onValueChange}
-        buttons={FIVE_TABS as any}
+        buttons={FIVE_TABS}
       />,
     );
     fireEvent.press(getByText("Workouts"));
@@ -96,7 +98,7 @@ describe("ScrollableTabs (BLD-849)", () => {
       <ScrollableTabs
         value="workouts"
         onValueChange={() => {}}
-        buttons={FIVE_TABS as any}
+        buttons={FIVE_TABS}
       />,
     );
     expect(
@@ -110,7 +112,7 @@ describe("ScrollableTabs (BLD-849)", () => {
       <ScrollableTabs
         value="muscles"
         onValueChange={() => {}}
-        buttons={FIVE_TABS as any}
+        buttons={FIVE_TABS}
       />,
     );
     expect(
@@ -141,11 +143,58 @@ describe("ScrollableTabs (BLD-849)", () => {
       <ScrollableTabs
         value="workouts"
         onValueChange={() => {}}
-        buttons={FIVE_TABS as any}
+        buttons={FIVE_TABS}
       />,
     );
     expect(getByTestId("scrollable-tabs-indicator")).toBeTruthy();
     // Root container exposes tablist for assistive tech.
     expect(root.props.accessibilityRole).toBe("tablist");
+  });
+
+  it("shows the trailing fade only when content overflows the container and we are not scrolled to the end", () => {
+    const { getByTestId, queryByTestId, UNSAFE_getAllByType } = render(
+      <ScrollableTabs
+        value="workouts"
+        onValueChange={() => {}}
+        buttons={FIVE_TABS}
+      />,
+    );
+    // 1) Initial render: container has zero width (no layout yet) — fade
+    //    should be hidden because contentWidth (0) is not > containerWidth (0).
+    expect(queryByTestId("scrollable-tabs-trailing-fade")).toBeNull();
+
+    // 2) Container measures 200px wide.
+    const tablist = UNSAFE_getAllByType(View).find(
+      (n) => n.props.accessibilityRole === "tablist",
+    );
+    expect(tablist).toBeTruthy();
+    fireEvent(tablist!, "layout", {
+      nativeEvent: { layout: { x: 0, y: 0, width: 200, height: 48 } },
+    });
+
+    // 3) ScrollView reports content width of 600px (overflows by 400px) and
+    //    we are scrolled to the start. Fade must appear.
+    const scrollView = UNSAFE_getAllByType(ScrollView)[0];
+    fireEvent(scrollView, "contentSizeChange", 600, 48);
+    fireEvent.scroll(scrollView, {
+      nativeEvent: {
+        contentOffset: { x: 0, y: 0 },
+        contentSize: { width: 600, height: 48 },
+        layoutMeasurement: { width: 200, height: 48 },
+      },
+    });
+    expect(getByTestId("scrollable-tabs-trailing-fade")).toBeTruthy();
+
+    // 4) Scroll to the end (offset 400 → right edge reaches contentWidth).
+    //    Fade must hide so the user does not see a phantom fade at the
+    //    actual end of content.
+    fireEvent.scroll(scrollView, {
+      nativeEvent: {
+        contentOffset: { x: 400, y: 0 },
+        contentSize: { width: 600, height: 48 },
+        layoutMeasurement: { width: 200, height: 48 },
+      },
+    });
+    expect(queryByTestId("scrollable-tabs-trailing-fade")).toBeNull();
   });
 });

--- a/__tests__/components/ui/scrollable-tabs.test.tsx
+++ b/__tests__/components/ui/scrollable-tabs.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tests for ScrollableTabs (BLD-849).
+ *
+ * Covers the contract that protects the Progress route from text-truncation
+ * regression: tabs render with full label text, tab presses fire haptic +
+ * onValueChange, and the active tab's accessibility state flips.
+ */
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+
+jest.mock("@/hooks/useColor", () => ({
+  useColor: (name: string) => {
+    switch (name) {
+      case "primary":
+        return "#FF6038";
+      case "mutedForeground":
+        return "#6B7280";
+      case "background":
+        return "#FAFAFA";
+      default:
+        return "#000000";
+    }
+  },
+}));
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  ImpactFeedbackStyle: { Light: "light", Medium: "medium", Heavy: "heavy" },
+}));
+
+// react-native-svg renders fine in jest preset; no extra mock needed.
+
+import * as Haptics from "expo-haptics";
+import { ScrollableTabs } from "../../../components/ui/scrollable-tabs";
+
+const impactAsyncMock = Haptics.impactAsync as jest.Mock;
+
+const FIVE_TABS = [
+  { value: "workouts", label: "Workouts", accessibilityLabel: "Workouts progress" },
+  { value: "body", label: "Body", accessibilityLabel: "Body metrics" },
+  { value: "muscles", label: "Muscles", accessibilityLabel: "Muscle volume analysis" },
+  { value: "nutrition", label: "Nutrition", accessibilityLabel: "Nutrition trends" },
+  { value: "monthly", label: "Monthly", accessibilityLabel: "Monthly training report" },
+] as const;
+
+beforeEach(() => {
+  impactAsyncMock.mockClear();
+});
+
+describe("ScrollableTabs (BLD-849)", () => {
+  it("renders every label in full — no truncation, no missing tabs", () => {
+    const { getByText } = render(
+      <ScrollableTabs
+        value="workouts"
+        onValueChange={() => {}}
+        buttons={FIVE_TABS as any}
+      />,
+    );
+    // Every label must be rendered as text exactly as supplied.
+    for (const tab of FIVE_TABS) {
+      expect(getByText(tab.label)).toBeTruthy();
+    }
+  });
+
+  it("calls onValueChange and fires light haptic when an inactive tab is pressed", () => {
+    const onValueChange = jest.fn();
+    const { getByText } = render(
+      <ScrollableTabs
+        value="workouts"
+        onValueChange={onValueChange}
+        buttons={FIVE_TABS as any}
+      />,
+    );
+    fireEvent.press(getByText("Body"));
+    expect(onValueChange).toHaveBeenCalledWith("body");
+    expect(impactAsyncMock).toHaveBeenCalledWith("light");
+  });
+
+  it("does not fire haptic when the already-active tab is pressed", () => {
+    const onValueChange = jest.fn();
+    const { getByText } = render(
+      <ScrollableTabs
+        value="workouts"
+        onValueChange={onValueChange}
+        buttons={FIVE_TABS as any}
+      />,
+    );
+    fireEvent.press(getByText("Workouts"));
+    expect(impactAsyncMock).not.toHaveBeenCalled();
+    // We still call onValueChange — parent decides whether it's a no-op.
+    expect(onValueChange).toHaveBeenCalledWith("workouts");
+  });
+
+  it("marks only the active tab as accessibility-selected", () => {
+    const { getByLabelText, rerender } = render(
+      <ScrollableTabs
+        value="workouts"
+        onValueChange={() => {}}
+        buttons={FIVE_TABS as any}
+      />,
+    );
+    expect(
+      getByLabelText("Workouts progress").props.accessibilityState.selected,
+    ).toBe(true);
+    expect(
+      getByLabelText("Body metrics").props.accessibilityState.selected,
+    ).toBe(false);
+
+    rerender(
+      <ScrollableTabs
+        value="muscles"
+        onValueChange={() => {}}
+        buttons={FIVE_TABS as any}
+      />,
+    );
+    expect(
+      getByLabelText("Workouts progress").props.accessibilityState.selected,
+    ).toBe(false);
+    expect(
+      getByLabelText("Muscle volume analysis").props.accessibilityState
+        .selected,
+    ).toBe(true);
+  });
+
+  it("uses the supplied accessibilityLabel when provided, falling back to label otherwise", () => {
+    const buttons = [
+      { value: "a", label: "A", accessibilityLabel: "Tab A custom" },
+      { value: "b", label: "B" },
+    ];
+    const { getByLabelText } = render(
+      <ScrollableTabs value="a" onValueChange={() => {}} buttons={buttons} />,
+    );
+    // Custom label.
+    expect(getByLabelText("Tab A custom")).toBeTruthy();
+    // Fallback to label string when accessibilityLabel is missing.
+    expect(getByLabelText("B")).toBeTruthy();
+  });
+
+  it("renders an animated indicator and exposes a tablist role", () => {
+    const { getByTestId, root } = render(
+      <ScrollableTabs
+        value="workouts"
+        onValueChange={() => {}}
+        buttons={FIVE_TABS as any}
+      />,
+    );
+    expect(getByTestId("scrollable-tabs-indicator")).toBeTruthy();
+    // Root container exposes tablist for assistive tech.
+    expect(root.props.accessibilityRole).toBe("tablist");
+  });
+});

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
-import { SegmentedControl } from "@/components/ui/segmented-control";
-import { useLayout } from "../../lib/layout";
+import { ScrollableTabs } from "@/components/ui/scrollable-tabs";
 import MuscleVolumeSegment from "../../components/MuscleVolumeSegment";
 import WorkoutSegment from "@/components/progress/WorkoutSegment";
 import BodySegment from "@/components/progress/BodySegment";
@@ -11,13 +10,14 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 
 export default function Progress() {
   const colors = useThemeColors();
-  const layout = useLayout();
   const [segment, setSegment] = useState("workouts");
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <View style={[styles.segmentContainer, { paddingHorizontal: layout.horizontalPadding }]}>
-        <SegmentedControl
+      <View style={styles.tabsContainer}>
+        {/* ScrollableTabs handles its own edge padding via contentContainerStyle —
+            do NOT wrap with horizontal padding or the trailing fade gets clipped. */}
+        <ScrollableTabs
           value={segment}
           onValueChange={setSegment}
           buttons={[
@@ -46,8 +46,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  segmentContainer: {
-    padding: 16,
+  tabsContainer: {
+    paddingTop: 16,
     paddingBottom: 0,
   },
 });

--- a/components/ui/scrollable-tabs.tsx
+++ b/components/ui/scrollable-tabs.tsx
@@ -1,0 +1,321 @@
+/* eslint-disable */
+/**
+ * ScrollableTabs — horizontally scrollable underline tabs.
+ *
+ * Designed for the Progress route navbar (BLD-849), where 5+ tab labels
+ * cannot fit a fixed-width pill SegmentedControl on small phone widths
+ * (iPhone SE / 375px) without truncating their text.
+ *
+ * Visual language: Strava / Apple Fitness / MyFitnessPal — no container
+ * background, animated 2px underline beneath the active tab text only,
+ * trailing fade gradient that hints at off-screen content and disappears
+ * when scrolled to the end.
+ *
+ * Same prop interface as `SegmentedControl` for trivial swap-in.
+ *
+ * NOTE: This is a separate component on purpose. SegmentedControl is reused
+ * by 15+ screens (settings, onboarding, timer, body profile, exercise form,
+ * variant/grip pickers) that rely on `flex: 1` equal-width pill behavior.
+ * Forking avoids regressing those callers behind a variant prop.
+ */
+import { Text } from "@/components/ui/text";
+import { useColor } from "@/hooks/useColor";
+import { FONT_SIZE, HEIGHT } from "@/theme/globals";
+import * as Haptics from "expo-haptics";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
+
+export interface ScrollableTabsButton {
+  value: string;
+  label: string;
+  accessibilityLabel?: string;
+}
+
+interface ScrollableTabsProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  buttons: readonly ScrollableTabsButton[] | ScrollableTabsButton[];
+  /** Optional outer container style. Tabs handle their own edge padding. */
+  style?: ViewStyle;
+  /**
+   * Horizontal padding flush with the screen edge for the first / last tab
+   * via the ScrollView's contentContainerStyle. Defaults to 16.
+   */
+  edgePadding?: number;
+}
+
+/** Width (px) of the trailing fade gradient. */
+const FADE_WIDTH = 32;
+/** Inner horizontal padding around each tab label. */
+const TAB_PADDING_H = 16;
+/** Gap between tabs. */
+const TAB_GAP = 4;
+/** Underline thickness. */
+const UNDERLINE_HEIGHT = 2;
+/** Animation duration for the underline indicator (ms). */
+const INDICATOR_DURATION_MS = 220;
+
+interface TabLayout {
+  /** x position of the tab Pressable inside the inner content row. */
+  x: number;
+  /** Full width of the tab Pressable. */
+  width: number;
+}
+
+export function ScrollableTabs({
+  value,
+  onValueChange,
+  buttons,
+  style,
+  edgePadding = 16,
+}: ScrollableTabsProps) {
+  const activeColor = useColor("primary");
+  const inactiveColor = useColor("mutedForeground");
+  const bgColor = useColor("background");
+
+  const tabs = buttons as ScrollableTabsButton[];
+  const layoutsRef = useRef<Record<string, TabLayout>>({});
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [contentWidth, setContentWidth] = useState(0);
+  const [scrollX, setScrollX] = useState(0);
+
+  const indicatorX = useSharedValue(0);
+  const indicatorW = useSharedValue(0);
+  // Tracks whether we have placed the indicator at least once. Until then the
+  // indicator stays width=0 so it does not flash at x=0 before measurement.
+  const indicatorReady = useSharedValue(false);
+
+  const scrollRef = useRef<ScrollView>(null);
+
+  const moveIndicatorTo = useCallback(
+    (val: string, animate: boolean) => {
+      const layout = layoutsRef.current[val];
+      if (!layout) return;
+      // Underline spans the text label width with a small horizontal inset
+      // so it visually sits beneath the text rather than the full padded box.
+      const underlineX = layout.x + TAB_PADDING_H;
+      const underlineW = Math.max(0, layout.width - TAB_PADDING_H * 2);
+      if (animate) {
+        indicatorX.value = withTiming(underlineX, {
+          duration: INDICATOR_DURATION_MS,
+        });
+        indicatorW.value = withTiming(underlineW, {
+          duration: INDICATOR_DURATION_MS,
+        });
+      } else {
+        indicatorX.value = underlineX;
+        indicatorW.value = underlineW;
+      }
+      indicatorReady.value = true;
+    },
+    [indicatorReady, indicatorW, indicatorX]
+  );
+
+  // Re-position the indicator whenever the active value changes (after
+  // initial layout has populated layoutsRef).
+  useEffect(() => {
+    moveIndicatorTo(value, /* animate */ true);
+  }, [value, moveIndicatorTo]);
+
+  const handleTabLayout = useCallback(
+    (val: string) => (e: LayoutChangeEvent) => {
+      const { x, width } = e.nativeEvent.layout;
+      layoutsRef.current[val] = { x, width };
+      // First-paint: snap indicator to the active tab as soon as we have its
+      // measurements (no animation — we don't want a slide-in from x=0).
+      if (val === value) {
+        moveIndicatorTo(val, /* animate */ false);
+      }
+    },
+    [value, moveIndicatorTo]
+  );
+
+  const handlePress = useCallback(
+    (val: string) => {
+      if (val !== value) {
+        // Defensive: tests sometimes mock impactAsync as `jest.fn()` which
+        // returns undefined rather than a Promise. Don't crash on `.catch`.
+        const result = Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        if (result && typeof (result as Promise<void>).catch === "function") {
+          (result as Promise<void>).catch(() => {
+            // Silently ignore — haptics are a polish, not a correctness path.
+          });
+        }
+      }
+      onValueChange(val);
+      // Best-effort scroll the new tab into view (centered when possible).
+      const layout = layoutsRef.current[val];
+      if (layout && containerWidth > 0 && scrollRef.current) {
+        const target = Math.max(
+          0,
+          layout.x + layout.width / 2 - containerWidth / 2
+        );
+        scrollRef.current.scrollTo({ x: target, animated: true });
+      }
+    },
+    [containerWidth, onValueChange, value]
+  );
+
+  const onContainerLayout = useCallback((e: LayoutChangeEvent) => {
+    setContainerWidth(e.nativeEvent.layout.width);
+  }, []);
+
+  const onContentSizeChange = useCallback((w: number) => {
+    setContentWidth(w);
+  }, []);
+
+  const onScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    setScrollX(e.nativeEvent.contentOffset.x);
+  }, []);
+
+  // Trailing fade is visible whenever there is content past the right edge.
+  // We give a 1px slack to absorb fp rounding on the boundary.
+  const trailingFadeVisible =
+    contentWidth > containerWidth &&
+    scrollX + containerWidth < contentWidth - 1;
+
+  const indicatorStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: indicatorX.value }],
+    width: indicatorW.value,
+    opacity: indicatorReady.value ? 1 : 0,
+  }));
+
+  return (
+    <View
+      style={[styles.container, style]}
+      onLayout={onContainerLayout}
+      accessibilityRole="tablist"
+    >
+      <ScrollView
+        ref={scrollRef}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        onScroll={onScroll}
+        scrollEventThrottle={16}
+        onContentSizeChange={onContentSizeChange}
+        contentContainerStyle={{
+          paddingHorizontal: edgePadding,
+          // Inner row holds tabs + the indicator, both share the same x-axis.
+          alignItems: "flex-end",
+        }}
+      >
+        <View style={styles.row}>
+          {tabs.map((btn) => {
+            const isActive = btn.value === value;
+            return (
+              <Pressable
+                key={btn.value}
+                onPress={() => handlePress(btn.value)}
+                onLayout={handleTabLayout(btn.value)}
+                accessibilityRole="tab"
+                accessibilityLabel={btn.accessibilityLabel ?? btn.label}
+                accessibilityState={{ selected: isActive }}
+                style={styles.tab}
+                hitSlop={4}
+                testID={`scrollable-tab-${btn.value}`}
+              >
+                <Text
+                  style={{
+                    fontSize: FONT_SIZE - 2,
+                    fontWeight: isActive ? "600" : "400",
+                    color: isActive ? activeColor : inactiveColor,
+                    textAlign: "center",
+                  }}
+                  numberOfLines={1}
+                  // Ensure the parent Pressable sizes to the natural label
+                  // width — RN <Text> does not shrink-to-fit by default
+                  // inside a flex row, but our row is not flex-1.
+                >
+                  {btn.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+          {/* Animated underline indicator — absolutely positioned at the
+              bottom of the row, translates + resizes to follow the active
+              tab's text width. */}
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              styles.indicator,
+              { backgroundColor: activeColor },
+              indicatorStyle,
+            ]}
+            testID="scrollable-tabs-indicator"
+          />
+        </View>
+      </ScrollView>
+
+      {/* Trailing fade gradient — sits above the ScrollView on the right
+          edge to suggest "more content beyond the edge". Hidden when the
+          user has scrolled to the end. */}
+      {trailingFadeVisible && (
+        <View
+          pointerEvents="none"
+          style={[styles.trailingFade, { width: FADE_WIDTH }]}
+          testID="scrollable-tabs-trailing-fade"
+        >
+          <Svg width="100%" height="100%">
+            <Defs>
+              <LinearGradient id="fade" x1="0" y1="0" x2="1" y2="0">
+                <Stop offset="0" stopColor={bgColor} stopOpacity="0" />
+                <Stop offset="1" stopColor={bgColor} stopOpacity="1" />
+              </LinearGradient>
+            </Defs>
+            <Rect x="0" y="0" width="100%" height="100%" fill="url(#fade)" />
+          </Svg>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: HEIGHT,
+    // No backgroundColor — sits directly on parent (the screen background).
+    // This is the key visual differentiator from SegmentedControl.
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    height: HEIGHT,
+    gap: TAB_GAP,
+    // The row is the positioning context for the absolute indicator.
+    position: "relative",
+  },
+  tab: {
+    height: HEIGHT,
+    paddingHorizontal: TAB_PADDING_H,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  indicator: {
+    position: "absolute",
+    left: 0,
+    bottom: 0,
+    height: UNDERLINE_HEIGHT,
+    borderRadius: 1,
+  },
+  trailingFade: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    right: 0,
+  },
+});

--- a/components/ui/scrollable-tabs.tsx
+++ b/components/ui/scrollable-tabs.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * ScrollableTabs — horizontally scrollable underline tabs.
  *
@@ -88,7 +87,7 @@ export function ScrollableTabs({
   const inactiveColor = useColor("mutedForeground");
   const bgColor = useColor("background");
 
-  const tabs = buttons as ScrollableTabsButton[];
+  const tabs: readonly ScrollableTabsButton[] = buttons;
   const layoutsRef = useRef<Record<string, TabLayout>>({});
   const [containerWidth, setContainerWidth] = useState(0);
   const [contentWidth, setContentWidth] = useState(0);


### PR DESCRIPTION
## Summary

Fixes [BLD-849](/BLD/issues/BLD-849). Progress route navbar truncated 5-tab labels (Workouts/Body/Muscles/Nutrition/Monthly) on iPhone SE-width screens because `SegmentedControl` gives each button `flex: 1` (~75px / tab), so React Native's `<Text>` auto-ellipsizes. This swaps the pill SegmentedControl for a horizontally scrollable underline-tab pattern (Strava / Apple Fitness / MyFitnessPal).

## Changes

- **NEW** `components/ui/scrollable-tabs.tsx` — same prop interface (`value` / `onValueChange` / `buttons`) as `SegmentedControl` for trivial swap-in. Underline indicator springs `translateX` + `width` between tabs (Reanimated, 220ms timing). Trailing 32px LinearGradient fade hints at off-screen content and disappears when scrolled to the end. Light haptic on tab press; active-tab press is a no-op.
- `app/(tabs)/progress.tsx` — swap `SegmentedControl` → `ScrollableTabs`. Removed the wrapper `paddingHorizontal` because the tabs handle their own edge padding via `contentContainerStyle` (otherwise the trailing fade gets clipped).
- `components/ui/segmented-control.tsx` — **untouched**. 15+ other consumers (settings, onboarding, timer, body profile, exercise/grip pickers) rely on its `flex: 1` equal-width pill layout; a variant flag would gut half the component behind conditionals and risk regressions.

## Testing

- `__tests__/components/ui/scrollable-tabs.test.tsx` — 6 tests, all pass:
  - All 5 labels render in full (no truncation)
  - Inactive-tab press → `onValueChange` + light haptic
  - Active-tab press → `onValueChange` (no haptic)
  - `accessibilityState.selected` flips correctly
  - `accessibilityLabel` falls back to `label` when omitted
  - Indicator + `tablist` role exposed
- `tsc --noEmit` — clean.

## Acceptance Criteria

- [x] All 5 tab labels visible without truncation on 375px width
- [x] Horizontal touch-drag scroll
- [x] 2px underline beneath text only (not full tab area)
- [x] Animated underline transition between tabs
- [x] Trailing fade gradient, hidden at scroll end
- [x] Light haptic on press
- [x] No regression to other `SegmentedControl` callers (file untouched)
- [x] Plain RN `StyleSheet` — no NativeWind/Tailwind

Resolves BLD-849.