### PR TITLE
fix: defensive JSON.parse wrappers to prevent SyntaxError crashes (BLD-906)

### DIFF
--- a/__tests__/lib/safe-parse.test.ts
+++ b/__tests__/lib/safe-parse.test.ts
@@ -1,0 +1,44 @@
+import { safeParse } from "../../lib/safe-parse";
+
+describe("safeParse", () => {
+  it("parses valid JSON and returns the value", () => {
+    expect(safeParse('["chest","shoulders"]', [], "test")).toEqual(["chest", "shoulders"]);
+  });
+
+  it("returns fallback for null input", () => {
+    expect(safeParse(null, [], "test")).toEqual([]);
+  });
+
+  it("returns fallback for undefined input", () => {
+    expect(safeParse(undefined, { x: 1 }, "test")).toEqual({ x: 1 });
+  });
+
+  it("returns fallback for empty string", () => {
+    expect(safeParse("", [], "test")).toEqual([]);
+  });
+
+  it("returns fallback for truncated JSON", () => {
+    expect(safeParse('["chest","shou', [], "truncated")).toEqual([]);
+  });
+
+  it("returns fallback for invalid JSON", () => {
+    expect(safeParse("not json at all", 42, "bad")).toBe(42);
+  });
+
+  it("returns fallback for malformed object", () => {
+    expect(safeParse("{key: value}", {}, "malformed")).toEqual({});
+  });
+
+  it("parses valid nested object", () => {
+    const input = '{"birthYear":1990,"weight":80}';
+    const result = safeParse<{ birthYear: number; weight: number } | null>(input, null, "profile");
+    expect(result).toEqual({ birthYear: 1990, weight: 80 });
+  });
+
+  it("does not throw on any input", () => {
+    const badInputs = [null, undefined, "", "}", "{", "[", '{"a":', "NaN", "\x00\x01\x02"];
+    for (const input of badInputs) {
+      expect(() => safeParse(input, "fallback", "fuzz")).not.toThrow();
+    }
+  });
+});

--- a/hooks/useBodyProfile.ts
+++ b/hooks/useBodyProfile.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useFocusEffect } from "@react-navigation/native";
 import { getAppSetting, setAppSetting, updateMacroTargets } from "../lib/db";
 import { getBodySettings, getLatestBodyWeight, updateBodySex } from "../lib/db/body";
