### PR TITLE
fix: defensive JSON.parse in MacroTargetsSheet (BLD-895)

### DIFF
--- a/__tests__/components/nutrition/MacroTargetsSheet-json-safety.test.tsx
+++ b/__tests__/components/nutrition/MacroTargetsSheet-json-safety.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * BLD-895: Verify MacroTargetsSheet handles corrupt nutrition_profile JSON
+ * without crashing (SyntaxError: Unexpected end of JSON input).
+ */
+import React from 'react'
+import { waitFor } from '@testing-library/react-native'
+import { renderScreen } from '../../helpers/render'
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+  useLocalSearchParams: () => ({}),
+  usePathname: () => '/test',
+  useFocusEffect: jest.fn(),
+  Stack: { Screen: () => null },
+  Redirect: () => null,
+  router: { push: jest.fn(), replace: jest.fn(), back: jest.fn() },
+}))
+
+jest.mock('@react-navigation/native', () => {
+  const RealReact = require('react')
+  return {
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('../../../lib/layout', () => ({
+  useLayout: () => ({ wide: false, width: 375, scale: 1.0, horizontalPadding: 16 }),
+}))
+
+const mockGetMacroTargets = jest.fn().mockResolvedValue({
+  calories: 2000, protein: 150, carbs: 250, fat: 65,
+})
+const mockGetAppSetting = jest.fn()
+
+jest.mock('../../../lib/db', () => ({
+  getAppSetting: (...args: unknown[]) => mockGetAppSetting(...args),
+  getMacroTargets: (...args: unknown[]) => mockGetMacroTargets(...args),
+  updateMacroTargets: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../../../lib/nutrition-calc', () => ({
+  calculateFromProfile: jest.fn(() => ({
+    calories: 2000, protein: 150, carbs: 250, fat: 65,
+  })),
+  migrateProfile: jest.fn((p: unknown) => p),
+}))
+
+import { MacroTargetsSheet } from '../../../components/nutrition/MacroTargetsSheet'
+
+describe('MacroTargetsSheet JSON safety (BLD-895)', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('does not crash when nutrition_profile is truncated JSON', async () => {
+    mockGetAppSetting.mockResolvedValue('{"birthYear":19')  // truncated
+
+    // Should render without throwing
+    renderScreen(
+      <MacroTargetsSheet visible={true} onClose={jest.fn()} />
+    )
+
+    await waitFor(() => {
+      expect(mockGetAppSetting).toHaveBeenCalledWith('nutrition_profile')
+    })
+  })
+
+  it('does not crash when nutrition_profile is empty string', async () => {
+    mockGetAppSetting.mockResolvedValue('')
+
+    renderScreen(
+      <MacroTargetsSheet visible={true} onClose={jest.fn()} />
+    )
+
+    await waitFor(() => {
+      expect(mockGetAppSetting).toHaveBeenCalledWith('nutrition_profile')
+    })
+  })
+
+  it('parses valid nutrition_profile without error', async () => {
+    const { migrateProfile } = require('../../../lib/nutrition-calc')
+    const validProfile = { birthYear: 1990, weight: 80, height: 180 }
+    mockGetAppSetting.mockResolvedValue(JSON.stringify(validProfile))
+
+    renderScreen(
+      <MacroTargetsSheet visible={true} onClose={jest.fn()} />
+    )
+
+    await waitFor(() => {
+      expect(migrateProfile).toHaveBeenCalledWith(validProfile)
+    })
+  })
+})

--- a/components/nutrition/MacroTargetsSheet.tsx
+++ b/components/nutrition/MacroTargetsSheet.tsx
@@ -33,7 +33,13 @@ export function MacroTargetsSheet({ visible, onClose }: Props) {
       setFat(String(t.fat));
     });
     getAppSetting("nutrition_profile").then((saved) => {
-      setProfile(saved ? migrateProfile(JSON.parse(saved)) : null);
+      if (!saved) { setProfile(null); return; }
+      try {
+        setProfile(migrateProfile(JSON.parse(saved)));
+      } catch {
+        if (__DEV__) console.warn("[MacroTargetsSheet] corrupt nutrition_profile, resetting");
+        setProfile(null);
+      }
     });
   }, [visible]);
 


### PR DESCRIPTION
## Summary

Wraps the unprotected JSON.parse call in MacroTargetsSheet with try/catch to prevent crashes when nutrition_profile contains corrupt/truncated JSON data.

## Root Cause (Sentry REACT-NATIVE-4)

The Sentry stack trace shows the crash originates in expo-sqlite WorkerChannel deserialize -> JSON.parse path, already patched by BLD-660. The 3 affected users were likely on an older build.

However, MacroTargetsSheet.tsx:36 had an unprotected JSON.parse(saved) inside a .then() callback with no error handling — a separate crash vector for corrupt AsyncStorage data.

## Changes

- components/nutrition/MacroTargetsSheet.tsx: Wrap JSON.parse in try/catch with null fallback
- __tests__/components/nutrition/MacroTargetsSheet-json-safety.test.tsx: 3 test cases

## Testing

- 3 new tests pass: truncated JSON, empty string, valid profile
- tsc --noEmit clean

Resolves BLD-895