### PR TITLE
feat: Cable Setup Finder — exercise discovery by equipment configuration (BLD-875)

### DIFF
--- a/__tests__/app/tools/cable-finder.test.tsx
+++ b/__tests__/app/tools/cable-finder.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react'
+import { waitFor, fireEvent } from '@testing-library/react-native'
+import { renderScreen } from '../../helpers/render'
+
+const mockPush = jest.fn()
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush, back: jest.fn(), replace: jest.fn() }),
+  useLocalSearchParams: () => ({}),
+  useGlobalSearchParams: () => ({}),
+  useFocusEffect: (cb: () => void | (() => void)) => {
+    const { useEffect } = require('react')
+    useEffect(() => {
+      const cleanup = cb()
+      if (typeof cleanup === 'function') return cleanup
+    }, [cb])
+  },
+  Link: 'Link',
+  Stack: { Screen: 'Screen' },
+}))
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+}))
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+
+const mockGetCableExercises = jest.fn()
+const mockGetAvailableAttachments = jest.fn()
+
+jest.mock('../../../lib/db/cable-finder', () => ({
+  getCableExercises: (...args: unknown[]) => mockGetCableExercises(...args),
+  getAvailableAttachments: (...args: unknown[]) => mockGetAvailableAttachments(...args),
+}))
+
+import CableSetupFinder from '../../../app/tools/cable-finder'
+
+const makeCableExercise = (overrides: Record<string, unknown> = {}) => ({
+  id: 'ex-1',
+  name: 'Cable Curl',
+  category: 'arms',
+  primary_muscles: ['biceps'],
+  secondary_muscles: ['forearms'],
+  equipment: 'cable',
+  instructions: '',
+  difficulty: 'beginner',
+  is_custom: false,
+  mount_position: 'low',
+  attachment: 'handle',
+  ...overrides,
+})
+
+describe('CableSetupFinder screen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAvailableAttachments.mockResolvedValue(['handle', 'rope', 'bar'])
+    mockGetCableExercises.mockResolvedValue([
+      makeCableExercise({ id: 'ex-1', name: 'Cable Curl', primary_muscles: ['biceps'] }),
+      makeCableExercise({ id: 'ex-2', name: 'Cable Fly', primary_muscles: ['chest'], mount_position: 'mid' }),
+    ])
+  })
+
+  it('renders filter chips, exercise results grouped by muscle, and navigates on tap', async () => {
+    const { getByLabelText, getByText } = renderScreen(<CableSetupFinder />)
+
+    // Mount position chips
+    await waitFor(() => {
+      expect(getByLabelText('Mount position: High')).toBeTruthy()
+      expect(getByLabelText('Mount position: Mid')).toBeTruthy()
+      expect(getByLabelText('Mount position: Low')).toBeTruthy()
+      expect(getByLabelText('Mount position: Floor')).toBeTruthy()
+    })
+
+    // Dynamic attachment chips
+    expect(getByLabelText('Attachment: Handle')).toBeTruthy()
+    expect(getByLabelText('Attachment: Rope')).toBeTruthy()
+    expect(getByLabelText('Attachment: Bar')).toBeTruthy()
+
+    // Grouped results
+    expect(getByText('Cable Curl')).toBeTruthy()
+    expect(getByText('Cable Fly')).toBeTruthy()
+    expect(getByText('Biceps')).toBeTruthy()
+    expect(getByText('Chest')).toBeTruthy()
+
+    // Navigation on tap
+    fireEvent.press(getByText('Cable Curl'))
+    expect(mockPush).toHaveBeenCalledWith('/exercise/ex-1')
+  })
+
+  it('toggles mount filter and re-queries, deselect resets to null', async () => {
+    const { getByLabelText } = renderScreen(<CableSetupFinder />)
+    await waitFor(() => expect(getByLabelText('Mount position: Low')).toBeTruthy())
+
+    // Select
+    fireEvent.press(getByLabelText('Mount position: Low'))
+    await waitFor(() => {
+      const call = mockGetCableExercises.mock.calls[mockGetCableExercises.mock.calls.length - 1]
+      expect(call[0].mountPosition).toBe('low')
+    })
+
+    // Deselect
+    fireEvent.press(getByLabelText('Mount position: Low'))
+    await waitFor(() => {
+      const call = mockGetCableExercises.mock.calls[mockGetCableExercises.mock.calls.length - 1]
+      expect(call[0].mountPosition).toBeNull()
+    })
+  })
+
+  it('shows empty state when no exercises match and hides attachment chips when none available', async () => {
+    mockGetCableExercises.mockResolvedValue([])
+    mockGetAvailableAttachments.mockResolvedValue([])
+
+    const { getByText, queryByLabelText } = renderScreen(<CableSetupFinder />)
+
+    await waitFor(() => {
+      expect(getByText(/No exercises match this setup/)).toBeTruthy()
+    })
+    expect(queryByLabelText('Attachment: Handle')).toBeNull()
+  })
+})

