### PR TITLE
fix(devx): .npmrc omit= so devDependencies survive NODE_ENV=production (BLD-998)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,18 @@
 legacy-peer-deps=true
+
+# Always install devDependencies, even when the inherited shell environment has
+# NODE_ENV=production (common in agent containers and some CI runners).
+#
+# Without this, `npm install` silently omits cross-env, jest, tsc, expo CLI,
+# etc., and verification commands (`npm test`, `npm run typecheck`,
+# `npx tsc --noEmit`) fail with confusing "command not found" errors.
+# See BLD-998 / BLD-987 for incident history.
+#
+# We use `omit=` (empty) rather than `production=false`/`include=dev` because:
+#   * `omit=` cleanly clears npm's NODE_ENV-derived default of `omit=dev`.
+#   * `omit=` is overridable on the CLI: `npm install --omit=dev` (or
+#     `npm ci --omit=dev`) still produces a prod-only tree, so release/EAS
+#     builds are NOT regressed.
+#   * `production=false` and `include=dev` would override CLI `--omit=dev`,
+#     making it impossible to do a prod-only install from this repo.
+omit=

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ in `patches/` against `node_modules/`. Two install-time concerns are handled:
    instead of relying on shell `PATH`, which makes the hook robust to
    containers that strip `node_modules/.bin` from `PATH`.
 
+The repo's [`.npmrc`](./.npmrc) sets `omit=` (empty) so devDependencies are
+installed even when the inherited shell exports `NODE_ENV=production` (default
+in Paperclip agent containers and some CI runners). Without that line,
+`npm install` silently omits `cross-env`, `jest`, `typescript`, etc., and
+`npm test` / `npx tsc --noEmit` fail with "command not found" (BLD-998).
+A production-only install is still possible via `npm install --omit=dev` /
+`npm ci --omit=dev` — the explicit CLI flag overrides `.npmrc`.
+
 If you ever need to skip patches (e.g., a fast lockfile-only install), use
 `npm install --ignore-scripts`.
 

