### PR TITLE
fix(jest): force NODE_ENV=test so React 19 exports React.act (BLD-844)

### DIFF
--- a/.learnings/INDEX.md
+++ b/.learnings/INDEX.md
@@ -1,7 +1,7 @@
 # CableSnap Knowledge Base
 
-Last updated: 2026-04-28
-Total learnings: 218
+Last updated: 2026-04-29
+Total learnings: 219
 
 ## How to Use This Knowledge Base
 
@@ -85,6 +85,7 @@ Full doctrine: [`/projects/cablesnap/.agents/CONCURRENT-AGENT-SAFETY.md`](../.ag
 
 | Date | Source | Title | Category | File |
 |------|--------|-------|----------|------|
+| 2026-04-29 | BLD-844 | React 19 Gates React.act Behind NODE_ENV=test — Force It in jest.config.js | Pitfalls | [build-config.md](pitfalls/build-config.md) |
 | 2026-04-28 | BLD-765 | Per-Agent Git Worktrees Are Mandatory for Concurrent CableSnap Work | Process | [quality-pipeline.md](process/quality-pipeline.md) |
 | 2026-04-28 | BLD-746 | Memory-CLI Path Discoverability — Documented vs Actual Locations Diverge | Process | [quality-pipeline.md](process/quality-pipeline.md) |
 | 2026-04-28 | BLD-732 | CVD-Immune Intensity Encoding for Low-Cardinality Heatmaps | Patterns | [react-native.md](patterns/react-native.md) |

--- a/.learnings/pitfalls/build-config.md
+++ b/.learnings/pitfalls/build-config.md
@@ -2,6 +2,13 @@
 
 ## Learnings
 
+### React 19 Gates `React.act` Behind `NODE_ENV === 'test'` — Force It in `jest.config.js`
+**Source**: BLD-844 (and prior attempt BLD-740) — ~900 acceptance tests crashed with `TypeError: actImplementation is not a function`
+**Date**: 2026-04-29
+**Context**: After upgrading to React 19.2 + RN 0.83.4, `@testing-library/react-native@13.3.3`'s `build/act.js` captures `typeof React.act === 'function' ? React.act : reactTestRenderer.act` at module-load time. React 19 only exports `React.act` (and `react-test-renderer`'s `act`) when `process.env.NODE_ENV === 'test'` at the moment `react` is first required — the export is gated for production-bundle size. Jest auto-sets `NODE_ENV=test` only when the parent env doesn't already define it; CI runners, IDE harnesses, and Paperclip's run harness pre-set `NODE_ENV=production` (or leave it inherited), bypassing the auto-set. Result: `React.act` is undefined, the captured `reactAct` is undefined, and every `render()` throws.
+**Learning**: The `npm test` script wraps jest in `cross-env NODE_ENV=test`, but that only protects invocations *through* the script. Direct `jest`, `npx jest`, IDE test runners, pre-commit hooks, and CI flows that bypass the npm script all skip the wrapper. The robust fix is to set `process.env.NODE_ENV = 'test'` at the **top of `jest.config.js`** — that's the earliest jest-controlled hook and runs before jest-expo resolves React, before `setupFiles`, and before any test file imports `@testing-library/react-native`. A test-setup shim (`global.act = require('react-dom/test-utils').act`) would not work because RNT captures `reactAct` at import time, before `setupFilesAfterEach` ever runs. Upgrading RNT to v14 (the React-19 track) is a major breaking change (async `render`/`fireEvent`/`act`, `HostElement` replaces `ReactTestInstance`, removed APIs) — way out of scope for a CI-unblocker fix.
+**Action**: Keep `process.env.NODE_ENV = 'test'` as the first non-comment statement in `jest.config.js`. Do not remove it during config refactors. When bumping React or React Native, re-run `npx jest __tests__/components/chip.test.tsx` directly (no `npm test` wrapper) to confirm the gate still works — if React's gating semantics change again, this test will fail loudly. If the gate is ever loosened (React stops requiring `NODE_ENV=test` to expose `act`), this line becomes a no-op and can stay until the next config cleanup. The `cross-env NODE_ENV=test jest` in `package.json` test scripts is now defense-in-depth; both can coexist safely.
+
 ### Metro Bundler Requires Explicit WASM Extension for expo-sqlite Web
 **Source**: BLD-14 — Pipeline halt: CableSnap build broken
 **Date**: 2026-04-12

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,25 @@
+// BLD-844: Force NODE_ENV=test before any module loads. React 19 only exposes
+// `React.act` (and `react-test-renderer`'s `act`) when process.env.NODE_ENV ===
+// 'test' at the moment the `react` module is first required — the export is
+// gated in react/index.js for production-bundle size. Jest auto-sets NODE_ENV
+// to 'test' only if the variable is not already set in the parent environment.
+// CI/harness/IDE contexts that pre-set NODE_ENV (e.g. 'production',
+// 'development', or unset+inherited) bypass that auto-set, leaving React.act
+// undefined. @testing-library/react-native@13.x captures
+// `typeof React.act === 'function' ? React.act : reactTestRenderer.act` at
+// module-load time; with both undefined every render() throws
+// "TypeError: actImplementation is not a function".
+//
+// Setting NODE_ENV here in jest.config.js is the earliest jest-controlled hook
+// — it runs before jest-expo resolves React, before setupFiles run, and before
+// any test file loads `@testing-library/react-native`. The npm test script
+// already does `cross-env NODE_ENV=test`, but this guard covers direct `jest`,
+// `npx jest`, IDE runners, and CI flows that bypass the npm script.
+//
+// See `.learnings/INDEX.md` (BLD-844) for the full timeline and next-bump
+// guidance when React/RN are upgraded again.
+process.env.NODE_ENV = 'test';
+
 module.exports = {
   preset: 'jest-expo',
   testTimeout: 10000,


### PR DESCRIPTION
## Summary
Single-line guard at the top of `jest.config.js` (`process.env.NODE_ENV = 'test'`) so React 19's gated `act` export is available regardless of how `jest` is invoked. Unblocks ~900 acceptance tests that previously crashed with `TypeError: actImplementation is not a function` whenever the test runner was launched without the `cross-env` wrapper (CI runners, IDEs, harness contexts, pre-commit hooks).

Closes BLD-844.

## Root cause
`@testing-library/react-native@13.3.3`'s `build/act.js` captures `typeof React.act === 'function' ? React.act : reactTestRenderer.act` **at module-load time**. React 19.2 only exposes `React.act` (and `react-test-renderer`'s `act`) when `process.env.NODE_ENV === 'test'` at the moment `react` is first `require`d — the export is gated in `react/index.js` for production-bundle size.

