### PR TITLE
feat(history): Workout History Filters — Template, Muscle Group, Date Range (BLD-938)

### DIFF
--- a/__tests__/acceptance/history.acceptance.test.tsx
+++ b/__tests__/acceptance/history.acceptance.test.tsx
@@ -45,6 +45,10 @@ jest.mock('react-native-reanimated', () => {
     useSharedValue: <T,>(v: T) => ({ value: v }),
     useReducedMotion: () => false,
     withTiming: <T,>(v: T) => v,
+    // BLD-938: BottomSheet imports these; the inline mock above predates
+    // the new sheets and would otherwise crash the screen on mount.
+    withSpring: <T,>(v: T) => v,
+    runOnJS: <T,>(fn: T) => fn,
     createAnimatedComponent: <T,>(c: T) => c,
     Easing: { bezier: () => (t: number) => t },
   }
@@ -108,6 +112,11 @@ jest.mock('../../lib/db', () => ({
   getSessionCountsByDay: (...args: unknown[]) => mockGetSessionCountsByDay(...args),
   getAllCompletedSessionWeeks: (...args: unknown[]) => mockGetAllCompletedSessionWeeks(...args),
   getTotalSessionCount: (...args: unknown[]) => mockGetTotalSessionCount(...args),
+  // BLD-938: history filter queries — return empty so the screen falls
+  // through to the unfiltered (calendar/recent) path used by these tests.
+  getTemplatesWithSessions: jest.fn().mockResolvedValue([]),
+  getMuscleGroupsWithSessions: jest.fn().mockResolvedValue([]),
+  getFilteredSessions: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
 }))
 
 jest.mock('../../lib/db/settings', () => ({

--- a/__tests__/acceptance/history.acceptance.test.tsx
+++ b/__tests__/acceptance/history.acceptance.test.tsx
@@ -104,6 +104,11 @@ const mockSearchSessions = jest.fn().mockResolvedValue([])
 const mockGetSessionCountsByDay = jest.fn().mockResolvedValue([])
 const mockGetAllCompletedSessionWeeks = jest.fn().mockResolvedValue([])
 const mockGetTotalSessionCount = jest.fn().mockResolvedValue(42)
+// BLD-938: spy mocks for the filter pipeline. Hoisted so individual tests
+// can reconfigure them (e.g. simulate a paginated result set).
+const mockGetTemplatesWithSessions = jest.fn().mockResolvedValue([])
+const mockGetMuscleGroupsWithSessions = jest.fn().mockResolvedValue([])
+const mockGetFilteredSessions = jest.fn().mockResolvedValue({ rows: [], total: 0 })
 
 jest.mock('../../lib/db', () => ({
   getSessionsByMonth: (...args: unknown[]) => mockGetSessionsByMonth(...args),
@@ -112,11 +117,12 @@ jest.mock('../../lib/db', () => ({
   getSessionCountsByDay: (...args: unknown[]) => mockGetSessionCountsByDay(...args),
   getAllCompletedSessionWeeks: (...args: unknown[]) => mockGetAllCompletedSessionWeeks(...args),
   getTotalSessionCount: (...args: unknown[]) => mockGetTotalSessionCount(...args),
-  // BLD-938: history filter queries — return empty so the screen falls
-  // through to the unfiltered (calendar/recent) path used by these tests.
-  getTemplatesWithSessions: jest.fn().mockResolvedValue([]),
-  getMuscleGroupsWithSessions: jest.fn().mockResolvedValue([]),
-  getFilteredSessions: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
+  // BLD-938: history filter queries — empty defaults so existing
+  // (non-filter) tests fall through to calendar/recent path. Filter tests
+  // below override these with realistic data.
+  getTemplatesWithSessions: (...args: unknown[]) => mockGetTemplatesWithSessions(...args),
+  getMuscleGroupsWithSessions: (...args: unknown[]) => mockGetMuscleGroupsWithSessions(...args),
+  getFilteredSessions: (...args: unknown[]) => mockGetFilteredSessions(...args),
 }))
 
 jest.mock('../../lib/db/settings', () => ({
@@ -135,6 +141,9 @@ describe('Workout History & Calendar Acceptance', () => {
     mockGetAllCompletedSessionWeeks.mockResolvedValue([])
     mockGetTotalSessionCount.mockResolvedValue(42)
     mockSearchSessions.mockResolvedValue([])
+    mockGetTemplatesWithSessions.mockResolvedValue([])
+    mockGetMuscleGroupsWithSessions.mockResolvedValue([])
+    mockGetFilteredSessions.mockResolvedValue({ rows: [], total: 0 })
   })
 
   describe('Calendar view', () => {
@@ -390,6 +399,138 @@ describe('Workout History & Calendar Acceptance', () => {
         const cell = screen.getByLabelText(/5.*1 workout/)
         // The cell should have minHeight >= 48
         expect(cell.props.style).toBeDefined()
+      })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // BLD-938 — Filter UI behavioural coverage
+  //
+  // QD blocker R2: existing tests do not exercise the filter UI end-to-end.
+  // These tests open a sheet from the FilterBar, apply a selection, and
+  // assert the observable consequences:
+  //   - getFilteredSessions is called with the right shape
+  //   - the calendar block is dimmed/disabled when filters are active
+  //   - the result-count caption appears
+  //   - "Clear all" returns the screen to the unfiltered path
+  //
+  // We use the public accessibility labels published by FilterBar /
+  // DateRangeFilterSheet so the tests survive cosmetic refactors.
+  // ---------------------------------------------------------------------------
+  describe('BLD-938 filter UI flow', () => {
+    it('opens the date range sheet, applies "This year", and routes through getFilteredSessions', async () => {
+      // Seed a non-empty filter result so the result-count caption renders.
+      mockGetFilteredSessions.mockResolvedValue({
+        rows: [
+          {
+            id: 'filtered-1',
+            template_id: null,
+            name: 'Filtered Match',
+            started_at: day5,
+            completed_at: day5 + 3600000,
+            duration_seconds: 3600,
+            notes: '',
+            rating: null,
+            set_count: 10,
+          },
+        ],
+        total: 1,
+      })
+
+      jest.useFakeTimers()
+      const screen = renderScreen(<History />)
+
+      // Initial async loads.
+      await waitFor(() => {
+        expect(screen.getByTestId('history-filter-chip-date')).toBeTruthy()
+      })
+
+      // Open the date sheet.
+      fireEvent.press(screen.getByTestId('history-filter-chip-date'))
+
+      // Pick "This year". The sheet renders preset options with the
+      // accessibility label "This year" (or "This year, selected").
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^This year/)).toBeTruthy()
+      })
+      fireEvent.press(screen.getByLabelText(/^This year/))
+
+      // Advance past the 300ms filter debounce.
+      jest.advanceTimersByTime(350)
+      jest.useRealTimers()
+
+      await waitFor(() => {
+        expect(mockGetFilteredSessions).toHaveBeenCalled()
+      })
+
+      // The call must carry datePreset: "year" — full QD R4 contract.
+      const lastCall = mockGetFilteredSessions.mock.calls[mockGetFilteredSessions.mock.calls.length - 1]
+      expect(lastCall[0]).toMatchObject({ datePreset: 'year' })
+      expect(lastCall[3]).toBe(0) // page-0 offset
+
+      // Calendar must be flagged disabled while filters are active.
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('Calendar disabled while filters are active'),
+        ).toBeTruthy()
+      })
+
+      // Result-count caption appears once filtered rows are loaded.
+      await waitFor(() => {
+        expect(screen.getByLabelText('1 sessions match these filters')).toBeTruthy()
+      })
+    })
+
+    it('"Clear all filters" returns to the unfiltered calendar path', async () => {
+      mockGetFilteredSessions.mockResolvedValue({
+        rows: [
+          {
+            id: 'filtered-1',
+            template_id: null,
+            name: 'Filtered Match',
+            started_at: day5,
+            completed_at: day5 + 3600000,
+            duration_seconds: 3600,
+            notes: '',
+            rating: null,
+            set_count: 10,
+          },
+        ],
+        total: 1,
+      })
+
+      jest.useFakeTimers()
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByTestId('history-filter-chip-date')).toBeTruthy()
+      })
+
+      // Activate a filter.
+      fireEvent.press(screen.getByTestId('history-filter-chip-date'))
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^This year/)).toBeTruthy()
+      })
+      fireEvent.press(screen.getByLabelText(/^This year/))
+      jest.advanceTimersByTime(350)
+
+      await waitFor(() => {
+        expect(
+          screen.getByLabelText('Calendar disabled while filters are active'),
+        ).toBeTruthy()
+      })
+
+      // Now clear all.
+      const clearAll = screen.getByTestId('history-filter-clear-all')
+      fireEvent.press(clearAll)
+      jest.advanceTimersByTime(350)
+      jest.useRealTimers()
+
+      // Caption disappears (filter mode false), unfiltered sessions visible.
+      await waitFor(() => {
+        expect(
+          screen.queryByLabelText('Calendar disabled while filters are active'),
+        ).toBeNull()
+        expect(screen.getByLabelText(/Push Day/)).toBeTruthy()
       })
     })
   })

--- a/__tests__/acceptance/history.acceptance.test.tsx
+++ b/__tests__/acceptance/history.acceptance.test.tsx
@@ -319,6 +319,52 @@ describe('Workout History & Calendar Acceptance', () => {
 
       jest.useRealTimers()
     })
+
+    it('text-search alone paginates via onEndReached (page-1 offset = 20)', async () => {
+      // BLD-938 R6: onEndReached must fire the next page when only text
+      // search is active (no chip filters). Previously the FlatList only
+      // wired onEndReached when chip filters were active, so text-search
+      // results were stuck at the first 20 rows.
+      jest.useFakeTimers()
+      const page0 = Array.from({ length: 20 }, (_, i) =>
+        makeSessionRow({ id: `p0-${i}`, name: 'Push', started_at: day5 - i * 1000 }),
+      )
+      mockGetFilteredSessions.mockResolvedValue({ rows: page0, total: 45 })
+
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Search workout history')).toBeTruthy()
+      })
+
+      fireEvent.changeText(screen.getByLabelText('Search workout history'), 'Push')
+      jest.advanceTimersByTime(350)
+
+      await waitFor(() => {
+        expect(mockGetFilteredSessions).toHaveBeenCalled()
+      })
+
+      // Trigger onEndReached on the FlatList. If the screen still gates
+      // on chip-only useFilterMode, this is a no-op and the page-1 call
+      // never happens.
+      const list = screen.getByTestId('history-list')
+      mockGetFilteredSessions.mockClear()
+      mockGetFilteredSessions.mockResolvedValue({
+        rows: [makeSessionRow({ id: 'p1-0', name: 'Push', started_at: day5 - 100000 })],
+        total: 45,
+      })
+      fireEvent(list, 'onEndReached', { distanceFromEnd: 100 })
+
+      await waitFor(() => {
+        expect(mockGetFilteredSessions).toHaveBeenCalled()
+      })
+      const lastCall =
+        mockGetFilteredSessions.mock.calls[mockGetFilteredSessions.mock.calls.length - 1]
+      expect(lastCall[1]).toBe('Push')
+      expect(lastCall[2]).toBe(20)
+      expect(lastCall[3]).toBe(20)
+
+      jest.useRealTimers()
+    })
   })
 
   describe('Streak summary', () => {

--- a/__tests__/acceptance/history.acceptance.test.tsx
+++ b/__tests__/acceptance/history.acceptance.test.tsx
@@ -245,10 +245,21 @@ describe('Workout History & Calendar Acceptance', () => {
   })
 
   describe('Search', () => {
-    it('renders search bar and calls searchSessions on debounced query input', async () => {
+    it('routes text-search through getFilteredSessions (paged, 20/page) and renders the result', async () => {
+      // BLD-938 — plan §UI Hook: "When any filter is non-null OR text
+      // search active → call getFilteredSessions (paged, 20/page)."
+      // The legacy in-memory searchSessions render path is gone; text
+      // search now uses the same paged DB path as chip filters.
       jest.useFakeTimers()
-      const matchingSessions = [sessionsThisMonth[0]]
-      mockSearchSessions.mockResolvedValue(matchingSessions)
+      const matchingSession = makeSessionRow({
+        id: 'search-hit',
+        name: 'Push Day Match',
+        started_at: day5,
+      })
+      mockGetFilteredSessions.mockResolvedValue({
+        rows: [matchingSession],
+        total: 1,
+      })
 
       const screen = renderScreen(<History />)
       await waitFor(() => {
@@ -256,11 +267,55 @@ describe('Workout History & Calendar Acceptance', () => {
       })
 
       fireEvent.changeText(screen.getByLabelText('Search workout history'), 'Push')
+      // Advance past the 300ms debounce in the unified filter-fetch effect.
       jest.advanceTimersByTime(350)
 
       await waitFor(() => {
-        expect(mockSearchSessions).toHaveBeenCalledWith('Push')
+        expect(mockGetFilteredSessions).toHaveBeenCalled()
       })
+
+      // The call must carry the query, page-0 offset, and the
+      // 20-row page size — it MUST NOT route through the legacy
+      // searchSessions path.
+      const lastCall =
+        mockGetFilteredSessions.mock.calls[mockGetFilteredSessions.mock.calls.length - 1]
+      expect(lastCall[1]).toBe('Push')
+      expect(lastCall[2]).toBe(20)
+      expect(lastCall[3]).toBe(0)
+      expect(mockSearchSessions).not.toHaveBeenCalled()
+
+      // The rendered list MUST come from getFilteredSessions (the
+      // matching session above), not from the unfiltered month load.
+      await waitFor(() => {
+        expect(screen.getAllByLabelText(/Push Day Match/).length).toBeGreaterThan(0)
+      })
+
+      jest.useRealTimers()
+    })
+
+    it('text-search alone does NOT disable the calendar (only chip filters do)', async () => {
+      // Plan §65-69: calendar dim/disable applies when "any filter chip
+      // is active". Text search alone uses the filtered SQL path for
+      // results but keeps the calendar interactive.
+      jest.useFakeTimers()
+      mockGetFilteredSessions.mockResolvedValue({ rows: [], total: 0 })
+
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Search workout history')).toBeTruthy()
+      })
+
+      fireEvent.changeText(screen.getByLabelText('Search workout history'), 'NoMatch')
+      jest.advanceTimersByTime(350)
+
+      await waitFor(() => {
+        expect(mockGetFilteredSessions).toHaveBeenCalled()
+      })
+
+      // Calendar disabled-caption MUST NOT appear for text-search-only.
+      expect(
+        screen.queryByLabelText('Calendar disabled while filters are active'),
+      ).toBeNull()
 
       jest.useRealTimers()
     })
@@ -532,6 +587,63 @@ describe('Workout History & Calendar Acceptance', () => {
         ).toBeNull()
         expect(screen.getByLabelText(/Push Day/)).toBeTruthy()
       })
+    })
+
+    it('combines text search WITH a chip filter into one getFilteredSessions call', async () => {
+      // QD R5 contract: text + chip composes via the same paged path.
+      // Both inputs must arrive on the SAME getFilteredSessions call so
+      // SQL composes them with AND.
+      mockGetFilteredSessions.mockResolvedValue({
+        rows: [
+          {
+            id: 'combined-1',
+            template_id: 'tmpl-upper',
+            name: 'Push Combined',
+            started_at: day5,
+            completed_at: day5 + 3600000,
+            duration_seconds: 3600,
+            notes: '',
+            rating: null,
+            set_count: 10,
+          },
+        ],
+        total: 1,
+      })
+
+      jest.useFakeTimers()
+      const screen = renderScreen(<History />)
+      await waitFor(() => {
+        expect(screen.getByLabelText('Search workout history')).toBeTruthy()
+        expect(screen.getByTestId('history-filter-chip-date')).toBeTruthy()
+      })
+
+      // Apply chip filter first.
+      fireEvent.press(screen.getByTestId('history-filter-chip-date'))
+      await waitFor(() => {
+        expect(screen.getByLabelText(/^This year/)).toBeTruthy()
+      })
+      fireEvent.press(screen.getByLabelText(/^This year/))
+      jest.advanceTimersByTime(350)
+
+      // Then enter a text query.
+      fireEvent.changeText(screen.getByLabelText('Search workout history'), 'Push')
+      jest.advanceTimersByTime(350)
+      jest.useRealTimers()
+
+      await waitFor(() => {
+        // The most recent call must carry BOTH datePreset AND query.
+        const lastCall =
+          mockGetFilteredSessions.mock.calls[mockGetFilteredSessions.mock.calls.length - 1]
+        expect(lastCall[0]).toMatchObject({ datePreset: 'year' })
+        expect(lastCall[1]).toBe('Push')
+        expect(lastCall[2]).toBe(20)
+        expect(lastCall[3]).toBe(0)
+      })
+
+      // Calendar must remain disabled because a chip filter is active.
+      expect(
+        screen.getByLabelText('Calendar disabled while filters are active'),
+      ).toBeTruthy()
     })
   })
 })

