### PR TITLE
fix: increase heatmap day-of-week labelWidth to 24px (BLD-927)

### DIFF
--- a/components/WorkoutHeatmap.tsx
+++ b/components/WorkoutHeatmap.tsx
@@ -130,8 +130,8 @@ export default function WorkoutHeatmap({ data, weeks = 16, onDayPress, totalAllT
     return g;
   }, [data, weeks]);
 
-  // BLD-686: bumped from 18 to 22 to accommodate 3-letter weekday labels (Mon/Wed/Fri).
-  const labelWidth = 22;
+  // BLD-686: bumped 18→22; BLD-927: bumped to 24 to prevent truncation on narrow (390px+) viewports.
+  const labelWidth = 24;
   const gap = 2;
   const availableWidth = layout.width - layout.horizontalPadding * 2 - labelWidth - gap;
   const cellSize = Math.max(14, Math.min(24, Math.floor((availableWidth - gap * (weeks - 1)) / weeks)));


### PR DESCRIPTION
## Summary

Increases `labelWidth` from 22px to 24px in `WorkoutHeatmap.tsx` to prevent day-of-week label truncation on narrow viewports (390px+).

## Changes

- `components/WorkoutHeatmap.tsx`: bumped `labelWidth` constant from 22 to 24

## Verification

- Cell size at 390px width with 16 weeks: (390 - 32 - 24 - 2 - 2*15) / 16 = 19.1px — above the 14px minimum
- TypeScript: tsc --noEmit passes with zero errors

## Issue

Resolves BLD-927