### PR TITLE
fix(history): widen heatmap day-of-week label column to prevent wrapping (BLD-910)

### DIFF
--- a/components/WorkoutHeatmap.tsx
+++ b/components/WorkoutHeatmap.tsx
@@ -130,8 +130,8 @@ export default function WorkoutHeatmap({ data, weeks = 16, onDayPress, totalAllT
     return g;
   }, [data, weeks]);
 
-  // BLD-686: bumped from 18 to 22 to accommodate 3-letter weekday labels (Mon/Wed/Fri).
-  const labelWidth = 22;
+  // BLD-686: bumped from 18→22; BLD-910: bumped to 28 to prevent wrapping on narrow viewports.
+  const labelWidth = 28;
   const gap = 2;
   const availableWidth = layout.width - layout.horizontalPadding * 2 - labelWidth - gap;
   const cellSize = Math.max(14, Math.min(24, Math.floor((availableWidth - gap * (weeks - 1)) / weeks)));
@@ -186,6 +186,7 @@ export default function WorkoutHeatmap({ data, weeks = 16, onDayPress, totalAllT
         <View key={rowIdx} style={styles.row}>
           <Text
             variant="caption"
+            numberOfLines={1}
             style={[styles.dayLabel, { width: labelWidth, fontSize: fontSizes.xs, color: colors.onSurfaceVariant }]}
           >
             {DAY_LABELS[rowIdx]}


### PR DESCRIPTION
## Summary

Widens the heatmap day-of-week label column from 22px to 28px to prevent 3-letter abbreviations (Mon/Wed/Fri) from wrapping to two lines on narrow mobile viewports (390px).

## Changes

- `components/WorkoutHeatmap.tsx:134`: `labelWidth` 22 → 28
- Added `numberOfLines={1}` guard on the day label `<Text>` component as a safety net

## Testing

- TypeScript passes with zero errors
- Visual: 28px accommodates "Mon"/"Wed"/"Fri" at fontSize.xs (12px) with ~6px breathing room

## Issue

Resolves BLD-910