### PR TITLE
fix(history): widen heatmap day-label column to fit 3-letter labels (BLD-955)

### DIFF
--- a/__tests__/components/WorkoutHeatmap.test.tsx
+++ b/__tests__/components/WorkoutHeatmap.test.tsx
@@ -151,6 +151,43 @@ describe("WorkoutHeatmap", () => {
     expect(getByText("Start working out to see your consistency here!")).toBeTruthy();
   });
 
+  // BLD-955: row-label column must be wide enough for 3-letter labels at 390px
+  // (mobile baseline). Previous labelWidth=24 (from BLD-927, when labels were
+  // single letters) caused "Wed" to wrap mid-word into "We"/"d". Assert the
+  // label column is now ≥ 36px so all three visible labels render on one line.
+  it("renders 3-letter day labels without mid-word wrap (BLD-955)", () => {
+    const { getByText } = renderScreen(
+      <WorkoutHeatmap data={emptyData} />
+    );
+    const wed = getByText("Wed");
+    // Walk up to the styled Text wrapper carrying the column-width style.
+    // RNTL exposes nested host components — we search the style chain on
+    // `wed` and its ancestors for the explicit `width` we set in the
+    // component's row-label <Text>.
+    const collectStyles = (node: typeof wed | null): Record<string, unknown> => {
+      let acc: Record<string, unknown> = {};
+      let cur: typeof wed | null = node;
+      while (cur) {
+        const s = cur.props?.style;
+        const arr = Array.isArray(s) ? s : [s];
+        for (const entry of arr) {
+          if (entry && typeof entry === "object") {
+            acc = { ...acc, ...(entry as Record<string, unknown>) };
+          }
+        }
+        cur = cur.parent as typeof wed | null;
+      }
+      return acc;
+    };
+    const flat = collectStyles(wed);
+    // Column width must accommodate 3-letter labels — regression guard against
+    // re-tightening to the BLD-927 single-letter value (24).
+    expect(typeof flat.width).toBe("number");
+    expect(flat.width as number).toBeGreaterThanOrEqual(36);
+    // Sanity: "Wed" is rendered as a single text node (not split by wrapping).
+    expect(wed.children).toEqual(["Wed"]);
+  });
+
   it("does not show empty state when data has workouts (regardless of totalAllTime)", () => {
     const data = new Map([["2026-04-14", 1]]);
     const { queryByText } = renderScreen(

--- a/components/WorkoutHeatmap.tsx
+++ b/components/WorkoutHeatmap.tsx
@@ -136,8 +136,9 @@ export default function WorkoutHeatmap({ data, weeks = 16, onDayPress, totalAllT
     return g;
   }, [data, weeks]);
 
-  // BLD-686: bumped 18→22; BLD-927: bumped to 24 to prevent truncation on narrow (390px+) viewports.
-  const labelWidth = 24;
+  // BLD-686: bumped 18→22; BLD-927: bumped to 24 to prevent truncation on narrow (390px+) viewports;
+  // BLD-955: 24→36 to fit 3-letter labels ("Mon"/"Wed"/"Fri") without mid-word wrap at 390px.
+  const labelWidth = 36;
   const gap = 2;
   const availableWidth = layout.width - layout.horizontalPadding * 2 - labelWidth - gap;
   const cellSize = Math.max(14, Math.min(24, Math.floor((availableWidth - gap * (weeks - 1)) / weeks)));


### PR DESCRIPTION
## Summary

The "Last 16 Weeks" activity heatmap row labels (`Mon` / `Wed` / `Fri`) wrapped mid-word at 390px viewports — `Wed` rendered as `We` / `d` on two lines. Bumps `labelWidth` from 24 to 36 so all three visible labels fit on one line at the mobile baseline.

## Changes

- `components/WorkoutHeatmap.tsx`: `labelWidth = 24 → 36`, with iteration comment updated to record the BLD-955 step.
- `__tests__/components/WorkoutHeatmap.test.tsx`: regression test asserting the row-label column width is `>= 36` and that `Wed` renders as a single text node.

## Root cause

`labelWidth` was originally tuned for the single-letter labels used before BLD-686, then bumped to 24 in BLD-927 — still too narrow once `Mon`/`Wed`/`Fri` shipped, because letter advance widths in `Wed` exceed those in `Mon`/`Fri` at `fontSizes.xs`.

## Testing

- `npm test -- __tests__/components/WorkoutHeatmap.test.tsx` → all 17 tests pass (16 existing + 1 new BLD-955 regression).
- `node_modules/.bin/tsc --noEmit` → 0 errors in app sources.
- Verified the regression test would fail when `labelWidth` is reverted to 24.

## Issue

Resolves BLD-955.