### PR TITLE
chore: regenerate changelog artifacts for v0.26.19

### DIFF
--- a/fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/76.txt
+++ b/fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/76.txt
@@ -1,0 +1,4 @@
+- Fixed Android crash on app open caused by WearOS module class-loading failure on devices without Google Play Services.
+- Replaced direct WearOS Wearable API import with Class.forName() reflection to prevent NoClassDefFoundError at startup.
+- Removed WearOSModule from Expo autolinker to prevent F-Droid build crashes.
+- Added Android emulator smoke test to CI pipeline to catch launch crashes before release.

--- a/lib/changelog.generated.ts
+++ b/lib/changelog.generated.ts
@@ -10,6 +10,12 @@ export interface ReleaseEntry {
 
 export const CHANGELOG: ReleaseEntry[] = [
   {
+    "version": "0.26.19",
+    "date": "2026-05-01",
+    "versionCode": 76,
+    "body": "- Fixed Android crash on app open caused by WearOS module class-loading failure on devices without Google Play Services.\n- Replaced direct WearOS Wearable API import with Class.forName() reflection to prevent NoClassDefFoundError at startup.\n- Removed WearOSModule from Expo autolinker to prevent F-Droid build crashes.\n- Added Android emulator smoke test to CI pipeline to catch launch crashes before release."
+  },
+  {
     "version": "0.26.12",
     "date": "2026-04-26",
     "versionCode": 65,


### PR DESCRIPTION
Regenerates lib/changelog.generated.ts and F-Droid sidecar for v0.26.19.