### PR TITLE
fix: guard WearOS module init to prevent crash on devices without GMS

### DIFF
--- a/modules/expo-wearos-bridge/android/src/main/java/com/persoack/cablesnap/wearbridge/WearOSModule.kt
+++ b/modules/expo-wearos-bridge/android/src/main/java/com/persoack/cablesnap/wearbridge/WearOSModule.kt
@@ -39,7 +39,15 @@ import expo.modules.kotlin.modules.ModuleDefinition
 class WearOSModule : Module() {
   companion object {
     @Suppress("unused")
-    private val WEARABLE_API_CLASS: Class<*> = Wearable::class.java
+    private val WEARABLE_API_CLASS: Class<*>? by lazy {
+      try {
+        Wearable::class.java
+      } catch (_: Throwable) {
+        // GMS Wearable not available — non-fatal for M0.
+        // M1 will add actual Wearable API usage with proper availability checks.
+        null
+      }
+    }
   }
 
   override fun definition() = ModuleDefinition {


### PR DESCRIPTION
## Summary
- Replace eager `Wearable::class.java` static initializer with `lazy` + `try-catch(Throwable)` to prevent `NoClassDefFoundError` crash on devices without Google Play Services
- Bytecode reference preserved for Play APK DEX pin (AC10a)
- Single-file, 10-line change

## Root Cause
`WearOSModule.kt` companion object loaded `Wearable::class.java` eagerly at class-load time during Expo autolinker registration. On devices without GMS, this throws `NoClassDefFoundError` before any JS runs.

## Fix
`by lazy { try { ... } catch (_: Throwable) { null } }` — defers loading, makes failure non-fatal.

Fixes: BLD-914