### PR TITLE
feat(audit): deterministic fingerprint dedup wrapper for ux-designer (BLD-969)

### DIFF
--- a/.agents/AGENTS-ux-designer.md
+++ b/.agents/AGENTS-ux-designer.md
@@ -130,28 +130,49 @@ Paperclip routine (09:00 PT, ab23d3ed-e434-4357-ab62-7ccf41159989)
 >   out of scope; note this caveat in the audit summary but do not try to
 >   compensate for it in individual findings.
 
-## Dedup Logic (QD#3)
+## Dedup Logic (QD#3 / BLD-969)
 
-Before filing a new finding issue:
+**Implementation: deterministic, code-enforced.** As of BLD-969 you MUST
+NOT call `clip.sh create-issue` directly for audit findings. Instead use
+the wrapper:
 
-1. **Compute fingerprint** (deterministic):
+```bash
+scripts/audit-create-finding.sh \
+  --fingerprint <12-hex> \
+  --title "<finding title>" \
+  --description-file <path-to-finding-md> \
+  --audit-tag audit-YYYY-MM-DD-<commit-short> \
+  --run-id "$PAPERCLIP_RUN_ID" \
+  --priority medium
+```
+
+The wrapper computes the dedup deterministically:
+
+1. **Compute fingerprint** (deterministic — same formula as before):
    ```
    fingerprint = sha256(normalize(description) + "|" + scenario + "|" + label + "|" + cvd_mode).slice(0,12)
    # normalize: lowercase, collapse whitespace, strip punctuation
    # cvd_mode ∈ {baseline, deuteranopia, protanopia, tritanopia}
    ```
