### PR TITLE
docs(agents): extend ux-designer prompt to consume CVD PNGs (BLD-958)

### DIFF
--- a/.agents/AGENTS-ux-designer.md
+++ b/.agents/AGENTS-ux-designer.md
@@ -72,14 +72,15 @@ Paperclip routine (09:00 PT, ab23d3ed-e434-4357-ab62-7ccf41159989)
    gh release download "$AUDIT_TAG" --dir /tmp/audit-bundle --clobber
    (cd /tmp/audit-bundle && unzip -o *.zip)
    ```
-2. **For EACH `<scenario>/<viewport>.png` + sibling `.json`**, run vision with
-   the canned prompt (§ Vision Prompt below).
+2. **For EACH `<scenario>/<viewport>{,-deuteranopia,-protanopia,-tritanopia}.png` + sibling `.json`**, run vision with the canned prompt (§ Vision Prompt below). Tag each invocation with its `cvd` mode (`baseline`, `deuteranopia`, `protanopia`, `tritanopia`) — pass it to the prompt and carry it through to the finding fingerprint.
 3. **Normalize findings**: each finding must include `{scenario, label,
    severity, description, suggested_fix}`.
 4. **Dedup before filing** (§ Dedup Logic below).
 5. **Check BLD-480 regression-catcher acceptance** (§ BLD-480 Trust Anchor below).
 6. **Update the audit issue**: post a summary comment (counts by severity),
    link the finding issues, close to `done`. If clean: `Clean audit ✅`.
+
+> **Acceptance for the CVD extension (BLD-958):** the audit must execute the vision prompt against all 4 PNGs per scenario (baseline + 3 CVD). On clean bundles, returning `[]` for all CVD passes is allowed; the requirement is that the iteration code path runs.
 
 ## Vision Prompt (canned, verbatim)
 
@@ -109,6 +110,20 @@ Paperclip routine (09:00 PT, ab23d3ed-e434-4357-ab62-7ccf41159989)
 > - **minor** — polish: small spacing inconsistencies, minor contrast,
 >   typography inconsistency.
 >
+> ### CVD pass (only when the input PNG is a CVD-emulation capture)
+>
+> When the screenshot is tagged `cvd: deuteranopia | protanopia | tritanopia`, the audit purpose CHANGES:
+>
+> - Only flag findings where a **critical-info color contrast collapses** under emulation. Examples: heatmap legend steps becoming indistinguishable, streak-state color (active vs. inactive) merging, primary CTA blending into background, success/error chip colors becoming ambiguous.
+> - Do **NOT** re-flag layout defects (truncation, overflow, alignment) that are already visible on the baseline capture — those belong to the baseline pass.
+> - If the CVD capture looks identical to baseline aside from hue shift and no information is lost, return `[]`.
+>
+> ### CVD severity sub-rubric
+>
+> - **major** — critical information is lost (user cannot distinguish a state, level, or category that the baseline conveys via color).
+> - **minor** — purely aesthetic hue shift; no information loss; visual polish only.
+> - **critical** is reserved for the baseline pass; do NOT escalate CVD findings to critical.
+>
 > ### Constraints
 >
 > - This is a WEB VIEWPORT audit — native (iOS/Android)-only layout bugs are
@@ -121,8 +136,9 @@ Before filing a new finding issue:
 
 1. **Compute fingerprint** (deterministic):
    ```
-   fingerprint = sha256(normalize(description) + "|" + scenario + "|" + label).slice(0,12)
+   fingerprint = sha256(normalize(description) + "|" + scenario + "|" + label + "|" + cvd_mode).slice(0,12)
    # normalize: lowercase, collapse whitespace, strip punctuation
+   # cvd_mode ∈ {baseline, deuteranopia, protanopia, tritanopia}
    ```
 2. **Search open `ux-audit`-labeled issues** for a matching
    `(scenario, fingerprint)` pair stored in the issue body under a
@@ -210,6 +226,7 @@ When creating the daily audit issue, use this template verbatim:
 **Scenario**: `<scenario-key>`
 **Route**: `<route>`
 **Viewport**: mobile (390×844)
+**CVD mode**: baseline | deuteranopia | protanopia | tritanopia
 **Commit audited**: `<SHA>`
 **Fingerprint**: `<12-char-hex>` ← used for dedup (QD#3)
 


### PR DESCRIPTION
## Summary

Extends the ux-designer canned vision prompt to consume the CVD-simulation PNGs (deuteranopia / protanopia / tritanopia) that are already captured per scenario, so the daily audit detects color-coded information collapse (e.g. heatmap legend steps under deutan) instead of only baseline layout defects.

This is a **prompt/spec edit only** — no TS/JS/Python code paths change.

## Changes

Single file: `.agents/AGENTS-ux-designer.md`

1. **§ Audit Flow, step 2** — iterate over all 4 PNGs per scenario (`<viewport>{,-deuteranopia,-protanopia,-tritanopia}.png`), tag each invocation with its `cvd` mode and thread it through to the fingerprint.
2. **§ Vision Prompt** — new `CVD pass` subsection + `CVD severity sub-rubric` (only flag when critical-info color contrast collapses; `major` if information is lost, `minor` if purely aesthetic; `critical` reserved for baseline).
3. **§ Dedup Logic** — fingerprint formula now includes `cvd_mode` so baseline and CVD passes don't collide. Finding Issue Body Template gets a new **CVD mode** line right after **Viewport**.
4. **§ Audit Flow** — acceptance note: audit must execute the prompt against all 4 PNGs per scenario; clean bundles returning `[]` for CVD passes is allowed.

## Testing

No build/test footprint — `.md` spec edit only. The behavioural test is the next audit run on `audit-2026-05-02-266dbbee-r2`, triggered by CEO post-merge.

## Issue

Resolves BLD-961
Parent: BLD-958
Calibration anchor: BLD-870 (heatmap-legend deutan-collapse)
Captures source: BLD-744 (Chromium CVD-emulation captures)