### PR TITLE
feat(template-edit): allow editing template name (BLD-992)

### DIFF
--- a/__tests__/acceptance/template-crud.acceptance.test.tsx
+++ b/__tests__/acceptance/template-crud.acceptance.test.tsx
@@ -267,5 +267,106 @@ describe('Template CRUD Acceptance', () => {
 
       expect(mockRouter.back).toHaveBeenCalled()
     })
+
+    describe('Rename name field (BLD-992)', () => {
+      it('pre-fills the name input with the current template name', async () => {
+        mockParams = { id: 'tpl-1' }
+
+        const { findByLabelText } = renderScreen(<EditTemplate />)
+
+        const input = await findByLabelText('Template Name')
+        expect(input.props.value).toBe('Push Day')
+      })
+
+      it('persists the renamed value via updateTemplateName on blur (happy path)', async () => {
+        mockParams = { id: 'tpl-1' }
+
+        const { findByLabelText } = renderScreen(<EditTemplate />)
+
+        const input = await findByLabelText('Template Name')
+        fireEvent.changeText(input, 'Pull Day')
+        fireEvent(input, 'blur')
+
+        await waitFor(() => {
+          expect(mockUpdateName).toHaveBeenCalledWith('tpl-1', 'Pull Day')
+        })
+      })
+
+      it('does not call updateTemplateName when the name is unchanged on blur', async () => {
+        mockParams = { id: 'tpl-1' }
+
+        const { findByLabelText } = renderScreen(<EditTemplate />)
+
+        const input = await findByLabelText('Template Name')
+        fireEvent(input, 'blur')
+
+        // Allow any pending microtask flush
+        await waitFor(() => {
+          expect(input.props.value).toBe('Push Day')
+        })
+        expect(mockUpdateName).not.toHaveBeenCalled()
+      })
+
+      it('rejects an empty/whitespace-only name with an inline error and does not persist', async () => {
+        mockParams = { id: 'tpl-1' }
+
+        const { findByLabelText, findByText } = renderScreen(<EditTemplate />)
+
+        const input = await findByLabelText('Template Name')
+        fireEvent.changeText(input, '   ')
+        fireEvent(input, 'blur')
+
+        expect(await findByText('Template name is required.')).toBeTruthy()
+        expect(mockUpdateName).not.toHaveBeenCalled()
+      })
+
+      it('rejects a name longer than 100 characters with an inline error and does not persist', async () => {
+        mockParams = { id: 'tpl-1' }
+
+        const { findByLabelText, findByText } = renderScreen(<EditTemplate />)
+
+        const input = await findByLabelText('Template Name')
+        // The Input has maxLength=100, but defensive: validate explicitly when we
+        // bypass it (e.g. paste handling differences) — drive validation via a
+        // 101-char value pushed through changeText.
+        const tooLong = 'x'.repeat(101)
+        fireEvent.changeText(input, tooLong)
+        fireEvent(input, 'blur')
+
+        expect(await findByText('Template name must be 100 characters or fewer.')).toBeTruthy()
+        expect(mockUpdateName).not.toHaveBeenCalled()
+      })
+
+      it('trims whitespace and persists the trimmed value, updating the displayed name', async () => {
+        mockParams = { id: 'tpl-1' }
+
+        const { findByLabelText } = renderScreen(<EditTemplate />)
+
+        const input = await findByLabelText('Template Name')
+        fireEvent.changeText(input, '  Leg Day  ')
+        fireEvent(input, 'blur')
+
+        await waitFor(() => {
+          expect(mockUpdateName).toHaveBeenCalledWith('tpl-1', 'Leg Day')
+        })
+        // After successful save, the field should reflect the trimmed value
+        await waitFor(() => {
+          expect(input.props.value).toBe('Leg Day')
+        })
+      })
+
+      it('does not render the name input for starter templates (read-only)', async () => {
+        mockParams = { id: 'tpl-starter' }
+        mockGetTemplateById.mockResolvedValueOnce(
+          createWorkoutTemplate({ id: 'tpl-starter', name: 'Starter Push', is_starter: true, exercises: [te1] }),
+        )
+
+        const { findByText, queryByLabelText } = renderScreen(<EditTemplate />)
+
+        // Wait for template to load
+        await findByText('Bench Press')
+        expect(queryByLabelText('Template Name')).toBeNull()
+      })
+    })
   })
 })