-2. **Search open `ux-audit`-labeled issues** for a matching
-   `(scenario, fingerprint)` pair stored in the issue body under a
-   `Fingerprint:` line.
-3. **On match**: post `+1 recurrence (<N> days since first seen)` comment on
-   the existing issue. Do NOT file a new one. Prevents CEO-inbox DoS.
-4. **Second dedup key — `(audit-date, commit SHA)`**: if the commit SHA in
-   today's bundle is flagged in a prior comment on the audit issue as
-   "build already known-broken" (e.g. claudecoder's prior reply), skip filing
-   P0s for that SHA.
+2. **The wrapper searches** the CableSnap project for any open issue
+   (`todo` / `in_progress` / `in_review` / `backlog`) whose description
+   contains the exact, case-sensitive substring `Fingerprint: <hash>`.
+   `cancelled` and `done` issues are deliberately excluded so a
+   re-occurrence after a fix files a fresh ticket.
+3. **On match**: the wrapper posts
+   `Same finding reproduced in audit-YYYY-MM-DD-<commit> (run <id>)` on
+   the existing issue and prints `RECURRENCE <BLD-N>`. **No new issue is
+   created.** This prevents CEO-inbox DoS (BLD-952 + BLD-956 incident).
+4. **No match**: the wrapper creates the new issue and prints
+   `CREATED <BLD-N>`.
 
-If TWO audit bundles land on the same day (manual re-run), review ONLY the
-later bundle (QD observation).
+**Second dedup key — `(audit-date, commit SHA)`**: if the commit SHA in
+today's bundle is flagged in a prior comment on the audit issue as
+"build already known-broken" (e.g. claudecoder's prior reply), skip
+filing P0s for that SHA. (LLM-side check; not enforced by the wrapper.)
+
+If TWO audit bundles land on the same day (manual re-run), review ONLY
+the later bundle (QD observation).
 
 ## BLD-480 Trust Anchor (QD#1 + QD#2)
 

--- a/scripts/__tests__/audit-create-finding.test.ts
+++ b/scripts/__tests__/audit-create-finding.test.ts
@@ -358,6 +358,84 @@ describe('audit-create-finding.sh — BLD-969 deterministic dedup', () => {
         await server.close();
       }
     });
+
+    it('PLAIN-format substring of a longer fingerprint does NOT match (regression for QD block)', async () => {
+      // QD blocked PR #488: with the original `grep -F "Fingerprint: $FP"`,
+      // a new fingerprint that is a PREFIX of an existing plain-format
+      // fingerprint would falsely dedup. The original test only covered
+      // the bold/backticked format, so the plain-format path was unguarded.
+      // Repro from QD: existing `Fingerprint: aabbccddeeff0011` (plain), new
+      // fingerprint `aabbccddeeff` returned `RECURRENCE BLD-70` instead of
+      // `CREATED BLD-...`. The fix enforces a non-hex token boundary after
+      // the hash on the plain-format match.
+      const longFp = 'aabbccddeeff0011';
+      const shortFp = 'aabbccddeeff';
+      const state: MockState = {
+        issues: [
+          {
+            identifier: 'BLD-70',
+            status: 'todo',
+            // PLAIN format — no bold, no backticks. This is the path the
+            // original grep -F mishandled.
+            description: `## prior\n\nFingerprint: ${longFp}\nMore detail.\n`,
+            title: 'long fingerprint plain',
+          },
+        ],
+        commentCalls: [],
+        createCalls: [],
+        nextId: 500,
+      };
+      const server = await startMockServer(makeMock(state));
+      const desc = writeDescFile(shortFp);
+      try {
+        const r = await runWrapper(COMMON_ARGS(desc, shortFp), server.url);
+        expect(r.status).toBe(0);
+        expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+        expect(state.createCalls).toHaveLength(1);
+        expect(state.commentCalls).toHaveLength(0);
+      } finally {
+        fs.unlinkSync(desc);
+        await server.close();
+      }
+    });
+
+    it('PLAIN-format EXACT fingerprint match still recurrence-matches', async () => {
+      // Guard the positive case for the plain format so the boundary fix
+      // doesn't accidentally regress real dedup. Description carries
+      // `Fingerprint: <hash>` followed by a newline (typical token boundary
+      // in audit descriptions).
+      const fp = 'cbe59de55e00';
+      const state: MockState = {
+        issues: [
+          {
+            identifier: 'BLD-71',
+            status: 'in_review',
+            description: `## prior finding\n\nFingerprint: ${fp}\nScenario: workout-history\n`,
+            title: 'prior finding plain',
+          },
+        ],
+        commentCalls: [],
+        createCalls: [],
+        nextId: 600,
+      };
+      const server = await startMockServer(makeMock(state));
+      const desc = writeDescFile(fp);
+      try {
+        const r = await runWrapper(COMMON_ARGS(desc, fp), server.url);
+        expect(r.status).toBe(0);
+        expect(r.stdout).toMatch(/^RECURRENCE BLD-71/);
+        expect(state.createCalls).toHaveLength(0);
+        expect(state.commentCalls).toEqual([
+          expect.objectContaining({
+            issueId: 'BLD-71',
+            body: expect.stringContaining('Same finding reproduced in audit-2026-05-02-266dbbee'),
+          }),
+        ]);
+      } finally {
+        fs.unlinkSync(desc);
+        await server.close();
+      }
+    });
   });
 
   describe('argument validation', () => {

--- a/scripts/__tests__/audit-create-finding.test.ts
+++ b/scripts/__tests__/audit-create-finding.test.ts
@@ -1,0 +1,414 @@
+/**
+ * @jest-environment node
+ *
+ * BLD-969 — Tests for `scripts/audit-create-finding.sh` deterministic dedup.
+ *
+ * Bug background:
+ *   The ux-designer agent created two parallel issues (BLD-952, BLD-956)
+ *   with the same fingerprint cbe59de55e00 on 2026-05-02. The dedup
+ *   instruction in the agent's prompt is LLM-enforced and was skipped.
+ *   This wrapper makes dedup deterministic by code.
+ *
+ * Acceptance criteria (from BLD-969):
+ *   1. When the audit runs twice with the same fingerprint, only ONE
+ *      Paperclip issue is created. The second invocation comments on the
+ *      first.
+ *   2. The de-dup check matches by exact, case-sensitive `Fingerprint: <hash>`
+ *      substring in the issue description.
+ *   3. Cancelled and `done` issues are NOT considered matches — a
+ *      re-occurrence after fix MUST file a fresh ticket.
+ *   4. On a duplicate, a comment is posted on the existing issue:
+ *      `Same finding reproduced in audit-YYYY-MM-DD-<commit> (run <id>)`.
+ *
+ * Test strategy:
+ *   We spin up a tiny http server on a random port that mocks the
+ *   Paperclip API endpoints clip.sh hits (`/api/companies/.../issues`,
+ *   `/api/issues/<id>`, `/api/issues/<id>/comments`). The wrapper invokes
+ *   the real clip.sh which, via PAPERCLIP_API_BASE, hits our mock. This
+ *   exercises the actual shell parsing/grep/jq logic end-to-end.
+ */
+import { spawn } from 'child_process';
+import * as http from 'http';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AddressInfo } from 'net';
+
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+
+const SCRIPT = path.resolve(__dirname, '..', 'audit-create-finding.sh');
+const CLIP = path.resolve(__dirname, '..', 'clip.sh');
+
+interface IssueFixture {
+  identifier: string;
+  status: string;
+  description: string;
+  title?: string;
+  priority?: string;
+}
+
+function startMockServer(handler: Handler): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(handler);
+    server.keepAliveTimeout = 100;
+    server.headersTimeout = 500;
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () =>
+          new Promise<void>((res) => {
+            (server as unknown as { closeAllConnections?: () => void }).closeAllConnections?.();
+            server.close(() => res());
+          }),
+      });
+    });
+  });
+}
+
+interface MockState {
+  issues: IssueFixture[];
+  /** Calls to POST .../comments — recorded for assertions. */
+  commentCalls: { issueId: string; body: string }[];
+  /** Calls to POST .../issues — recorded for assertions. */
+  createCalls: { title: string; description: string; priority?: string }[];
+  /** Auto-incrementing identifier suffix for newly-created issues. */
+  nextId: number;
+}
+
+function makeMock(state: MockState): Handler {
+  return (req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      const url = req.url || '';
+      const method = req.method || 'GET';
+
+      // GET /api/companies/<UUID>/issues?... — list-issues
+      if (method === 'GET' && /^\/api\/companies\/[^/]+\/issues/.test(url)) {
+        const qs = url.includes('?') ? url.split('?')[1] : '';
+        const params = new URLSearchParams(qs);
+        const q = params.get('q') || '';
+        const matches = state.issues.filter((i) =>
+          q ? i.description.includes(q) || (i.title || '').includes(q) : true,
+        );
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(matches));
+        return;
+      }
+
+      // GET /api/issues/<id> — get-issue
+      const getMatch = url.match(/^\/api\/issues\/([A-Z]+-\d+)$/);
+      if (method === 'GET' && getMatch) {
+        const ident = getMatch[1];
+        const issue = state.issues.find((i) => i.identifier === ident);
+        if (!issue) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'not found' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(issue));
+        return;
+      }
+
+      // POST /api/issues/<id>/comments — comment-issue
+      const commentMatch = url.match(/^\/api\/issues\/([A-Z]+-\d+)\/comments$/);
+      if (method === 'POST' && commentMatch) {
+        const ident = commentMatch[1];
+        const parsed = body ? JSON.parse(body) : {};
+        state.commentCalls.push({ issueId: ident, body: parsed.body || '' });
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ id: 'cm-mock', body: parsed.body }));
+        return;
+      }
+
+      // POST /api/companies/<UUID>/issues — create-issue
+      if (method === 'POST' && /^\/api\/companies\/[^/]+\/issues/.test(url)) {
+        const parsed = body ? JSON.parse(body) : {};
+        state.createCalls.push({
+          title: parsed.title,
+          description: parsed.description,
+          priority: parsed.priority,
+        });
+        const ident = `BLD-${state.nextId++}`;
+        const created: IssueFixture = {
+          identifier: ident,
+          status: 'todo',
+          description: parsed.description,
+          title: parsed.title,
+          priority: parsed.priority,
+        };
+        state.issues.push(created);
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(created));
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unhandled mock route', method, url }));
+    });
+  };
+}
+
+function runWrapper(
+  args: string[],
+  apiBase: string,
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [SCRIPT, '--clip', CLIP, ...args], {
+      env: {
+        ...process.env,
+        PAPERCLIP_API_BASE: apiBase,
+        PAPERCLIP_AGENT_API_KEY: 'test-key',
+        CLIP_COMPANY: '00000000-0000-0000-0000-000000000001',
+        CLIP_AGENT: '00000000-0000-0000-0000-000000000002',
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => (stdout += c.toString()));
+    child.stderr.on('data', (c) => (stderr += c.toString()));
+    child.on('error', reject);
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+let __descSeq = 0;
+function writeDescFile(fingerprint: string, body = 'mock description body'): string {
+  const file = path.join(
+    os.tmpdir(),
+    `audit-finding-desc-${process.pid}-${Date.now()}-${++__descSeq}.md`,
+  );
+  // Match the real ux-designer template: a `Fingerprint: <hash>` line.
+  fs.writeFileSync(
+    file,
+    `## UX: mock finding\n\n**Fingerprint**: \`${fingerprint}\`\n\n${body}\n`,
+  );
+  return file;
+}
+
+const COMMON_ARGS = (descFile: string, fp: string) => [
+  '--fingerprint', fp,
+  '--title', `UX: mock finding (${fp})`,
+  '--description-file', descFile,
+  '--audit-tag', 'audit-2026-05-02-266dbbee',
+  '--run-id', 'run-test-123',
+  '--project-id', '00000000-0000-0000-0000-0000000000aa',
+];
+
+describe('audit-create-finding.sh — BLD-969 deterministic dedup', () => {
+  describe('AC#1: dedup by fingerprint', () => {
+    it('first call CREATES; second call with same fingerprint COMMENTS', async () => {
+      const fp = 'cbe59de55e00';
+      const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 100 };
+      const server = await startMockServer(makeMock(state));
+      const desc = writeDescFile(fp);
+      try {
+        const first = await runWrapper(COMMON_ARGS(desc, fp), server.url);
+        expect(first.status).toBe(0);
+        expect(first.stdout).toMatch(/^CREATED BLD-\d+/);
+        expect(state.createCalls).toHaveLength(1);
+        expect(state.commentCalls).toHaveLength(0);
+
+        const second = await runWrapper(COMMON_ARGS(desc, fp), server.url);
+        expect(second.status).toBe(0);
+        expect(second.stdout).toMatch(/^RECURRENCE BLD-\d+/);
+        // No second issue created.
+        expect(state.createCalls).toHaveLength(1);
+        // Recurrence comment posted on the existing issue.
+        expect(state.commentCalls).toHaveLength(1);
+        expect(state.commentCalls[0].body).toContain('Same finding reproduced in audit-2026-05-02-266dbbee');
+        expect(state.commentCalls[0].body).toContain('run-test-123');
+      } finally {
+        fs.unlinkSync(desc);
+        await server.close();
+      }
+    });
+
+    it('different fingerprints CREATE separate issues', async () => {
+      const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 200 };
+      const server = await startMockServer(makeMock(state));
+      const fpA = 'aaaaaaaaaaaa';
+      const fpB = 'bbbbbbbbbbbb';
+      const descA = writeDescFile(fpA);
+      const descB = writeDescFile(fpB);
+      try {
+        const a = await runWrapper(COMMON_ARGS(descA, fpA), server.url);
+        const b = await runWrapper(COMMON_ARGS(descB, fpB), server.url);
+        expect(a.status).toBe(0);
+        expect(b.status).toBe(0);
+        expect(a.stdout).toMatch(/^CREATED BLD-/);
+        expect(b.stdout).toMatch(/^CREATED BLD-/);
+        expect(state.createCalls).toHaveLength(2);
+        expect(state.commentCalls).toHaveLength(0);
+      } finally {
+        fs.unlinkSync(descA);
+        fs.unlinkSync(descB);
+        await server.close();
+      }
+    });
+  });
+
+  describe('AC#3: cancelled/done are not matches — re-occurrence files fresh ticket', () => {
+    it.each(['cancelled', 'done'])(
+      'pre-existing %s issue with same fingerprint is IGNORED — new issue is CREATED',
+      async (closedStatus) => {
+        const fp = 'deadbeef0001';
+        const state: MockState = {
+          issues: [
+            {
+              identifier: 'BLD-50',
+              status: closedStatus,
+              description: `## prior finding\n\n**Fingerprint**: \`${fp}\`\n`,
+              title: 'old finding',
+            },
+          ],
+          commentCalls: [],
+          createCalls: [],
+          nextId: 300,
+        };
+        const server = await startMockServer(makeMock(state));
+        const desc = writeDescFile(fp);
+        try {
+          const r = await runWrapper(COMMON_ARGS(desc, fp), server.url);
+          expect(r.status).toBe(0);
+          expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+          expect(state.createCalls).toHaveLength(1);
+          expect(state.commentCalls).toHaveLength(0);
+        } finally {
+          fs.unlinkSync(desc);
+          await server.close();
+        }
+      },
+    );
+
+    it.each(['todo', 'in_progress', 'in_review', 'backlog'])(
+      'pre-existing %s issue with same fingerprint IS matched — comment posted',
+      async (openStatus) => {
+        const fp = 'deadbeef0002';
+        const state: MockState = {
+          issues: [
+            {
+              identifier: 'BLD-60',
+              status: openStatus,
+              description: `## existing finding\n\n**Fingerprint**: \`${fp}\`\n`,
+              title: 'existing',
+            },
+          ],
+          commentCalls: [],
+          createCalls: [],
+          nextId: 400,
+        };
+        const server = await startMockServer(makeMock(state));
+        const desc = writeDescFile(fp);
+        try {
+          const r = await runWrapper(COMMON_ARGS(desc, fp), server.url);
+          expect(r.status).toBe(0);
+          expect(r.stdout).toMatch(/^RECURRENCE BLD-60/);
+          expect(state.createCalls).toHaveLength(0);
+          expect(state.commentCalls).toEqual([
+            expect.objectContaining({
+              issueId: 'BLD-60',
+              body: expect.stringContaining('Same finding reproduced in audit-2026-05-02-266dbbee'),
+            }),
+          ]);
+        } finally {
+          fs.unlinkSync(desc);
+          await server.close();
+        }
+      },
+    );
+  });
+
+  describe('AC#2: case-sensitive exact-match', () => {
+    it('substring of a longer fingerprint does NOT match', async () => {
+      // Issue stored with a 16-char fingerprint; lookup uses a 12-char prefix.
+      // The longer issue contains the shorter as a substring, but our query
+      // searches for the exact line `Fingerprint: <12-hex>` — which the
+      // longer fingerprint's line does NOT contain (it has an extra suffix).
+      // Without exact-line matching this would falsely dedup.
+      const longFp = 'aabbccddeeff0011';
+      const shortFp = 'aabbccddeeff';
+      const state: MockState = {
+        issues: [
+          {
+            identifier: 'BLD-70',
+            status: 'todo',
+            description: `## prior\n\n**Fingerprint**: \`${longFp}\`\n`,
+            title: 'long fingerprint',
+          },
+        ],
+        commentCalls: [],
+        createCalls: [],
+        nextId: 500,
+      };
+      const server = await startMockServer(makeMock(state));
+      const desc = writeDescFile(shortFp);
+      try {
+        const r = await runWrapper(COMMON_ARGS(desc, shortFp), server.url);
+        expect(r.status).toBe(0);
+        // Should NOT recurrence-match. Must create fresh.
+        expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+        expect(state.createCalls).toHaveLength(1);
+        expect(state.commentCalls).toHaveLength(0);
+      } finally {
+        fs.unlinkSync(desc);
+        await server.close();
+      }
+    });
+  });
+
+  describe('argument validation', () => {
+    it('rejects missing --fingerprint', async () => {
+      const desc = writeDescFile('xxxxxxxxxxxx');
+      try {
+        const r = await runWrapper(
+          [
+            '--title', 't',
+            '--description-file', desc,
+            '--audit-tag', 'tag',
+            '--run-id', 'r',
+          ],
+          'http://127.0.0.1:1', // unused — script exits before any HTTP
+        );
+        expect(r.status).toBe(2);
+        expect(r.stderr).toContain('missing --fingerprint');
+      } finally {
+        fs.unlinkSync(desc);
+      }
+    });
+
+    it('rejects non-hex fingerprint', async () => {
+      const desc = writeDescFile('not-hex!');
+      try {
+        const r = await runWrapper(
+          [
+            ...COMMON_ARGS(desc, 'not-hex!'),
+          ],
+          'http://127.0.0.1:1',
+        );
+        expect(r.status).toBe(2);
+        expect(r.stderr).toContain('fingerprint must be 6-64 hex chars');
+      } finally {
+        fs.unlinkSync(desc);
+      }
+    });
+
+    it('rejects missing description file', async () => {
+      const r = await runWrapper(
+        [
+          '--fingerprint', 'aabbccddeeff',
+          '--title', 't',
+          '--description-file', '/tmp/definitely-does-not-exist-bld969.md',
+          '--audit-tag', 'tag',
+          '--run-id', 'r',
+        ],
+        'http://127.0.0.1:1',
+      );
+      expect(r.status).toBe(2);
+      expect(r.stderr).toContain('description file not found');
+    });
+  });
+});