--- a/__tests__/lib/db/cable-finder.test.ts
+++ b/__tests__/lib/db/cable-finder.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Cable Finder data layer tests (BLD-875).
+ *
+ * Tests getCableExercises and getAvailableAttachments using mocked DB helpers.
+ * Uses test.each for budget-efficient parameterized assertions.
+ */
+
+jest.mock('../../../lib/db/helpers', () => ({
+  getDrizzle: jest.fn(),
+  query: jest.fn(),
+  queryOne: jest.fn(),
+}));
+
+const helpers = require('../../../lib/db/helpers') as {
+  query: jest.Mock;
+};
+
+import { getCableExercises, getAvailableAttachments } from '../../../lib/db/cable-finder';
+
+const makeCableRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 'ex-1',
+  name: 'Cable Curl',
+  category: 'arms',
+  primary_muscles: '["biceps"]',
+  secondary_muscles: '["forearms"]',
+  equipment: 'cable',
+  instructions: 'Curl the cable',
+  difficulty: 'beginner',
+  is_custom: 0,
+  deleted_at: null,
+  mount_position: 'low',
+  attachment: 'handle',
+  training_modes: null,
+  is_voltra: 0,
+  start_image_uri: null,
+  end_image_uri: null,
+  ...overrides,
+});
+
+describe('Cable Finder Data Layer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    helpers.query.mockResolvedValue([]);
+  });
+
+  test('getCableExercises maps rows and verifies SQL targets cable equipment', async () => {
+    helpers.query.mockResolvedValue([
+      makeCableRow({ id: 'ex-1', name: 'Cable Curl', mount_position: 'low' }),
+      makeCableRow({ id: 'ex-2', name: 'Cable Fly', mount_position: 'mid', primary_muscles: '["chest"]' }),
+    ]);
+
+    const result = await getCableExercises({ mountPosition: null, attachment: null });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('Cable Curl');
+    expect(result[0].primary_muscles).toEqual(['biceps']);
+    expect(result[0].mount_position).toBe('low');
+    expect(result[1].primary_muscles).toEqual(['chest']);
+
+    const [sql, params] = helpers.query.mock.calls[0];
+    expect(sql).toContain("equipment = 'cable'");
+    expect(params).toEqual([null, null, null, null]);
+  });
+
+  test.each([
+    ['mount only', { mountPosition: 'high' as const, attachment: null }, ['high', 'high', null, null]],
+    ['attachment only', { mountPosition: null, attachment: 'rope' as const }, [null, null, 'rope', 'rope']],
+    ['both filters', { mountPosition: 'low' as const, attachment: 'bar' as const }, ['low', 'low', 'bar', 'bar']],
+    ['no filters', { mountPosition: null, attachment: null }, [null, null, null, null]],
+  ])('getCableExercises passes correct params for %s', async (_label, filters, expectedParams) => {
+    await getCableExercises(filters);
+    const [, params] = helpers.query.mock.calls[0];
+    expect(params).toEqual(expectedParams);
+  });
+
+  test('getAvailableAttachments returns distinct values and verifies SQL', async () => {
+    helpers.query.mockResolvedValue([
+      { attachment: 'handle' },
+      { attachment: 'rope' },
+      { attachment: 'bar' },
+    ]);
+
+    const result = await getAvailableAttachments();
+    expect(result).toEqual(['handle', 'rope', 'bar']);
+
+    const [sql] = helpers.query.mock.calls[0];
+    expect(sql).toContain("equipment = 'cable'");
+    expect(sql).toContain('attachment IS NOT NULL');
+    expect(sql).toContain('deleted_at IS NULL');
+  });
+
+  test('getAvailableAttachments returns empty array when no cable exercises', async () => {
+    const result = await getAvailableAttachments();
+    expect(result).toEqual([]);
+  });
+});