--- a/__tests__/acceptance/template-crud.acceptance.test.tsx
+++ b/__tests__/acceptance/template-crud.acceptance.test.tsx
@@ -34,6 +34,7 @@ jest.mock('../../components/ui/bna-toast', () => {
   }
 })
 jest.mock('../../lib/layout', () => ({ useLayout: () => ({ wide: false, width: 375, scale: 1.0 }) }))
+jest.mock('../../lib/query', () => ({ bumpQueryVersion: jest.fn(), getQueryVersion: jest.fn().mockReturnValue(0), useFocusRefetch: jest.fn() }))
 jest.mock('../../lib/errors', () => ({ logError: jest.fn(), generateReport: jest.fn().mockResolvedValue('{}'), getRecentErrors: jest.fn().mockResolvedValue([]), generateGitHubURL: jest.fn().mockReturnValue('https://github.com') }))
 jest.mock('../../lib/interactions', () => ({ log: jest.fn(), recent: jest.fn().mockResolvedValue([]) }))
 jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
@@ -101,6 +102,7 @@ const mockDuplicate = jest.fn()
 const mockCreateExerciseLink = jest.fn()
 const mockUnlinkGroup = jest.fn()
 const mockUnlinkSingle = jest.fn()
+let mockBumpQueryVersion: jest.Mock
 
 jest.mock('../../lib/db', () => ({
   createTemplate: (...args: unknown[]) => mockCreateTemplate(...args),
@@ -124,6 +126,7 @@ describe('Template CRUD Acceptance', () => {
     resetIds()
     mockParams = {}
     jest.spyOn(Alert, 'alert').mockImplementation(() => {})
+    mockBumpQueryVersion = require('../../lib/query').bumpQueryVersion
     mockCreateTemplate.mockResolvedValue(
       createWorkoutTemplate({ id: 'tpl-new', name: 'Push Day', exercises: [] }),
     )
@@ -366,6 +369,51 @@ describe('Template CRUD Acceptance', () => {
         // Wait for template to load
         await findByText('Bench Press')
         expect(queryByLabelText('Template Name')).toBeNull()
+      })
+
+      it('resets name when navigating to a different template id (Duplicate→Edit regression)', async () => {
+        // Template A is loaded first, then user navigates to template B (Duplicate flow)
+        const templateA = createWorkoutTemplate({ id: 'tpl-A', name: 'Template A', exercises: [te1] })
+        const templateB = createWorkoutTemplate({ id: 'tpl-B', name: 'Template B', exercises: [te2] })
+
+        // First mount: template A
+        mockParams = { id: 'tpl-A' }
+        mockGetTemplateById.mockResolvedValue(templateA)
+        const { findByLabelText: findA, unmount } = renderScreen(<EditTemplate />)
+        await findA('Template Name')
+        unmount()
+
+        // Second mount: template B (simulates router.replace after Duplicate)
+        mockParams = { id: 'tpl-B' }
+        mockGetTemplateById.mockResolvedValue(templateB)
+        const { findByLabelText: findB, getByLabelText } = renderScreen(<EditTemplate />)
+        await findB('Template Name')
+
+        // Name must reflect template B, not the stale template A value
+        expect(getByLabelText('Template Name').props.value).toBe('Template B')
+
+        // Blurring should write to template B
+        fireEvent.changeText(getByLabelText('Template Name'), 'Template B Renamed')
+        fireEvent(getByLabelText('Template Name'), 'blur')
+        await waitFor(() => {
+          expect(mockUpdateName).toHaveBeenCalledWith('tpl-B', 'Template B Renamed')
+        })
+        expect(mockUpdateName).not.toHaveBeenCalledWith('tpl-A', expect.anything())
+      })
+
+      it('calls bumpQueryVersion("home") after a successful rename', async () => {
+        mockParams = { id: 'tpl-1' }
+
+        const { findByLabelText } = renderScreen(<EditTemplate />)
+
+        const input = await findByLabelText('Template Name')
+        fireEvent.changeText(input, 'New Name')
+        fireEvent(input, 'blur')
+
+        await waitFor(() => {
+          expect(mockUpdateName).toHaveBeenCalledWith('tpl-1', 'New Name')
+        })
+        expect(mockBumpQueryVersion).toHaveBeenCalledWith('home')
       })
     })
   })

--- a/app/template/[id].tsx
+++ b/app/template/[id].tsx
@@ -3,6 +3,7 @@ import { FlatList, StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { Chip } from "@/components/ui/chip";
+import { Input } from "@/components/ui/input";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useLayout } from "@/lib/layout";
 import { useTemplateEditor } from "@/hooks/useTemplateEditor";
@@ -17,13 +18,14 @@ export default function EditTemplate() {
   const { id } = useLocalSearchParams<{ id: string }>();
 
   const {
-    template, exercises, selecting, selected,
+    template, exercises, name, nameError, selecting, selected,
     pickerOpen, editing, linkIds, palette, colors,
     setPickerOpen, setEditing,
     startSelection, cancelSelection, confirmLink,
     move, remove, toggleSelect,
     handleUnlink, handleUnlinkSingle,
     handlePickExercise, handleEditSave, handleDuplicate,
+    handleNameChange, handleNameBlur,
   } = useTemplateEditor({ id, router });
 
   const starter = !!template?.is_starter;
@@ -67,8 +69,21 @@ export default function EditTemplate() {
 
   return (
     <>
-      <Stack.Screen options={{ title: template.name }} />
+      <Stack.Screen options={{ title: (name.trim() || template.name) }} />
       <View style={[styles.container, { backgroundColor: colors.background, paddingHorizontal: layout.horizontalPadding }]}>
+        {!starter && (
+          <Input
+            label="Name"
+            placeholder="e.g. Upper Body, Push Day"
+            value={name}
+            onChangeText={handleNameChange}
+            onBlur={handleNameBlur}
+            error={nameError ?? undefined}
+            maxLength={100}
+            containerStyle={styles.nameInput}
+            accessibilityLabel="Template Name"
+          />
+        )}
         <View style={styles.section}>
           <View style={styles.headerRow}>
             <Text variant="title" style={{ color: colors.onBackground, flexShrink: 1 }}>
@@ -127,6 +142,7 @@ const styles = StyleSheet.create({
   section: { marginBottom: 8 },
   headerRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", gap: 8 },
   list: { flex: 1 },
+  nameInput: { marginBottom: 12 },
   addBtn: { marginTop: 8 },
   doneBtn: { marginTop: 16 },
   empty: { alignItems: "center", paddingVertical: 24 },

--- a/hooks/useTemplateEditor.ts
+++ b/hooks/useTemplateEditor.ts
@@ -13,6 +13,7 @@ import {
   unlinkExerciseGroup,
   unlinkSingleExercise,
   updateTemplateExercise,
+  updateTemplateName,
 } from "@/lib/db";
 import type { Exercise, SetType, TemplateExercise, WorkoutTemplate } from "@/lib/types";
 
@@ -30,6 +31,8 @@ export function useTemplateEditor({ id, router }: { id: string | undefined; rout
   const colors = useThemeColors();
   const [template, setTemplate] = useState<WorkoutTemplate | null>(null);
   const [exercises, setExercises] = useState<TemplateExercise[]>([]);
+  const [name, setName] = useState<string>("");
+  const [nameError, setNameError] = useState<string | null>(null);
   const [selecting, setSelecting] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [, setUndo] = useState<(() => Promise<void>) | null>(null);
@@ -57,6 +60,7 @@ export function useTemplateEditor({ id, router }: { id: string | undefined; rout
     if (tpl) {
       setTemplate(tpl);
       setExercises(tpl.exercises ?? []);
+      setName((current) => (current === "" ? tpl.name : current));
     }
   }, [id]);
 
@@ -188,9 +192,45 @@ export function useTemplateEditor({ id, router }: { id: string | undefined; rout
     router.replace(`/template/${newId}`);
   };
 
+  const validateName = useCallback((value: string): string | null => {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return "Template name is required.";
+    if (trimmed.length > 100) return "Template name must be 100 characters or fewer.";
+    return null;
+  }, []);
+
+  const handleNameChange = useCallback((value: string) => {
+    setName(value);
+    // Clear error eagerly when user starts typing again
+    if (nameError) setNameError(null);
+  }, [nameError]);
+
+  const handleNameBlur = useCallback(async () => {
+    if (!template) return;
+    const trimmed = name.trim();
+    const err = validateName(name);
+    if (err) {
+      setNameError(err);
+      return;
+    }
+    setNameError(null);
+    if (trimmed === template.name) return;
+    try {
+      await updateTemplateName(template.id, trimmed);
+      // Reflect persisted value (including trim) locally so the header title updates.
+      setTemplate({ ...template, name: trimmed, updated_at: Date.now() });
+      setName(trimmed);
+    } catch {
+      setNameError("Failed to save name. Please try again.");
+      showError("Failed to update template name");
+    }
+  }, [template, name, validateName, showError]);
+
   return {
     template,
     exercises,
+    name,
+    nameError,
     selecting,
     selected,
     pickerOpen,
@@ -212,5 +252,7 @@ export function useTemplateEditor({ id, router }: { id: string | undefined; rout
     handlePickExercise,
     handleEditSave,
     handleDuplicate,
+    handleNameChange,
+    handleNameBlur,
   };
 }

--- a/hooks/useTemplateEditor.ts
+++ b/hooks/useTemplateEditor.ts
@@ -15,6 +15,7 @@ import {
   updateTemplateExercise,
   updateTemplateName,
 } from "@/lib/db";
+import { bumpQueryVersion } from "@/lib/query";
 import type { Exercise, SetType, TemplateExercise, WorkoutTemplate } from "@/lib/types";
 
 export function linkLabel(exercises: TemplateExercise[], linkId: string, idx: number): string {
@@ -60,7 +61,8 @@ export function useTemplateEditor({ id, router }: { id: string | undefined; rout
     if (tpl) {
       setTemplate(tpl);
       setExercises(tpl.exercises ?? []);
-      setName((current) => (current === "" ? tpl.name : current));
+      setName(tpl.name);
+      setNameError(null);
     }
   }, [id]);
 
@@ -217,6 +219,7 @@ export function useTemplateEditor({ id, router }: { id: string | undefined; rout
     if (trimmed === template.name) return;
     try {
       await updateTemplateName(template.id, trimmed);
+      bumpQueryVersion("home");
       // Reflect persisted value (including trim) locally so the header title updates.
       setTemplate({ ...template, name: trimmed, updated_at: Date.now() });
       setName(trimmed);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cablesnap",
-  "version": "0.26.17",
+  "version": "0.26.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cablesnap",
-      "version": "0.26.17",
+      "version": "0.26.20",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {


### PR DESCRIPTION
## Summary

Adds an inline name input at the top of the Edit Workout Template screen (`/template/[id]`), eliminating the need to delete-and-recreate or use the Create flow just to rename a template.

## Changes

- `app/template/[id].tsx` — render an `<Input label="Name">` above the "Exercises (N)" header (hidden for starter templates). Stack title now reflects the pending edit so the navbar updates as the user types.
- `hooks/useTemplateEditor.ts` — manage `name` / `nameError` state, `handleNameChange`, and `handleNameBlur`. On blur: trim, validate, and call existing `updateTemplateName` only when the value actually changed.
- Validation mirrors Create flow conventions: required (non-empty after trim), max 100 chars, inline error via Input's `error` prop. `maxLength={100}` on the input as a UX guardrail.
- Starter templates remain read-only (no name input rendered) to match existing "STARTER" chip semantics.

## Testing

- 7 new acceptance tests in `__tests__/acceptance/template-crud.acceptance.test.tsx`:
  - Pre-fills with current template name
  - Persists via `updateTemplateName` on blur (happy path)
  - Skips DB call when name is unchanged on blur
  - Rejects empty/whitespace-only names with inline error
  - Rejects >100-char names with inline error
  - Trims whitespace and reflects trimmed value in the field
  - Does not render the input for starter templates
- All 17 tests in the file pass: `__tests__/acceptance/template-crud.acceptance.test.tsx`
- `tsc --noEmit` clean

## Issue

Resolves BLD-992.