### PR TITLE
fix: guard on-disk patch test against missing node_modules (BLD-835)

### DIFF
--- a/__tests__/lib/expo-sqlite-worker-channel-length.test.ts
+++ b/__tests__/lib/expo-sqlite-worker-channel-length.test.ts
@@ -25,7 +25,7 @@
  * and fixed forms so the regression cannot return.
  */
 
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 
 describe('expo-sqlite-web WorkerChannel length-prefix protocol (BLD-660)', () => {
@@ -144,6 +144,14 @@ describe('expo-sqlite-web WorkerChannel length-prefix protocol (BLD-660)', () =>
   });
 
   it('expo-sqlite WorkerChannel.ts on disk uses the fixed length writer (patch is applied)', () => {
+    if (!existsSync(workerChannelPath)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'expo-sqlite not installed — run npm install to verify patch',
+      );
+      return;
+    }
+
     const src = readFileSync(workerChannelPath, 'utf8');
     // Strip line/block comments before scanning so we can reference the buggy
     // form in our explanatory comments without false-positives.


### PR DESCRIPTION
## Summary

The expo-sqlite WorkerChannel.ts on disk test threw ENOENT when node_modules/expo-sqlite wasn't populated (clean checkout, CI without native deps, etc.). This adds an existsSync guard that skips the test with a warning when the file is absent.

## Changes

- Add existsSync import and guard to the on-disk patch verification test
- When node_modules/expo-sqlite/web/WorkerChannel.ts doesn't exist, the test logs a warning and returns
- When the file exists, behavior is unchanged — patch presence is verified, absence fails

## Testing

- tsc --noEmit passes with zero errors
- The other 4 in-memory tests in the suite are unaffected

## Issue

Resolves BLD-835