### PR TITLE
fix(progress): clear floating navbar in Monthly view share button (BLD-988)

### DIFF
--- a/__tests__/app/source-checks-batch.test.ts
+++ b/__tests__/app/source-checks-batch.test.ts
@@ -800,6 +800,8 @@ describe("Tab screens use useFloatingTabBarHeight (BLD-212)", () => {
     { label: "exercises.tsx", file: "app/(tabs)/exercises.tsx" },
     { label: "nutrition.tsx", file: "app/(tabs)/nutrition.tsx" },
     { label: "progress (WorkoutSegment)", file: "components/progress/WorkoutSegment.tsx" },
+    { label: "progress (NutritionSegment)", file: "components/progress/NutritionSegment.tsx" },
+    { label: "progress (MonthlyReportSegment)", file: "components/progress/MonthlyReportSegment.tsx" },
     { label: "settings.tsx", file: "app/(tabs)/settings.tsx" },
   ];
 

--- a/components/progress/MonthlyReportSegment.tsx
+++ b/components/progress/MonthlyReportSegment.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react-native";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useLayout } from "@/lib/layout";
+import { useFloatingTabBarHeight } from "@/components/FloatingTabBar";
 import { spacing, fontSizes } from "@/constants/design-tokens";
 import { useMonthlyReport, formatMonthLabel, formatVolume } from "@/hooks/useMonthlyReport";
 import { toDisplay } from "@/lib/units";
@@ -23,6 +24,7 @@ import {
 export default function MonthlyReportSegment() {
   const colors = useThemeColors();
   const layout = useLayout();
+  const tabBarHeight = useFloatingTabBarHeight();
   const {
     data,
     loading,
@@ -69,7 +71,10 @@ export default function MonthlyReportSegment() {
   return (
     <ScrollView
       style={styles.scroll}
-      contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
+      contentContainerStyle={[
+        styles.content,
+        { paddingHorizontal: layout.horizontalPadding, paddingBottom: tabBarHeight + 16 },
+      ]}
     >
       {/* Month navigation */}
       <View style={styles.navRow}>
@@ -185,7 +190,6 @@ const styles = StyleSheet.create({
   },
   content: {
     paddingVertical: spacing.base,
-    paddingBottom: spacing.xxxl,
   },
   center: {
     flex: 1,


### PR DESCRIPTION
## Summary

The "Share Report" button at the bottom of Progress → Monthly view was hidden behind the floating tab bar on devices with small/zero bottom safe-area insets. This applies the same `useFloatingTabBarHeight` pattern already used by the sibling Workouts, Nutrition, and Muscles Progress segments.

## Changes

- `components/progress/MonthlyReportSegment.tsx`
  - Import `useFloatingTabBarHeight` from `@/components/FloatingTabBar`
  - Read `tabBarHeight` and inject `paddingBottom: tabBarHeight + 16` on the ScrollView's `contentContainerStyle`
  - Drop the now-redundant static `paddingBottom: spacing.xxxl` from `styles.content`
- `__tests__/app/source-checks-batch.test.ts`
  - Extend the BLD-212 "Tab screens use useFloatingTabBarHeight" test to also cover `MonthlyReportSegment` and `NutritionSegment`
  - `BodySegment` intentionally excluded — tracked separately as BLD-990

## Testing

- `npx tsc --noEmit` → clean
- `jest __tests__/app/source-checks-batch.test.ts` → 210/210 pass
- Behavior now matches Muscles / Workouts / Nutrition Progress sub-tabs

## Issue

Resolves BLD-988.