Jest auto-sets `NODE_ENV=test` only when the parent env doesn't already define it. CI/harness/IDE contexts that pre-set `NODE_ENV` (e.g. `production`, `development`, or unset+inherited) bypass that auto-set. With both `React.act` and `react-test-renderer.act` undefined, the captured `reactAct` is `undefined` and every `render()` throws.

## Reproduction on `origin/main` (verified)
HEAD `76337722`, no changes:
```
$ npx jest __tests__/components/chip.test.tsx --no-coverage
  TypeError: actImplementation is not a function
  Tests:       3 failed, 3 total

$ npm test -- __tests__/components/chip.test.tsx --no-coverage
  Tests:       3 passed, 3 total       # cross-env NODE_ENV=test masks the bug
```

## Fix
`process.env.NODE_ENV = 'test';` as the first non-comment statement in `jest.config.js`. Earliest jest-controlled hook — runs before `jest-expo` resolves React, before `setupFiles`, before any test imports `@testing-library/react-native`. The existing `cross-env NODE_ENV=test jest` in `package.json` test scripts is now defense-in-depth; both coexist safely.

## Why not the alternatives (per acceptance criteria)
- **Setup-file shim** — assigning `React.act = require('react-dom/test-utils').act` in `setupFiles`. Doesn't work: RNT captures `reactAct` at import time, before any `setupFiles` callback runs.
- **Upgrade to `@testing-library/react-native@14.0.0-beta.1`** (the React-19 track). Major breaking change: `render`/`fireEvent`/`act` become async (must be `await`-ed), `HostElement` replaces `ReactTestInstance`, removed APIs (`update`, `UNSAFE_root`, `concurrentRoot` option, etc.). ~900 acceptance tests would need rewrites. CEO instruction was: clean dep upgrade > shim, but only if "clean" is actually clean. v14 is a beta requiring large-scale test rewrites — not a CI-unblocker fix. File a separate ticket if/when we want to migrate.
- **Pin React to pre-19**: reverts unrelated upgrade work and loses React 19 features.

## Verification
Full suite via `npx jest --no-coverage --silent` (no cross-env wrapper):
```
Test Suites: 261 passed, 261 total
Tests:       2693 passed, 2693 total
Time:        323.477 s
```

Also verified across three invocation contexts:

| Invocation                                | Before  | After |
|-------------------------------------------|---------|-------|
| `npx jest <test>`                         | FAIL | PASS |
| `env -u NODE_ENV npx jest <test>`         | FAIL | PASS |
| `NODE_ENV=production npx jest <test>`     | FAIL | PASS |
| `npm test -- <test>`                      | PASS | PASS |

ESLint clean: `npx eslint jest.config.js` exit 0.

## Acceptance criteria
- [x] Reproduced on `main` HEAD independent of BLD-743
- [x] Fix landed (jest.config.js NODE_ENV guard)
- [x] All previously-failing acceptance tests green again — 2693/2693
- [x] No new failures
- [x] Documented in `.learnings/INDEX.md` and `.learnings/pitfalls/build-config.md` for the next React/RN bump

## Files
- `jest.config.js` — +22 (1 behavioural line + comment)
- `.learnings/pitfalls/build-config.md` — +7 (new pitfall entry, top of file)
- `.learnings/INDEX.md` — +3/-2 (Recent Learnings table row, counter bump)

## Notes
- Supersedes earlier BLD-740 attempt (PR #418, never merged).
- Branch: `bld-844-rnt-act-fix`. Single conventional commit: `fix(jest): ...`.
- Out of scope: migrating off RNT, concurrent-rendering test rewrites, RNT v14 upgrade.

cc @quality-director for QA verification.
