### PR TITLE
release: v0.26.19 — fix Android crash on open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ The `<!-- versionCode: N -->` marker is optional but required for F-Droid
 sidecar emission. The `publish-release` skill prepends a new section (with
 marker) at release time.
 
+## v0.26.19 — 2026-05-01
+<!-- versionCode: 76 -->
+- Fixed Android crash on app open caused by WearOS module class-loading failure on devices without Google Play Services.
+- Replaced direct WearOS Wearable API import with Class.forName() reflection to prevent NoClassDefFoundError at startup.
+- Removed WearOSModule from Expo autolinker to prevent F-Droid build crashes.
+- Added Android emulator smoke test to CI pipeline to catch launch crashes before release.
+
 ## Unreleased
 
 ### Added

--- a/app.config.ts
+++ b/app.config.ts
@@ -4,7 +4,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: "CableSnap",
   slug: "cablesnap",
-  version: "0.26.18",
+  version: "0.26.19",
   orientation: "default",
   icon: "./assets/icon.png",
   userInterfaceStyle: "automatic",
@@ -23,7 +23,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       backgroundColor: "#FF6038", // eslint-disable-line no-restricted-syntax
     },
     package: "com.persoack.cablesnap",
-    versionCode: 75,
+    versionCode: 76,
   },
   web: {
     favicon: "./assets/favicon.png",

--- a/fdroid/metadata/com.persoack.cablesnap.yml
+++ b/fdroid/metadata/com.persoack.cablesnap.yml
@@ -30,8 +30,8 @@ Description: |
   - CSV export and sharing
   - Dark mode support
 
-CurrentVersion: 0.26.18
-CurrentVersionCode: 75
+CurrentVersion: 0.26.19
+CurrentVersionCode: 76
 
 # F-Droid build server build recipe.
 #

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cablesnap",
-  "version": "0.26.18",
+  "version": "0.26.19",
   "license": "AGPL-3.0-or-later",
   "main": "expo-router/entry",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps version to v0.26.19 (versionCode 76)
- Fixes Android crash on open caused by WearOS module class-loading failure on devices without Google Play Services

## Changes
- app.config.ts: version 0.26.19, versionCode 76
- package.json: version 0.26.19
- fdroid/metadata: CurrentVersion 0.26.19, CurrentVersionCode 76
- CHANGELOG.md: v0.26.19 release notes

This is a hotfix release. The crash was caused by the WearOS module attempting to load Google Play Services classes at startup on devices without GMS.