+import { safeParse } from "../lib/safe-parse";
 import { useToast } from "@/components/ui/bna-toast";
 import {
   calculateFromProfile,
@@ -117,7 +118,9 @@ export function useBodyProfile(
       setSex(bodySettings.sex);
 
       if (saved) {
-        const profile: NutritionProfile = migrateProfile(JSON.parse(saved));
+        const parsed = safeParse<Record<string, unknown> | null>(saved, null, "useBodyProfile.nutrition_profile");
+        if (!parsed) { setCardState("ready"); return; }
+        const profile: NutritionProfile = migrateProfile(parsed);
         setBirthYear(String(profile.birthYear));
         const displayWeight = convertWeight(
           profile.weight,

--- a/lib/db/exercises.ts
+++ b/lib/db/exercises.ts
@@ -1,5 +1,6 @@
 import { eq, and, isNull, inArray } from "drizzle-orm";
 import type { Exercise } from "../types";
+import { safeParse } from "../safe-parse";
 import { uuid } from "../uuid";
 import { getDrizzle, query, withTransaction } from "./helpers";
 import { exercises, templateExercises } from "./schema";
@@ -10,8 +11,8 @@ function mapRow(row: ExerciseRow): Exercise {
     id: row.id,
     name: row.name,
     category: row.category as Exercise["category"],
-    primary_muscles: JSON.parse(row.primary_muscles) as Exercise["primary_muscles"],
-    secondary_muscles: JSON.parse(row.secondary_muscles) as Exercise["secondary_muscles"],
+    primary_muscles: safeParse(row.primary_muscles, [] as Exercise["primary_muscles"], "exercises.primary_muscles"),
+    secondary_muscles: safeParse(row.secondary_muscles, [] as Exercise["secondary_muscles"], "exercises.secondary_muscles"),
     equipment: row.equipment as Exercise["equipment"],
     instructions: row.instructions,
     difficulty: row.difficulty as Exercise["difficulty"],

--- a/lib/db/recovery.ts
+++ b/lib/db/recovery.ts
@@ -1,4 +1,5 @@
 import type { MuscleGroup } from "../types";
+import { safeParse } from "../safe-parse";
 import { query } from "./helpers";
 
 export type RecoveryStatus = "recovered" | "partial" | "fatigued" | "no_data";
@@ -67,7 +68,7 @@ export async function getMuscleRecoveryStatus(): Promise<MuscleRecoveryStatus[]>
   const latestByMuscle = new Map<MuscleGroup, number>();
 
   for (const row of rows) {
-    const muscles: MuscleGroup[] = JSON.parse(row.primary_muscles);
+    const muscles = safeParse<MuscleGroup[]>(row.primary_muscles, [], "recovery.primary_muscles");
     if (muscles.includes("full_body")) continue;
 
     for (const m of muscles) {

--- a/lib/db/templates.ts
+++ b/lib/db/templates.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import { eq, sql, and, inArray, asc, desc, isNull, count } from "drizzle-orm";
 import type { CoachTemplateImportData } from "../schemas";
+import { safeParse } from "../safe-parse";
 import type { WorkoutTemplate, TemplateExercise, MuscleGroup, SetType, TemplateSource } from "../types";
 import { uuid } from "../uuid";
 import { getDrizzle, withTransaction } from "./helpers";
@@ -658,7 +659,7 @@ export async function getTemplatePrimaryMuscles(
   for (const row of rows) {
     if (!row.primary_muscles) continue;
     if (!result[row.template_id]) result[row.template_id] = new Set();
-    const muscles: MuscleGroup[] = JSON.parse(row.primary_muscles);
+    const muscles = safeParse<MuscleGroup[]>(row.primary_muscles, [], "templates.primary_muscles");
     for (const m of muscles) {
       if (m !== "full_body") result[row.template_id].add(m);
     }

--- a/lib/safe-parse.ts
+++ b/lib/safe-parse.ts
@@ -1,0 +1,29 @@
+/**
+ * Defensive JSON.parse wrapper that returns a fallback value on failure.
+ *
+ * Use this for any runtime JSON.parse of user data or stored state where a
+ * corrupted/truncated payload should NOT crash the app.
+ *
+ * @param raw - The raw string to parse (may be null/undefined/empty/truncated)
+ * @param fallback - Value to return when parsing fails
+ * @param context - A short label for the console.warn log (e.g. "primary_muscles")
+ * @returns The parsed value on success, or `fallback` on any failure
+ */
+export function safeParse<T>(raw: string | null | undefined, fallback: T, context?: string): T {
+  if (raw == null || raw === "") {
+    return fallback;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch (e) {
+    if (__DEV__) {
+      const preview = raw.length > 120 ? raw.slice(0, 120) + "…" : raw;
+      console.warn(
+        `[safeParse] ${context ?? "unknown"}: failed to parse JSON — returning fallback. ` +
+        `Raw (${raw.length} chars): ${preview}`,
+        e,
+      );
+    }
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary

Addresses Sentry REACT-NATIVE-4 — recurring SyntaxError: Unexpected end of JSON input from JSON.parse affecting 4 users (11 events). Adds a centralized safeParse() utility and wraps all unguarded runtime JSON.parse calls that process user data or stored state.

## Changes

- **New lib/safe-parse.ts**: safeParse<T>(raw, fallback, context) utility that returns a fallback on parse failure and logs console.warn in __DEV__ mode with context and raw string preview
- **lib/db/exercises.ts**: mapRow() — primary_muscles and secondary_muscles parsing now uses safeParse with [] fallback
- **lib/db/recovery.ts**: primary_muscles parsing now uses safeParse with [] fallback
- **lib/db/templates.ts**: muscle group aggregation now uses safeParse with [] fallback
- **hooks/useBodyProfile.ts**: nutrition_profile from AsyncStorage now uses safeParse with null fallback (graceful empty state)
- **New __tests__/lib/safe-parse.test.ts**: 9 tests covering valid JSON, null/undefined/empty, truncated, invalid, and fuzz inputs

## Testing

- tsc --noEmit passes with zero errors
- 9 new unit tests for safeParse all pass
- All existing tests pass

## Issue

Resolves BLD-906