--- a/scripts/audit-create-finding.sh
+++ b/scripts/audit-create-finding.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# audit-create-finding.sh — BLD-969 deterministic dedup wrapper for ux-designer.
+#
+# Background:
+#   The ux-designer agent's prompt instructs it to dedup findings by
+#   fingerprint before calling `clip.sh create-issue`. Because that's
+#   LLM-enforced advice (not code-enforced), the agent occasionally creates
+#   duplicates — concretely BLD-952 + BLD-956 on 2026-05-02 both carried
+#   fingerprint cbe59de55e00 for the same workout-history defect.
+#
+#   This script makes the dedup deterministic. The agent calls THIS script
+#   instead of `clip.sh create-issue` for every audit finding. It searches
+#   for an open/in_review/in_progress issue containing the same
+#   `Fingerprint: <hash>` line, and either comments on it ("recurrence")
+#   or creates a new issue.
+#
+# Behaviour:
+#   1. Search project issues whose description contains "Fingerprint: <hash>".
+#   2. For each candidate, fetch the full issue and confirm:
+#        - description contains the EXACT case-sensitive substring
+#          `Fingerprint: <hash>` (or `\`<hash>\`` formatted equivalents),
+#        - status ∈ {todo, in_progress, in_review, backlog}
+#          (i.e. NOT cancelled, NOT done — re-occurrence after fix
+#          should re-open as a new issue per BLD-969 acceptance).
+#   3. If a match is found → comment on the existing issue with
+#      "Same finding reproduced in audit-YYYY-MM-DD-<commit> (run <id>)"
+#      and print `RECURRENCE <identifier>` to stdout. Exit 0.
+#   4. Otherwise → invoke `clip.sh create-issue` with the provided args
+#      and print `CREATED <identifier>` to stdout. Exit 0.
+#
+# Why a wrapper rather than embedding into clip.sh?
+#   `clip.sh` is a thin generic API helper used by every agent for many
+#   purposes. The dedup behaviour is specific to the visual-audit pipeline
+#   and needs to know the fingerprint convention. Keeping it in a dedicated
+#   script also keeps the API helper's surface stable.
+#
+# Refs: BLD-969, BLD-952, BLD-956, BLD-939.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: audit-create-finding.sh \
+         --fingerprint <12-hex> \
+         --title <issue-title> \
+         --description-file <path> \
+         --audit-tag <audit-YYYY-MM-DD-COMMIT> \
+         --run-id <heartbeat-run-id> \
+         [--priority <urgent|critical|high|medium|low|none>] \
+         [--project-id <UUID>] \
+         [--clip <path/to/clip.sh>]
+
+Searches the active CableSnap project for an open issue containing the
+exact line `Fingerprint: <hash>`. If one exists, posts a recurrence
+comment on it. Otherwise creates a new issue from --description-file.
+
+Exit codes:
+  0  Either reused an existing issue (printed `RECURRENCE <ID>`) or
+     created a new one (printed `CREATED <ID>`).
+  2  Bad arguments / missing required flag.
+  3  clip.sh failed unexpectedly.
+EOF
+  exit "${1:-2}"
+}
+
+# ---------- arg parsing ----------
+FINGERPRINT=""
+TITLE=""
+DESC_FILE=""
+AUDIT_TAG=""
+RUN_ID=""
+PRIORITY="medium"
+# Default to CableSnap project. Caller may override for tests.
+PROJECT_ID="${PROJECT_ID:-c3d4e5f6-a7b8-9012-cdef-123456789012}"
+CLIP="${CLIP:-$(cd "$(dirname "$0")" && pwd)/clip.sh}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fingerprint)      FINGERPRINT="$2"; shift 2;;
+    --title)            TITLE="$2"; shift 2;;
+    --description-file) DESC_FILE="$2"; shift 2;;
+    --audit-tag)        AUDIT_TAG="$2"; shift 2;;
+    --run-id)           RUN_ID="$2"; shift 2;;
+    --priority)         PRIORITY="$2"; shift 2;;
+    --project-id)       PROJECT_ID="$2"; shift 2;;
+    --clip)             CLIP="$2"; shift 2;;
+    -h|--help)          usage 0;;
+    *) echo "Unknown option: $1" >&2; usage 2;;
+  esac
+done
+
+# ---------- validation ----------
+[[ -n "$FINGERPRINT" ]] || { echo "missing --fingerprint" >&2; usage 2; }
+[[ -n "$TITLE"        ]] || { echo "missing --title" >&2; usage 2; }
+[[ -n "$DESC_FILE"    ]] || { echo "missing --description-file" >&2; usage 2; }
+[[ -n "$AUDIT_TAG"    ]] || { echo "missing --audit-tag" >&2; usage 2; }
+[[ -n "$RUN_ID"       ]] || { echo "missing --run-id" >&2; usage 2; }
+[[ -f "$DESC_FILE"    ]] || { echo "description file not found: $DESC_FILE" >&2; exit 2; }
+
+# Exact-match dedup, per BLD-969 AC: case-sensitive on the fingerprint hash.
+# Validate the hash looks like a hex slug to avoid accidentally matching
+# unrelated substrings (e.g. a description that says "Fingerprint: <pending>").
+if ! [[ "$FINGERPRINT" =~ ^[0-9a-fA-F]{6,64}$ ]]; then
+  echo "fingerprint must be 6-64 hex chars (got: '$FINGERPRINT')" >&2
+  exit 2
+fi
+
+# Statuses considered "open" for dedup purposes. Cancelled/done MUST be
+# excluded so a re-occurrence after a fix files a fresh ticket (AC#3).
+is_open_status() {
+  case "$1" in
+    todo|in_progress|in_review|backlog) return 0;;
+    *) return 1;;
+  esac
+}
+
+# ---------- search for existing issue ----------
+# Free-text search across the project. The fingerprint hex is unique enough
+# that this returns a tiny candidate set (typically 0-2 issues). We then
+# fetch each candidate and verify the literal `Fingerprint: <hash>` line
+# is present in the description, plus that the status is open.
+SEARCH_OUT="$(mktemp)"
+trap 'rm -f "$SEARCH_OUT"' EXIT
+
+# We search by the bare fingerprint hash (12+ hex chars) rather than
+# `Fingerprint: <hash>` because clip.sh's `-q` value goes straight into
+# a URL query string and currently does NOT URL-encode spaces — they
+# break curl. The hex slug is unique enough on its own; the description
+# verification step below confirms an exact `Fingerprint: <hash>` line.
+if ! "$CLIP" list-issues --project "$PROJECT_ID" -q "$FINGERPRINT" \
+       > "$SEARCH_OUT" 2>/dev/null; then
+  echo "audit-create-finding: clip.sh list-issues failed" >&2
+  exit 3
+fi
+
+# list-issues prints jq-projected one-object-per-line `{identifier, title, status, priority}`.
+# Extract identifiers regardless of formatting (multi-line or single-line jq output).
+CANDIDATES="$(grep -oE '"identifier"[[:space:]]*:[[:space:]]*"[A-Z]+-[0-9]+"' "$SEARCH_OUT" \
+                | sed -E 's/.*"([A-Z]+-[0-9]+)".*/\1/' \
+                | awk '!seen[$0]++' \
+                || true)"
+
+EXISTING=""
+if [[ -n "$CANDIDATES" ]]; then
+  while IFS= read -r ident; do
+    [[ -z "$ident" ]] && continue
+    DETAIL="$("$CLIP" get-issue "$ident" 2>/dev/null || true)"
+    [[ -z "$DETAIL" ]] && continue
+
+    # Status check.
+    STATUS="$(printf '%s' "$DETAIL" | grep -oE '"status"[[:space:]]*:[[:space:]]*"[a-z_]+"' \
+                | head -1 | sed -E 's/.*"([a-z_]+)"$/\1/')"
+    is_open_status "$STATUS" || continue
+
+    # Description check — exact, case-sensitive `Fingerprint: <hash>` substring
+    # (literal hash, no regex specials in valid hex). Use plain `grep -F` so
+    # the hex is matched verbatim and is not misinterpreted as a regex.
+    DESC="$(printf '%s' "$DETAIL" | grep -oE '"description"[[:space:]]*:[[:space:]]*"([^"\\]|\\.)*"' || true)"
+    if printf '%s' "$DESC" | grep -F -q "Fingerprint: $FINGERPRINT" \
+       || printf '%s' "$DESC" | grep -F -q "Fingerprint**: \`$FINGERPRINT\`"; then
+      EXISTING="$ident"
+      break
+    fi
+  done <<< "$CANDIDATES"
+fi
+
+# ---------- recurrence path ----------
+if [[ -n "$EXISTING" ]]; then
+  COMMENT="Same finding reproduced in ${AUDIT_TAG} (run ${RUN_ID})"
+  if ! "$CLIP" comment-issue "$EXISTING" --body "$COMMENT" >/dev/null; then
+    echo "audit-create-finding: failed to post recurrence comment on $EXISTING" >&2
+    exit 3
+  fi
+  echo "RECURRENCE $EXISTING"
+  exit 0
+fi
+
+# ---------- create path ----------
+DESC_BODY="$(cat "$DESC_FILE")"
+CREATE_OUT="$(mktemp)"
+# shellcheck disable=SC2064 — capture EXISTING value of trap path now.
+trap 'rm -f "$SEARCH_OUT" "$CREATE_OUT"' EXIT
+
+if ! "$CLIP" create-issue \
+       --title "$TITLE" \
+       --description "$DESC_BODY" \
+       --priority "$PRIORITY" \
+       --project-id "$PROJECT_ID" \
+       > "$CREATE_OUT" 2>&1; then
+  echo "audit-create-finding: clip.sh create-issue failed" >&2
+  cat "$CREATE_OUT" >&2 || true
+  exit 3
+fi
+
+NEW_ID="$(grep -oE '"identifier"[[:space:]]*:[[:space:]]*"[A-Z]+-[0-9]+"' "$CREATE_OUT" \
+            | head -1 | sed -E 's/.*"([A-Z]+-[0-9]+)".*/\1/')"
+
+if [[ -z "$NEW_ID" ]]; then
+  echo "audit-create-finding: created issue but could not parse identifier from response:" >&2
+  cat "$CREATE_OUT" >&2
+  exit 3
+fi
+
+echo "CREATED $NEW_ID"
+exit 0

--- a/scripts/audit-create-finding.sh
+++ b/scripts/audit-create-finding.sh
@@ -152,11 +152,18 @@ if [[ -n "$CANDIDATES" ]]; then
                 | head -1 | sed -E 's/.*"([a-z_]+)"$/\1/')"
     is_open_status "$STATUS" || continue
 
-    # Description check — exact, case-sensitive `Fingerprint: <hash>` substring
-    # (literal hash, no regex specials in valid hex). Use plain `grep -F` so
-    # the hex is matched verbatim and is not misinterpreted as a regex.
+    # Description check — exact, case-sensitive `Fingerprint: <hash>` token
+    # (literal hash, no regex specials in valid hex). We must enforce a
+    # token boundary on the trailing side so a short fingerprint does NOT
+    # prefix-match a longer one (e.g. `Fingerprint: aabbccddeeff` must NOT
+    # match an existing description containing `Fingerprint: aabbccddeeff0011`).
+    # Both accepted formats are checked:
+    #   - plain:  `Fingerprint: <hash>`     followed by a non-hex char
+    #   - bold:   `Fingerprint**: \`<hash>\`` (backtick is the boundary)
+    # The hash is constrained to [0-9a-fA-F]+ by --fingerprint validation
+    # so it is regex-safe to inline.
     DESC="$(printf '%s' "$DETAIL" | grep -oE '"description"[[:space:]]*:[[:space:]]*"([^"\\]|\\.)*"' || true)"
-    if printf '%s' "$DESC" | grep -F -q "Fingerprint: $FINGERPRINT" \
+    if printf '%s' "$DESC" | grep -Eq "Fingerprint: ${FINGERPRINT}([^0-9a-fA-F]|\$)" \
        || printf '%s' "$DESC" | grep -F -q "Fingerprint**: \`$FINGERPRINT\`"; then
       EXISTING="$ident"
       break


### PR DESCRIPTION
## Summary

The ux-designer agent created two parallel issues (BLD-952 cancelled, BLD-956 in_review) with the same fingerprint `cbe59de55e00` on 2026-05-02 because the dedup step in its prompt is LLM-enforced advice. This PR replaces it with a code-enforced wrapper that the agent MUST call instead of `clip.sh create-issue`.

## Changes

- **`scripts/audit-create-finding.sh`** — new wrapper. Searches the CableSnap project for an open issue (`todo`/`in_progress`/`in_review`/`backlog`) containing the exact case-sensitive substring `Fingerprint: <hash>`. On match: posts `Same finding reproduced in audit-YYYY-MM-DD-<commit> (run <id>)` and exits with `RECURRENCE <BLD-N>`. Otherwise: forwards to `clip.sh create-issue` and exits with `CREATED <BLD-N>`.
- **`scripts/__tests__/audit-create-finding.test.ts`** — 12 tests, mock-server pattern matching `clip-error-surfacing.test.ts`. Covers all 4 BLD-969 acceptance criteria.
- **`.agents/AGENTS-ux-designer.md`** — Dedup section now mandates the wrapper.

## Acceptance criteria mapping (BLD-969)

| AC | Test |
|---|---|
| 1. Same fingerprint twice → ONE issue | AC#1: first call CREATES; second call with same fingerprint COMMENTS |
| 2. Exact-match, case-sensitive on `Fingerprint: <hash>` line | AC#2: substring of a longer fingerprint does NOT match |
| 3. Cancelled / done are NOT matches (re-occurrence files fresh) | AC#3: pre-existing cancelled/done is IGNORED (×2) + matched-on-open (×4) |
| 4. Recurrence comment text `Same finding reproduced in audit-YYYY-MM-DD-<commit> (run <id>)` | Asserted in AC#1 + AC#3 |

## Testing

```
npx jest scripts/__tests__/audit-create-finding.test.ts --no-coverage
# 12/12 passed
npx tsc --noEmit
# zero errors
```

## Out of scope (matches issue)

- Fuzzy matching of similar fingerprints — exact-only for v1.
- Cross-project dedup.

## Issue

Resolves BLD-969