### PR TITLE
ci: wire audit-vocab.sh into ux-audit CI workflow (BLD-811)

### DIFF
--- a/.github/workflows/ux-audit.yml
+++ b/.github/workflows/ux-audit.yml
@@ -24,6 +24,10 @@ name: UX Audit (Daily Visual Capture)
 
 on:
   workflow_dispatch: {}
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
   schedule:
     # Daily at 09:00 UTC — matches BLD-481 spec ("daily 09:00 local"). UTC is
     # used because GH cron has no timezone support; agent triage absorbs the
@@ -39,8 +43,22 @@ permissions:
   contents: read
 
 jobs:
+  vocab-audit:
+    name: Vocab consistency audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run vocab consistency audit
+        run: bash scripts/audit-vocab.sh
+
   capture:
     name: Capture scenario screenshots
+    # Only run the heavy screenshot capture on schedule or manual dispatch,
+    # not on every PR/push (where we only need the vocab audit).
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -463,7 +463,7 @@ export function useSessionActions({
     // Mirrors the bodyweight smart-default pattern above:
     //   1. fetchQuery against React Query so siblings within staleTime share.
     //   2. Per-attribute resolution via getLastVariant() — so if user has
-    //      last attachment='rope' but no recent mount_position, only
+     //      last attachment is e.g. rope but no recent mount_position, only
     //      attachment is autofilled (AC line 199 independent attributes).
     //   3. Persisted via updateSetVariant() — same entry point the picker
     //      uses, so the silent-default-trap closure (QD-B2) is uniform.
@@ -510,7 +510,7 @@ export function useSessionActions({
     // set can only enter one of the two blocks.
     //
     // Per-attribute resolution via `getLastBodyweightGripVariant()` — if the
-    // user's last set has grip_type='overhand' but no grip_width, only
+     // user's last set has e.g. grip_type of overhand but no grip_width, only
     // grip_type autofills. NULL/NULL when no prior history (closes the QD-B2
     // silent-default trap; there is no exercise-level default to fall back
     // onto for grip — the column doesn't exist on `exercises`).


### PR DESCRIPTION
## Summary

Wires the existing `scripts/audit-vocab.sh` into the ux-audit CI workflow so vocabulary fork violations (hardcoded cable/bodyweight-variant string literals outside canonical sources) are caught automatically on every PR and push to main.

## Changes

- Added `vocab-audit` job to `.github/workflows/ux-audit.yml` — runs `bash scripts/audit-vocab.sh` on PR and push to main
- Gated the heavy screenshot capture job to only run on schedule/dispatch (not on every PR)
- Fixed two comment-only false positives in `hooks/useSessionActions.ts` where quoted string literals in code comments triggered the audit

## Testing

- `bash scripts/audit-vocab.sh` passes cleanly on main (424 files scanned)
- `tsc --noEmit` passes with zero errors

## Issue

Resolves BLD-811. Follow-up from BLD-771 / PR #426.