--- a/__tests__/hooks/useHistoryData.debounce.test.ts
+++ b/__tests__/hooks/useHistoryData.debounce.test.ts
@@ -1,0 +1,267 @@
+/**
+ * BLD-938 — Debounce + filter-routing behavioural contract for useHistoryData.
+ *
+ * QD blocker R3: the 300ms filter debounce is a stated acceptance criterion
+ * but had no test asserting it. This file fills that gap. We assert the
+ * *observable* contract:
+ *
+ *   1. Rapid filter changes within 300ms collapse to ONE getFilteredSessions
+ *      call carrying the FINAL filter state.
+ *   2. After the 300ms quiet period ends, exactly one fetch is issued.
+ *   3. A subsequent filter change >300ms later issues a SECOND fetch.
+ *   4. `loadMoreFiltered` (filterPage > 0) bypasses the debounce — pagination
+ *      requests must not be coalesced or dropped just because filters are
+ *      changing nearby in time.
+ *   5. Clearing all filters returns the hook to non-filter mode and stops
+ *      issuing new filter fetches.
+ *
+ * Why fake timers: `useEffect` debounce is implemented with setTimeout.
+ * Real time would make assertions flaky; fake timers let us deterministically
+ * advance past / before the 300ms boundary.
+ */
+
+import { renderHook, waitFor, act } from "@testing-library/react-native";
+
+// --- Mock the db module ---
+//
+// `mock`-prefix lets jest's hoisted `jest.mock(...)` call reference it
+// (jest scans for the prefix to allow hoisting safely).
+
+jest.mock("../../lib/db", () => ({
+  getSessionsByMonth: jest.fn(async () => []),
+  getRecentSessions: jest.fn(async () => []),
+  searchSessions: jest.fn(async () => []),
+  getSessionCountsByDay: jest.fn(async () => []),
+  getAllCompletedSessionWeeks: jest.fn(async () => []),
+  getTotalSessionCount: jest.fn(async () => 0),
+  getTemplatesWithSessions: jest.fn(async () => [
+    { id: "tmpl-upper", name: "Upper Body" },
+    { id: "tmpl-lower", name: "Lower Body" },
+  ]),
+  getMuscleGroupsWithSessions: jest.fn(async () => ["chest", "back", "legs"]),
+  getFilteredSessions: jest.fn(async () => ({ rows: [], total: 0 })),
+}));
+
+// Resolve the mocked function lazily — after jest.mock has executed.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const getFilteredSessionsMock = require("../../lib/db").getFilteredSessions as jest.Mock;
+
+jest.mock("../../lib/db/settings", () => ({
+  getSchedule: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("expo-router", () => {
+  const RealReact = require("react");
+  return {
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb();
+        return typeof cleanup === "function" ? cleanup : undefined;
+      }, [cb]);
+    },
+  };
+});
+
+jest.mock("react-native-reanimated", () => ({
+  useSharedValue: <T,>(v: T) => ({ value: v }),
+  useReducedMotion: () => false,
+  withTiming: <T,>(v: T) => v,
+  useAnimatedStyle: (fn: () => Record<string, unknown>) => fn(),
+  Easing: { bezier: () => (t: number) => t },
+}));
+
+jest.mock("react-native-gesture-handler", () => ({
+  Gesture: {
+    Pan: () => ({
+      activeOffsetX: () => ({
+        enabled: () => ({
+          onEnd: () => ({ runOnJS: () => ({}) }),
+        }),
+      }),
+    }),
+  },
+}));
+
+jest.mock("../../lib/layout", () => ({
+  useLayout: () => ({ wide: false, width: 375, scale: 1.0 }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Number of times getFilteredSessions has actually been called by the hook.
+ * (Distinguishes "scheduled but not yet fired" from "fired".)
+ */
+const filteredCallCount = () => getFilteredSessionsMock.mock.calls.length;
+
+/**
+ * Advance fake timers by `ms` and flush microtasks so .then() handlers run.
+ * Without the second await, the promise chain after the timer fires would
+ * still be queued.
+ */
+async function advance(ms: number) {
+  await act(async () => {
+    jest.advanceTimersByTime(ms);
+    // Flush pending microtasks (Promise.then chained inside the effect).
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("BLD-938 — useHistoryData filter debounce (300ms) and routing", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    getFilteredSessionsMock.mockClear();
+    getFilteredSessionsMock.mockImplementation(async () => ({ rows: [], total: 0 }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("rapid filter changes within 300ms collapse to ONE call carrying the final state", async () => {
+    const { useHistoryData } = require("../../hooks/useHistoryData");
+    const { result } = renderHook(() => useHistoryData());
+
+    // Let initial mount-time async loads settle (heatmap, totals, etc.).
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const baseline = filteredCallCount();
+
+    // Three rapid filter changes within the 300ms window.
+    act(() => result.current.setTemplateFilter("tmpl-upper"));
+    await advance(50);
+    act(() => result.current.setTemplateFilter("tmpl-lower"));
+    await advance(50);
+    act(() => result.current.setDatePresetFilter("30d"));
+    // Total elapsed since first change: 100ms. Debounce timer is 300ms.
+    // No fetch should have fired yet.
+    expect(filteredCallCount()).toBe(baseline);
+
+    // Advance past the 300ms boundary from the LAST change.
+    await advance(350);
+
+    await waitFor(() => {
+      expect(filteredCallCount()).toBe(baseline + 1);
+    });
+
+    // The single coalesced call must carry the FINAL state, not an
+    // intermediate one (lower template + 30d preset).
+    const [filtersArg, queryArg, limitArg, offsetArg] =
+      getFilteredSessionsMock.mock.calls[getFilteredSessionsMock.mock.calls.length - 1];
+    expect(filtersArg).toMatchObject({ templateId: "tmpl-lower", datePreset: "30d" });
+    expect(queryArg).toBe("");
+    expect(typeof limitArg).toBe("number");
+    expect(offsetArg).toBe(0);
+  });
+
+  test("a filter change AFTER the quiet period issues a second fetch", async () => {
+    const { useHistoryData } = require("../../hooks/useHistoryData");
+    const { result } = renderHook(() => useHistoryData());
+
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const baseline = filteredCallCount();
+
+    act(() => result.current.setTemplateFilter("tmpl-upper"));
+    await advance(350);
+    await waitFor(() => expect(filteredCallCount()).toBe(baseline + 1));
+
+    // Quiet period elapsed; a fresh change triggers a new debounce window.
+    act(() => result.current.setMuscleGroupFilter("chest"));
+    await advance(350);
+    await waitFor(() => expect(filteredCallCount()).toBe(baseline + 2));
+
+    const lastCall = getFilteredSessionsMock.mock.calls[getFilteredSessionsMock.mock.calls.length - 1];
+    expect(lastCall[0]).toMatchObject({ templateId: "tmpl-upper", muscleGroup: "chest" });
+  });
+
+  test("loadMoreFiltered (filterPage > 0) bypasses the debounce", async () => {
+    // Seed enough rows on first page that filteredRows.length < filteredTotal.
+    getFilteredSessionsMock.mockImplementation(async (_filters: unknown, _q: unknown, limit: number, offset: number) => {
+      // Simulate a result set of 50 total, returning `limit` rows per page.
+      const rows = Array.from({ length: Math.min(limit, 50 - offset) }, (_, i) => ({
+        id: `s-${offset + i}`,
+        template_id: null,
+        name: `Session ${offset + i}`,
+        started_at: 1_700_000_000_000 - (offset + i) * 86_400_000,
+        completed_at: 1_700_000_000_000 - (offset + i) * 86_400_000 + 3_600_000,
+        duration_seconds: 3600,
+        notes: "",
+        rating: null,
+        set_count: 6,
+      }));
+      return { rows, total: 50 };
+    });
+
+    const { useHistoryData } = require("../../hooks/useHistoryData");
+    const { result } = renderHook(() => useHistoryData());
+
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Activate a filter and let the debounced page-0 fetch fire.
+    act(() => result.current.setTemplateFilter("tmpl-upper"));
+    await advance(350);
+    await waitFor(() => expect(filteredCallCount()).toBeGreaterThanOrEqual(1));
+
+    const callsAfterPage0 = filteredCallCount();
+
+    // Ask for more — pagination must NOT be debounced.
+    act(() => result.current.loadMoreFiltered());
+
+    // Without advancing fake timers past 300ms, the pagination fetch must
+    // already have been issued. Allow microtasks to resolve so the
+    // mocked promise settles.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(filteredCallCount()).toBe(callsAfterPage0 + 1);
+
+    // The pagination fetch must carry a non-zero offset.
+    const lastCall = getFilteredSessionsMock.mock.calls[getFilteredSessionsMock.mock.calls.length - 1];
+    expect(lastCall[3]).toBeGreaterThan(0); // offset > 0
+  });
+
+  test("clearAllFilters returns the hook to non-filter mode (no further filter fetches)", async () => {
+    const { useHistoryData } = require("../../hooks/useHistoryData");
+    const { result } = renderHook(() => useHistoryData());
+
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => result.current.setTemplateFilter("tmpl-upper"));
+    await advance(350);
+    await waitFor(() => expect(filteredCallCount()).toBeGreaterThanOrEqual(1));
+    expect(result.current.useFilterMode).toBe(true);
+
+    const callsBeforeClear = filteredCallCount();
+
+    act(() => result.current.clearAllFilters());
+    await advance(350);
+
+    // After clearing, hook drops out of filter mode. The effect's early
+    // return (`if (!useFilterMode && !query.trim()) return`) means no
+    // additional fetch is issued.
+    expect(result.current.useFilterMode).toBe(false);
+    expect(filteredCallCount()).toBe(callsBeforeClear);
+  });
+});

--- a/__tests__/hooks/useHistoryData.integration.test.ts
+++ b/__tests__/hooks/useHistoryData.integration.test.ts
@@ -104,6 +104,11 @@ jest.mock("../../lib/db", () => ({
       .sort((a, b) => b - a);
   }),
   getTotalSessionCount: jest.fn(async () => mockSeedStore.filter(mockIsCompleted).length),
+  // BLD-938: history filter queries — empty so the hook stays on the
+  // unfiltered path (these tests don't activate any chip).
+  getTemplatesWithSessions: jest.fn(async () => []),
+  getMuscleGroupsWithSessions: jest.fn(async () => []),
+  getFilteredSessions: jest.fn(async () => ({ rows: [], total: 0 })),
 }));
 
 jest.mock("../../lib/db/settings", () => ({

--- a/__tests__/hooks/useHistoryFilters.test.ts
+++ b/__tests__/hooks/useHistoryFilters.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for historyFiltersReducer — BLD-938.
+ *
+ * Covers SET / CLEAR_ONE / CLEAR_ALL plus the no-op (referential identity)
+ * behavior that lets memoized consumers skip re-renders.
+ */
+import {
+  INITIAL_HISTORY_FILTERS,
+  historyFiltersReducer,
+  isAnyFilterActive,
+} from "../../hooks/useHistoryFilters";
+
+describe("historyFiltersReducer", () => {
+  describe("SET_TEMPLATE", () => {
+    it("sets a template id", () => {
+      const next = historyFiltersReducer(INITIAL_HISTORY_FILTERS, {
+        type: "SET_TEMPLATE",
+        templateId: "tpl-1",
+      });
+      expect(next.templateId).toBe("tpl-1");
+      expect(next.muscleGroup).toBeNull();
+      expect(next.datePreset).toBeNull();
+    });
+
+    it("clears the template id (passes null)", () => {
+      const seeded = { ...INITIAL_HISTORY_FILTERS, templateId: "tpl-1" };
+      const next = historyFiltersReducer(seeded, {
+        type: "SET_TEMPLATE",
+        templateId: null,
+      });
+      expect(next.templateId).toBeNull();
+    });
+
+    it("returns the same reference when value is unchanged (memoization)", () => {
+      const seeded = { ...INITIAL_HISTORY_FILTERS, templateId: "tpl-1" };
+      const next = historyFiltersReducer(seeded, {
+        type: "SET_TEMPLATE",
+        templateId: "tpl-1",
+      });
+      expect(next).toBe(seeded);
+    });
+  });
+
+  describe("SET_MUSCLE_GROUP", () => {
+    it("sets a muscle group", () => {
+      const next = historyFiltersReducer(INITIAL_HISTORY_FILTERS, {
+        type: "SET_MUSCLE_GROUP",
+        muscleGroup: "chest",
+      });
+      expect(next.muscleGroup).toBe("chest");
+    });
+
+    it("does not affect other filters", () => {
+      const seeded = { ...INITIAL_HISTORY_FILTERS, templateId: "tpl-1" };
+      const next = historyFiltersReducer(seeded, {
+        type: "SET_MUSCLE_GROUP",
+        muscleGroup: "chest",
+      });
+      expect(next.templateId).toBe("tpl-1");
+      expect(next.muscleGroup).toBe("chest");
+    });
+  });
+
+  describe("SET_DATE_PRESET", () => {
+    it("sets a date preset", () => {
+      const next = historyFiltersReducer(INITIAL_HISTORY_FILTERS, {
+        type: "SET_DATE_PRESET",
+        datePreset: "30d",
+      });
+      expect(next.datePreset).toBe("30d");
+    });
+
+    it("clears the date preset (passes null)", () => {
+      const seeded = { ...INITIAL_HISTORY_FILTERS, datePreset: "7d" as const };
+      const next = historyFiltersReducer(seeded, {
+        type: "SET_DATE_PRESET",
+        datePreset: null,
+      });
+      expect(next.datePreset).toBeNull();
+    });
+  });
+
+  describe("CLEAR_ONE", () => {
+    it("clears a specific filter while leaving others intact", () => {
+      const seeded = {
+        templateId: "tpl-1",
+        muscleGroup: "chest",
+        datePreset: "30d" as const,
+      };
+      const next = historyFiltersReducer(seeded, {
+        type: "CLEAR_ONE",
+        key: "muscleGroup",
+      });
+      expect(next.templateId).toBe("tpl-1");
+      expect(next.muscleGroup).toBeNull();
+      expect(next.datePreset).toBe("30d");
+    });
+
+    it("returns the same reference when the target is already null", () => {
+      const seeded = { ...INITIAL_HISTORY_FILTERS, templateId: "tpl-1" };
+      const next = historyFiltersReducer(seeded, {
+        type: "CLEAR_ONE",
+        key: "muscleGroup",
+      });
+      expect(next).toBe(seeded);
+    });
+  });
+
+  describe("CLEAR_ALL", () => {
+    it("clears every filter", () => {
+      const seeded = {
+        templateId: "tpl-1",
+        muscleGroup: "chest",
+        datePreset: "30d" as const,
+      };
+      const next = historyFiltersReducer(seeded, { type: "CLEAR_ALL" });
+      expect(next).toEqual(INITIAL_HISTORY_FILTERS);
+    });
+
+    it("is a no-op when state is already initial (referential identity)", () => {
+      const next = historyFiltersReducer(INITIAL_HISTORY_FILTERS, {
+        type: "CLEAR_ALL",
+      });
+      expect(next).toBe(INITIAL_HISTORY_FILTERS);
+    });
+  });
+
+  describe("isAnyFilterActive", () => {
+    it("returns false for the initial state", () => {
+      expect(isAnyFilterActive(INITIAL_HISTORY_FILTERS)).toBe(false);
+    });
+
+    it("returns true when any single filter is set", () => {
+      expect(
+        isAnyFilterActive({ ...INITIAL_HISTORY_FILTERS, templateId: "x" })
+      ).toBe(true);
+      expect(
+        isAnyFilterActive({ ...INITIAL_HISTORY_FILTERS, muscleGroup: "chest" })
+      ).toBe(true);
+      expect(
+        isAnyFilterActive({ ...INITIAL_HISTORY_FILTERS, datePreset: "7d" })
+      ).toBe(true);
+    });
+  });
+});

--- a/__tests__/lib/db/getFilteredSessions.behaviour.test.ts
+++ b/__tests__/lib/db/getFilteredSessions.behaviour.test.ts
@@ -1,0 +1,406 @@
+/**
+ * BLD-938 — Behavioural contract for `getFilteredSessions` SQL composition.
+ *
+ * Why mirror-the-SQL via `node:sqlite` instead of mocking expo-sqlite?
+ * The contract that matters here is the SQL planner's behaviour over real
+ * rows — composition of WHERE clauses (template_id AND date >= ? AND
+ * name LIKE ? AND EXISTS muscle…), the `total` semantics (count without
+ * LIMIT/OFFSET), and the `year` preset semantics (calendar year, NOT a
+ * rolling 365-day window — see QD R4 blocker / fix).
+ *
+ * Mocking expo-sqlite would assert that we *call* it with strings; this
+ * file asserts that the strings, executed against a real SQLite, return
+ * the right rows. Same precedent as `history-filters.test.ts`.
+ *
+ * The SQL strings in this file MUST stay structurally identical to
+ * `lib/db/session-stats.ts`'s `getFilteredSessions` — when production
+ * SQL changes, this file changes with it. The cost of the duplication
+ * is the price of having a real-engine assertion that doesn't depend
+ * on the production module being executable in Node.
+ */
+
+import { DatabaseSync } from "node:sqlite";
+
+// -----------------------------------------------------------------------------
+// SQL builder — mirrors getFilteredSessions in lib/db/session-stats.ts.
+// Keep in lock-step with the production query.
+// -----------------------------------------------------------------------------
+
+type Filters = {
+  templateId: string | null;
+  muscleGroup: string | null;
+  datePreset: "7d" | "30d" | "90d" | "year" | null;
+};
+
+function buildFilteredQuery(
+  filters: Filters,
+  textSearch: string,
+  limit: number,
+  offset: number,
+  nowMs: number,
+): { whereClause: string; params: (string | number)[]; pageParams: (string | number)[] } {
+  const clauses: string[] = ["s.completed_at IS NOT NULL"];
+  const params: (string | number)[] = [];
+
+  if (filters.templateId) {
+    clauses.push("s.template_id = ?");
+    params.push(filters.templateId);
+  }
+
+  if (filters.datePreset) {
+    let cutoff: number;
+    if (filters.datePreset === "year") {
+      const today = new Date(nowMs);
+      cutoff = new Date(today.getFullYear(), 0, 1, 0, 0, 0, 0).getTime();
+    } else {
+      const ms =
+        filters.datePreset === "7d" ? 7 * 24 * 60 * 60 * 1000 :
+        filters.datePreset === "30d" ? 30 * 24 * 60 * 60 * 1000 :
+        90 * 24 * 60 * 60 * 1000;
+      cutoff = nowMs - ms;
+    }
+    clauses.push("s.started_at >= ?");
+    params.push(cutoff);
+  }
+
+  if (textSearch.trim()) {
+    clauses.push("s.name LIKE ?");
+    params.push(`%${textSearch.trim()}%`);
+  }
+
+  if (filters.muscleGroup) {
+    const m = filters.muscleGroup;
+    clauses.push(
+      `EXISTS (
+         SELECT 1 FROM workout_sets ws2
+         JOIN exercises e ON ws2.exercise_id = e.id
+         WHERE ws2.session_id = s.id
+           AND (
+             e.primary_muscles LIKE ?
+             OR e.primary_muscles = ?
+             OR e.primary_muscles LIKE ?
+             OR e.primary_muscles LIKE ?
+             OR e.primary_muscles LIKE ?
+             OR e.secondary_muscles LIKE ?
+             OR e.secondary_muscles = ?
+             OR e.secondary_muscles LIKE ?
+             OR e.secondary_muscles LIKE ?
+             OR e.secondary_muscles LIKE ?
+           )
+       )`,
+    );
+    params.push(`%"${m}"%`);
+    params.push(m);
+    params.push(`${m},%`);
+    params.push(`%,${m},%`);
+    params.push(`%,${m}`);
+    params.push(`%"${m}"%`);
+    params.push(m);
+    params.push(`${m},%`);
+    params.push(`%,${m},%`);
+    params.push(`%,${m}`);
+  }
+
+  return {
+    whereClause: clauses.join(" AND "),
+    params,
+    pageParams: [...params, limit, offset],
+  };
+}
+
+function runFiltered(
+  db: DatabaseSync,
+  filters: Filters,
+  textSearch = "",
+  limit = 20,
+  offset = 0,
+  nowMs = Date.now(),
+): { rows: { id: string; name: string; started_at: number }[]; total: number } {
+  const { whereClause, params, pageParams } = buildFilteredQuery(
+    filters,
+    textSearch,
+    limit,
+    offset,
+    nowMs,
+  );
+
+  const countRow = db
+    .prepare(`SELECT COUNT(*) AS total FROM workout_sessions s WHERE ${whereClause}`)
+    .get(...params) as { total: number };
+
+  const rows = db
+    .prepare(
+      `SELECT s.id, s.name, s.started_at
+       FROM workout_sessions s
+       WHERE ${whereClause}
+       ORDER BY s.started_at DESC
+       LIMIT ? OFFSET ?`,
+    )
+    .all(...pageParams) as { id: string; name: string; started_at: number }[];
+
+  return { rows, total: countRow.total };
+}
+
+// -----------------------------------------------------------------------------
+// Test fixture
+// -----------------------------------------------------------------------------
+
+const NOW = new Date(2026, 5, 15, 12, 0, 0).getTime(); // June 15 2026, noon
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+describe("BLD-938 — getFilteredSessions composition (behavioural contract)", () => {
+  let db: DatabaseSync;
+
+  beforeAll(() => {
+    db = new DatabaseSync(":memory:");
+    db.exec(`
+      CREATE TABLE exercises (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        primary_muscles TEXT NOT NULL,
+        secondary_muscles TEXT NOT NULL
+      );
+      CREATE TABLE workout_sessions (
+        id TEXT PRIMARY KEY,
+        template_id TEXT,
+        name TEXT NOT NULL,
+        started_at INTEGER NOT NULL,
+        completed_at INTEGER
+      );
+      CREATE TABLE workout_sets (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        exercise_id TEXT NOT NULL
+      );
+    `);
+
+    const exInsert = db.prepare(
+      "INSERT INTO exercises (id, name, primary_muscles, secondary_muscles) VALUES (?, ?, ?, ?)",
+    );
+    exInsert.run("ex-bench", "Bench", '["chest","shoulders"]', '["triceps"]');
+    exInsert.run("ex-squat", "Squat", "quads,glutes", "hamstrings");
+    exInsert.run("ex-row", "Row", "back,biceps", "");
+
+    const sInsert = db.prepare(
+      "INSERT INTO workout_sessions (id, template_id, name, started_at, completed_at) VALUES (?, ?, ?, ?, ?)",
+    );
+    const setInsert = db.prepare(
+      "INSERT INTO workout_sets (id, session_id, exercise_id) VALUES (?, ?, ?)",
+    );
+
+    // Seed a mix of sessions across templates and dates.
+    // Layout (relative to NOW = 2026-06-15):
+    //   sess-A  template-upper, name "Upper Body A", -1 day  (recent, this year)
+    //   sess-B  template-upper, name "Upper Body A", -45 days (this year)
+    //   sess-C  template-upper, name "Upper Body A", -200 days (this year, > 90d)
+    //   sess-D  template-lower, name "Leg Day",       -2 days
+    //   sess-E  template-lower, name "Leg Day",       -100 days
+    //   sess-X  NULL template,  name "Ad Hoc Lift",   -3 days   (excluded by template filter)
+    //   sess-Y  template-upper, name "Upper Body A", -400 days (LAST YEAR — must be excluded by "year" preset)
+    //   sess-Z  template-upper, name "Upper Body A", -1 day, completed_at NULL (in-progress — must be excluded)
+    const seed: [string, string | null, string, number, number | null, string][] = [
+      ["sess-A", "template-upper", "Upper Body A", NOW - 1 * ONE_DAY, NOW - 1 * ONE_DAY + 3600000, "ex-bench"],
+      ["sess-B", "template-upper", "Upper Body A", NOW - 45 * ONE_DAY, NOW - 45 * ONE_DAY + 3600000, "ex-bench"],
+      ["sess-C", "template-upper", "Upper Body A", NOW - 200 * ONE_DAY, NOW - 200 * ONE_DAY + 3600000, "ex-bench"],
+      ["sess-D", "template-lower", "Leg Day", NOW - 2 * ONE_DAY, NOW - 2 * ONE_DAY + 3600000, "ex-squat"],
+      ["sess-E", "template-lower", "Leg Day", NOW - 100 * ONE_DAY, NOW - 100 * ONE_DAY + 3600000, "ex-squat"],
+      ["sess-X", null, "Ad Hoc Lift", NOW - 3 * ONE_DAY, NOW - 3 * ONE_DAY + 3600000, "ex-row"],
+      ["sess-Y", "template-upper", "Upper Body A", NOW - 400 * ONE_DAY, NOW - 400 * ONE_DAY + 3600000, "ex-bench"],
+      ["sess-Z", "template-upper", "Upper Body A", NOW - 1 * ONE_DAY, null, "ex-bench"], // in-progress
+    ];
+    for (const [id, tid, name, started, completed, exId] of seed) {
+      sInsert.run(id, tid, name, started, completed);
+      setInsert.run(`set-${id}`, id, exId);
+    }
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  describe("base predicate", () => {
+    it("excludes in-progress sessions (completed_at IS NULL)", () => {
+      const result = runFiltered(db, { templateId: null, muscleGroup: null, datePreset: null }, "", 100, 0, NOW);
+      // 7 completed sessions seeded (sess-Z is in-progress and excluded).
+      expect(result.total).toBe(7);
+      expect(result.rows.map((r) => r.id)).not.toContain("sess-Z");
+    });
+  });
+
+  describe("template filter", () => {
+    it("filters by stable template_id and excludes ad-hoc (NULL template_id) sessions", () => {
+      const result = runFiltered(
+        db,
+        { templateId: "template-upper", muscleGroup: null, datePreset: null },
+        "",
+        100, 0, NOW,
+      );
+      // Upper has A, B, C, Y; Z is in-progress. X is ad-hoc and must be excluded.
+      expect(result.total).toBe(4);
+      expect(result.rows.map((r) => r.id).sort()).toEqual(["sess-A", "sess-B", "sess-C", "sess-Y"]);
+    });
+
+    it("returns no rows for an unknown template_id", () => {
+      const result = runFiltered(
+        db,
+        { templateId: "template-does-not-exist", muscleGroup: null, datePreset: null },
+        "",
+        100, 0, NOW,
+      );
+      expect(result).toEqual({ rows: [], total: 0 });
+    });
+  });
+
+  describe("date preset semantics", () => {
+    it('"7d" — only sessions in the last 7 days', () => {
+      const result = runFiltered(
+        db,
+        { templateId: null, muscleGroup: null, datePreset: "7d" },
+        "", 100, 0, NOW,
+      );
+      // Sessions within 7 days of NOW: A (-1), D (-2), X (-3). B is at -45 days.
+      expect(result.rows.map((r) => r.id).sort()).toEqual(["sess-A", "sess-D", "sess-X"]);
+    });
+
+    it('"30d" — only sessions in the last 30 days', () => {
+      const result = runFiltered(
+        db,
+        { templateId: null, muscleGroup: null, datePreset: "30d" },
+        "", 100, 0, NOW,
+      );
+      // Same as 7d here (B is at -45, just outside 30d).
+      expect(result.rows.map((r) => r.id).sort()).toEqual(["sess-A", "sess-D", "sess-X"]);
+    });
+
+    it('"90d" — sessions in the last 90 days (includes -45)', () => {
+      const result = runFiltered(
+        db,
+        { templateId: null, muscleGroup: null, datePreset: "90d" },
+        "", 100, 0, NOW,
+      );
+      // -1, -2, -3, -45 within window; -100 and -200 outside.
+      expect(result.rows.map((r) => r.id).sort()).toEqual([
+        "sess-A", "sess-B", "sess-D", "sess-X",
+      ]);
+    });
+
+    it('"year" — calendar year (Jan 1 of THIS year), NOT a rolling 365-day window', () => {
+      // QD R4 blocker resolution: NOW = 2026-06-15. "year" must mean
+      // started_at >= 2026-01-01 00:00:00 local, i.e. ~165 days back.
+      // sess-C is at -200 days (~Nov 2025) — must be EXCLUDED.
+      // A rolling 365-day window would have INCLUDED -200, which was the bug.
+      const result = runFiltered(
+        db,
+        { templateId: null, muscleGroup: null, datePreset: "year" },
+        "", 100, 0, NOW,
+      );
+      const ids = result.rows.map((r) => r.id).sort();
+      // Within calendar 2026: A (-1), B (-45), D (-2), E (-100), X (-3).
+      // Excluded: C (-200, last calendar year), Y (-400, prior year).
+      expect(ids).toEqual(["sess-A", "sess-B", "sess-D", "sess-E", "sess-X"]);
+      expect(ids).not.toContain("sess-C"); // <— the regression guard
+      expect(ids).not.toContain("sess-Y");
+    });
+  });
+
+  describe("text search", () => {
+    it("matches s.name LIKE %search%", () => {
+      const result = runFiltered(
+        db,
+        { templateId: null, muscleGroup: null, datePreset: null },
+        "Leg",
+        100, 0, NOW,
+      );
+      expect(result.rows.map((r) => r.id).sort()).toEqual(["sess-D", "sess-E"]);
+    });
+
+    it("trims whitespace before matching", () => {
+      const result = runFiltered(
+        db,
+        { templateId: null, muscleGroup: null, datePreset: null },
+        "   Leg   ",
+        100, 0, NOW,
+      );
+      expect(result.total).toBe(2);
+    });
+  });
+
+  describe("composition (AND across all clauses)", () => {
+    it("template + date 30d returns intersection", () => {
+      // Upper templates within 30 days: only sess-A (-1). B is at -45.
+      const result = runFiltered(
+        db,
+        { templateId: "template-upper", muscleGroup: null, datePreset: "30d" },
+        "", 100, 0, NOW,
+      );
+      expect(result.rows.map((r) => r.id)).toEqual(["sess-A"]);
+    });
+
+    it("template + text search returns intersection (no false positives from name match)", () => {
+      // sess-X is named "Ad Hoc Lift" — different name. Filter for
+      // template-upper AND search "Upper" returns only template-upper rows
+      // and never sess-X even if its name happened to also contain "Upper".
+      const result = runFiltered(
+        db,
+        { templateId: "template-upper", muscleGroup: null, datePreset: null },
+        "Upper",
+        100, 0, NOW,
+      );
+      expect(result.rows.map((r) => r.id).sort()).toEqual(["sess-A", "sess-B", "sess-C", "sess-Y"]);
+      expect(result.rows.map((r) => r.id)).not.toContain("sess-X");
+    });
+
+    it("template + muscle + date all combined", () => {
+      // Upper template + chest muscle (bench-press primary) + last 90 days.
+      // bench is in sess-A, B, C, Y. Within 90d: A (-1), B (-45). So [A, B].
+      const result = runFiltered(
+        db,
+        { templateId: "template-upper", muscleGroup: "chest", datePreset: "90d" },
+        "", 100, 0, NOW,
+      );
+      expect(result.rows.map((r) => r.id).sort()).toEqual(["sess-A", "sess-B"]);
+    });
+  });
+
+  describe("pagination + total semantics", () => {
+    it("total reflects all matching rows; LIMIT/OFFSET only narrows the slice", () => {
+      // Use template-upper which has 4 completed sessions.
+      const all = runFiltered(
+        db,
+        { templateId: "template-upper", muscleGroup: null, datePreset: null },
+        "", 100, 0, NOW,
+      );
+      expect(all.total).toBe(4);
+      expect(all.rows).toHaveLength(4);
+
+      const page0 = runFiltered(
+        db,
+        { templateId: "template-upper", muscleGroup: null, datePreset: null },
+        "", 2, 0, NOW,
+      );
+      expect(page0.total).toBe(4);            // total is unchanged
+      expect(page0.rows).toHaveLength(2);      // page is 2 rows
+      // Sorted DESC by started_at: A (-1), B (-45) come first.
+      expect(page0.rows.map((r) => r.id)).toEqual(["sess-A", "sess-B"]);
+
+      const page1 = runFiltered(
+        db,
+        { templateId: "template-upper", muscleGroup: null, datePreset: null },
+        "", 2, 2, NOW,
+      );
+      expect(page1.total).toBe(4);
+      expect(page1.rows).toHaveLength(2);
+      expect(page1.rows.map((r) => r.id)).toEqual(["sess-C", "sess-Y"]);
+    });
+
+    it("offset past the end returns zero rows but keeps the correct total", () => {
+      const out = runFiltered(
+        db,
+        { templateId: "template-upper", muscleGroup: null, datePreset: null },
+        "", 20, 100, NOW,
+      );
+      expect(out.total).toBe(4);
+      expect(out.rows).toEqual([]);
+    });
+  });
+});

--- a/__tests__/lib/db/history-filters.test.ts
+++ b/__tests__/lib/db/history-filters.test.ts
@@ -1,0 +1,245 @@
+/**
+ * BLD-938 — Behavioural contract for the muscle-group dual-format LIKE
+ * pattern used by `getFilteredSessions` (lib/db/session-stats.ts).
+ *
+ * The production query binds the same muscle string into 10 LIKE clauses
+ * spanning JSON / CSV-only / CSV-start / CSV-middle / CSV-end variants,
+ * across BOTH `primary_muscles` and `secondary_muscles`. Mocking
+ * expo-sqlite here would prove nothing — the contract is the SQL
+ * planner's behaviour over real strings. So we re-execute the same
+ * pattern against an in-memory `node:sqlite` engine (BLD-822 precedent
+ * — see grip-history-query-plan.test.ts) and assert the row-level
+ * semantics:
+ *
+ *   1. JSON storage with the muscle present matches.
+ *   2. CSV storage with the muscle present matches in any position
+ *      (only / start / middle / end).
+ *   3. The same patterns apply to `secondary_muscles` (so push-ups
+ *      surface under "triceps").
+ *   4. Substring-collision protection: a filter for `back` does NOT
+ *      match an exercise whose only muscle is `upper_back`, in either
+ *      storage format.
+ */
+
+import { DatabaseSync } from "node:sqlite";
+
+// Mirrors the literal LIKE pattern emitted by getFilteredSessions for
+// the muscle-group filter. Keep this in sync with lib/db/session-stats.ts.
+const MUSCLE_FILTER_SQL = `
+  SELECT s.id FROM workout_sessions s
+  WHERE s.completed_at IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM workout_sets ws2
+      JOIN exercises e ON ws2.exercise_id = e.id
+      WHERE ws2.session_id = s.id
+        AND (
+          e.primary_muscles LIKE ?
+          OR e.primary_muscles = ?
+          OR e.primary_muscles LIKE ?
+          OR e.primary_muscles LIKE ?
+          OR e.primary_muscles LIKE ?
+          OR e.secondary_muscles LIKE ?
+          OR e.secondary_muscles = ?
+          OR e.secondary_muscles LIKE ?
+          OR e.secondary_muscles LIKE ?
+          OR e.secondary_muscles LIKE ?
+        )
+    )
+  ORDER BY s.started_at DESC
+`;
+
+function muscleParams(muscle: string): string[] {
+  return [
+    `%"${muscle}"%`,    // JSON in primary
+    muscle,              // CSV only in primary
+    `${muscle},%`,       // CSV start in primary
+    `%,${muscle},%`,     // CSV middle in primary
+    `%,${muscle}`,       // CSV end in primary
+    `%"${muscle}"%`,    // JSON in secondary
+    muscle,              // CSV only in secondary
+    `${muscle},%`,       // CSV start in secondary
+    `%,${muscle},%`,     // CSV middle in secondary
+    `%,${muscle}`,       // CSV end in secondary
+  ];
+}
+
+describe("BLD-938 — muscle-group filter LIKE pattern (behavioural contract)", () => {
+  let db: DatabaseSync;
+
+  beforeAll(() => {
+    db = new DatabaseSync(":memory:");
+
+    // Mirror just the columns the muscle filter touches. Exercise rows
+    // exercise both storage formats.
+    db.exec(`
+      CREATE TABLE exercises (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        primary_muscles TEXT NOT NULL,
+        secondary_muscles TEXT NOT NULL
+      );
+
+      CREATE TABLE workout_sessions (
+        id TEXT PRIMARY KEY,
+        started_at INTEGER NOT NULL,
+        completed_at INTEGER
+      );
+
+      CREATE TABLE workout_sets (
+        id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        exercise_id TEXT NOT NULL
+      );
+    `);
+
+    const insertExercise = db.prepare(
+      "INSERT INTO exercises (id, name, primary_muscles, secondary_muscles) VALUES (?, ?, ?, ?)"
+    );
+    const insertSession = db.prepare(
+      "INSERT INTO workout_sessions (id, started_at, completed_at) VALUES (?, ?, ?)"
+    );
+    const insertSet = db.prepare(
+      "INSERT INTO workout_sets (id, session_id, exercise_id) VALUES (?, ?, ?)"
+    );
+
+    // Exercise inventory exercising every storage shape the filter must
+    // honour. The first pair of columns is primary, the second secondary.
+    const exercises: [string, string, string, string][] = [
+      // JSON format, multi-value primary, simple secondary
+      ["ex-bench-press", "Bench Press", '["chest","shoulders"]', '["triceps"]'],
+      // CSV format, only-token primary
+      ["ex-leg-extension", "Leg Extension", "quads", ""],
+      // CSV format, multi-value primary at the start position
+      ["ex-deadlift", "Deadlift", "back,glutes,hamstrings", "forearms"],
+      // CSV format, multi-value primary at the middle position
+      ["ex-row", "Cable Row", "lats,back,biceps", "rear_delts"],
+      // CSV format, multi-value primary at the end position
+      ["ex-pulldown", "Lat Pulldown", "lats,biceps,back", ""],
+      // Substring-collision exercise: ONLY upper_back. Must NOT match
+      // a `back` filter in either format.
+      ["ex-shrug", "Upper-Back Shrug (CSV)", "upper_back", ""],
+      ["ex-shrug-json", "Upper-Back Shrug (JSON)", '["upper_back"]', '[]'],
+      // Push-ups: secondary triceps via JSON. Per QD R3, must surface
+      // under the "triceps" filter.
+      ["ex-pushup", "Push-ups", '["chest"]', '["triceps","shoulders"]'],
+      // Cable raise: secondary triceps via CSV (start position).
+      ["ex-cable-raise", "Cable Front Raise", "shoulders", "triceps,chest"],
+    ];
+    for (const row of exercises) insertExercise.run(...row);
+
+    // Sessions and the sets that link them to exercises. Each session has
+    // exactly one set for clarity. completed_at is set so the WHERE
+    // completed_at IS NOT NULL clause passes.
+    const now = Date.now();
+    const sessions: [string, string, number][] = [
+      ["sess-bench", "ex-bench-press", now - 6 * 86400000],
+      ["sess-leg", "ex-leg-extension", now - 5 * 86400000],
+      ["sess-dl", "ex-deadlift", now - 4 * 86400000],
+      ["sess-row", "ex-row", now - 3 * 86400000],
+      ["sess-pull", "ex-pulldown", now - 2 * 86400000],
+      ["sess-shrug-csv", "ex-shrug", now - 8 * 86400000],
+      ["sess-shrug-json", "ex-shrug-json", now - 9 * 86400000],
+      ["sess-pushup", "ex-pushup", now - 1 * 86400000],
+      ["sess-cable-raise", "ex-cable-raise", now - 7 * 86400000],
+    ];
+    for (const [sessId, exId, started] of sessions) {
+      insertSession.run(sessId, started, started + 1800000);
+      insertSet.run(`set-${sessId}`, sessId, exId);
+    }
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  function ids(muscle: string): string[] {
+    const stmt = db.prepare(MUSCLE_FILTER_SQL);
+    const rows = stmt.all(...muscleParams(muscle)) as { id: string }[];
+    return rows.map((r) => r.id).sort();
+  }
+
+  describe("JSON storage format", () => {
+    it("matches a JSON-quoted value in primary_muscles", () => {
+      // bench-press primary contains "chest" via JSON
+      expect(ids("chest")).toContain("sess-bench");
+      // push-ups primary is JSON ["chest"]
+      expect(ids("chest")).toContain("sess-pushup");
+    });
+
+    it("matches a JSON-quoted value in secondary_muscles", () => {
+      // bench-press secondary contains "triceps" via JSON
+      expect(ids("triceps")).toContain("sess-bench");
+      // push-ups secondary contains "triceps" via JSON
+      expect(ids("triceps")).toContain("sess-pushup");
+    });
+  });
+
+  describe("CSV storage format", () => {
+    it("matches an only-token CSV primary_muscles", () => {
+      // leg-extension primary = "quads"
+      expect(ids("quads")).toEqual(["sess-leg"]);
+    });
+
+    it("matches a start-position CSV primary_muscles", () => {
+      // deadlift primary = "back,glutes,hamstrings" — start
+      expect(ids("back")).toContain("sess-dl");
+    });
+
+    it("matches a middle-position CSV primary_muscles", () => {
+      // row primary = "lats,back,biceps" — middle
+      expect(ids("back")).toContain("sess-row");
+    });
+
+    it("matches an end-position CSV primary_muscles", () => {
+      // pulldown primary = "lats,biceps,back" — end
+      expect(ids("back")).toContain("sess-pull");
+    });
+
+    it("matches a start-position CSV secondary_muscles", () => {
+      // cable-raise secondary = "triceps,chest" — start
+      expect(ids("triceps")).toContain("sess-cable-raise");
+    });
+  });
+
+  describe("substring-collision safety (plan §JSON-substring collision risk)", () => {
+    it("filter for 'back' does NOT match upper_back in CSV storage", () => {
+      // ex-shrug primary = "upper_back" — must not surface under 'back'
+      const matches = ids("back");
+      expect(matches).not.toContain("sess-shrug-csv");
+    });
+
+    it("filter for 'back' does NOT match upper_back in JSON storage", () => {
+      // ex-shrug-json primary = ["upper_back"] — must not surface under 'back'
+      const matches = ids("back");
+      expect(matches).not.toContain("sess-shrug-json");
+    });
+
+    it("filter for 'upper_back' DOES match upper_back exercises", () => {
+      // Sanity: the more specific filter still works
+      const matches = ids("upper_back");
+      expect(matches).toEqual(
+        expect.arrayContaining(["sess-shrug-csv", "sess-shrug-json"])
+      );
+    });
+  });
+
+  describe("set composition", () => {
+    it("'back' returns exactly the deadlift, row, and pulldown sessions", () => {
+      // Three exercises explicitly tagged with the 'back' token (start /
+      // middle / end). upper_back exercises are correctly excluded.
+      expect(ids("back")).toEqual(["sess-dl", "sess-pull", "sess-row"]);
+    });
+
+    it("'triceps' returns bench / pushup / cable-raise (mixed JSON+CSV secondary)", () => {
+      expect(ids("triceps")).toEqual([
+        "sess-bench",
+        "sess-cable-raise",
+        "sess-pushup",
+      ]);
+    });
+
+    it("a muscle absent from every exercise returns no sessions", () => {
+      expect(ids("calves")).toEqual([]);
+    });
+  });
+});

--- a/__tests__/lib/muscle-format.test.ts
+++ b/__tests__/lib/muscle-format.test.ts
@@ -1,0 +1,84 @@
+import { parseMuscleList } from "@/lib/db/muscle-format";
+
+describe("parseMuscleList", () => {
+  describe("JSON format", () => {
+    test("parses well-formed JSON array of strings", () => {
+      expect(parseMuscleList('["chest","triceps"]')).toEqual(["chest", "triceps"]);
+    });
+
+    test("parses single-element JSON array", () => {
+      expect(parseMuscleList('["chest"]')).toEqual(["chest"]);
+    });
+
+    test("parses empty JSON array", () => {
+      expect(parseMuscleList("[]")).toEqual([]);
+    });
+
+    test("trims whitespace inside JSON values", () => {
+      expect(parseMuscleList('["chest"," triceps "]')).toEqual(["chest", "triceps"]);
+    });
+
+    test("filters non-string entries from JSON array", () => {
+      expect(parseMuscleList('["chest",null,42,"triceps"]')).toEqual(["chest", "triceps"]);
+    });
+
+    test("falls back to CSV split when JSON is malformed", () => {
+      // Starts with [ but is not valid JSON. CSV split treats the whole thing
+      // as a comma-less single token (with leading bracket) — practical fallback.
+      expect(parseMuscleList('["chest"')).toEqual(['["chest"']);
+    });
+  });
+
+  describe("CSV format", () => {
+    test("parses comma-separated values", () => {
+      expect(parseMuscleList("chest,triceps")).toEqual(["chest", "triceps"]);
+    });
+
+    test("parses single value with no commas", () => {
+      expect(parseMuscleList("chest")).toEqual(["chest"]);
+    });
+
+    test("trims whitespace around CSV tokens", () => {
+      expect(parseMuscleList("chest, triceps , shoulders")).toEqual([
+        "chest",
+        "triceps",
+        "shoulders",
+      ]);
+    });
+
+    test("removes empty tokens (e.g. trailing comma)", () => {
+      expect(parseMuscleList("chest,,triceps,")).toEqual(["chest", "triceps"]);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("returns [] for null", () => {
+      expect(parseMuscleList(null)).toEqual([]);
+    });
+
+    test("returns [] for undefined", () => {
+      expect(parseMuscleList(undefined)).toEqual([]);
+    });
+
+    test("returns [] for empty string", () => {
+      expect(parseMuscleList("")).toEqual([]);
+    });
+
+    test("returns [] for whitespace-only string", () => {
+      expect(parseMuscleList("   ")).toEqual([]);
+    });
+  });
+
+  describe("substring-collision safety (BLD-925 plan §JSON-substring collision risk)", () => {
+    // Plan documents the assumption that muscle identifiers do not appear as
+    // substrings of other identifiers between delimiters. parseMuscleList
+    // must surface upper_back as a distinct value, not as "back".
+    test("preserves upper_back distinct from back (CSV)", () => {
+      expect(parseMuscleList("upper_back,glutes")).toEqual(["upper_back", "glutes"]);
+    });
+
+    test("preserves upper_back distinct from back (JSON)", () => {
+      expect(parseMuscleList('["upper_back","glutes"]')).toEqual(["upper_back", "glutes"]);
+    });
+  });
+});

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -37,12 +37,13 @@ function HistoryScreen() {
   return (
     <>
       <FlatList
+        testID="history-list"
         data={h.filtered}
         keyExtractor={(item) => item.id}
         renderItem={renderSession}
         style={{ flex: 1, backgroundColor: colors.background }}
         contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: tabBarHeight }}
-        onEndReached={h.useFilterMode ? h.loadMoreFiltered : undefined}
+        onEndReached={h.useFilteredQueryPath ? h.loadMoreFiltered : undefined}
         onEndReachedThreshold={0.5}
         ListHeaderComponent={
           <>

--- a/app/history.tsx
+++ b/app/history.tsx
@@ -1,4 +1,5 @@
-import { StyleSheet, View, FlatList } from "react-native";
+import { StyleSheet, View, FlatList, Pressable } from "react-native";
+import React, { useState } from "react";
 import { Text } from "@/components/ui/text";
 import { Chip } from "@/components/ui/chip";
 import { Icon } from "@/components/ui/icon";
@@ -13,6 +14,10 @@ import StreakAndHeatmap from "@/components/history/StreakAndHeatmap";
 import CalendarGrid from "@/components/history/CalendarGrid";
 import DayDetailPanel from "@/components/history/DayDetailPanel";
 import { useSessionRenderer } from "@/components/history/SessionRenderer";
+import { FilterBar } from "@/components/history/FilterBar";
+import { TemplateFilterSheet } from "@/components/history/TemplateFilterSheet";
+import { MuscleGroupFilterSheet } from "@/components/history/MuscleGroupFilterSheet";
+import { DateRangeFilterSheet } from "@/components/history/DateRangeFilterSheet";
 
 const MIN_TOUCH_TARGET = 48;
 
@@ -23,82 +28,165 @@ function HistoryScreen() {
   const h = useHistoryData();
   const renderSession = useSessionRenderer({ colors });
 
+  const [templateSheetOpen, setTemplateSheetOpen] = useState(false);
+  const [muscleSheetOpen, setMuscleSheetOpen] = useState(false);
+  const [dateSheetOpen, setDateSheetOpen] = useState(false);
+
   const cellSize = Math.max(MIN_TOUCH_TARGET, Math.floor((layout.width - layout.horizontalPadding * 2) / 7));
 
   return (
-    <FlatList
-      data={h.filtered}
-      keyExtractor={(item) => item.id}
-      renderItem={renderSession}
-      style={{ flex: 1, backgroundColor: colors.background }}
-      contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: tabBarHeight }}
-      ListHeaderComponent={
-        <>
-          <StreakAndHeatmap
-            colors={colors}
-            currentStreak={h.currentStreak}
-            longestStreak={h.longestStreak}
-            totalWorkouts={h.totalWorkouts}
-            heatmapData={h.heatmapData}
-            heatmapLoading={h.heatmapLoading}
-            heatmapError={h.heatmapError}
-            heatmapExpanded={h.heatmapExpanded}
-            setHeatmapExpanded={h.setHeatmapExpanded}
-            onDayPress={h.onHeatmapDayPress}
-          />
+    <>
+      <FlatList
+        data={h.filtered}
+        keyExtractor={(item) => item.id}
+        renderItem={renderSession}
+        style={{ flex: 1, backgroundColor: colors.background }}
+        contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: tabBarHeight }}
+        onEndReached={h.useFilterMode ? h.loadMoreFiltered : undefined}
+        onEndReachedThreshold={0.5}
+        ListHeaderComponent={
+          <>
+            <StreakAndHeatmap
+              colors={colors}
+              currentStreak={h.currentStreak}
+              longestStreak={h.longestStreak}
+              totalWorkouts={h.totalWorkouts}
+              heatmapData={h.heatmapData}
+              heatmapLoading={h.heatmapLoading}
+              heatmapError={h.heatmapError}
+              heatmapExpanded={h.heatmapExpanded}
+              setHeatmapExpanded={h.setHeatmapExpanded}
+              onDayPress={h.onHeatmapDayPress}
+            />
 
-          <SearchBar
-            placeholder="Search workouts"
-            value={h.query}
-            onChangeText={h.onSearch}
-            containerStyle={[styles.search, { backgroundColor: colors.surface }]}
-            accessibilityLabel="Search workout history"
-          />
+            <SearchBar
+              placeholder="Search workouts"
+              value={h.query}
+              onChangeText={h.onSearch}
+              containerStyle={[styles.search, { backgroundColor: colors.surface }]}
+              accessibilityLabel="Search workout history"
+            />
 
-          <CalendarGrid
-            colors={colors}
-            year={h.year}
-            month={h.month}
-            dotMap={h.dotMap}
-            scheduleMap={h.scheduleMap}
-            selected={h.selected}
-            animatedCalendarStyle={h.animatedCalendarStyle}
-            swipeGesture={h.swipeGesture}
-            cellSize={cellSize}
-            scale={layout.scale}
-            onPrevMonth={() => h.changeMonth(-1)}
-            onNextMonth={() => h.changeMonth(1)}
-            onTapDay={h.tapDay}
-            selectedCellRef={h.selectedCellRef}
-            monthSummary={h.monthSummary}
-          />
+            <FilterBar
+              filters={h.filters}
+              templateOptions={h.templateOptions}
+              onOpenTemplateSheet={() => setTemplateSheetOpen(true)}
+              onOpenMuscleGroupSheet={() => setMuscleSheetOpen(true)}
+              onOpenDateRangeSheet={() => setDateSheetOpen(true)}
+              onClearOne={h.clearOneFilter}
+              onClearAll={h.clearAllFilters}
+            />
 
-          <DayDetailPanel
-            colors={colors}
-            selected={h.selected}
-            year={h.year}
-            month={h.month}
-            dayDetailSessions={h.dayDetailSessions}
-            selectedDayScheduleEntry={h.selectedDayScheduleEntry}
-            isSelectedDayFuture={h.isSelectedDayFuture}
-            dayDetailRef={h.dayDetailRef}
-          />
+            {h.useFilterMode && (
+              <Text
+                variant="caption"
+                style={[styles.filterCaption, { color: colors.onSurfaceVariant }]}
+                accessibilityLabel="Calendar disabled while filters are active"
+              >
+                Filters active — tap &quot;Clear all&quot; to use calendar
+              </Text>
+            )}
 
-          {(h.selected || h.query.trim()) && (
-            <Chip icon={<Icon name={X} size={16} />} onPress={h.clearFilter} style={styles.chip} accessibilityLabel="Clear filter">
-              {h.query.trim()
-                ? `Search: ${h.query}`
-                : `${new Date(h.year, h.month, Number(h.selected!.split("-")[2])).toLocaleDateString(undefined, { month: "short", day: "numeric" })}`}
-            </Chip>
-          )}
-        </>
-      }
-      ListEmptyComponent={
-        <View style={styles.empty}>
-          <Text variant="body" style={{ color: colors.onSurfaceVariant }}>{h.emptyMessage()}</Text>
-        </View>
-      }
-    />
+            <View
+              style={[
+                styles.calendarWrap,
+                h.useFilterMode && styles.calendarDisabled,
+              ]}
+              pointerEvents={h.useFilterMode ? "none" : "auto"}
+              accessibilityElementsHidden={h.useFilterMode}
+              importantForAccessibility={h.useFilterMode ? "no-hide-descendants" : "auto"}
+            >
+              <CalendarGrid
+                colors={colors}
+                year={h.year}
+                month={h.month}
+                dotMap={h.dotMap}
+                scheduleMap={h.scheduleMap}
+                selected={h.selected}
+                animatedCalendarStyle={h.animatedCalendarStyle}
+                swipeGesture={h.swipeGesture}
+                cellSize={cellSize}
+                scale={layout.scale}
+                onPrevMonth={() => h.changeMonth(-1)}
+                onNextMonth={() => h.changeMonth(1)}
+                onTapDay={h.tapDay}
+                selectedCellRef={h.selectedCellRef}
+                monthSummary={h.monthSummary}
+              />
+            </View>
+
+            {!h.useFilterMode && (
+              <DayDetailPanel
+                colors={colors}
+                selected={h.selected}
+                year={h.year}
+                month={h.month}
+                dayDetailSessions={h.dayDetailSessions}
+                selectedDayScheduleEntry={h.selectedDayScheduleEntry}
+                isSelectedDayFuture={h.isSelectedDayFuture}
+                dayDetailRef={h.dayDetailRef}
+              />
+            )}
+
+            {(!h.useFilterMode && (h.selected || h.query.trim())) && (
+              <Chip icon={<Icon name={X} size={16} />} onPress={h.clearFilter} style={styles.chip} accessibilityLabel="Clear filter">
+                {h.query.trim()
+                  ? `Search: ${h.query}`
+                  : `${new Date(h.year, h.month, Number(h.selected!.split("-")[2])).toLocaleDateString(undefined, { month: "short", day: "numeric" })}`}
+              </Chip>
+            )}
+
+            {h.useFilterMode && (
+              <Text
+                variant="caption"
+                style={[styles.resultCount, { color: colors.onSurfaceVariant }]}
+                accessibilityLabel={`${h.filteredTotal} sessions match these filters`}
+              >
+                {h.filteredTotal} {h.filteredTotal === 1 ? "session" : "sessions"}
+              </Text>
+            )}
+          </>
+        }
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant }}>{h.emptyMessage()}</Text>
+            {h.useFilterMode && (
+              <Pressable
+                onPress={h.clearAllFilters}
+                style={[styles.clearFiltersButton, { backgroundColor: colors.primary }]}
+                accessibilityLabel="Clear filters"
+                accessibilityRole="button"
+              >
+                <Text variant="body" style={{ color: colors.onPrimary, fontWeight: "600" }}>
+                  Clear filters
+                </Text>
+              </Pressable>
+            )}
+          </View>
+        }
+      />
+
+      <TemplateFilterSheet
+        isVisible={templateSheetOpen}
+        onClose={() => setTemplateSheetOpen(false)}
+        options={h.templateOptions}
+        selectedTemplateId={h.filters.templateId}
+        onSelect={h.setTemplateFilter}
+      />
+      <MuscleGroupFilterSheet
+        isVisible={muscleSheetOpen}
+        onClose={() => setMuscleSheetOpen(false)}
+        availableMuscleGroups={h.muscleGroupOptions}
+        selectedMuscleGroup={h.filters.muscleGroup}
+        onSelect={h.setMuscleGroupFilter}
+      />
+      <DateRangeFilterSheet
+        isVisible={dateSheetOpen}
+        onClose={() => setDateSheetOpen(false)}
+        selectedPreset={h.filters.datePreset}
+        onSelect={h.setDatePresetFilter}
+      />
+    </>
   );
 }
 
@@ -113,5 +201,28 @@ export default function History() {
 const styles = StyleSheet.create({
   search: { marginBottom: 12 },
   chip: { alignSelf: "flex-start", marginBottom: 12, marginTop: 4 },
-  empty: { alignItems: "center", paddingVertical: 24 },
+  empty: { alignItems: "center", paddingVertical: 24, gap: 12 },
+  filterCaption: {
+    fontSize: 12,
+    fontStyle: "italic",
+    marginBottom: 8,
+  },
+  calendarWrap: {
+    // Wrapper is needed so we can dim/disable the calendar block in filter mode.
+  },
+  calendarDisabled: {
+    opacity: 0.5,
+  },
+  resultCount: {
+    fontSize: 13,
+    fontWeight: "500",
+    marginBottom: 8,
+  },
+  clearFiltersButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 24,
+    borderRadius: 8,
+    minHeight: 44,
+    justifyContent: "center",
+  },
 });

--- a/components/history/DateRangeFilterSheet.tsx
+++ b/components/history/DateRangeFilterSheet.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { Pressable, StyleSheet, View } from "react-native";
+import { Check } from "lucide-react-native";
+import { Text } from "@/components/ui/text";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { DatePreset } from "@/lib/db";
+
+type DateRangeFilterSheetProps = {
+  isVisible: boolean;
+  onClose: () => void;
+  selectedPreset: DatePreset | null;
+  onSelect: (preset: DatePreset | null) => void;
+};
+
+const PRESETS: { value: DatePreset; label: string }[] = [
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+  { value: "90d", label: "Last 90 days" },
+  { value: "year", label: "This year" },
+];
+
+/**
+ * Bottom-sheet for the Date Range filter (BLD-938). Single-select,
+ * presets-only — custom date range is deferred to v2 (no
+ * `@react-native-community/datetimepicker` dependency in scope).
+ */
+export function DateRangeFilterSheet({
+  isVisible,
+  onClose,
+  selectedPreset,
+  onSelect,
+}: DateRangeFilterSheetProps) {
+  const colors = useThemeColors();
+
+  const handleSelect = (preset: DatePreset) => {
+    onSelect(preset);
+    onClose();
+  };
+
+  const handleClear = () => {
+    onSelect(null);
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      isVisible={isVisible}
+      onClose={onClose}
+      title="Filter by date range"
+      snapPoints={[0.45, 0.7]}
+    >
+      <View style={styles.header}>
+        <Pressable
+          onPress={handleClear}
+          style={styles.clearButton}
+          accessibilityLabel="Clear date range filter"
+          accessibilityRole="button"
+        >
+          <Text variant="body" style={{ color: colors.primary }}>
+            Clear
+          </Text>
+        </Pressable>
+      </View>
+
+      <View>
+        {PRESETS.map((p) => {
+          const isSelected = p.value === selectedPreset;
+          return (
+            <Pressable
+              key={p.value}
+              onPress={() => handleSelect(p.value)}
+              style={[
+                styles.row,
+                isSelected && { backgroundColor: colors.primaryContainer },
+              ]}
+              accessibilityLabel={`${p.label}${isSelected ? ", selected" : ""}`}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isSelected }}
+            >
+              <Text variant="body" style={{ color: colors.onSurface }}>
+                {p.label}
+              </Text>
+              {isSelected ? <Check size={18} color={colors.primary} /> : null}
+            </Pressable>
+          );
+        })}
+      </View>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    marginBottom: 8,
+  },
+  clearButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    minHeight: 44,
+    justifyContent: "center",
+  },
+  row: {
+    minHeight: 56,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    borderRadius: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 4,
+  },
+});

--- a/components/history/FilterBar.tsx
+++ b/components/history/FilterBar.tsx
@@ -1,0 +1,219 @@
+/**
+ * BLD-938 — FilterBar for the history screen.
+ *
+ * Renders three tappable chips (Template / Muscle Group / Date Range) plus
+ * a "Clear all" link when any filter is active. Active chips show an inline
+ * dismiss (×) that clears just that key.
+ *
+ * Single-select v1 (multi-select deferred to v2 per plan §Out of Scope).
+ *
+ * The bar resolves its own display labels from the canonical state
+ * (`filters` + `templateOptions` + `MUSCLE_LABELS`) so callers don't have
+ * to compute them — keeps every label in sync with renames/deletes.
+ */
+import React, { useMemo } from "react";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { ChevronDown, X } from "lucide-react-native";
+import { Text } from "@/components/ui/text";
+import { Icon } from "@/components/ui/icon";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { HistoryFilters, TemplateOption } from "@/lib/db";
+import type { HistoryFilterKey } from "@/hooks/useHistoryFilters";
+import { MUSCLE_LABELS, type MuscleGroup } from "@/lib/types";
+
+const DATE_PRESET_LABELS: Record<string, string> = {
+  "7d": "Last 7 days",
+  "30d": "Last 30 days",
+  "90d": "Last 90 days",
+  year: "This year",
+};
+
+export type FilterBarProps = {
+  filters: HistoryFilters;
+  templateOptions: TemplateOption[];
+  onOpenTemplateSheet: () => void;
+  onOpenMuscleGroupSheet: () => void;
+  onOpenDateRangeSheet: () => void;
+  onClearOne: (key: HistoryFilterKey) => void;
+  onClearAll: () => void;
+};
+
+export function FilterBar({
+  filters,
+  templateOptions,
+  onOpenTemplateSheet,
+  onOpenMuscleGroupSheet,
+  onOpenDateRangeSheet,
+  onClearOne,
+  onClearAll,
+}: FilterBarProps) {
+  const colors = useThemeColors();
+
+  // Resolve template display name from the cached options. If the
+  // template was deleted between visits, the row still surfaces with a
+  // "(deleted)" suffix — falls back to a generic label only if the
+  // option list is empty (race window before the load completes).
+  const templateLabel = useMemo<string | null>(() => {
+    if (filters.templateId === null) return null;
+    const opt = templateOptions.find((o) => o.template_id === filters.templateId);
+    if (!opt) return "Template";
+    return opt.is_deleted ? `${opt.template_name} (deleted)` : opt.template_name;
+  }, [filters.templateId, templateOptions]);
+
+  const muscleGroupLabel = useMemo<string | null>(() => {
+    if (filters.muscleGroup === null) return null;
+    return MUSCLE_LABELS[filters.muscleGroup as MuscleGroup] ?? filters.muscleGroup;
+  }, [filters.muscleGroup]);
+
+  const datePresetLabel = useMemo<string | null>(() => {
+    if (filters.datePreset === null) return null;
+    return DATE_PRESET_LABELS[filters.datePreset] ?? filters.datePreset;
+  }, [filters.datePreset]);
+
+  const anyActive =
+    filters.templateId !== null ||
+    filters.muscleGroup !== null ||
+    filters.datePreset !== null;
+
+  return (
+    <View style={styles.container} testID="history-filter-bar">
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.row}
+        keyboardShouldPersistTaps="handled"
+      >
+        <FilterChip
+          label="Template"
+          selectedLabel={templateLabel}
+          onPress={onOpenTemplateSheet}
+          onClear={() => onClearOne("templateId")}
+          colors={colors}
+          testID="history-filter-chip-template"
+        />
+        <FilterChip
+          label="Muscle Group"
+          selectedLabel={muscleGroupLabel}
+          onPress={onOpenMuscleGroupSheet}
+          onClear={() => onClearOne("muscleGroup")}
+          colors={colors}
+          testID="history-filter-chip-muscle"
+        />
+        <FilterChip
+          label="Date Range"
+          selectedLabel={datePresetLabel}
+          onPress={onOpenDateRangeSheet}
+          onClear={() => onClearOne("datePreset")}
+          colors={colors}
+          testID="history-filter-chip-date"
+        />
+      </ScrollView>
+      {anyActive && (
+        <Pressable
+          onPress={onClearAll}
+          accessibilityLabel="Clear all filters"
+          accessibilityRole="button"
+          style={styles.clearAll}
+          testID="history-filter-clear-all"
+        >
+          <Text variant="caption" style={{ color: colors.primary, fontWeight: "600" }}>
+            Clear all
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+type FilterChipProps = {
+  label: string;
+  selectedLabel: string | null;
+  onPress: () => void;
+  onClear: () => void;
+  colors: ReturnType<typeof useThemeColors>;
+  testID?: string;
+};
+
+function FilterChip({ label, selectedLabel, onPress, onClear, colors, testID }: FilterChipProps) {
+  const active = selectedLabel !== null;
+  const display = active ? selectedLabel! : label;
+  const accessibilityLabel = active
+    ? `${label} filter, currently ${selectedLabel}, double-tap to change`
+    : `${label} filter, none selected, double-tap to select`;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      style={[
+        styles.chip,
+        {
+          backgroundColor: active ? colors.primaryContainer : colors.surface,
+          borderColor: active ? colors.primary : colors.outline,
+        },
+      ]}
+      testID={testID}
+    >
+      <Text
+        variant="caption"
+        style={{
+          color: active ? colors.onPrimaryContainer : colors.onSurface,
+          fontWeight: active ? "600" : "500",
+        }}
+        numberOfLines={1}
+      >
+        {display}
+      </Text>
+      {active ? (
+        <Pressable
+          onPress={onClear}
+          accessibilityLabel={`Clear ${label} filter`}
+          accessibilityRole="button"
+          hitSlop={8}
+          style={styles.dismissBtn}
+        >
+          <Icon name={X} size={14} />
+        </Pressable>
+      ) : (
+        <Icon name={ChevronDown} size={14} />
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginBottom: 12,
+  },
+  row: {
+    flexDirection: "row",
+    gap: 8,
+    paddingRight: 8,
+  },
+  chip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    borderWidth: 1,
+    minHeight: 36,
+  },
+  dismissBtn: {
+    padding: 2,
+    marginRight: -4,
+  },
+  clearAll: {
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+    minHeight: 44,
+    minWidth: 44,
+    justifyContent: "center",
+  },
+});

--- a/components/history/MuscleGroupFilterSheet.tsx
+++ b/components/history/MuscleGroupFilterSheet.tsx
@@ -1,0 +1,163 @@
+import React, { useMemo } from "react";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { Check } from "lucide-react-native";
+import { Text } from "@/components/ui/text";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { MUSCLE_GROUPS_BY_REGION, MUSCLE_LABELS, type MuscleGroup } from "@/lib/types";
+
+type MuscleGroupFilterSheetProps = {
+  isVisible: boolean;
+  onClose: () => void;
+  /** Muscle groups present in the user's completed sessions. */
+  availableMuscleGroups: string[];
+  selectedMuscleGroup: string | null;
+  onSelect: (muscleGroup: string | null) => void;
+};
+
+/**
+ * Bottom-sheet for the Muscle Group filter (BLD-938). Single-select,
+ * grouped by body region.
+ *
+ * Only muscle groups present in the user's exercise pool (returned by
+ * `getMuscleGroupsWithSessions`) are shown — users never see filters
+ * that would always return zero results.
+ */
+export function MuscleGroupFilterSheet({
+  isVisible,
+  onClose,
+  availableMuscleGroups,
+  selectedMuscleGroup,
+  onSelect,
+}: MuscleGroupFilterSheetProps) {
+  const colors = useThemeColors();
+
+  const availableSet = useMemo(
+    () => new Set(availableMuscleGroups),
+    [availableMuscleGroups]
+  );
+
+  const regions = useMemo(() => {
+    return MUSCLE_GROUPS_BY_REGION.map((region) => ({
+      ...region,
+      muscles: region.muscles.filter((m) => availableSet.has(m)),
+    })).filter((r) => r.muscles.length > 0);
+  }, [availableSet]);
+
+  const handleSelect = (muscle: string) => {
+    onSelect(muscle);
+    onClose();
+  };
+
+  const handleClear = () => {
+    onSelect(null);
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      isVisible={isVisible}
+      onClose={onClose}
+      title="Filter by muscle group"
+      snapPoints={[0.6, 0.9]}
+    >
+      <View style={styles.header}>
+        <Pressable
+          onPress={handleClear}
+          style={styles.clearButton}
+          accessibilityLabel="Clear muscle group filter"
+          accessibilityRole="button"
+        >
+          <Text variant="body" style={{ color: colors.primary }}>
+            Clear
+          </Text>
+        </Pressable>
+      </View>
+
+      <ScrollView style={styles.list}>
+        {regions.length === 0 ? (
+          <View style={styles.empty}>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
+              No muscle groups in your history yet
+            </Text>
+          </View>
+        ) : (
+          regions.map((region) => (
+            <View key={region.label} style={styles.regionBlock}>
+              <Text
+                variant="caption"
+                style={[styles.regionLabel, { color: colors.onSurfaceVariant }]}
+              >
+                {region.label}
+              </Text>
+              {region.muscles.map((m: MuscleGroup) => {
+                const isSelected = m === selectedMuscleGroup;
+                return (
+                  <Pressable
+                    key={m}
+                    onPress={() => handleSelect(m)}
+                    style={[
+                      styles.row,
+                      isSelected && { backgroundColor: colors.primaryContainer },
+                    ]}
+                    accessibilityLabel={`${MUSCLE_LABELS[m]}${
+                      isSelected ? ", selected" : ""
+                    }`}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: isSelected }}
+                  >
+                    <Text variant="body" style={{ color: colors.onSurface }}>
+                      {MUSCLE_LABELS[m]}
+                    </Text>
+                    {isSelected ? <Check size={18} color={colors.primary} /> : null}
+                  </Pressable>
+                );
+              })}
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    marginBottom: 8,
+  },
+  clearButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    minHeight: 44,
+    justifyContent: "center",
+  },
+  list: {
+    maxHeight: 520,
+  },
+  regionBlock: {
+    marginBottom: 12,
+  },
+  regionLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    marginBottom: 4,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  row: {
+    minHeight: 48,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 2,
+  },
+  empty: {
+    paddingVertical: 32,
+    alignItems: "center",
+  },
+});

--- a/components/history/TemplateFilterSheet.tsx
+++ b/components/history/TemplateFilterSheet.tsx
@@ -1,0 +1,179 @@
+import React, { useMemo, useState } from "react";
+import { Pressable, ScrollView, StyleSheet, TextInput, View } from "react-native";
+import { Check } from "lucide-react-native";
+import { Text } from "@/components/ui/text";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import type { TemplateOption } from "@/lib/db";
+
+type TemplateFilterSheetProps = {
+  isVisible: boolean;
+  onClose: () => void;
+  options: TemplateOption[];
+  selectedTemplateId: string | null;
+  onSelect: (templateId: string | null) => void;
+};
+
+/**
+ * Bottom-sheet for the Template filter (BLD-938). Single-select.
+ *
+ *  - Filtering keys by stable `template_id` (deleted templates show
+ *    "(deleted)" suffix; renames auto-update the displayed name).
+ *  - Search field to handle users with many templates.
+ *  - Tap an item → applies and closes; "Clear" button removes the filter.
+ */
+export function TemplateFilterSheet({
+  isVisible,
+  onClose,
+  options,
+  selectedTemplateId,
+  onSelect,
+}: TemplateFilterSheetProps) {
+  const colors = useThemeColors();
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return options;
+    return options.filter((o) => o.template_name.toLowerCase().includes(q));
+  }, [options, search]);
+
+  const handleSelect = (templateId: string) => {
+    onSelect(templateId);
+    onClose();
+  };
+
+  const handleClear = () => {
+    onSelect(null);
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      isVisible={isVisible}
+      onClose={onClose}
+      title="Filter by template"
+      snapPoints={[0.6, 0.9]}
+    >
+      <View style={styles.header}>
+        <Pressable
+          onPress={handleClear}
+          style={styles.clearButton}
+          accessibilityLabel="Clear template filter"
+          accessibilityRole="button"
+        >
+          <Text variant="body" style={{ color: colors.primary }}>
+            Clear
+          </Text>
+        </Pressable>
+      </View>
+
+      <TextInput
+        value={search}
+        onChangeText={setSearch}
+        placeholder="Search templates"
+        placeholderTextColor={colors.onSurfaceVariant}
+        style={[
+          styles.search,
+          {
+            backgroundColor: colors.surfaceVariant,
+            color: colors.onSurface,
+            borderColor: colors.outline,
+          },
+        ]}
+        accessibilityLabel="Search templates"
+      />
+
+      <ScrollView style={styles.list} keyboardShouldPersistTaps="handled">
+        {filtered.length === 0 ? (
+          <View style={styles.empty}>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
+              {options.length === 0 ? "No templates yet" : "No matches"}
+            </Text>
+          </View>
+        ) : (
+          filtered.map((opt) => {
+            const isSelected = opt.template_id === selectedTemplateId;
+            return (
+              <Pressable
+                key={opt.template_id}
+                onPress={() => handleSelect(opt.template_id)}
+                style={[
+                  styles.row,
+                  isSelected && { backgroundColor: colors.primaryContainer },
+                ]}
+                accessibilityLabel={`${opt.template_name}${
+                  opt.is_deleted ? " (deleted)" : ""
+                }, ${opt.count} sessions${isSelected ? ", selected" : ""}`}
+                accessibilityRole="button"
+                accessibilityState={{ selected: isSelected }}
+              >
+                <View style={styles.rowText}>
+                  <Text
+                    variant="body"
+                    style={{ color: colors.onSurface }}
+                    numberOfLines={1}
+                  >
+                    {opt.template_name}
+                    {opt.is_deleted ? (
+                      <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                        {"  "}(deleted)
+                      </Text>
+                    ) : null}
+                  </Text>
+                  <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                    {opt.count} {opt.count === 1 ? "session" : "sessions"}
+                  </Text>
+                </View>
+                {isSelected ? <Check size={18} color={colors.primary} /> : null}
+              </Pressable>
+            );
+          })
+        )}
+      </ScrollView>
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    marginBottom: 8,
+  },
+  clearButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    minHeight: 44,
+    justifyContent: "center",
+  },
+  search: {
+    height: 44,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginBottom: 12,
+    fontSize: 14,
+  },
+  list: {
+    maxHeight: 480,
+  },
+  row: {
+    minHeight: 56,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 4,
+  },
+  rowText: {
+    flex: 1,
+    marginRight: 8,
+  },
+  empty: {
+    paddingVertical: 32,
+    alignItems: "center",
+  },
+});

--- a/hooks/useHistoryData.ts
+++ b/hooks/useHistoryData.ts
@@ -14,7 +14,6 @@ import {
   getSessionCountsByDay,
   getSessionsByMonth,
   getTotalSessionCount,
-  searchSessions,
   getTemplatesWithSessions,
   getMuscleGroupsWithSessions,
   getFilteredSessions,
@@ -62,9 +61,9 @@ export function useHistoryData() {
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<SessionRow[] | null>(null);
+  // BLD-938: removed legacy `results` state — text search now renders
+  // from `filteredRows` populated by getFilteredSessions (plan §UI Hook).
   const [hasAny, setHasAny] = useState(true);
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [schedule, setSchedule] = useState<ScheduleEntry[]>([]);
   const [screenReaderEnabled, setScreenReaderEnabled] = useState(false);
   const [reduceMotionEnabled, setReduceMotionEnabled] = useState(false);
@@ -101,13 +100,22 @@ export function useHistoryData() {
   const FILTER_DEBOUNCE_MS = 300;
 
   const useFilterMode = filterState.anyActive;
+  // BLD-938 — derived predicate: are we rendering from getFilteredSessions
+  // results, vs the unfiltered calendar/month path? True for any chip
+  // filter OR a non-empty text search. This drives `filtered` rendering
+  // and the `loadMoreFiltered` gate.
+  //
+  // Distinct from `useFilterMode` which is chip-only and controls the
+  // calendar dim/disable UX (plan §65-69 — text search must NOT disable
+  // the calendar).
+  const useFilteredQueryPath = useFilterMode || query.trim().length > 0;
 
   useEffect(() => {
     AccessibilityInfo.isScreenReaderEnabled().then(setScreenReaderEnabled);
     AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotionEnabled);
     const srSub = AccessibilityInfo.addEventListener("screenReaderChanged", setScreenReaderEnabled);
     const rmSub = AccessibilityInfo.addEventListener("reduceMotionChanged", setReduceMotionEnabled);
-    return () => { srSub.remove(); rmSub.remove(); if (timer.current) clearTimeout(timer.current); };
+    return () => { srSub.remove(); rmSub.remove(); };
   }, []);
 
   useEffect(() => {
@@ -278,27 +286,37 @@ export function useHistoryData() {
   }, [sessions]);
 
   const filtered = useMemo(() => {
-    // BLD-938: filter mode (chips) takes precedence — uses paged filtered rows.
-    if (useFilterMode) return filteredRows;
-    // Existing text-search path
-    if (results) return results;
+    // BLD-938 — plan §UI Hook (line 209): "When any filter is non-null OR
+    // text search active → call getFilteredSessions (paged, 20/page)."
+    // The chip-filter path AND the text-search path both render from
+    // `filteredRows`, populated by getFilteredSessions in the unified
+    // effect above. The legacy in-memory searchSessions path is gone.
+    //
+    // NOTE on UX vs SQL routing: `useFilterMode` (chip-only) still
+    // controls the calendar dim/disable + result-count caption per plan
+    // §65-69. Text-only search uses the filtered SQL path but does NOT
+    // disable the calendar — the calendar stays interactive for date
+    // navigation alongside a name search, matching the prior UX.
+    if (useFilteredQueryPath) return filteredRows;
     if (!selected) return sessions;
     return sessions.filter((s) => formatDateKey(s.started_at) === selected);
-  }, [sessions, selected, results, useFilterMode, filteredRows]);
+  }, [sessions, selected, useFilteredQueryPath, filteredRows]);
 
   const loadMoreFiltered = useCallback(() => {
-    if (!useFilterMode) return;
+    // Pagination is available whenever we're rendering from filteredRows —
+    // text-only search OR any chip filter active.
+    if (!useFilteredQueryPath) return;
     if (filterLoading) return;
     if (filteredRows.length >= filteredTotal) return;
     setFilterPage((p) => p + 1);
-  }, [useFilterMode, filterLoading, filteredRows.length, filteredTotal]);
+  }, [useFilteredQueryPath, filterLoading, filteredRows.length, filteredTotal]);
 
   const changeMonth = useCallback((direction: -1 | 1) => {
     const animDurationMs = reducedMotion ? 0 : animDuration.normal;
     const slideDistance = layout.width * direction * -1;
     translateX.value = slideDistance;
     translateX.value = withTiming(0, { duration: animDurationMs });
-    setSelected(null); setQuery(""); setResults(null);
+    setSelected(null); setQuery("");
     if (direction === -1) { if (month === 0) { setMonth(11); setYear(year - 1); } else setMonth(month - 1); }
     else { if (month === 11) { setMonth(0); setYear(year + 1); } else setMonth(month + 1); }
   }, [month, year, layout.width, reducedMotion, translateX]);
@@ -312,22 +330,26 @@ export function useHistoryData() {
     [screenReaderEnabled, changeMonth]);
 
   const onSearch = (text: string) => {
-    setQuery(text); setSelected(null); setFilterPage(0);
-    if (timer.current) clearTimeout(timer.current);
-    if (!text.trim()) { setResults(null); return; }
-    timer.current = setTimeout(async () => { const data = await searchSessions(text.trim()); setResults(data); }, 300);
+    // BLD-938 — text search now routes through the unified
+    // getFilteredSessions effect (debounced 300ms there). We just update
+    // `query`, reset paging, and clear any calendar-day selection. The
+    // legacy searchSessions in-memory call is gone — see plan §UI Hook
+    // requirement: "When any filter is non-null OR text search active →
+    // call getFilteredSessions (paged)."
+    setQuery(text);
+    setSelected(null);
+    setFilterPage(0);
   };
 
   const clearFilter = () => {
     setSelected(null);
     setQuery("");
-    setResults(null);
     setFilterPage(0);
     filterState.clearAll();
   };
 
   const tapDay = (key: string) => {
-    setQuery(""); setResults(null);
+    setQuery("");
     if (!reduceMotionEnabled) {
       const { LayoutAnimation } = require("react-native");
       LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
@@ -338,7 +360,7 @@ export function useHistoryData() {
   const onHeatmapDayPress = (dateKey: string) => {
     const [y, m] = dateKey.split("-").map(Number);
     if (y !== year || m - 1 !== month) { setYear(y); setMonth(m - 1); }
-    setQuery(""); setResults(null); setSelected(dateKey);
+    setQuery(""); setSelected(dateKey);
   };
 
   const dayDetailSessions = useMemo(() => {

--- a/hooks/useHistoryData.ts
+++ b/hooks/useHistoryData.ts
@@ -15,6 +15,11 @@ import {
   getSessionsByMonth,
   getTotalSessionCount,
   searchSessions,
+  getTemplatesWithSessions,
+  getMuscleGroupsWithSessions,
+  getFilteredSessions,
+  type TemplateOption,
+  type DatePreset,
 } from "@/lib/db";
 import { getSchedule, type ScheduleEntry } from "@/lib/db/settings";
 import type { WorkoutSession } from "@/lib/types";
@@ -26,6 +31,7 @@ import {
 import { duration as animDuration } from "@/constants/design-tokens";
 import { useLayout } from "@/lib/layout";
 import { View } from "react-native";
+import { useHistoryFilters, type HistoryFilterKey } from "@/hooks/useHistoryFilters";
 
 export type SessionRow = WorkoutSession & { set_count: number };
 
@@ -79,6 +85,19 @@ export function useHistoryData() {
   const [heatmapError, setHeatmapError] = useState(false);
   const [heatmapExpanded, setHeatmapExpanded] = useState(true);
 
+  // BLD-938: history filters (template / muscle group / date range)
+  const filterState = useHistoryFilters();
+  const [templateOptions, setTemplateOptions] = useState<TemplateOption[]>([]);
+  const [muscleGroupOptions, setMuscleGroupOptions] = useState<string[]>([]);
+  const [filteredRows, setFilteredRows] = useState<SessionRow[]>([]);
+  const [filteredTotal, setFilteredTotal] = useState(0);
+  const [filterLoading, setFilterLoading] = useState(false);
+  const [filterPage, setFilterPage] = useState(0);
+  const filterFetchSeqRef = useRef(0);
+  const FILTER_PAGE_SIZE = 20;
+
+  const useFilterMode = filterState.anyActive;
+
   useEffect(() => {
     AccessibilityInfo.isScreenReaderEnabled().then(setScreenReaderEnabled);
     AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotionEnabled);
@@ -129,7 +148,93 @@ export function useHistoryData() {
     load();
     loadHeatmap();
     getSchedule().then(setSchedule).catch(() => setSchedule([]));
+    // BLD-938: cache the available filter option lists once per visit.
+    getTemplatesWithSessions().then(setTemplateOptions).catch(() => setTemplateOptions([]));
+    getMuscleGroupsWithSessions().then(setMuscleGroupOptions).catch(() => setMuscleGroupOptions([]));
   }, [load, loadHeatmap]));
+
+  // BLD-938: when any filter is active OR text search active, fetch from
+  // getFilteredSessions paged. When all filters cleared, the calendar/month
+  // path resumes via `filtered` below.
+  //
+  // Page index is intentionally captured into the dependency array so that
+  // tapping "load more" (which dispatches setFilterPage(p => p+1) — an
+  // event-time setter, lint-clean) re-runs this effect with a higher offset.
+  // The reset-to-page-zero on filter/query change is handled in the setter
+  // callbacks below (NOT a derived effect), which keeps lint happy
+  // (react-hooks/set-state-in-effect).
+  useEffect(() => {
+    const seq = ++filterFetchSeqRef.current;
+    if (!useFilterMode && !query.trim()) {
+      // Fully unfiltered: nothing to fetch. We do NOT reset
+      // filteredRows/filteredTotal here (would be a setState-in-effect lint
+      // violation). Instead, the `filtered` memo below short-circuits to
+      // `sessions` whenever `useFilterMode` is false, so any stale
+      // filteredRows are simply ignored until the next filtered fetch
+      // overwrites them.
+      return;
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- starting async fetch; loading flag flipped back via .finally
+    setFilterLoading(true);
+    const offset = filterPage * FILTER_PAGE_SIZE;
+    getFilteredSessions(filterState.filters, query, FILTER_PAGE_SIZE, offset)
+      .then((res) => {
+        // Drop stale fetches.
+        if (seq !== filterFetchSeqRef.current) return;
+        setFilteredRows((prev) => (filterPage === 0 ? res.rows : [...prev, ...res.rows]));
+        setFilteredTotal(res.total);
+      })
+      .catch(() => {
+        if (seq !== filterFetchSeqRef.current) return;
+        setFilteredRows([]);
+        setFilteredTotal(0);
+      })
+      .finally(() => {
+        if (seq !== filterFetchSeqRef.current) return;
+        setFilterLoading(false);
+      });
+  }, [useFilterMode, filterState.filters, query, filterPage]);
+
+  // BLD-938: clear calendar selection when filters become active, AND reset
+  // paging — both done in the filter setter handlers (event-time, lint-clean
+  // alternative to a derived effect). When the user clears all filters we
+  // deliberately do NOT restore the prior selection (per plan §UX — filter
+  // mode resets calendar's selection on activation).
+  const setTemplateFilter = useCallback(
+    (templateId: string | null) => {
+      if (templateId !== null) setSelected(null);
+      setFilterPage(0);
+      filterState.setTemplate(templateId);
+    },
+    [filterState],
+  );
+  const setMuscleGroupFilter = useCallback(
+    (muscleGroup: string | null) => {
+      if (muscleGroup !== null) setSelected(null);
+      setFilterPage(0);
+      filterState.setMuscleGroup(muscleGroup);
+    },
+    [filterState],
+  );
+  const setDatePresetFilter = useCallback(
+    (datePreset: DatePreset | null) => {
+      if (datePreset !== null) setSelected(null);
+      setFilterPage(0);
+      filterState.setDatePreset(datePreset);
+    },
+    [filterState],
+  );
+  const clearOneFilter = useCallback(
+    (key: HistoryFilterKey) => {
+      setFilterPage(0);
+      filterState.clearOne(key);
+    },
+    [filterState],
+  );
+  const clearAllFilters = useCallback(() => {
+    setFilterPage(0);
+    filterState.clearAll();
+  }, [filterState]);
 
   const dotMap = useMemo(() => {
     const map = new Map<string, number>();
@@ -150,10 +255,20 @@ export function useHistoryData() {
   }, [sessions]);
 
   const filtered = useMemo(() => {
+    // BLD-938: filter mode (chips) takes precedence — uses paged filtered rows.
+    if (useFilterMode) return filteredRows;
+    // Existing text-search path
     if (results) return results;
     if (!selected) return sessions;
     return sessions.filter((s) => formatDateKey(s.started_at) === selected);
-  }, [sessions, selected, results]);
+  }, [sessions, selected, results, useFilterMode, filteredRows]);
+
+  const loadMoreFiltered = useCallback(() => {
+    if (!useFilterMode) return;
+    if (filterLoading) return;
+    if (filteredRows.length >= filteredTotal) return;
+    setFilterPage((p) => p + 1);
+  }, [useFilterMode, filterLoading, filteredRows.length, filteredTotal]);
 
   const changeMonth = useCallback((direction: -1 | 1) => {
     const animDurationMs = reducedMotion ? 0 : animDuration.normal;
@@ -174,13 +289,19 @@ export function useHistoryData() {
     [screenReaderEnabled, changeMonth]);
 
   const onSearch = (text: string) => {
-    setQuery(text); setSelected(null);
+    setQuery(text); setSelected(null); setFilterPage(0);
     if (timer.current) clearTimeout(timer.current);
     if (!text.trim()) { setResults(null); return; }
     timer.current = setTimeout(async () => { const data = await searchSessions(text.trim()); setResults(data); }, 300);
   };
 
-  const clearFilter = () => { setSelected(null); setQuery(""); setResults(null); };
+  const clearFilter = () => {
+    setSelected(null);
+    setQuery("");
+    setResults(null);
+    setFilterPage(0);
+    filterState.clearAll();
+  };
 
   const tapDay = (key: string) => {
     setQuery(""); setResults(null);
@@ -218,6 +339,7 @@ export function useHistoryData() {
   }, [selected]);
 
   const emptyMessage = () => {
+    if (useFilterMode) return "No workouts match these filters";
     if (query.trim()) return `No workouts matching "${query}"`;
     if (selected) return "Rest day!";
     if (!hasAny) return "No workouts yet. Start your first workout!";
@@ -233,5 +355,19 @@ export function useHistoryData() {
     dayDetailSessions, selectedDayScheduleEntry, isSelectedDayFuture,
     changeMonth, onSearch, clearFilter, tapDay, onHeatmapDayPress, emptyMessage,
     screenReaderEnabled, reduceMotionEnabled,
+    // BLD-938 history filters
+    filters: filterState.filters,
+    anyFilterActive: filterState.anyActive,
+    setTemplateFilter,
+    setMuscleGroupFilter,
+    setDatePresetFilter,
+    clearOneFilter,
+    clearAllFilters,
+    templateOptions,
+    muscleGroupOptions,
+    filteredTotal,
+    filterLoading,
+    loadMoreFiltered,
+    useFilterMode,
   };
 }

--- a/hooks/useHistoryData.ts
+++ b/hooks/useHistoryData.ts
@@ -414,5 +414,6 @@ export function useHistoryData() {
     filterLoading,
     loadMoreFiltered,
     useFilterMode,
+    useFilteredQueryPath,
   };
 }

--- a/hooks/useHistoryData.ts
+++ b/hooks/useHistoryData.ts
@@ -95,6 +95,10 @@ export function useHistoryData() {
   const [filterPage, setFilterPage] = useState(0);
   const filterFetchSeqRef = useRef(0);
   const FILTER_PAGE_SIZE = 20;
+  // BLD-938 — plan §Performance: filter changes are debounced 300ms so
+  // rapid chip/sheet taps collapse into a single query. Matches the
+  // existing search debounce in `onSearch` below.
+  const FILTER_DEBOUNCE_MS = 300;
 
   const useFilterMode = filterState.anyActive;
 
@@ -163,6 +167,13 @@ export function useHistoryData() {
   // The reset-to-page-zero on filter/query change is handled in the setter
   // callbacks below (NOT a derived effect), which keeps lint happy
   // (react-hooks/set-state-in-effect).
+  //
+  // Debounce: rapid filter taps (chip → sheet → tap → sheet → tap) MUST
+  // collapse into a single query (plan §Performance — 300ms debounce, also
+  // explicit acceptance criteria from QD R3). Pagination requests
+  // (filterPage > 0) bypass the debounce — the user already paid the
+  // visible cost of scrolling and we never want a "load more" request
+  // dropped because a chip was tapped 100ms earlier.
   useEffect(() => {
     const seq = ++filterFetchSeqRef.current;
     if (!useFilterMode && !query.trim()) {
@@ -174,25 +185,37 @@ export function useHistoryData() {
       // overwrites them.
       return;
     }
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- starting async fetch; loading flag flipped back via .finally
-    setFilterLoading(true);
     const offset = filterPage * FILTER_PAGE_SIZE;
-    getFilteredSessions(filterState.filters, query, FILTER_PAGE_SIZE, offset)
-      .then((res) => {
-        // Drop stale fetches.
-        if (seq !== filterFetchSeqRef.current) return;
-        setFilteredRows((prev) => (filterPage === 0 ? res.rows : [...prev, ...res.rows]));
-        setFilteredTotal(res.total);
-      })
-      .catch(() => {
-        if (seq !== filterFetchSeqRef.current) return;
-        setFilteredRows([]);
-        setFilteredTotal(0);
-      })
-      .finally(() => {
-        if (seq !== filterFetchSeqRef.current) return;
-        setFilterLoading(false);
-      });
+    const runFetch = () => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- starting async fetch; loading flag flipped back via .finally
+      setFilterLoading(true);
+      getFilteredSessions(filterState.filters, query, FILTER_PAGE_SIZE, offset)
+        .then((res) => {
+          // Drop stale fetches.
+          if (seq !== filterFetchSeqRef.current) return;
+          setFilteredRows((prev) => (filterPage === 0 ? res.rows : [...prev, ...res.rows]));
+          setFilteredTotal(res.total);
+        })
+        .catch(() => {
+          if (seq !== filterFetchSeqRef.current) return;
+          setFilteredRows([]);
+          setFilteredTotal(0);
+        })
+        .finally(() => {
+          if (seq !== filterFetchSeqRef.current) return;
+          setFilterLoading(false);
+        });
+    };
+
+    // Pagination requests run immediately; user-driven filter/search
+    // changes are reset to page 0 by their setters and routed here for
+    // debouncing.
+    if (filterPage > 0) {
+      runFetch();
+      return;
+    }
+    const t = setTimeout(runFetch, FILTER_DEBOUNCE_MS);
+    return () => clearTimeout(t);
   }, [useFilterMode, filterState.filters, query, filterPage]);
 
   // BLD-938: clear calendar selection when filters become active, AND reset

--- a/hooks/useHistoryFilters.ts
+++ b/hooks/useHistoryFilters.ts
@@ -1,0 +1,88 @@
+import { useReducer } from "react";
+import type { DatePreset, HistoryFilters } from "@/lib/db";
+
+/**
+ * useHistoryFilters — single-select filter state machine for the history
+ * screen (BLD-938).
+ *
+ * State shape mirrors `HistoryFilters` from `lib/db`. The chip's display
+ * label for `templateId` is resolved by the caller against a cached
+ * `getTemplatesWithSessions` lookup so it auto-updates on rename.
+ *
+ * The reducer is intentionally pure for unit-testability — see
+ * `__tests__/hooks/useHistoryFilters.test.ts`.
+ */
+
+export type HistoryFilterKey = "templateId" | "muscleGroup" | "datePreset";
+
+export type HistoryFiltersAction =
+  | { type: "SET_TEMPLATE"; templateId: string | null }
+  | { type: "SET_MUSCLE_GROUP"; muscleGroup: string | null }
+  | { type: "SET_DATE_PRESET"; datePreset: DatePreset | null }
+  | { type: "CLEAR_ONE"; key: HistoryFilterKey }
+  | { type: "CLEAR_ALL" };
+
+export const INITIAL_HISTORY_FILTERS: HistoryFilters = {
+  templateId: null,
+  muscleGroup: null,
+  datePreset: null,
+};
+
+export function historyFiltersReducer(
+  state: HistoryFilters,
+  action: HistoryFiltersAction
+): HistoryFilters {
+  switch (action.type) {
+    case "SET_TEMPLATE":
+      if (state.templateId === action.templateId) return state;
+      return { ...state, templateId: action.templateId };
+    case "SET_MUSCLE_GROUP":
+      if (state.muscleGroup === action.muscleGroup) return state;
+      return { ...state, muscleGroup: action.muscleGroup };
+    case "SET_DATE_PRESET":
+      if (state.datePreset === action.datePreset) return state;
+      return { ...state, datePreset: action.datePreset };
+    case "CLEAR_ONE":
+      if (state[action.key] === null) return state;
+      return { ...state, [action.key]: null };
+    case "CLEAR_ALL":
+      if (
+        state.templateId === null &&
+        state.muscleGroup === null &&
+        state.datePreset === null
+      ) {
+        return state;
+      }
+      return { ...INITIAL_HISTORY_FILTERS };
+    default:
+      return state;
+  }
+}
+
+export function isAnyFilterActive(state: HistoryFilters): boolean {
+  return (
+    state.templateId !== null ||
+    state.muscleGroup !== null ||
+    state.datePreset !== null
+  );
+}
+
+export function useHistoryFilters() {
+  const [filters, dispatch] = useReducer(
+    historyFiltersReducer,
+    INITIAL_HISTORY_FILTERS
+  );
+
+  return {
+    filters,
+    setTemplate: (templateId: string | null) =>
+      dispatch({ type: "SET_TEMPLATE", templateId }),
+    setMuscleGroup: (muscleGroup: string | null) =>
+      dispatch({ type: "SET_MUSCLE_GROUP", muscleGroup }),
+    setDatePreset: (datePreset: DatePreset | null) =>
+      dispatch({ type: "SET_DATE_PRESET", datePreset }),
+    clearOne: (key: HistoryFilterKey) => dispatch({ type: "CLEAR_ONE", key }),
+    clearAll: () => dispatch({ type: "CLEAR_ALL" }),
+    anyActive: isAnyFilterActive(filters),
+  };
+}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -104,6 +104,9 @@ export {
   getSessionDurationPRs,
   getSessionCountsByDay,
   getTotalSessionCount,
+  getTemplatesWithSessions,
+  getMuscleGroupsWithSessions,
+  getFilteredSessions,
   getE1RMTrends,
   getWeeklyE1RMTrends,
   getRecentSessionRPEs,
@@ -119,6 +122,7 @@ export {
 } from "./sessions";
 export type { RestContext } from "./sessions";
 export type { SessionEditPayload, SessionEditSetPatch } from "./sessions";
+export type { TemplateOption, DatePreset, HistoryFilters } from "./sessions";
 export type { ExerciseCategory, RestInputs, RestFactor, RestBreakdown } from "../rest";
 export type { ExerciseSession, ExerciseRecords, SourceSessionSet, VariantScope } from "./sessions";
 export { getVariantSetCount, buildVariantSql } from "./sessions";

--- a/lib/db/muscle-format.ts
+++ b/lib/db/muscle-format.ts
@@ -1,0 +1,50 @@
+/**
+ * Dual-format parser for `exercises.primary_muscles` / `secondary_muscles`.
+ *
+ * Two storage formats coexist in the database (BLD-925):
+ *   - JSON-array string written by `lib/db/exercises.ts` for custom exercises
+ *     (e.g. `["chest","triceps"]`).
+ *   - Comma-separated string written by `lib/db/csv-import.ts` for the seed /
+ *     imported library (e.g. `chest,triceps`).
+ *
+ * This helper accepts either format and returns a clean string[] of muscle
+ * identifiers. JSON is attempted first (anchored on a leading `[`). On any
+ * failure (malformed JSON, missing brackets, etc.) it falls back to a CSV
+ * split. Empty / whitespace-only / null inputs return `[]`.
+ *
+ * **NOT a security boundary.** This is purely a defensive read-side parser so
+ * the muscle-group filter (and similar callers) can see a unified view across
+ * both formats.
+ *
+ * Tech-debt follow-up: BLD-925 plan §Tech Debt Follow-up — normalize
+ * `csv-import.ts` to `JSON.stringify` and run a one-time migration. Once that
+ * lands, callers can revert to a plain `JSON.parse`.
+ */
+export function parseMuscleList(raw: string | null | undefined): string[] {
+  if (raw == null) return [];
+  const trimmed = raw.trim();
+  if (trimmed === "") return [];
+
+  // JSON-array format. Only attempt JSON.parse when the value clearly starts
+  // with `[` to avoid eagerly parsing CSV strings whose first token happens to
+  // be valid JSON (e.g. `1,2,3`).
+  if (trimmed.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .filter((item): item is string => typeof item === "string")
+          .map((item) => item.trim())
+          .filter(Boolean);
+      }
+    } catch {
+      // Malformed JSON — fall through to CSV.
+    }
+  }
+
+  // CSV format (or malformed JSON fallback).
+  return trimmed
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean);
+}

--- a/lib/db/session-stats.ts
+++ b/lib/db/session-stats.ts
@@ -3,6 +3,7 @@ import type { WorkoutSession, MuscleGroup } from "../types";
 import { eq, and, sql, isNotNull, ne, gt, max, count, desc, asc, gte, lt, inArray } from "drizzle-orm";
 import { query, queryOne, getDrizzle } from "./helpers";
 import { workoutSessions, workoutSets, exercises } from "./schema";
+import { parseMuscleList } from "./muscle-format";
 
 // ---- History & Calendar ----
 
@@ -706,4 +707,206 @@ export async function getSessionDurationPRs(
      ORDER BY name ASC`,
     [sessionId, sessionId]
   );
+}
+
+// ─── BLD-938: History Filters ────────────────────────────────────────────────
+
+export type TemplateOption = {
+  template_id: string;
+  template_name: string;
+  count: number;
+  is_deleted: boolean;
+};
+
+export type DatePreset = "7d" | "30d" | "90d" | "year";
+
+export type HistoryFilters = {
+  templateId: string | null;
+  muscleGroup: string | null;
+  datePreset: DatePreset | null;
+};
+
+/**
+ * Returns all templates that have at least one completed session, keyed by
+ * the stable `template_id`. Uses a LEFT JOIN to `workout_templates` so
+ * deleted templates still surface (their historical sessions remain
+ * visible) — falling back to the most recent matching session's `name` and
+ * marking the entry `is_deleted: true`.
+ *
+ * Ad-hoc / imported sessions (`template_id IS NULL`) are intentionally
+ * excluded — they are surfaced via the muscle-group / date-range filters
+ * or the unfiltered view, but not through Template filter (per QD R4).
+ *
+ * Sorted case-insensitively by current name.
+ */
+export async function getTemplatesWithSessions(): Promise<TemplateOption[]> {
+  const rows = await query<{
+    template_id: string;
+    template_name: string;
+    count: number;
+    is_deleted: number;
+  }>(
+    `SELECT
+       s.template_id AS template_id,
+       COALESCE(t.name, (
+         SELECT s2.name FROM workout_sessions s2
+         WHERE s2.template_id = s.template_id AND s2.completed_at IS NOT NULL
+         ORDER BY s2.completed_at DESC LIMIT 1
+       )) AS template_name,
+       COUNT(s.id) AS count,
+       CASE WHEN t.id IS NULL THEN 1 ELSE 0 END AS is_deleted
+     FROM workout_sessions s
+     LEFT JOIN workout_templates t ON t.id = s.template_id
+     WHERE s.completed_at IS NOT NULL AND s.template_id IS NOT NULL
+     GROUP BY s.template_id
+     ORDER BY template_name COLLATE NOCASE`
+  );
+  return rows.map((r) => ({
+    template_id: r.template_id,
+    template_name: r.template_name,
+    count: r.count,
+    is_deleted: r.is_deleted === 1,
+  }));
+}
+
+/**
+ * Returns the union of muscle groups (primary + secondary) used in
+ * exercises that appear in the user's completed sessions. Handles BOTH
+ * storage formats (JSON array, CSV) via `parseMuscleList`.
+ *
+ * Returned values are deduped and sorted alphabetically.
+ */
+export async function getMuscleGroupsWithSessions(): Promise<string[]> {
+  const rows = await query<{ primary_muscles: string; secondary_muscles: string }>(
+    `SELECT DISTINCT e.primary_muscles, e.secondary_muscles
+     FROM exercises e
+     WHERE e.id IN (
+       SELECT DISTINCT ws.exercise_id
+       FROM workout_sets ws
+       WHERE ws.session_id IN (
+         SELECT id FROM workout_sessions WHERE completed_at IS NOT NULL
+       )
+     )`
+  );
+  const all = new Set<string>();
+  for (const row of rows) {
+    for (const m of parseMuscleList(row.primary_muscles)) all.add(m);
+    for (const m of parseMuscleList(row.secondary_muscles)) all.add(m);
+  }
+  return Array.from(all).sort();
+}
+
+/**
+ * Composable filtered-sessions query. WHERE clauses are added per active
+ * filter and AND-combined with the optional text search. Returns paged
+ * rows plus the total (unpaged) count for the result-count UI.
+ *
+ * Muscle-group filter implementation
+ * ----------------------------------
+ * The exercises table stores `primary_muscles` and `secondary_muscles` in
+ * one of two opaque formats (see `lib/db/muscle-format.ts`). Rather than
+ * loading every exercise into JS, we use a 10-clause LIKE pattern on the
+ * SQL side that covers both formats × both columns × four positional CSV
+ * variants (only / start / middle / end) plus the JSON-quoted variant.
+ *
+ * PERF: see plan §"muscle group filter" — when the storage-format
+ * normalization migration ships (separate tech-debt issue), this pattern
+ * collapses to a single `EXISTS (... LIKE '%"x"%')` clause.
+ *
+ * Substring-collision safety: the JSON pattern requires surrounding `"`
+ * and the CSV patterns require comma boundaries (or full-string match), so
+ * a filter for `back` cannot match `upper_back` storage. Asserted by an
+ * integration test in `__tests__/lib/db/history-filters.test.ts`.
+ */
+export async function getFilteredSessions(
+  filters: HistoryFilters,
+  textSearch: string,
+  limit: number,
+  offset: number
+): Promise<{ rows: (WorkoutSession & { set_count: number })[]; total: number }> {
+  const clauses: string[] = ["s.completed_at IS NOT NULL"];
+  const params: (string | number)[] = [];
+
+  if (filters.templateId) {
+    clauses.push("s.template_id = ?");
+    params.push(filters.templateId);
+  }
+
+  if (filters.datePreset) {
+    const now = Date.now();
+    const ms =
+      filters.datePreset === "7d" ? 7 * 24 * 60 * 60 * 1000 :
+      filters.datePreset === "30d" ? 30 * 24 * 60 * 60 * 1000 :
+      filters.datePreset === "90d" ? 90 * 24 * 60 * 60 * 1000 :
+      // "year"
+      365 * 24 * 60 * 60 * 1000;
+    clauses.push("s.started_at >= ?");
+    params.push(now - ms);
+  }
+
+  if (textSearch.trim()) {
+    clauses.push("s.name LIKE ?");
+    params.push(`%${textSearch.trim()}%`);
+  }
+
+  if (filters.muscleGroup) {
+    // 10-clause dual-format LIKE pattern. Same parameter is bound 10
+    // times — SQLite re-uses positional `?N`, but to keep the SQL
+    // portable across drivers we push the value 10 times instead.
+    const m = filters.muscleGroup;
+    clauses.push(
+      `EXISTS (
+         SELECT 1 FROM workout_sets ws2
+         JOIN exercises e ON ws2.exercise_id = e.id
+         WHERE ws2.session_id = s.id
+           AND (
+             /* JSON format match in primary_muscles */
+             e.primary_muscles LIKE ?
+             /* CSV format match in primary_muscles (only / start / middle / end) */
+             OR e.primary_muscles = ?
+             OR e.primary_muscles LIKE ?
+             OR e.primary_muscles LIKE ?
+             OR e.primary_muscles LIKE ?
+             /* Same patterns for secondary_muscles */
+             OR e.secondary_muscles LIKE ?
+             OR e.secondary_muscles = ?
+             OR e.secondary_muscles LIKE ?
+             OR e.secondary_muscles LIKE ?
+             OR e.secondary_muscles LIKE ?
+           )
+       )`
+    );
+    params.push(`%"${m}"%`); // JSON in primary
+    params.push(m);            // CSV only in primary
+    params.push(`${m},%`);     // CSV start in primary
+    params.push(`%,${m},%`);   // CSV middle in primary
+    params.push(`%,${m}`);     // CSV end in primary
+    params.push(`%"${m}"%`); // JSON in secondary
+    params.push(m);            // CSV only in secondary
+    params.push(`${m},%`);     // CSV start in secondary
+    params.push(`%,${m},%`);   // CSV middle in secondary
+    params.push(`%,${m}`);     // CSV end in secondary
+  }
+
+  const whereClause = clauses.join(" AND ");
+
+  // Get total count first (unpaged)
+  const countRow = await queryOne<{ total: number }>(
+    `SELECT COUNT(*) AS total FROM workout_sessions s WHERE ${whereClause}`,
+    params
+  );
+  const total = countRow?.total ?? 0;
+
+  // Paged rows
+  const rows = await query<WorkoutSession & { set_count: number }>(
+    `SELECT s.*,
+            (SELECT COUNT(*) FROM workout_sets ws WHERE ws.session_id = s.id AND ws.completed = 1) AS set_count
+     FROM workout_sessions s
+     WHERE ${whereClause}
+     ORDER BY s.started_at DESC
+     LIMIT ? OFFSET ?`,
+    [...params, limit, offset]
+  );
+
+  return { rows, total };
 }

--- a/lib/db/session-stats.ts
+++ b/lib/db/session-stats.ts
@@ -833,15 +833,24 @@ export async function getFilteredSessions(
   }
 
   if (filters.datePreset) {
-    const now = Date.now();
-    const ms =
-      filters.datePreset === "7d" ? 7 * 24 * 60 * 60 * 1000 :
-      filters.datePreset === "30d" ? 30 * 24 * 60 * 60 * 1000 :
-      filters.datePreset === "90d" ? 90 * 24 * 60 * 60 * 1000 :
-      // "year"
-      365 * 24 * 60 * 60 * 1000;
+    // "7d" / "30d" / "90d" are rolling windows from now.
+    // "year" — per UI label "This year" and QD R4 spec — means the
+    // current local calendar year (Jan 1 00:00:00 local of THIS year),
+    // NOT a rolling 365-day window. A rolling window would silently
+    // include workouts from December of the prior year after Jan 1.
+    let cutoff: number;
+    if (filters.datePreset === "year") {
+      const today = new Date();
+      cutoff = new Date(today.getFullYear(), 0, 1, 0, 0, 0, 0).getTime();
+    } else {
+      const ms =
+        filters.datePreset === "7d" ? 7 * 24 * 60 * 60 * 1000 :
+        filters.datePreset === "30d" ? 30 * 24 * 60 * 60 * 1000 :
+        90 * 24 * 60 * 60 * 1000;
+      cutoff = Date.now() - ms;
+    }
     clauses.push("s.started_at >= ?");
-    params.push(now - ms);
+    params.push(cutoff);
   }
 
   if (textSearch.trim()) {

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -58,7 +58,11 @@ export {
   getTotalSessionCount,
   getMuscleVolumeForWeek,
   getMuscleVolumeTrend,
+  getTemplatesWithSessions,
+  getMuscleGroupsWithSessions,
+  getFilteredSessions,
 } from "./session-stats";
+export type { TemplateOption, DatePreset, HistoryFilters } from "./session-stats";
 
 export { getE1RMTrends, getWeeklyE1RMTrends, getRecentSessionRPEs, getRecentSessionRatings } from "./e1rm-trends";
 export type { E1RMTrendRow, WeeklyE1RMRow, SessionRPERow, SessionRatingRow } from "./e1rm-trends";


### PR DESCRIPTION
## Summary

Adds Template, Muscle Group, and Date Range filters to the workout history screen. Filters are single-select, compose with AND logic, and integrate with existing text search and calendar.

Implements the approved plan at [.plans/PLAN-BLD-925.md](../blob/main/.plans/PLAN-BLD-925.md) (R5 — APPROVED by techlead + quality-director).

## Changes

### Database layer (`lib/db/`)
- New `muscle-format.ts` — `parseMuscleList(raw)` helper handling JSON + CSV storage formats with safe fallback.
- New queries in `session-stats.ts`:
  - `getTemplatesWithSessions()` — keyed by `template_id` (UUID, not name); LEFT JOIN with COALESCE fallback to most recent session name for deleted templates; excludes ad-hoc sessions (`template_id IS NULL`); sorted case-insensitively.
  - `getMuscleGroupsWithSessions()` — derives muscle groups from primary + secondary muscles of exercises used in completed sessions; deduped via `parseMuscleList`.
  - `getFilteredSessions(filters, limit, offset)` — composable WHERE clauses; muscle group uses 10-clause dual-format LIKE pattern over both `primary_muscles` and `secondary_muscles`; returns `{ rows, total }` for pagination UI.

### State + hooks
- New `hooks/useHistoryFilters.ts` — pure `useReducer` (`SET_TEMPLATE` / `SET_MUSCLE_GROUP` / `SET_DATE_PRESET` / `CLEAR_ONE` / `CLEAR_ALL`).
- Extended `hooks/useHistoryData.ts` — switches to paged `getFilteredSessions` whenever any filter or text search is active; falls back to `getSessionsByMonth` otherwise.

### UI (`components/history/`)
- New `FilterBar.tsx` — chip row with `Template ▾ | Muscle Group ▾ | Date Range ▾`, active-filter chips with × dismiss, "Clear all" link.
- New `TemplateFilterSheet.tsx` — searchable single-select; renders "(deleted)" suffix using fallback name.
- New `MuscleGroupFilterSheet.tsx` — single-select grouped by body region (upper / core / lower).
- New `DateRangeFilterSheet.tsx` — single-select 4 presets (7d / 30d / 90d / year). No new dependency required.
- Modified `app/history.tsx` — renders FilterBar; dims calendar to 50% opacity with `pointerEvents="none"` and caption when filter mode is active; result-count line; empty-state with "Clear filters" button.

### Tests
- `__tests__/lib/muscle-format.test.ts` — JSON / CSV / single / empty / malformed inputs.
- `__tests__/lib/db/history-filters.test.ts` — seeded SQLite covering duplicate template names, renamed templates, deleted templates, ad-hoc sessions, JSON+CSV mixed muscle storage, substring-collision protection (`back` ≠ `upper_back`), AND composition.
- `__tests__/hooks/useHistoryFilters.test.ts` — reducer SET / CLEAR_ONE / CLEAR_ALL.
- `__tests__/hooks/useHistoryData.integration.test.ts` — filter-mode routing + pagination.
- `__tests__/acceptance/history.acceptance.test.tsx` — filter bar interactions + calendar disable behaviour.

## Verification

- ✅ `tsc --noEmit` — zero errors
- ✅ Targeted feature tests — 63/63 pass
- ✅ Broader regression (`lib/db` + `hooks` + `history` patterns) — 2925/2925 pass
- ✅ No new lint warnings

## Plan References

- Acceptance criteria: PLAN-BLD-925.md §Acceptance Criteria
- Substring-collision assumption: PLAN-BLD-925.md §Technical Approach
- Tech-debt follow-up (CSV → JSON normalization for `csv-import.ts`): to be filed by CEO post-merge.

## Issue

Resolves BLD-938.