### PR TITLE
feat: add equipment & muscle group filters to exercise library (BLD-878)

### DIFF
--- a/__tests__/app/exercises/exercise-filters.test.ts
+++ b/__tests__/app/exercises/exercise-filters.test.ts
@@ -1,0 +1,155 @@
+import type { Exercise, Equipment, MuscleGroup, Category } from '../../../lib/types';
+
+/**
+ * Exercise filter logic — extracted to match the useMemo in exercises.tsx.
+ * This allows testing the filter logic without rendering the full screen.
+ */
+function filterExercises(
+  exercises: Exercise[],
+  opts: {
+    query?: string;
+    categories?: Set<Category>;
+    customOnly?: boolean;
+    equipment?: Set<Equipment>;
+    muscles?: Set<MuscleGroup>;
+  }
+): Exercise[] {
+  const normalize = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+  const q = opts.query ? normalize(opts.query) : '';
+  return exercises.filter((ex) => {
+    if (q && !normalize(ex.name).includes(q)) return false;
+    if (opts.customOnly && !ex.is_custom) return false;
+    if (opts.categories && opts.categories.size > 0 && !opts.categories.has(ex.category))
+      return false;
+    if (opts.equipment && opts.equipment.size > 0 && !opts.equipment.has(ex.equipment))
+      return false;
+    if (
+      opts.muscles &&
+      opts.muscles.size > 0 &&
+      !ex.primary_muscles.some((m: MuscleGroup) => opts.muscles!.has(m))
+    )
+      return false;
+    return true;
+  });
+}
+
+// --- Fixture data ---
+
+const makeExercise = (overrides: Partial<Exercise> & { id: string; name: string }): Exercise => ({
+  category: 'back' as Category,
+  primary_muscles: ['back'] as MuscleGroup[],
+  secondary_muscles: [],
+  equipment: 'cable' as Equipment,
+  instructions: '',
+  difficulty: 'intermediate',
+  is_custom: false,
+  ...overrides,
+});
+
+const EXERCISES: Exercise[] = [
+  makeExercise({ id: '1', name: 'Cable Row', equipment: 'cable', category: 'back', primary_muscles: ['back', 'biceps'] }),
+  makeExercise({ id: '2', name: 'Barbell Bench Press', equipment: 'barbell', category: 'chest', primary_muscles: ['chest', 'triceps'] }),
+  makeExercise({ id: '3', name: 'Dumbbell Curl', equipment: 'dumbbell', category: 'arms', primary_muscles: ['biceps'] }),
+  makeExercise({ id: '4', name: 'Bodyweight Push-up', equipment: 'bodyweight', category: 'chest', primary_muscles: ['chest', 'triceps'] }),
+  makeExercise({ id: '5', name: 'Machine Leg Press', equipment: 'machine', category: 'legs_glutes', primary_muscles: ['quads', 'glutes'] }),
+  makeExercise({ id: '6', name: 'Kettlebell Swing', equipment: 'kettlebell', category: 'legs_glutes', primary_muscles: ['glutes', 'hamstrings'] }),
+  makeExercise({ id: '7', name: 'Band Pull Apart', equipment: 'band', category: 'back', primary_muscles: ['back', 'shoulders'] }),
+  makeExercise({ id: '8', name: 'Custom Stretch', equipment: 'other', category: 'abs_core', primary_muscles: ['core'], is_custom: true }),
+];
+
+describe('Exercise filter logic', () => {
+  it('returns all exercises when no filters active', () => {
+    const result = filterExercises(EXERCISES, {});
+    expect(result).toHaveLength(8);
+  });
+
+  it('filters by single equipment type', () => {
+    const result = filterExercises(EXERCISES, { equipment: new Set(['cable'] as Equipment[]) });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Cable Row');
+  });
+
+  it('filters by multiple equipment types (OR within dimension)', () => {
+    const result = filterExercises(EXERCISES, {
+      equipment: new Set(['dumbbell', 'barbell'] as Equipment[]),
+    });
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.name).sort()).toEqual(['Barbell Bench Press', 'Dumbbell Curl']);
+  });
+
+  it('filters by single muscle group', () => {
+    const result = filterExercises(EXERCISES, { muscles: new Set(['biceps'] as MuscleGroup[]) });
+    expect(result).toHaveLength(2); // Cable Row (back, biceps) + Dumbbell Curl (biceps)
+    expect(result.map((e) => e.name).sort()).toEqual(['Cable Row', 'Dumbbell Curl']);
+  });
+
+  it('shows exercise if ANY primary muscle matches (OR within muscle dimension)', () => {
+    const result = filterExercises(EXERCISES, {
+      muscles: new Set(['glutes', 'shoulders'] as MuscleGroup[]),
+    });
+    // Machine Leg Press (quads, glutes), Kettlebell Swing (glutes, hamstrings), Band Pull Apart (back, shoulders)
+    expect(result).toHaveLength(3);
+  });
+
+  it('applies AND logic across dimensions (category + equipment)', () => {
+    const result = filterExercises(EXERCISES, {
+      categories: new Set(['chest'] as Category[]),
+      equipment: new Set(['barbell'] as Equipment[]),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Barbell Bench Press');
+  });
+
+  it('applies AND logic across all three dimensions (category + equipment + muscle)', () => {
+    const result = filterExercises(EXERCISES, {
+      categories: new Set(['back'] as Category[]),
+      equipment: new Set(['cable'] as Equipment[]),
+      muscles: new Set(['biceps'] as MuscleGroup[]),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Cable Row');
+  });
+
+  it('returns empty when no exercises match combined filters', () => {
+    const result = filterExercises(EXERCISES, {
+      categories: new Set(['arms'] as Category[]),
+      equipment: new Set(['cable'] as Equipment[]),
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns all exercises when all filters cleared', () => {
+    const result = filterExercises(EXERCISES, {
+      categories: new Set(),
+      equipment: new Set(),
+      muscles: new Set(),
+    });
+    expect(result).toHaveLength(8);
+  });
+
+  it('combines with text search', () => {
+    const result = filterExercises(EXERCISES, {
+      query: 'press',
+      equipment: new Set(['barbell'] as Equipment[]),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Barbell Bench Press');
+  });
+
+  it('shows custom exercise with equipment "other" when Other selected', () => {
+    const result = filterExercises(EXERCISES, {
+      equipment: new Set(['other'] as Equipment[]),
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Custom Stretch');
+    expect(result[0].is_custom).toBe(true);
+  });
+
+  it('exercise with multiple primary muscles shown if ANY matches', () => {
+    // Cable Row has primary_muscles: ['back', 'biceps']
+    const result = filterExercises(EXERCISES, {
+      muscles: new Set(['biceps'] as MuscleGroup[]),
+    });
+    expect(result.some((e) => e.name === 'Cable Row')).toBe(true);
+  });
+});

--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   FlatList,
+  Pressable,
   StyleSheet,
   View,
   useColorScheme,
@@ -17,7 +18,9 @@ import {
   CATEGORIES,
   CATEGORY_LABELS,
   type Category,
+  type Equipment,
   type Exercise,
+  type MuscleGroup,
 } from "../../lib/types";
 import { CATEGORY_ICONS, muscle } from "../../constants/theme";
 import { useLayout } from "../../lib/layout";
@@ -26,6 +29,8 @@ import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
 import { useProfileGender } from "../../lib/useProfileGender";
 import { ExerciseCard } from "../../components/exercises/ExerciseCard";
 import { ExerciseDetailPane } from "../../components/exercises/ExerciseDetailPane";
+import { ExerciseFilterSheet, FilterButton } from "../../components/ExerciseFilterSheet";
+import { useBottomSheet } from "../../components/ui/bottom-sheet";
 
 type FilterType = Category | "custom";
 const FILTER_ALL: FilterType[] = [...CATEGORIES, "custom"];
@@ -40,7 +45,10 @@ export default function Exercises() {
   const mc = isDark ? muscle.dark : muscle.light;
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<Set<FilterType>>(new Set());
+  const [selectedEquipment, setSelectedEquipment] = useState<Set<Equipment>>(new Set());
+  const [selectedMuscles, setSelectedMuscles] = useState<Set<MuscleGroup>>(new Set());
   const [detail, setDetail] = useState<Exercise | null>(null);
+  const filterSheet = useBottomSheet();
 
   const { data: exercises = [], isLoading: loading } = useQuery({
     queryKey: ["exercises"],
@@ -59,9 +67,17 @@ export default function Exercises() {
       }
       if (customFilter && !ex.is_custom) return false;
       if (cats.size > 0 && !cats.has(ex.category)) return false;
+      // Equipment filter (OR within dimension)
+      if (selectedEquipment.size > 0 && !selectedEquipment.has(ex.equipment)) return false;
+      // Muscle group filter (OR within dimension)
+      if (
+        selectedMuscles.size > 0 &&
+        !ex.primary_muscles.some((m) => selectedMuscles.has(m))
+      )
+        return false;
       return true;
     });
-  }, [exercises, query, selected]);
+  }, [exercises, query, selected, selectedEquipment, selectedMuscles]);
 
   useEffect(() => {
     if (layout.atLeastMedium && !detail && filtered.length > 0) {
@@ -76,6 +92,20 @@ export default function Exercises() {
       else next.add(f);
       return next;
     });
+  }, []);
+
+  const handleApplyFilters = useCallback(
+    (equipment: Set<Equipment>, muscles: Set<MuscleGroup>) => {
+      setSelectedEquipment(equipment);
+      setSelectedMuscles(muscles);
+    },
+    []
+  );
+
+  const clearAllFilters = useCallback(() => {
+    setSelected(new Set());
+    setSelectedEquipment(new Set());
+    setSelectedMuscles(new Set());
   }, []);
 
   const onPress = useCallback(
@@ -104,6 +134,9 @@ export default function Exercises() {
 
   const keyExtractor = useCallback((item: Exercise) => item.id, []);
 
+  const activeFilterCount = selectedEquipment.size + selectedMuscles.size;
+  const totalActiveCount = activeFilterCount + selected.size;
+
   const empty = useCallback(
     () =>
       loading ? null : (
@@ -112,24 +145,48 @@ export default function Exercises() {
             No exercises found
           </Text>
           <Text variant="body" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
-            Try adjusting your search or filters
+            {totalActiveCount > 0
+              ? `Try adjusting your filters. (${totalActiveCount} filter${totalActiveCount !== 1 ? "s" : ""} active)`
+              : "Try adjusting your search or filters"}
           </Text>
+          {totalActiveCount > 0 && (
+            <Pressable
+              onPress={clearAllFilters}
+              style={styles.clearFiltersButton}
+              accessibilityLabel="Clear all filters"
+              accessibilityRole="button"
+            >
+              <Text variant="body" style={{ color: colors.primary, fontWeight: "600" }}>
+                Clear filters
+              </Text>
+            </Pressable>
+          )}
         </View>
       ),
-    [loading, colors]
+    [loading, colors, totalActiveCount, clearAllFilters]
   );
 
   const filterLabel = (f: FilterType) => (f === "custom" ? "Custom" : CATEGORY_LABELS[f]);
 
   const list = (
     <View style={layout.atLeastMedium ? { flex: 2 } : { flex: 1 }}>
-      <SearchBar
-        placeholder="Search exercises..."
-        value={query}
-        onChangeText={setQuery}
-        style={[styles.search, { backgroundColor: colors.surface }]}
-        accessibilityLabel="Search exercises"
-      />
+      <View style={styles.searchRow}>
+        <SearchBar
+          placeholder="Search exercises..."
+          value={query}
+          onChangeText={setQuery}
+          style={[styles.search, { backgroundColor: colors.surface, flex: 1 }]}
+          accessibilityLabel="Search exercises"
+        />
+        <FilterButton
+          activeCount={activeFilterCount}
+          onPress={filterSheet.open}
+          backgroundColor={colors.surface}
+          activeColor={colors.primary}
+          inactiveColor={colors.onSurface}
+          badgeTextColor={colors.onPrimary}
+        />
+      </View>
       <View style={styles.chips}>
         <FlatList
           horizontal
@@ -176,6 +233,13 @@ export default function Exercises() {
         ListEmptyComponent={empty}
         contentContainerStyle={{ paddingBottom: tabBarHeight }}
       />
+      <ExerciseFilterSheet
+        isVisible={filterSheet.isVisible}
+        onClose={filterSheet.close}
+        selectedEquipment={selectedEquipment}
+        selectedMuscles={selectedMuscles}
+        onApply={handleApplyFilters}
+      />
     </View>
   );
 
@@ -202,9 +266,17 @@ const styles = StyleSheet.create({
   wideRow: {
     flexDirection: "row",
   },
+  searchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingTop: 12,
+    paddingBottom: 4,
+    gap: 8,
+  },
   search: {
-    margin: 12,
-    marginBottom: 4,
+    flex: 1,
+    margin: 0,
   },
   chips: {
     paddingHorizontal: 12,
@@ -213,13 +285,13 @@ const styles = StyleSheet.create({
   filterChip: {
     marginRight: 6,
   },
-
   empty: {
     alignItems: "center",
     paddingTop: 48,
   },
-  emptyList: {
-    flexGrow: 1,
+  clearFiltersButton: {
+    marginTop: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
   },
-
 });

--- a/components/ExerciseFilterSheet.tsx
+++ b/components/ExerciseFilterSheet.tsx
@@ -1,0 +1,347 @@
+import React, { useCallback, useState } from "react";
+import { View, StyleSheet, Pressable } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Chip } from "@/components/ui/chip";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import {
+  EQUIPMENT_LIST,
+  EQUIPMENT_LABELS,
+  MUSCLE_GROUPS_BY_REGION,
+  MUSCLE_LABELS,
+  type Equipment,
+  type MuscleGroup,
+} from "../lib/types";
+import { EQUIPMENT_ICONS } from "../constants/theme";
+
+type ExerciseFilterSheetProps = {
+  isVisible: boolean;
+  onClose: () => void;
+  selectedEquipment: Set<Equipment>;
+  selectedMuscles: Set<MuscleGroup>;
+  onApply: (equipment: Set<Equipment>, muscles: Set<MuscleGroup>) => void;
+};
+
+/**
+ * Wrapper that only mounts the inner form when visible,
+ * ensuring draft state is freshly initialized from props each time.
+ */
+export function ExerciseFilterSheet({
+  isVisible,
+  onClose,
+  selectedEquipment,
+  selectedMuscles,
+  onApply,
+}: ExerciseFilterSheetProps) {
+  return (
+    <BottomSheet
+      isVisible={isVisible}
+      onClose={onClose}
+      title="Filters"
+      snapPoints={[0.6, 0.85]}
+    >
+      {isVisible && (
+        <ExerciseFilterSheetContent
+          initialEquipment={selectedEquipment}
+          initialMuscles={selectedMuscles}
+          onApply={onApply}
+          onClose={onClose}
+        />
+      )}
+    </BottomSheet>
+  );
+}
+
+type ContentProps = {
+  initialEquipment: Set<Equipment>;
+  initialMuscles: Set<MuscleGroup>;
+  onApply: (equipment: Set<Equipment>, muscles: Set<MuscleGroup>) => void;
+  onClose: () => void;
+};
+
+function ExerciseFilterSheetContent({
+  initialEquipment,
+  initialMuscles,
+  onApply,
+  onClose,
+}: ContentProps) {
+  const colors = useThemeColors();
+
+  const [draftEquipment, setDraftEquipment] = useState<Set<Equipment>>(
+    () => new Set(initialEquipment)
+  );
+  const [draftMuscles, setDraftMuscles] = useState<Set<MuscleGroup>>(
+    () => new Set(initialMuscles)
+  );
+
+  const toggleEquipment = useCallback((eq: Equipment) => {
+    setDraftEquipment((prev) => {
+      const next = new Set(prev);
+      if (next.has(eq)) next.delete(eq);
+      else next.add(eq);
+      return next;
+    });
+  }, []);
+
+  const toggleMuscle = useCallback((m: MuscleGroup) => {
+    setDraftMuscles((prev) => {
+      const next = new Set(prev);
+      if (next.has(m)) next.delete(m);
+      else next.add(m);
+      return next;
+    });
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setDraftEquipment(new Set());
+    setDraftMuscles(new Set());
+  }, []);
+
+  const handleApply = useCallback(() => {
+    onApply(draftEquipment, draftMuscles);
+    onClose();
+  }, [draftEquipment, draftMuscles, onApply, onClose]);
+
+  const totalSelected = draftEquipment.size + draftMuscles.size;
+
+  return (
+    <>
+      {/* Equipment Section */}
+      <View
+        style={styles.section}
+        accessibilityRole="toolbar"
+        accessibilityLabel="Equipment filters"
+      >
+        <Text
+          variant="subtitle"
+          style={[styles.sectionTitle, { color: colors.onSurfaceVariant }]}
+        >
+          Equipment
+        </Text>
+        <View style={styles.chipGrid}>
+          {EQUIPMENT_LIST.map((eq) => {
+            const active = draftEquipment.has(eq);
+            return (
+              <Chip
+                key={eq}
+                selected={active}
+                onPress={() => toggleEquipment(eq)}
+                style={StyleSheet.flatten([
+                  styles.chip,
+                  active && { backgroundColor: colors.primaryContainer },
+                ])}
+                compact
+                icon={
+                  EQUIPMENT_ICONS[eq] ? (
+                    <MaterialCommunityIcons
+                      name={
+                        EQUIPMENT_ICONS[eq] as keyof typeof MaterialCommunityIcons.glyphMap
+                      }
+                      size={16}
+                      color={
+                        active
+                          ? colors.onPrimaryContainer
+                          : colors.onSurface
+                      }
+                    />
+                  ) : undefined
+                }
+                accessibilityLabel={`Filter by equipment: ${EQUIPMENT_LABELS[eq]}`}
+                accessibilityRole="button"
+                accessibilityState={{ selected: active }}
+              >
+                {EQUIPMENT_LABELS[eq]}
+              </Chip>
+            );
+          })}
+        </View>
+      </View>
+
+      {/* Muscle Group Sections */}
+      <View
+        style={styles.section}
+        accessibilityRole="toolbar"
+        accessibilityLabel="Muscle group filters"
+      >
+        <Text
+          variant="subtitle"
+          style={[styles.sectionTitle, { color: colors.onSurfaceVariant }]}
+        >
+          Muscle Groups
+        </Text>
+        {MUSCLE_GROUPS_BY_REGION.map((region) => (
+          <View key={region.label} style={styles.regionBlock}>
+            <Text
+              variant="caption"
+              style={[styles.regionLabel, { color: colors.onSurfaceVariant }]}
+            >
+              {region.label}
+            </Text>
+            <View style={styles.chipGrid}>
+              {region.muscles.map((m) => {
+                const active = draftMuscles.has(m);
+                return (
+                  <Chip
+                    key={m}
+                    selected={active}
+                    onPress={() => toggleMuscle(m)}
+                    style={StyleSheet.flatten([
+                      styles.chip,
+                      active && { backgroundColor: colors.primaryContainer },
+                    ])}
+                    compact
+                    accessibilityLabel={`Filter by muscle: ${MUSCLE_LABELS[m]}`}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: active }}
+                  >
+                    {MUSCLE_LABELS[m]}
+                  </Chip>
+                );
+              })}
+            </View>
+          </View>
+        ))}
+      </View>
+
+      {/* Actions */}
+      <View style={styles.actions}>
+        <Pressable
+          onPress={clearAll}
+          style={styles.clearButton}
+          accessibilityLabel="Clear all filters"
+          accessibilityRole="button"
+        >
+          <Text
+            variant="body"
+            style={{ color: colors.onSurfaceVariant }}
+          >
+            Clear All
+          </Text>
+        </Pressable>
+        <Pressable
+          onPress={handleApply}
+          style={[
+            styles.applyButton,
+            { backgroundColor: colors.primary },
+          ]}
+          accessibilityLabel={`Apply ${totalSelected} filters`}
+          accessibilityRole="button"
+        >
+          <Text
+            variant="body"
+            style={{ color: colors.onPrimary, fontWeight: "600" }}
+          >
+            {totalSelected > 0 ? `Apply (${totalSelected})` : "Apply"}
+          </Text>
+        </Pressable>
+      </View>
+    </>
+  );
+}
+
+// --- Exported FilterButton for use in exercises.tsx ---
+
+type FilterButtonProps = {
+  activeCount: number;
+  onPress: () => void;
+  backgroundColor: string;
+  activeColor: string;
+  inactiveColor: string;
+  badgeTextColor: string;
+};
+
+export function FilterButton({
+  activeCount,
+  onPress,
+  backgroundColor,
+  activeColor,
+  inactiveColor,
+  badgeTextColor,
+}: FilterButtonProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[styles.filterButton, { backgroundColor }]}
+      accessibilityLabel={`Open filters${activeCount > 0 ? `, ${activeCount} active` : ""}`}
+      accessibilityRole="button"
+    >
+      <MaterialCommunityIcons
+        name="filter-variant"
+        size={22}
+        color={activeCount > 0 ? activeColor : inactiveColor}
+      />
+      {activeCount > 0 && (
+        <View style={[styles.badge, { backgroundColor: activeColor }]}>
+          <Text
+            variant="caption"
+            style={{ color: badgeTextColor, fontSize: 11, fontWeight: "700" }}
+          >
+            {activeCount}
+          </Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  filterButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    justifyContent: "center",
+    alignItems: "center",
+    position: "relative" as const,
+  },
+  badge: {
+    position: "absolute" as const,
+    top: 4,
+    right: 4,
+    minWidth: 16,
+    height: 16,
+    borderRadius: 8,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 3,
+  },
+  section: {
+    marginBottom: 20,
+  },
+  sectionTitle: {
+    marginBottom: 8,
+    fontWeight: "600",
+  },
+  regionBlock: {
+    marginBottom: 12,
+  },
+  regionLabel: {
+    marginBottom: 4,
+    fontSize: 12,
+  },
+  chipGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+  },
+  chip: {
+    marginBottom: 2,
+  },
+  actions: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingTop: 16,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "rgba(128,128,128,0.3)",
+  },
+  clearButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  applyButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+  },
+});

--- a/components/MuscleVolumeSegment.tsx
+++ b/components/MuscleVolumeSegment.tsx
@@ -16,7 +16,6 @@ import { getVolumeStatus } from "../lib/volume-landmarks";
 import VolumeBarChart from "./muscle-volume/VolumeBarChart";
 import VolumeTrendChart from "./muscle-volume/VolumeTrendChart";
 import VolumeLandmarksSheet from "./muscle-volume/VolumeLandmarksSheet";
-
 const MuscleRow = React.memo(function MuscleRow({
   item,
   selected,

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -110,6 +110,19 @@ export const CATEGORY_ICONS: Record<string, string> = {
   shoulders: "account-arrow-up",
 };
 
+// ─── Equipment Icon Map ────────────────────────────────────────────
+
+export const EQUIPMENT_ICONS: Record<string, string> = {
+  barbell: "weight-lifter",
+  dumbbell: "dumbbell",
+  cable: "cable-data",
+  machine: "cog",
+  bodyweight: "human",
+  kettlebell: "kettlebell",
+  band: "resistor",
+  other: "dots-horizontal",
+};
+
 export function difficultyText(level: string): string {
   if (level === "intermediate") return semantic.onIntermediate;
   if (level === "advanced") return semantic.onAdvanced;


### PR DESCRIPTION
## Summary

Add equipment and muscle group filters to the exercise library screen using a bottom sheet pattern. Users can now filter exercises by equipment type (barbell, dumbbell, cable, etc.) and target muscle group (chest, back, biceps, etc.) in addition to the existing category filters.

## Changes

- `constants/theme.ts` — Add EQUIPMENT_ICONS map
- `components/ExerciseFilterSheet.tsx` — New bottom sheet with equipment chips (icons), muscle group chips sectioned by region, Clear All / Apply buttons, exported FilterButton
- `app/(tabs)/exercises.tsx` — Filter button with badge, selectedEquipment/selectedMuscles state, extended filter logic (AND across dimensions, OR within), updated empty state
- `components/MuscleVolumeSegment.tsx` — Remove blank line (pre-existing FTA fix)

## Filter Logic

- AND across dimensions: Cable + Back = only cable back exercises
- OR within dimension: Dumbbell + Barbell = exercises using either
- Combined with search: text search ANDs with all filter dimensions

## Testing

- 12 unit tests for filter logic
- All 2732 existing tests pass
- TypeScript passes, lint passes

## Issue

Resolves BLD-882