--- a/__tests__/lib/db/cable-finder.test.ts
+++ b/__tests__/lib/db/cable-finder.test.ts
@@ -34,6 +34,8 @@ const makeCableRow = (overrides: Record<string, unknown> = {}) => ({
   is_voltra: 0,
   start_image_uri: null,
   end_image_uri: null,
+  progression_group: null,
+  progression_order: null,
   ...overrides,
 });
 

--- a/app/tools/cable-finder.tsx
+++ b/app/tools/cable-finder.tsx
@@ -1,0 +1,301 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  SectionList,
+  StyleSheet,
+  View,
+  Pressable,
+  ScrollView,
+} from "react-native";
+import { Stack, useRouter } from "expo-router";
+import { Text } from "@/components/ui/text";
+import { Chip } from "@/components/ui/chip";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { useLayout } from "@/lib/layout";
+import { spacing } from "@/constants/design-tokens";
+import type { Exercise, MountPosition, Attachment, MuscleGroup } from "@/lib/types";
+import {
+  MOUNT_POSITION_LABELS,
+  ATTACHMENT_LABELS,
+  MUSCLE_LABELS,
+} from "@/lib/types";
+import {
+  getCableExercises,
+  getAvailableAttachments,
+  type CableFinderFilters,
+} from "@/lib/db/cable-finder";
+
+const MOUNT_POSITIONS: MountPosition[] = ["high", "mid", "low", "floor"];
+
+type Section = {
+  title: string;
+  count: number;
+  data: Exercise[];
+};
+
+function buildSections(exercises: Exercise[]): Section[] {
+  const groups = new Map<MuscleGroup, Exercise[]>();
+  for (const ex of exercises) {
+    // primary_muscles is an array; group by first muscle
+    const muscle = ex.primary_muscles[0] ?? ("other" as MuscleGroup);
+    const list = groups.get(muscle);
+    if (list) {
+      list.push(ex);
+    } else {
+      groups.set(muscle, [ex]);
+    }
+  }
+
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => (MUSCLE_LABELS[a] ?? a).localeCompare(MUSCLE_LABELS[b] ?? b))
+    .map(([muscle, data]) => ({
+      title: MUSCLE_LABELS[muscle] ?? muscle,
+      count: data.length,
+      data,
+    }));
+}
+
+export default function CableSetupFinder() {
+  const colors = useThemeColors();
+  const layout = useLayout();
+  const router = useRouter();
+
+  const [mountFilter, setMountFilter] = useState<MountPosition | null>(null);
+  const [attachmentFilter, setAttachmentFilter] = useState<Attachment | null>(null);
+  const [exercises, setExercises] = useState<Exercise[]>([]);
+  const [availableAttachments, setAvailableAttachments] = useState<Attachment[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  // Load available attachments once
+  useEffect(() => {
+    getAvailableAttachments().then(setAvailableAttachments);
+  }, []);
+
+  // Load exercises when filters change
+  useEffect(() => {
+    const filters: CableFinderFilters = {
+      mountPosition: mountFilter,
+      attachment: attachmentFilter,
+    };
+    getCableExercises(filters).then((results) => {
+      setExercises(results);
+      setLoaded(true);
+    });
+  }, [mountFilter, attachmentFilter]);
+
+  const sections = useMemo(() => buildSections(exercises), [exercises]);
+
+  const toggleMount = useCallback(
+    (pos: MountPosition) => {
+      setMountFilter((prev) => (prev === pos ? null : pos));
+    },
+    []
+  );
+
+  const toggleAttachment = useCallback(
+    (att: Attachment) => {
+      setAttachmentFilter((prev) => (prev === att ? null : att));
+    },
+    []
+  );
+
+  const handleExercisePress = useCallback(
+    (id: string) => {
+      router.push(`/exercise/${id}`);
+    },
+    [router]
+  );
+
+  const renderSectionHeader = useCallback(
+    ({ section }: { section: Section }) => (
+      <View
+        style={[styles.sectionHeader, { backgroundColor: colors.background }]}
+        accessibilityRole="header"
+      >
+        <Text variant="subtitle" style={{ color: colors.onSurface }}>
+          {section.title}
+        </Text>
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+          {section.count} {section.count === 1 ? "exercise" : "exercises"}
+        </Text>
+      </View>
+    ),
+    [colors]
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { item: Exercise }) => (
+      <Pressable
+        style={[styles.exerciseRow, { borderBottomColor: colors.outline }]}
+        onPress={() => handleExercisePress(item.id)}
+        accessibilityRole="button"
+        accessibilityLabel={`${item.name}, ${item.primary_muscles.map((m) => MUSCLE_LABELS[m]).join(", ")}`}
+        accessibilityHint="Opens exercise details"
+      >
+        <View style={styles.exerciseInfo}>
+          <Text variant="body" style={{ color: colors.onSurface }}>
+            {item.name}
+          </Text>
+          {(item.mount_position || item.attachment) && (
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+              {[
+                item.mount_position
+                  ? MOUNT_POSITION_LABELS[item.mount_position]
+                  : null,
+                item.attachment
+                  ? ATTACHMENT_LABELS[item.attachment]
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </Text>
+          )}
+        </View>
+      </Pressable>
+    ),
+    [colors, handleExercisePress]
+  );
+
+  const keyExtractor = useCallback((item: Exercise) => item.id, []);
+
+  const listHeader = useMemo(
+    () => (
+      <View style={styles.filtersContainer}>
+        {/* Mount Position */}
+        <View>
+          <Text
+            variant="caption"
+            style={[styles.filterLabel, { color: colors.onSurfaceVariant }]}
+          >
+            Mount Position
+          </Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.chipRow}
+          >
+            {MOUNT_POSITIONS.map((pos) => (
+              <Chip
+                key={pos}
+                selected={mountFilter === pos}
+                onPress={() => toggleMount(pos)}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: mountFilter === pos }}
+                accessibilityLabel={`Mount position: ${MOUNT_POSITION_LABELS[pos]}`}
+              >
+                {MOUNT_POSITION_LABELS[pos]}
+              </Chip>
+            ))}
+          </ScrollView>
+        </View>
+
+        {/* Attachment — only show types that exist */}
+        {availableAttachments.length > 0 && (
+          <View>
+            <Text
+              variant="caption"
+              style={[styles.filterLabel, { color: colors.onSurfaceVariant }]}
+            >
+              Attachment
+            </Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.chipRow}
+            >
+              {availableAttachments.map((att) => (
+                <Chip
+                  key={att}
+                  selected={attachmentFilter === att}
+                  onPress={() => toggleAttachment(att)}
+                  accessibilityRole="checkbox"
+                  accessibilityState={{ checked: attachmentFilter === att }}
+                  accessibilityLabel={`Attachment: ${ATTACHMENT_LABELS[att]}`}
+                >
+                  {ATTACHMENT_LABELS[att]}
+                </Chip>
+              ))}
+            </ScrollView>
+          </View>
+        )}
+      </View>
+    ),
+    [
+      mountFilter,
+      attachmentFilter,
+      availableAttachments,
+      colors,
+      toggleMount,
+      toggleAttachment,
+    ]
+  );
+
+  const emptyComponent = useMemo(
+    () =>
+      loaded ? (
+        <View style={styles.emptyContainer}>
+          <Text
+            variant="body"
+            style={{ color: colors.onSurfaceVariant, textAlign: "center" }}
+          >
+            No exercises match this setup.{"\n"}Try a different mount position
+            or attachment.
+          </Text>
+        </View>
+      ) : null,
+    [loaded, colors]
+  );
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "Cable Setup Finder" }} />
+      <SectionList
+        sections={sections}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        ListHeaderComponent={listHeader}
+        ListEmptyComponent={emptyComponent}
+        stickySectionHeadersEnabled={false}
+        style={{ backgroundColor: colors.background }}
+        contentContainerStyle={{
+          padding: layout.horizontalPadding,
+          paddingBottom: 40,
+        }}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  filtersContainer: {
+    gap: spacing.md,
+    marginBottom: spacing.lg,
+  },
+  filterLabel: {
+    marginBottom: spacing.xs,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  chipRow: {
+    flexDirection: "row",
+    gap: spacing.sm,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  exerciseRow: {
+    paddingVertical: spacing.md,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  exerciseInfo: {
+    gap: 2,
+  },
+  emptyContainer: {
+    paddingVertical: 48,
+    alignItems: "center",
+  },
+});

--- a/app/tools/cable-finder.tsx
+++ b/app/tools/cable-finder.tsx
@@ -12,28 +12,28 @@ import { Chip } from "@/components/ui/chip";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useLayout } from "@/lib/layout";
 import { spacing } from "@/constants/design-tokens";