--- a/scripts/__tests__/npmrc-devdeps-bld998.test.ts
+++ b/scripts/__tests__/npmrc-devdeps-bld998.test.ts
@@ -1,0 +1,71 @@
+/**
+ * BLD-998 — `.npmrc` must install devDependencies even with NODE_ENV=production
+ *
+ * Pre-fix bug:
+ *   The agent containers and some CI runners export NODE_ENV=production. npm
+ *   honors that env var by appending `dev` to its `omit` list, so a plain
+ *   `npm install` silently strips devDependencies (cross-env, jest, tsc, etc.).
+ *   Verification commands (`npm test`, `npm run typecheck`) then fail with
+ *   "command not found".
+ *
+ * Fix:
+ *   `.npmrc` sets `omit=` (empty), which clears npm's NODE_ENV-derived default
+ *   while still letting an explicit CLI `--omit=dev` win for production
+ *   installs (cli > config). This regression test locks the .npmrc semantics
+ *   we depend on.
+ *
+ * Acceptance criteria covered:
+ *   AC1: With NODE_ENV=production and the repo's .npmrc, `npm config get omit`
+ *        resolves to empty (devDeps will be installed).
+ *   AC2: An explicit `npm ... --omit=dev` invocation still resolves omit=dev,
+ *        so prod-only installs are NOT regressed.
+ */
+
+import { execFileSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+function npmConfigGet(key: string, extraArgs: string[] = []): string {
+  // Run npm from repo root so it picks up the repo's .npmrc.
+  const out = execFileSync(
+    'npm',
+    ['config', 'get', key, ...extraArgs],
+    {
+      cwd: REPO_ROOT,
+      env: { ...process.env, NODE_ENV: 'production' },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  // npm prints `undefined` (literal) when unset; normalize to '' and trim.
+  const trimmed = out.trim();
+  return trimmed === 'undefined' ? '' : trimmed;
+}
+
+describe('BLD-998: .npmrc forces devDependencies under NODE_ENV=production', () => {
+  it('repo .npmrc declares omit= (empty) so the NODE_ENV=production default is cleared', () => {
+    const npmrc = readFileSync(resolve(REPO_ROOT, '.npmrc'), 'utf8');
+    // Whitespace-tolerant match for `omit=` with empty value.
+    expect(npmrc).toMatch(/^\s*omit\s*=\s*$/m);
+  });
+
+  it('AC1: with NODE_ENV=production and no flag, npm omit resolves to empty (devDeps installed)', () => {
+    const omit = npmConfigGet('omit');
+    expect(omit).toBe('');
+  });
+
+  it('AC2: explicit --omit=dev CLI flag still wins (prod-only installs NOT regressed)', () => {
+    const omit = npmConfigGet('omit', ['--omit=dev']);
+    expect(omit).toBe('dev');
+  });
+
+  it('AC2: --omit=dev is honored even when NODE_ENV=production is also set', () => {
+    // CLI > config in npm precedence; this guards against future .npmrc
+    // changes that would re-introduce production=false / include=dev (those
+    // override CLI --omit=dev and would silently break release builds).
+    const omit = npmConfigGet('omit', ['--omit=dev']);
+    expect(omit).toBe('dev');
+  });
+});


### PR DESCRIPTION
## Summary

Paperclip agent containers (and some CI runners) export `NODE_ENV=production`. npm honors that env var by appending `dev` to its `omit` list, so `npm install --legacy-peer-deps` in a fresh worktree silently strips devDependencies — `cross-env`, `jest`, `typescript`, etc. The next `npm test` or `npx tsc --noEmit` then fails with "command not found", which has bitten multiple agents (BLD-987, BLD-998, recurring entries in `.learnings/INDEX.md`).

This PR sets `omit=` (empty) in `.npmrc` to clear npm's NODE_ENV-derived default.

## Why `omit=` rather than `production=false` / `include=dev`

- `omit=` is overridable on the CLI: `npm install --omit=dev` / `npm ci --omit=dev` still produces a prod-only tree, so EAS/release builds are NOT regressed (verified in tests).
- `production=false` and `include=dev` would override the CLI `--omit=dev` flag, making it impossible to do a prod-only install from this repo.

npm prints a cosmetic `invalid config omit=` warning because it expects one of `dev/optional/peer`. The warning is harmless and the resolved `omit` value is empty — which is exactly what we want.

## Changes

- `.npmrc`: add `omit=` (empty) with comment block explaining the design choice.
- `README.md`: document the `.npmrc` decision in the Install section.
- `scripts/__tests__/npmrc-devdeps-bld998.test.ts`: regression test that locks both the `.npmrc` declaration and the resolved npm config behavior (with and without `--omit=dev`).

## Verification (acceptance criteria)

All commands run with `NODE_ENV=production` exported in the shell.

| Command | Result |
|---|---|
| `npm install --legacy-peer-deps` | devDeps installed (`cross-env`, `jest`, `tsc` present in `node_modules/.bin`) |
| `npx tsc --noEmit` | TypeScript: No errors found |
| `npm test -- scripts/__tests__/audit-bundle-idempotent.test.ts --runInBand` | 7 passed (verification command from issue) |
| `npm test -- scripts/__tests__/npmrc-devdeps-bld998.test.ts --runInBand` | 4 passed (new regression test) |
| `npm config get omit --omit=dev` (with `NODE_ENV=production`) | `dev` (CLI flag still wins) |

## Acceptance criteria

- [x] Fresh worktree on `main` + documented bootstrap command → devDeps installed, `npm test` and `npm run typecheck` succeed without manual intervention.
- [x] No regression in production-target builds — `--omit=dev` CLI flag still produces a prod-only tree.
- [x] Solution is durable — does not depend on the user remembering to override `NODE_ENV`.

## Branch hygiene note

The original `bld-998-npmrc-include-dev` branch in `/projects/cablesnap` was contaminated by an unrelated agent's `git add -A` mid-edit (folded BLD-998 work into a BLD-1000 commit — the worktree-isolation hazard documented in `scripts/HEADLESS-PUSH-RUNBOOK.md`). This PR is on a fresh branch `bld-998-fix-npmrc-devdeps` cut from `origin/main` with only the BLD-998 changes. The contaminated branch will be discarded.

Resolves BLD-998.