### PR TITLE
feat: enrich cable footer a11y label to match grip's enumerated format (BLD-823)

### DIFF
--- a/__tests__/components/session/SetRow-cable-footer-a11y.test.tsx
+++ b/__tests__/components/session/SetRow-cable-footer-a11y.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * BLD-823 — Cable footer composite a11y labels matching grip footer parity.
+ *
+ * Coverage:
+ *  - Composite a11y label, all 4 cases (both set / only attachment / only
+ *    position / both null) — QD-8 enumerated-label spec, cable side.
+ *  - Mirrors the grip footer test in SetRow-grip-footer.test.tsx.
+ */
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => {
+  const { Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  notificationAsync: jest.fn(),
+  selectionAsync: jest.fn().mockResolvedValue(undefined),
+  ImpactFeedbackStyle: { Light: "light", Medium: "medium", Heavy: "heavy" },
+  NotificationFeedbackType: { Success: "success" },
+}));
+
+jest.mock("@/lib/audio", () => ({
+  play: jest.fn().mockResolvedValue(undefined),
+  setEnabled: jest.fn(),
+  preload: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/lib/db", () => ({
+  getAppSetting: jest.fn().mockResolvedValue(null),
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#6200ee", primaryContainer: "#e8def8", onPrimary: "#ffffff",
+    onSurface: "#1c1b1f", onSurfaceVariant: "#49454f",
+    surface: "#fffbfe", surfaceVariant: "#e7e0ec",
+    tertiaryContainer: "#f8e1e7", onTertiaryContainer: "#31101d",
+    errorContainer: "#ffdad6", onErrorContainer: "#410002",
+    error: "#b3261e", outline: "#79747e",
+    background: "#fffbfe", onError: "#ffffff",
+  }),
+}));
+
+jest.mock("../../../components/WeightPicker", () => {
+  const { Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ value, accessibilityLabel }: { value: number; accessibilityLabel: string }) => (
+      <Text accessibilityLabel={accessibilityLabel}>{value}</Text>
+    ),
+  };
+});
+
+jest.mock("../../../components/session/PlateHint", () => ({ PlateHint: () => null }));
+
+jest.mock("../../../components/SwipeRowAction", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+import { SetRow, type SetRowProps } from "../../../components/session/SetRow";
+import type { SetWithMeta } from "../../../components/session/types";
+import type { Attachment, Equipment, MountPosition } from "../../../lib/types";
+
+function makeSet(over: Partial<SetWithMeta> = {}): SetWithMeta {
+  return {
+    id: "s1",
+    session_id: "sess",
+    exercise_id: "ex1",
+    set_number: 1,
+    round: null,
+    weight: null,
+    reps: 10,
+    rpe: null,
+    notes: "",
+    completed: false,
+    completed_at: null,
+    set_type: "normal",
+    duration_seconds: null,
+    link_id: null,
+    training_mode: null,
+    tempo: null,
+    swapped_from_exercise_id: null,
+    exercise_position: 0,
+    previous: "",
+    is_pr: false,
+    ...over,
+  } as unknown as SetWithMeta;
+}
+
+function baseProps(over: Partial<SetRowProps> = {}): SetRowProps {
+  const noop = jest.fn();
+  return {
+    set: makeSet(),
+    step: 2.5,
+    unit: "kg",
+    trackingMode: "reps",
+    equipment: "cable" as Equipment,
+    onUpdate: jest.fn(),
+    onCheck: jest.fn(),
+    onDelete: jest.fn(),
+    onCycleSetType: noop,
+    onLongPressSetType: noop,
+    isBodyweight: false,
+    exerciseName: "Cable Pulldown",
+    onOpenBodyweightGripPicker: jest.fn(),
+    onClearBodyweightGrip: jest.fn(),
+    onOpenBodyweightModifier: jest.fn(),
+    onClearBodyweightModifier: jest.fn(),
+    onOpenVariantPicker: jest.fn(),
+    onClearVariant: jest.fn(),
+    ...over,
+  };
+}
+
+describe("SetRow cable footer — BLD-823 composite a11y labels (QD-8 parity)", () => {
+  it.each<[Attachment | null, MountPosition | null, string]>([
+    ["rope", "low", "Set 1 cable variant: Rope, Low. Double-tap to edit."],
+    ["rope", null, "Set 1 cable variant: Rope, position not set. Double-tap to edit."],
+    [null, "low", "Set 1 cable variant: attachment not set, Low. Double-tap to edit."],
+    [null, null, "Set 1 cable variant: not set. Double-tap to choose."],
+  ])("attachment=%s, mount_position=%s → %s", (att, mp, expected) => {
+    const set = makeSet({ attachment: att, mount_position: mp });
+    const { getByLabelText } = render(<SetRow {...baseProps({ set })} />);
+    expect(getByLabelText(expected)).toBeTruthy();
+  });
+});

--- a/components/session/SetRow.tsx
+++ b/components/session/SetRow.tsx
@@ -39,7 +39,7 @@ import { SET_TYPE_LABELS, type Equipment } from "../../lib/types";
 import { fontSizes } from "@/constants/design-tokens";
 import { PlateHint } from "./PlateHint";
 import { useSetCompletionFeedback } from "@/hooks/useSetCompletionFeedback";
-import { isCableExercise } from "../../lib/cable-variant";
+import { isCableExercise, formatAttachmentLabel, formatMountPositionLabel } from "../../lib/cable-variant";
 import { isBodyweightGripExercise, formatGripTypeLabel, formatGripWidthLabel } from "../../lib/bodyweight-grip-variant";
 
 const SWIPE_COMPLETE_HINT_KEY = "hint:swipe-complete-set:v1";
@@ -531,16 +531,24 @@ export const SetRow = memo(function SetRow({
           }}
           onLongPress={() => onClearVariant?.(set.id)}
           accessibilityRole="button"
-          // QD-8 (BLD-822): a11y composite labels diverge intentionally — cable
-          // footer is terse (legacy BLD-771): `"Set 1 cable variant"`. Grip
-          // footer (BLD-822, below) enumerates values:
-          // `"Set 1 grip variant: Overhand, Narrow"`. Per ux-designer rev-2
-          // verdict, ratchet UP via BLD-823 (enrich cable a11y to match
-          // grip's enumerated labels), never downgrade grip. Standardize when
-          // BLD-823 is implemented; do NOT diverge further without updating
-          // both sides.
-          accessibilityLabel={`Set ${set.set_number} cable variant`}
-          accessibilityHint="Double tap to choose attachment and pulley position; long press to clear"
+          // QD-8 (BLD-822 → BLD-823): a11y composite labels now have parity
+          // between cable and grip footers. Both enumerate selected values:
+          //   cable: "Set 1 cable variant: Rope, Low. Double-tap to edit."
+          //   grip:  "Set 1 grip variant: Overhand, Narrow. Double-tap to edit."
+          // Keep both blocks in sync; do NOT diverge without updating both.
+          accessibilityLabel={(() => {
+            const att = set.attachment ?? null;
+            const mp = set.mount_position ?? null;
+            if (att != null && mp != null) {
+              return `Set ${set.set_number} cable variant: ${formatAttachmentLabel(att)}, ${formatMountPositionLabel(mp)}. Double-tap to edit.`;
+            } else if (att != null) {
+              return `Set ${set.set_number} cable variant: ${formatAttachmentLabel(att)}, position not set. Double-tap to edit.`;
+            } else if (mp != null) {
+              return `Set ${set.set_number} cable variant: attachment not set, ${formatMountPositionLabel(mp)}. Double-tap to edit.`;
+            }
+            return `Set ${set.set_number} cable variant: not set. Double-tap to choose.`;
+          })()}
+          accessibilityHint="Long press to clear attachment and position"
           style={styles.variantFooter}
         >
           {set.attachment == null && set.mount_position == null ? (
@@ -604,9 +612,9 @@ export const SetRow = memo(function SetRow({
           - only grip:   "Set 1 grip variant: Overhand, width not set. Double-tap to edit."
           - only width:  "Set 1 grip variant: grip not set, Narrow. Double-tap to edit."
           - both null:   "Set 1 grip variant: not set. Double-tap to choose."
-        Cable footer's terse `"Set 1 cable variant"` (above) is intentionally
-        terse for now; BLD-823 will ratchet it UP to match this format. Do
-        NOT diverge further without updating both blocks.
+        Both cable and grip footers now enumerate values in identical format
+        (BLD-823). Keep both blocks in sync; do NOT diverge without updating
+        both.
       */}
       {isBodyweightGripExercise({ equipment, name: exerciseName }) ? (() => {
         const gt = set.grip_type ?? null;


### PR DESCRIPTION
## Summary

Enriches the cable variant footer's accessibility label to enumerate selected attachment and mount-position values, matching the format established by the BLD-822 grip footer. Screen-reader users now get equivalent fidelity across both per-set variant footers.

## Changes

- Cable footer accessibilityLabel now builds a composite label from set.attachment and set.mount_position:
  - Both null: `Set N cable variant: not set. Double-tap to choose.`
  - Only attachment: `Set N cable variant: Rope, position not set. Double-tap to edit.`
  - Only position: `Set N cable variant: attachment not set, Low. Double-tap to edit.`
  - Both set: `Set N cable variant: Rope, Low. Double-tap to edit.`
- Updated TL-N1 cross-reference comments to reflect parity achieved (removed 'diverge intentionally')
- Added formatAttachmentLabel and formatMountPositionLabel to cable-variant import

## Testing

- New test: SetRow-cable-footer-a11y.test.tsx — 4 cases covering all composite label states
- Existing grip footer tests (17 cases) pass with no regression
- tsc --noEmit: zero errors

Resolves BLD-823