### PR TITLE
feat: add RPE & session rating trend charts (BLD-886)

### DIFF
--- a/__tests__/components/progress/TrendCards.test.tsx
+++ b/__tests__/components/progress/TrendCards.test.tsx
@@ -28,9 +28,27 @@ jest.mock('victory-native', () => {
   }
 })
 
+jest.mock('expo-router', () => ({
+  useFocusEffect: (cb: () => void) => cb(),
+}))
+
+const mockGetRecentSessionRPEs = jest.fn().mockResolvedValue([])
+const mockGetRecentSessionRatings = jest.fn().mockResolvedValue([])
+
+jest.mock('@/lib/db/e1rm-trends', () => ({
+  getRecentSessionRPEs: (...args: unknown[]) => mockGetRecentSessionRPEs(...args),
+  getRecentSessionRatings: (...args: unknown[]) => mockGetRecentSessionRatings(...args),
+}))
+
 import { TrendLineCard, RPETrendCard, RatingTrendCard } from '@/components/progress/TrendCards'
 
 describe('TrendCards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetRecentSessionRPEs.mockResolvedValue([])
+    mockGetRecentSessionRatings.mockResolvedValue([])
+  })
+
   describe('TrendLineCard', () => {
     test('shows empty state message when data is empty', () => {
       const { getByText } = render(
@@ -85,45 +103,32 @@ describe('TrendCards', () => {
   describe('RPETrendCard', () => {
     test('shows RPE empty state when no data', () => {
       const { getByText } = render(
-        <RPETrendCard rpeData={[]} chartWidth={300} />
+        <RPETrendCard chartWidth={300} />
       )
       expect(getByText('Avg RPE per Session (1–10)')).toBeTruthy()
       expect(getByText('Log RPE on your sets to see trends here.')).toBeTruthy()
+      expect(mockGetRecentSessionRPEs).toHaveBeenCalled()
     })
 
-    test('renders RPE chart with session data', () => {
-      const rpeData = [
-        { session_id: 's1', started_at: 1000, avg_rpe: 7.5 },
-        { session_id: 's2', started_at: 2000, avg_rpe: 8.0 },
-      ]
-      const { getByText, getByLabelText } = render(
-        <RPETrendCard rpeData={rpeData} chartWidth={300} />
-      )
-      expect(getByText('Avg RPE per Session (1–10)')).toBeTruthy()
-      expect(getByLabelText('Avg RPE per Session (1–10): latest value 8.0, 2 sessions')).toBeTruthy()
+    test('fetches RPE data on focus', () => {
+      render(<RPETrendCard chartWidth={300} />)
+      expect(mockGetRecentSessionRPEs).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('RatingTrendCard', () => {
     test('shows rating empty state when no data', () => {
       const { getByText } = render(
-        <RatingTrendCard ratingData={[]} chartWidth={300} />
+        <RatingTrendCard chartWidth={300} />
       )
       expect(getByText('Session Ratings (1–5)')).toBeTruthy()
       expect(getByText('Rate your sessions to see trends here.')).toBeTruthy()
+      expect(mockGetRecentSessionRatings).toHaveBeenCalled()
     })
 
-    test('renders rating chart with session data', () => {
-      const ratingData = [
-        { session_id: 's1', started_at: 1000, rating: 4 },
-        { session_id: 's2', started_at: 2000, rating: 3 },
-        { session_id: 's3', started_at: 3000, rating: 5 },
-      ]
-      const { getByText, getByLabelText } = render(
-        <RatingTrendCard ratingData={ratingData} chartWidth={300} />
-      )
-      expect(getByText('Session Ratings (1–5)')).toBeTruthy()
-      expect(getByLabelText('Session Ratings (1–5): latest value 5.0, 3 sessions')).toBeTruthy()
+    test('fetches rating data on focus', () => {
+      render(<RatingTrendCard chartWidth={300} />)
+      expect(mockGetRecentSessionRatings).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/__tests__/components/progress/TrendCards.test.tsx
+++ b/__tests__/components/progress/TrendCards.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+
+jest.mock('@/hooks/useThemeColors', () => ({
+  useThemeColors: () => ({
+    primary: '#6200ee',
+    secondary: '#03dac6',
+    tertiary: '#bb86fc',
+    onSurface: '#000',
+    onSurfaceVariant: '#666',
+    surface: '#fff',
+  }),
+}))
+
+jest.mock('@/components/ui/card', () => {
+  const { View } = require('react-native')
+  return { Card: ({ children, style }: { children: React.ReactNode; style?: object }) => <View style={style}>{children}</View> }
+})
+
+jest.mock('victory-native', () => {
+  const { View } = require('react-native')
+  return {
+    CartesianChart: ({ children }: { children: (args: { points: { y: [] } }) => React.ReactNode }) => (
+      <View>{typeof children === 'function' ? children({ points: { y: [] } }) : children}</View>
+    ),
+    Line: () => null,
+    Scatter: () => null,
+  }
+})
+
+import { TrendLineCard, RPETrendCard, RatingTrendCard } from '@/components/progress/TrendCards'
+
+describe('TrendCards', () => {
+  describe('TrendLineCard', () => {
+    test('shows empty state message when data is empty', () => {
+      const { getByText } = render(
+        <TrendLineCard
+          title="Test Chart"
+          data={[]}
+          yDomain={[1, 10]}
+          lineColor="#000"
+          emptyMessage="No data yet."
+          chartWidth={300}
+        />
+      )
+      expect(getByText('Test Chart')).toBeTruthy()
+      expect(getByText('No data yet.')).toBeTruthy()
+    })
+
+    test('renders chart with title and accessibility label when data exists', () => {
+      const data = [
+        { x: 0, y: 5.0 },
+        { x: 1, y: 7.5 },
+        { x: 2, y: 6.2 },
+      ]
+      const { getByText, getByLabelText } = render(
+        <TrendLineCard
+          title="Avg RPE"
+          data={data}
+          yDomain={[1, 10]}
+          lineColor="#000"
+          emptyMessage="No data."
+          chartWidth={300}
+        />
+      )
+      expect(getByText('Avg RPE')).toBeTruthy()
+      expect(getByLabelText('Avg RPE: latest value 6.2, 3 sessions')).toBeTruthy()
+    })
+
+    test('single data point accessibility label uses singular "session"', () => {
+      const { getByLabelText } = render(
+        <TrendLineCard
+          title="Rating"
+          data={[{ x: 0, y: 4.0 }]}
+          yDomain={[1, 5]}
+          lineColor="#000"
+          emptyMessage="No data."
+          chartWidth={300}
+        />
+      )
+      expect(getByLabelText('Rating: latest value 4.0, 1 session')).toBeTruthy()
+    })
+  })
+
+  describe('RPETrendCard', () => {
+    test('shows RPE empty state when no data', () => {
+      const { getByText } = render(
+        <RPETrendCard rpeData={[]} chartWidth={300} />
+      )
+      expect(getByText('Avg RPE per Session (1–10)')).toBeTruthy()
+      expect(getByText('Log RPE on your sets to see trends here.')).toBeTruthy()
+    })
+
+    test('renders RPE chart with session data', () => {
+      const rpeData = [
+        { session_id: 's1', started_at: 1000, avg_rpe: 7.5 },
+        { session_id: 's2', started_at: 2000, avg_rpe: 8.0 },
+      ]
+      const { getByText, getByLabelText } = render(
+        <RPETrendCard rpeData={rpeData} chartWidth={300} />
+      )
+      expect(getByText('Avg RPE per Session (1–10)')).toBeTruthy()
+      expect(getByLabelText('Avg RPE per Session (1–10): latest value 8.0, 2 sessions')).toBeTruthy()
+    })
+  })
+
+  describe('RatingTrendCard', () => {
+    test('shows rating empty state when no data', () => {
+      const { getByText } = render(
+        <RatingTrendCard ratingData={[]} chartWidth={300} />
+      )
+      expect(getByText('Session Ratings (1–5)')).toBeTruthy()
+      expect(getByText('Rate your sessions to see trends here.')).toBeTruthy()
+    })
+
+    test('renders rating chart with session data', () => {
+      const ratingData = [
+        { session_id: 's1', started_at: 1000, rating: 4 },
+        { session_id: 's2', started_at: 2000, rating: 3 },
+        { session_id: 's3', started_at: 3000, rating: 5 },
+      ]
+      const { getByText, getByLabelText } = render(
+        <RatingTrendCard ratingData={ratingData} chartWidth={300} />
+      )
+      expect(getByText('Session Ratings (1–5)')).toBeTruthy()
+      expect(getByLabelText('Session Ratings (1–5): latest value 5.0, 3 sessions')).toBeTruthy()
+    })
+  })
+})

--- a/components/progress/TrendCards.tsx
+++ b/components/progress/TrendCards.tsx
@@ -1,8 +1,15 @@
+import { useCallback, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Card } from "@/components/ui/card";
 import { Text } from "@/components/ui/text";
 import { CartesianChart, Line, Scatter } from "victory-native";
+import { useFocusEffect } from "expo-router";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import {
+  getRecentSessionRPEs,
+  getRecentSessionRatings,
+} from "../../lib/db/e1rm-trends";
+import type { SessionRPERow, SessionRatingRow } from "../../lib/db/e1rm-trends";
 
 type TrendLineCardProps = {
   title: string;
@@ -90,28 +97,26 @@ export function TrendLineCard({
   );
 }
 
-// ─── Pre-built RPE & Rating Cards ──────────────────────────────────
-
-type SessionRPERow = {
-  session_id: string;
-  started_at: number;
-  avg_rpe: number;
-};
-
-type SessionRatingRow = {
-  session_id: string;
-  started_at: number;
-  rating: number;
-};
+// ─── Self-Fetching RPE & Rating Cards ──────────────────────────────
 
 type RPETrendCardProps = {
-  rpeData: SessionRPERow[];
   chartWidth: number;
   style?: object;
 };
 
-export function RPETrendCard({ rpeData, chartWidth, style }: RPETrendCardProps) {
+export function RPETrendCard({ chartWidth, style }: RPETrendCardProps) {
   const colors = useThemeColors();
+  const [rpeData, setRpeData] = useState<SessionRPERow[]>([]);
+
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        const rows = await getRecentSessionRPEs();
+        setRpeData(rows);
+      })();
+    }, []),
+  );
+
   const data = rpeData.map((d, i) => ({ x: i, y: d.avg_rpe }));
 
   return (
@@ -128,17 +133,23 @@ export function RPETrendCard({ rpeData, chartWidth, style }: RPETrendCardProps) 
 }
 
 type RatingTrendCardProps = {
-  ratingData: SessionRatingRow[];
   chartWidth: number;
   style?: object;
 };
 
-export function RatingTrendCard({
-  ratingData,
-  chartWidth,
-  style,
-}: RatingTrendCardProps) {
+export function RatingTrendCard({ chartWidth, style }: RatingTrendCardProps) {
   const colors = useThemeColors();
+  const [ratingData, setRatingData] = useState<SessionRatingRow[]>([]);
+
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        const rows = await getRecentSessionRatings();
+        setRatingData(rows);
+      })();
+    }, []),
+  );
+
   const data = ratingData.map((d, i) => ({ x: i, y: d.rating }));
 
   return (

--- a/components/progress/TrendCards.tsx
+++ b/components/progress/TrendCards.tsx
@@ -1,0 +1,166 @@
+import { StyleSheet, View } from "react-native";
+import { Card } from "@/components/ui/card";
+import { Text } from "@/components/ui/text";
+import { CartesianChart, Line, Scatter } from "victory-native";
+import { useThemeColors } from "@/hooks/useThemeColors";
+
+type TrendLineCardProps = {
+  title: string;
+  data: { x: number; y: number }[];
+  yDomain: [number, number];
+  lineColor: string;
+  emptyMessage: string;
+  chartWidth: number;
+  style?: object;
+};
+
+export function TrendLineCard({
+  title,
+  data,
+  yDomain,
+  lineColor,
+  emptyMessage,
+  chartWidth,
+  style,
+}: TrendLineCardProps) {
+  const colors = useThemeColors();
+
+  if (data.length === 0) {
+    return (
+      <Card style={[styles.card, style]}>
+        <Text
+          variant="subtitle"
+          style={{ color: colors.onSurface, marginBottom: 8 }}
+        >
+          {title}
+        </Text>
+        <View style={styles.emptyContainer}>
+          <Text style={{ color: colors.onSurfaceVariant, textAlign: "center" }}>
+            {emptyMessage}
+          </Text>
+        </View>
+      </Card>
+    );
+  }
+
+  const latest = data[data.length - 1];
+  const accessibilityLabel = `${title}: latest value ${latest.y.toFixed(1)}, ${data.length} session${data.length === 1 ? "" : "s"}`;
+
+  return (
+    <Card style={[styles.card, style]}>
+      <Text
+        variant="subtitle"
+        style={{ color: colors.onSurface, marginBottom: 12 }}
+      >
+        {title}
+      </Text>
+      <View
+        style={{ width: chartWidth, height: 180 }}
+        accessibilityRole="image"
+        accessibilityLabel={accessibilityLabel}
+      >
+        <CartesianChart
+          data={data}
+          xKey="x"
+          yKeys={["y"]}
+          domain={{ y: yDomain }}
+          domainPadding={{ left: 10, right: 10 }}
+        >
+          {({ points }) => (
+            <>
+              <Line
+                points={points.y}
+                color={lineColor}
+                strokeWidth={2}
+                curveType="monotoneX"
+              />
+              {data.length === 1 && (
+                <Scatter
+                  points={points.y}
+                  color={lineColor}
+                  radius={5}
+                  shape="circle"
+                />
+              )}
+            </>
+          )}
+        </CartesianChart>
+      </View>
+    </Card>
+  );
+}
+
+// ─── Pre-built RPE & Rating Cards ──────────────────────────────────
+
+type SessionRPERow = {
+  session_id: string;
+  started_at: number;
+  avg_rpe: number;
+};
+
+type SessionRatingRow = {
+  session_id: string;
+  started_at: number;
+  rating: number;
+};
+
+type RPETrendCardProps = {
+  rpeData: SessionRPERow[];
+  chartWidth: number;
+  style?: object;
+};
+
+export function RPETrendCard({ rpeData, chartWidth, style }: RPETrendCardProps) {
+  const colors = useThemeColors();
+  const data = rpeData.map((d, i) => ({ x: i, y: d.avg_rpe }));
+
+  return (
+    <TrendLineCard
+      title="Avg RPE per Session (1–10)"
+      data={data}
+      yDomain={[1, 10]}
+      lineColor={colors.tertiary}
+      emptyMessage="Log RPE on your sets to see trends here."
+      chartWidth={chartWidth}
+      style={style}
+    />
+  );
+}
+
+type RatingTrendCardProps = {
+  ratingData: SessionRatingRow[];
+  chartWidth: number;
+  style?: object;
+};
+
+export function RatingTrendCard({
+  ratingData,
+  chartWidth,
+  style,
+}: RatingTrendCardProps) {
+  const colors = useThemeColors();
+  const data = ratingData.map((d, i) => ({ x: i, y: d.rating }));
+
+  return (
+    <TrendLineCard
+      title="Session Ratings (1–5)"
+      data={data}
+      yDomain={[1, 5]}
+      lineColor={colors.secondary}
+      emptyMessage="Rate your sessions to see trends here."
+      chartWidth={chartWidth}
+      style={style}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: 16,
+  },
+  emptyContainer: {
+    height: 80,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/components/progress/WorkoutSegment.tsx
+++ b/components/progress/WorkoutSegment.tsx
@@ -18,6 +18,11 @@ import {
   getRecentPRsWithDelta,
   getPRStats,
 } from "../../lib/db/pr-dashboard";
+import {
+  getRecentSessionRPEs,
+  getRecentSessionRatings,
+} from "../../lib/db/e1rm-trends";
+import type { SessionRPERow, SessionRatingRow } from "../../lib/db/e1rm-trends";
 import type { RecentPR, PRStats } from "../../lib/db/pr-dashboard";
 import { useLayout } from "../../lib/layout";
 import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
@@ -25,6 +30,7 @@ import WeeklySummary from "../../components/WeeklySummary";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { WorkoutChartCard, SessionsCard } from "./WorkoutCards";
 import { PRSummaryCard } from "./PRSummaryCard";
+import { RPETrendCard, RatingTrendCard } from "./TrendCards";
 import CalendarView from "./CalendarView";
 import StrengthLevelsCard from "./StrengthLevelsCard";
 import ActiveGoalsCard from "./ActiveGoalsCard";
@@ -74,17 +80,21 @@ export default function WorkoutSegment() {
   const [prStats, setPRStats] = useState<PRStats>({ totalPRs: 0, prsThisMonth: 0 });
   const [weightUnit, setWeightUnit] = useState<"kg" | "lb">("kg");
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [rpeData, setRpeData] = useState<SessionRPERow[]>([]);
+  const [ratingData, setRatingData] = useState<SessionRatingRow[]>([]);
 
   useFocusEffect(
     useCallback(() => {
       (async () => {
-        const [f, v, rp, ps, s, settings] = await Promise.all([
+        const [f, v, rp, ps, s, settings, rpes, ratings] = await Promise.all([
           getWeeklySessionCounts(),
           getWeeklyVolume(),
           getRecentPRsWithDelta(3),
           getPRStats(),
           getCompletedSessionsWithSetCount(),
           getBodySettings(),
+          getRecentSessionRPEs(),
+          getRecentSessionRatings(),
         ]);
         setFreq(f);
         setVol(v);
@@ -92,6 +102,8 @@ export default function WorkoutSegment() {
         setPRStats(ps);
         setSessions(s);
         setWeightUnit(settings.weight_unit as "kg" | "lb");
+        setRpeData(rpes);
+        setRatingData(ratings);
       })();
     }, []),
   );
@@ -213,6 +225,10 @@ export default function WorkoutSegment() {
               {volCard}
             </View>
             <View style={styles.grid}>
+              <RPETrendCard rpeData={rpeData} chartWidth={chartWidth} style={wideCard} />
+              <RatingTrendCard ratingData={ratingData} chartWidth={chartWidth} style={wideCard} />
+            </View>
+            <View style={styles.grid}>
               <PRSummaryCard
                 recentPRs={recentPRs}
                 stats={prStats}
@@ -232,6 +248,8 @@ export default function WorkoutSegment() {
             {achievementsCard}
             {freqCard}
             {volCard}
+            <RPETrendCard rpeData={rpeData} chartWidth={chartWidth} />
+            <RatingTrendCard ratingData={ratingData} chartWidth={chartWidth} />
             <PRSummaryCard
               recentPRs={recentPRs}
               stats={prStats}

--- a/components/progress/WorkoutSegment.tsx
+++ b/components/progress/WorkoutSegment.tsx
@@ -18,11 +18,6 @@ import {
   getRecentPRsWithDelta,
   getPRStats,
 } from "../../lib/db/pr-dashboard";
-import {
-  getRecentSessionRPEs,
-  getRecentSessionRatings,
-} from "../../lib/db/e1rm-trends";
-import type { SessionRPERow, SessionRatingRow } from "../../lib/db/e1rm-trends";
 import type { RecentPR, PRStats } from "../../lib/db/pr-dashboard";
 import { useLayout } from "../../lib/layout";
 import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
@@ -80,21 +75,17 @@ export default function WorkoutSegment() {
   const [prStats, setPRStats] = useState<PRStats>({ totalPRs: 0, prsThisMonth: 0 });
   const [weightUnit, setWeightUnit] = useState<"kg" | "lb">("kg");
   const [sessions, setSessions] = useState<SessionRow[]>([]);
-  const [rpeData, setRpeData] = useState<SessionRPERow[]>([]);
-  const [ratingData, setRatingData] = useState<SessionRatingRow[]>([]);
 
   useFocusEffect(
     useCallback(() => {
       (async () => {
-        const [f, v, rp, ps, s, settings, rpes, ratings] = await Promise.all([
+        const [f, v, rp, ps, s, settings] = await Promise.all([
           getWeeklySessionCounts(),
           getWeeklyVolume(),
           getRecentPRsWithDelta(3),
           getPRStats(),
           getCompletedSessionsWithSetCount(),
           getBodySettings(),
-          getRecentSessionRPEs(),
-          getRecentSessionRatings(),
         ]);
         setFreq(f);
         setVol(v);
@@ -102,8 +93,6 @@ export default function WorkoutSegment() {
         setPRStats(ps);
         setSessions(s);
         setWeightUnit(settings.weight_unit as "kg" | "lb");
-        setRpeData(rpes);
-        setRatingData(ratings);
       })();
     }, []),
   );
@@ -225,8 +214,8 @@ export default function WorkoutSegment() {
               {volCard}
             </View>
             <View style={styles.grid}>
-              <RPETrendCard rpeData={rpeData} chartWidth={chartWidth} style={wideCard} />
-              <RatingTrendCard ratingData={ratingData} chartWidth={chartWidth} style={wideCard} />
+              <RPETrendCard chartWidth={chartWidth} style={wideCard} />
+              <RatingTrendCard chartWidth={chartWidth} style={wideCard} />
             </View>
             <View style={styles.grid}>
               <PRSummaryCard
@@ -248,8 +237,8 @@ export default function WorkoutSegment() {
             {achievementsCard}
             {freqCard}
             {volCard}
-            <RPETrendCard rpeData={rpeData} chartWidth={chartWidth} />
-            <RatingTrendCard ratingData={ratingData} chartWidth={chartWidth} />
+            <RPETrendCard chartWidth={chartWidth} />
+            <RatingTrendCard chartWidth={chartWidth} />
             <PRSummaryCard
               recentPRs={recentPRs}
               stats={prStats}


### PR DESCRIPTION
## Summary

Add two new line chart cards to Progress > Workouts tab showing RPE and session rating trends over 6 weeks. Uses existing DB queries and victory-native chart components.

## Changes

- **CREATE** `components/progress/TrendCards.tsx` — reusable `TrendLineCard` component plus `RPETrendCard` and `RatingTrendCard` wrappers
- **MODIFY** `components/progress/WorkoutSegment.tsx` — fetch RPE/rating data in existing Promise.all, render trend cards after Weekly Volume and before PR Summary

## Technical Details

- Fixed Y-axis domains via `domain={{ y: [1, 10] }}` and `[1, 5]` (victory-native v41 API)
- `curveType="monotoneX"` to prevent overshoot on bounded scales
- Single data point: `Scatter` overlay with radius=5 renders a visible dot
- Dynamic `accessibilityLabel` with latest value and session count
- Tablet: side-by-side in flex row; Phone: full-width stacked
- Data transforms inside card components (no new state in WorkoutSegment beyond raw data)

## Testing

- `tsc --noEmit` passes (0 new errors; 3 pre-existing errors in scripts/ unrelated to this PR)
- ESLint passes on changed files
- Pre-existing test failures (STARTER_PROGRAMS not iterable) are unrelated to these changes

## Issue

Resolves BLD-886