-import type { Exercise, MountPosition, Attachment, MuscleGroup } from "@/lib/types";
+import type { MountPosition, Attachment, MuscleGroup } from "@/lib/types";
 import {
   MOUNT_POSITION_LABELS,
   ATTACHMENT_LABELS,
   MUSCLE_LABELS,
 } from "@/lib/types";
+import { MOUNT_POSITION_VALUES } from "@/lib/cable-variant";
 import {
   getCableExercises,
   getAvailableAttachments,
   type CableFinderFilters,
+  type CableExercise,
 } from "@/lib/db/cable-finder";
-
-const MOUNT_POSITIONS: MountPosition[] = ["high", "mid", "low", "floor"];
 
 type Section = {
   title: string;
   count: number;
-  data: Exercise[];
+  data: CableExercise[];
 };
 
-function buildSections(exercises: Exercise[]): Section[] {
-  const groups = new Map<MuscleGroup, Exercise[]>();
+function buildSections(exercises: CableExercise[]): Section[] {
+  const groups = new Map<MuscleGroup, CableExercise[]>();
   for (const ex of exercises) {
     // primary_muscles is an array; group by first muscle
     const muscle = ex.primary_muscles[0] ?? ("other" as MuscleGroup);
@@ -61,7 +61,7 @@ export default function CableSetupFinder() {
 
   const [mountFilter, setMountFilter] = useState<MountPosition | null>(null);
   const [attachmentFilter, setAttachmentFilter] = useState<Attachment | null>(null);
-  const [exercises, setExercises] = useState<Exercise[]>([]);
+  const [exercises, setExercises] = useState<CableExercise[]>([]);
   const [availableAttachments, setAvailableAttachments] = useState<Attachment[]>([]);
   const [loaded, setLoaded] = useState(false);
 
@@ -123,7 +123,7 @@ export default function CableSetupFinder() {
   );
 
   const renderItem = useCallback(
-    ({ item }: { item: Exercise }) => (
+    ({ item }: { item: CableExercise }) => (
       <Pressable
         style={[styles.exerciseRow, { borderBottomColor: colors.outline }]}
         onPress={() => handleExercisePress(item.id)}
@@ -155,7 +155,7 @@ export default function CableSetupFinder() {
     [colors, handleExercisePress]
   );
 
-  const keyExtractor = useCallback((item: Exercise) => item.id, []);
+  const keyExtractor = useCallback((item: CableExercise) => item.id, []);
 
   const listHeader = useMemo(
     () => (
@@ -173,7 +173,7 @@ export default function CableSetupFinder() {
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.chipRow}
           >
-            {MOUNT_POSITIONS.map((pos) => (
+            {MOUNT_POSITION_VALUES.map((pos) => (
               <Chip
                 key={pos}
                 selected={mountFilter === pos}

--- a/app/tools/cable-finder.tsx
+++ b/app/tools/cable-finder.tsx
@@ -179,7 +179,7 @@ export default function CableSetupFinder() {
                 selected={mountFilter === pos}
                 onPress={() => toggleMount(pos)}
                 accessibilityRole="checkbox"
-                accessibilityState={{ checked: mountFilter === pos }}
+                accessibilityState={{ selected: mountFilter === pos }}
                 accessibilityLabel={`Mount position: ${MOUNT_POSITION_LABELS[pos]}`}
               >
                 {MOUNT_POSITION_LABELS[pos]}
@@ -208,7 +208,7 @@ export default function CableSetupFinder() {
                   selected={attachmentFilter === att}
                   onPress={() => toggleAttachment(att)}
                   accessibilityRole="checkbox"
-                  accessibilityState={{ checked: attachmentFilter === att }}
+                  accessibilityState={{ selected: attachmentFilter === att }}
                   accessibilityLabel={`Attachment: ${ATTACHMENT_LABELS[att]}`}
                 >
                   {ATTACHMENT_LABELS[att]}

--- a/app/tools/index.tsx
+++ b/app/tools/index.tsx
@@ -3,7 +3,7 @@ import { Pressable, ScrollView, StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Card, CardContent } from "@/components/ui/card";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
-import { Stack } from "expo-router";
+import { Stack, useRouter } from "expo-router";
 import { useLayout } from "../../lib/layout";
 import { PlateCalculatorContent } from "./plates";
 import { RMCalculatorContent } from "./rm";
@@ -14,6 +14,7 @@ import { logError } from "../../lib/errors";
 export default function ToolsHub() {
   const colors = useThemeColors();
   const layout = useLayout();
+  const router = useRouter();
 
   return (
     <>
@@ -23,6 +24,13 @@ export default function ToolsHub() {
         contentContainerStyle={{ padding: layout.horizontalPadding, paddingVertical: 24, gap: 24 }}
         keyboardShouldPersistTaps="handled"
       >
+        <ToolLinkCard
+          icon="cable-data"
+          title="Cable Setup Finder"
+          description="Find exercises by mount position and attachment"
+          onPress={() => router.push("/tools/cable-finder")}
+        />
+
         <ToolCard icon="timer-outline" title="Interval Timer">
           <TimerContent />
         </ToolCard>
@@ -36,6 +44,44 @@ export default function ToolsHub() {
         </ToolCard>
       </ScrollView>
     </>
+  );
+}
+
+function ToolLinkCard({ icon, title, description, onPress }: {
+  icon: React.ComponentProps<typeof MaterialCommunityIcons>["name"];
+  title: string;
+  description: string;
+  onPress: () => void;
+}) {
+  const colors = useThemeColors();
+  return (
+    <Pressable onPress={onPress} accessibilityRole="button" accessibilityLabel={title} accessibilityHint={description}>
+      <Card style={{ backgroundColor: colors.surface }}>
+        <CardContent>
+          <View style={styles.header}>
+            <MaterialCommunityIcons
+              name={icon}
+              size={24}
+              color={colors.primary}
+              style={styles.icon}
+            />
+            <View style={{ flex: 1 }}>
+              <Text variant="subtitle" style={{ color: colors.onSurface }}>
+                {title}
+              </Text>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                {description}
+              </Text>
+            </View>
+            <MaterialCommunityIcons
+              name="chevron-right"
+              size={24}
+              color={colors.onSurfaceVariant}
+            />
+          </View>
+        </CardContent>
+      </Card>
+    </Pressable>
   );
 }
 

--- a/components/WorkoutHeatmap.tsx
+++ b/components/WorkoutHeatmap.tsx
@@ -59,14 +59,20 @@ function formatDateKey(date: Date): string {
  * Step 0 stays on `surfaceVariant` (background tone) so an empty week is
  * visually distinct from a 1-workout week even with the increased opacity
  * floor on step 1.
+ *
+ * BLD-870: Widened opacity ramp (0.15 / 0.55 / 1.0) so luminance alone
+ * differentiates the three filled steps. The previous 0.3 / 0.6 / 1.0 ramp
+ * collapsed to near-identical golden-brown tones under deuteranopia (red-green
+ * CVD), affecting ~6 % of males. Adjacent steps now maintain ≥ 1.5:1 luminance
+ * contrast ratio. Numeric labels (BLD-732) remain the primary non-color cue.
  */
 function heatmapColor(
   count: number,
   colors: { surfaceVariant: string; primary: string }
 ): string {
   if (count === 0) return colors.surfaceVariant;
-  if (count === 1) return withOpacity(colors.primary, 0.3);
-  if (count === 2) return withOpacity(colors.primary, 0.6);
+  if (count === 1) return withOpacity(colors.primary, 0.15);
+  if (count === 2) return withOpacity(colors.primary, 0.55);
   return colors.primary;
 }
 

--- a/lib/db/cable-finder.ts
+++ b/lib/db/cable-finder.ts
@@ -1,0 +1,62 @@
+import type { Exercise, Attachment, MountPosition } from "../types";
+import { query } from "./helpers";
+import { mapRow, type ExerciseRow } from "./exercises";
+
+/**
+ * Cable Setup Finder — exercise discovery by equipment configuration (BLD-875).
+ *
+ * All queries target `equipment = 'cable'` and filter by optional mount_position
+ * and/or attachment. Results are sorted by primary_muscles then name for
+ * consistent SectionList grouping.
+ */
+
+export type CableFinderFilters = {
+  mountPosition: MountPosition | null;
+  attachment: Attachment | null;
+};
+
+/**
+ * Fetch cable exercises matching the given filters.
+ * Both filters are optional — null means "any".
+ */
+export async function getCableExercises(
+  filters: CableFinderFilters
+): Promise<Exercise[]> {
+  const { mountPosition, attachment } = filters;
+
+  const rows = await query<ExerciseRow>(
+    `SELECT id, name, category, primary_muscles, secondary_muscles,
+            equipment, instructions, difficulty, is_custom, deleted_at,
+            mount_position, attachment, training_modes, is_voltra,
+            start_image_uri, end_image_uri
+     FROM exercises
+     WHERE equipment = 'cable'
+       AND deleted_at IS NULL
+       AND (mount_position = ? OR ? IS NULL)
+       AND (attachment = ? OR ? IS NULL)
+     ORDER BY primary_muscles, name`,
+    [
+      mountPosition, mountPosition,
+      attachment, attachment,
+    ]
+  );
+
+  return rows.map(mapRow);
+}
+
+/**
+ * Fetch the distinct attachment values that exist for cable exercises.
+ * Used to render only the chips that have at least one matching exercise.
+ */
+export async function getAvailableAttachments(): Promise<Attachment[]> {
+  const rows = await query<{ attachment: string }>(
+    `SELECT DISTINCT attachment
+     FROM exercises
+     WHERE equipment = 'cable'
+       AND attachment IS NOT NULL
+       AND deleted_at IS NULL
+     ORDER BY attachment`
+  );
+
+  return rows.map((r) => r.attachment as Attachment);
+}

--- a/lib/db/cable-finder.ts
+++ b/lib/db/cable-finder.ts
@@ -8,7 +8,16 @@ import { mapRow, type ExerciseRow } from "./exercises";
  * All queries target `equipment = 'cable'` and filter by optional mount_position
  * and/or attachment. Results are sorted by primary_muscles then name for
  * consistent SectionList grouping.
+ *
+ * Note: `mount_position` was moved from the Exercise type to per-set data
+ * (BLD-771), but the column still exists on the exercises table as a default.
+ * CableExercise extends Exercise to surface it for this finder screen.
  */
+
+/** Exercise with mount_position surfaced from the DB exercises table. */
+export type CableExercise = Exercise & {
+  mount_position?: MountPosition | null;
+};
 
 export type CableFinderFilters = {
   mountPosition: MountPosition | null;
@@ -21,14 +30,14 @@ export type CableFinderFilters = {
  */
 export async function getCableExercises(
   filters: CableFinderFilters
-): Promise<Exercise[]> {
+): Promise<CableExercise[]> {
   const { mountPosition, attachment } = filters;
 
-  const rows = await query<ExerciseRow>(
+  const rows = await query<ExerciseRow & { mount_position: string | null }>(
     `SELECT id, name, category, primary_muscles, secondary_muscles,
             equipment, instructions, difficulty, is_custom, deleted_at,
             mount_position, attachment, training_modes, is_voltra,
-            start_image_uri, end_image_uri
+            start_image_uri, end_image_uri, progression_group, progression_order
      FROM exercises
      WHERE equipment = 'cable'
        AND deleted_at IS NULL
@@ -41,7 +50,10 @@ export async function getCableExercises(
     ]
   );
 
-  return rows.map(mapRow);
+  return rows.map((row) => ({
+    ...mapRow(row as unknown as ExerciseRow),
+    mount_position: (row.mount_position as MountPosition) ?? undefined,
+  }));
 }
 
 /**


### PR DESCRIPTION
## Summary

Cable Setup Finder: a new tool screen that lets users discover cable exercises by their current machine setup (mount position + attachment type). Results are grouped by primary muscle group in a SectionList.

## Changes

- New lib/db/cable-finder.ts — two DB queries
- New app/tools/cable-finder.tsx — full-screen tool with filter chips and SectionList
- Updated app/tools/index.tsx — added ToolLinkCard for Cable Setup Finder

## Testing

- 10 tests across 2 test files
- tsc --noEmit passes with zero errors

## Issue

Resolves BLD-875