### PR TITLE
feat(programs): Curated Programs Library — r/bodyweightfitness RR v1 (BLD-1000)

### DIFF
--- a/__tests__/components/home/curated-programs-ui.test.tsx
+++ b/__tests__/components/home/curated-programs-ui.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * BLD-1000: Curated Programs Library — UI, a11y, and AC coverage.
+ *
+ * Covers:
+ *   AC3  — ProgramsList filter chip semantics (All / Curated / Mine)
+ *   AC4  — RR detail attribution footer (text, link role, Linking.openURL)
+ *   AC5  — a11y roles/labels: filter chips, list rows, attribution link,
+ *            caption dismiss button + useCuratedCaption persistence
+ *   AC6  — maxFontSizeMultiplier smoke assertion (attribution + caption)
+ *   AC7  — color-independent selected chip style (background fill + bold weight)
+ *
+ * Test budget: consolidated into 5 it() blocks to stay within MAX_TESTS=2200.
+ * Each block covers one AC; assertions within each block are logically grouped.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from "react";
+import { Linking } from "react-native";
+import { render, fireEvent, waitFor, act } from "@testing-library/react-native";
+import type { Program } from "../../../lib/types";
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const MOCK_PRIMARY = "#6200EE";
+const MOCK_MUTED = "#E5E7EB";
+
+const MOCK_COLORS = {
+  primary: MOCK_PRIMARY,
+  primaryForeground: "#FFFFFF",
+  onPrimary: "#FFFFFF",
+  onBackground: "#000000",
+  onSurface: "#000000",
+  onSurfaceVariant: "#6B7280",
+  surface: "#FFFFFF",
+  surfaceVariant: "#F3F4F6",
+  muted: MOCK_MUTED,
+  outline: "#D1D5DB",
+  background: "#FFFFFF",
+  text: "#111111",
+};
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => MOCK_COLORS,
+}));
+
+jest.mock("@/hooks/useColorScheme", () => ({
+  useColorScheme: () => "light",
+}));
+
+jest.mock("@/hooks/useColor", () => ({
+  useColor: (key: string) => MOCK_COLORS[key as keyof typeof MOCK_COLORS] ?? "#000000",
+}));
+
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => "Icon");
+
+const mockGetAppSetting = jest.fn();
+const mockSetAppSetting = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("../../../lib/db", () => ({
+  getAppSetting: (...args: unknown[]) => mockGetAppSetting(...args),
+  setAppSetting: (...args: unknown[]) => mockSetAppSetting(...args),
+}));
+
+// ─── Subject imports ──────────────────────────────────────────────────────────
+
+import { ProgramsList } from "../../../components/home/ProgramsList";
+import {
+  AttributionFooter,
+  CuratedCaption,
+  useCuratedCaption,
+} from "../../../components/program/CuratedExtras";
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const BASE: Pick<Program, "current_day_id" | "created_at" | "updated_at" | "deleted_at"> = {
+  current_day_id: null, created_at: 0, updated_at: 0, deleted_at: null,
+};
+
+const PROGRAMS: Program[] = [
+  { ...BASE, id: "s1", name: "Starter PPL", description: "", is_active: false, is_starter: true,  is_curated: false },
+  { ...BASE, id: "c1", name: "r/bodyweightfitness Recommended Routine", description: "", is_active: false, is_starter: false, is_curated: true },
+  { ...BASE, id: "u1", name: "My Custom Program", description: "", is_active: false, is_starter: false, is_curated: false },
+];
+
+const DAY_COUNTS: Record<string, number> = { s1: 3, c1: 3, u1: 2 };
+const NOOP = () => {};
+
+function renderList() {
+  return render(
+    <ProgramsList
+      colors={MOCK_COLORS as any}
+      programs={PROGRAMS}
+      dayCounts={DAY_COUNTS}
+      onPress={NOOP}
+      onDelete={NOOP}
+      onOptions={NOOP}
+    />
+  );
+}
+
+const RR = {
+  label: "r/bodyweightfitness Recommended Routine",
+  url: "https://www.reddit.com/r/bodyweightfitness/wiki/kb/recommended_routine",
+  license: "CC-BY-SA 3.0",
+};
+
+// ─── AC3 + AC5 filter chips ───────────────────────────────────────────────────
+
+it("AC3/AC5 — filter chips: All/Curated/Mine semantics and a11y labels", async () => {
+  mockGetAppSetting.mockResolvedValue("1");
+  const { getByLabelText, queryByText, getByText } = renderList();
+
+  // chips exist with correct labels (AC5)
+  expect(getByLabelText("All programs filter, selected")).toBeTruthy();
+  expect(getByLabelText("Curated programs filter")).toBeTruthy();
+  expect(getByLabelText("Mine programs filter")).toBeTruthy();
+
+  // program card a11y labels (AC5)
+  expect(getByLabelText(/Curated program: r\/bodyweightfitness Recommended Routine/)).toBeTruthy();
+  expect(getByLabelText(/Starter program: Starter PPL/)).toBeTruthy();
+
+  // All (default) shows everything (AC3)
+  expect(getByText("Starter PPL")).toBeTruthy();
+  expect(getByText("r/bodyweightfitness Recommended Routine")).toBeTruthy();
+  expect(getByText("My Custom Program")).toBeTruthy();
+
+  // Curated filter: starter + curated visible, user hidden (AC3)
+  fireEvent.press(getByLabelText("Curated programs filter"));
+  await waitFor(() => {
+    expect(getByText("Starter PPL")).toBeTruthy();
+    expect(getByText("r/bodyweightfitness Recommended Routine")).toBeTruthy();
+    expect(queryByText("My Custom Program")).toBeNull();
+  });
+
+  // Mine filter: only user program visible (AC3)
+  fireEvent.press(getByLabelText("Mine programs filter"));
+  await waitFor(() => {
+    expect(getByText("My Custom Program")).toBeTruthy();
+    expect(queryByText("Starter PPL")).toBeNull();
+    expect(queryByText("r/bodyweightfitness Recommended Routine")).toBeNull();
+  });
+});
+
+// ─── AC7 chip style ───────────────────────────────────────────────────────────
+
+it("AC7 — selected chip has primary bg fill and bold text; unselected has muted bg", () => {
+  mockGetAppSetting.mockResolvedValue("1");
+  const { getByLabelText, getByText } = renderList();
+
+  // selected chip background = primary
+  const allChip = getByLabelText("All programs filter, selected");
+  const chipStyle = Array.isArray(allChip.props.style)
+    ? Object.assign({}, ...allChip.props.style)
+    : allChip.props.style;
+  expect(chipStyle.backgroundColor).toBe(MOCK_PRIMARY);
+
+  // selected chip text is bold
+  const allText = getByText("All");
+  const textStyle = Array.isArray(allText.props.style)
+    ? Object.assign({}, ...allText.props.style)
+    : allText.props.style;
+  expect(textStyle.fontWeight).toBe("600");
+
+  // unselected chip background = muted (not primary)
+  const curatedChip = getByLabelText("Curated programs filter");
+  const curatedStyle = Array.isArray(curatedChip.props.style)
+    ? Object.assign({}, ...curatedChip.props.style)
+    : curatedChip.props.style;
+  expect(curatedStyle.backgroundColor).toBe(MOCK_MUTED);
+  expect(curatedStyle.backgroundColor).not.toBe(MOCK_PRIMARY);
+});
+
+// ─── AC4 + AC5 attribution footer ─────────────────────────────────────────────
+
+it("AC4/AC5 — AttributionFooter: text, link role, a11y label, Linking.openURL, absent when undefined", () => {
+  const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined);
+
+  const { getByRole, getByText, queryByRole, rerender } = render(
+    <AttributionFooter attribution={RR} primary={MOCK_COLORS.primary} onSurfaceVariant={MOCK_COLORS.onSurfaceVariant} />
+  );
+
+  // text content (AC4)
+  expect(getByText(/Adapted from/)).toBeTruthy();
+  expect(getByText("r/bodyweightfitness Recommended Routine")).toBeTruthy();
+
+  // role + a11y label (AC5)
+  const link = getByRole("link");
+  expect(link).toBeTruthy();
+  expect(link.props.accessibilityLabel).toMatch(/r\/bodyweightfitness Recommended Routine/);
+  expect(link.props.accessibilityLabel).toMatch(/CC-BY-SA 3\.0/);
+
+  // tap dispatches Linking.openURL (AC4)
+  fireEvent.press(link);
+  expect(openURL).toHaveBeenCalledWith(RR.url);
+  openURL.mockRestore();
+
+  // absent when attribution=undefined (AC4)
+  rerender(
+    <AttributionFooter attribution={undefined} primary={MOCK_COLORS.primary} onSurfaceVariant={MOCK_COLORS.onSurfaceVariant} />
+  );
+  expect(queryByRole("link")).toBeNull();
+});
+
+// ─── AC6 maxFontSizeMultiplier ────────────────────────────────────────────────
+
+it("AC6 — maxFontSizeMultiplier=1.5 on attribution text and caption text", () => {
+  const { getByText: getAttr } = render(
+    <AttributionFooter attribution={RR} primary={MOCK_COLORS.primary} onSurfaceVariant={MOCK_COLORS.onSurfaceVariant} />
+  );
+  expect(getAttr(/Adapted from/).props.maxFontSizeMultiplier).toBe(1.5);
+
+  const { getByText: getCap } = render(
+    <CuratedCaption visible onDismiss={NOOP} surface="#fff" outline="#ccc" onSurfaceVariant="#666" />
+  );
+  expect(getCap(/Curated programs are added by CableSnap/).props.maxFontSizeMultiplier).toBe(1.5);
+});
+
+// ─── AC5 CuratedCaption + useCuratedCaption hook ──────────────────────────────
+
+it("AC5 — CuratedCaption a11y, dismiss, and useCuratedCaption persistence", async () => {
+  // visible/hidden toggling
+  const { queryByText: qHidden } = render(
+    <CuratedCaption visible={false} onDismiss={NOOP} surface="#fff" outline="#ccc" onSurfaceVariant="#666" />
+  );
+  expect(qHidden(/Curated programs are added by CableSnap/)).toBeNull();
+
+  const onDismiss = jest.fn();
+  const { getByRole, getByLabelText, getByText: capText } = render(
+    <CuratedCaption visible onDismiss={onDismiss} surface="#fff" outline="#ccc" onSurfaceVariant="#666" />
+  );
+  expect(capText(/Curated programs are added by CableSnap/)).toBeTruthy();
+  // dismiss button a11y (AC5)
+  expect(getByRole("button")).toBeTruthy();
+  expect(getByLabelText("Dismiss curated programs info")).toBeTruthy();
+  // pressing dismiss calls onDismiss
+  fireEvent.press(getByRole("button"));
+  expect(onDismiss).toHaveBeenCalledTimes(1);
+
+  // hook: caption visible on first launch (null key)
+  mockGetAppSetting.mockResolvedValue(null);
+  function HookHarness() {
+    const { visible, dismiss } = useCuratedCaption();
+    return <CuratedCaption visible={visible} onDismiss={dismiss} surface="#fff" outline="#ccc" onSurfaceVariant="#666" />;
+  }
+  const { findByRole } = render(<HookHarness />);
+  const btn = await findByRole("button");
+  expect(btn).toBeTruthy();
+
+  // tapping dismiss persists key to app_settings
+  await act(async () => { fireEvent.press(btn); });
+  expect(mockSetAppSetting).toHaveBeenCalledWith("curated_intro_dismissed", "1");
+
+  // hook: caption hidden when key already '1'
+  mockGetAppSetting.mockResolvedValue("1");
+  const { queryByText: qDismissed } = render(<HookHarness />);
+  await act(async () => {});
+  expect(qDismissed(/Curated programs are added by CableSnap/)).toBeNull();
+});

--- a/__tests__/lib/db.exercises-templates.test.ts
+++ b/__tests__/lib/db.exercises-templates.test.ts
@@ -163,12 +163,12 @@ describe("templates CRUD", () => {
   it("getTemplates returns all templates", async () => {
     await ctx.initDb();
     setDrizzleQueryResult([
-      { id: "t1", name: "Push", created_at: 100, updated_at: 200, is_starter: 0, source: null },
+      { id: "t1", name: "Push", created_at: 100, updated_at: 200, is_starter: 0, is_curated: 0, source: null },
     ]);
 
     const result = await ctx.db.getTemplates();
     expect(result).toEqual([
-      { id: "t1", name: "Push", created_at: 100, updated_at: 200, is_starter: false, source: null },
+      { id: "t1", name: "Push", created_at: 100, updated_at: 200, is_starter: false, is_curated: false, source: null },
     ]);
     resetDrizzleResults();
   });

--- a/__tests__/lib/db/seed-curated.test.ts
+++ b/__tests__/lib/db/seed-curated.test.ts
@@ -1,0 +1,371 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * BLD-1002/BLD-1000: Tests for curated program seeding.
+ *
+ * Coverage:
+ *   AC2  — seed presence on upgrade (STARTER_VERSION 5→6) and UPDATE gate
+ *   AC8  — build-time exercise-id integrity for CURATED_TEMPLATES
+ *   AC9  — runtime orphan handling (error_log write, no crash, skip only orphan)
+ *   AC10 — idempotency (no duplicate rows on second seed run)
+ *   AC11 — user-edit preservation for curated template_exercises
+ */
+
+import { CURATED_TEMPLATES, CURATED_PROGRAMS } from "../../../lib/curated-programs";
+import { STARTER_TEMPLATES } from "../../../lib/starter-templates";
+import { seedExercises } from "../../../lib/seed";
+
+// ── AC8: Build-time exercise-id integrity ─────────────────────────────────────
+
+describe("AC8 — curated exercise-id integrity (build-time gate)", () => {
+  const allExercises = seedExercises();
+  const exerciseIds = new Set(allExercises.map((e) => e.id));
+
+  it("all CURATED_TEMPLATES exercise IDs resolve in the seed exercise list", () => {
+    const orphans: string[] = [];
+    for (const tpl of CURATED_TEMPLATES) {
+      for (const ex of tpl.exercises) {
+        if (!exerciseIds.has(ex.exercise_id)) {
+          orphans.push(`${tpl.id}: ${ex.exercise_id}`);
+        }
+      }
+    }
+    expect(orphans).toEqual([]);
+  });
+
+  it("all CURATED_TEMPLATES template-exercise IDs are globally unique", () => {
+    const seen = new Set<string>();
+    const dupes: string[] = [];
+    for (const tpl of CURATED_TEMPLATES) {
+      for (const ex of tpl.exercises) {
+        if (seen.has(ex.id)) dupes.push(ex.id);
+        seen.add(ex.id);
+      }
+    }
+    expect(dupes).toEqual([]);
+  });
+
+  it("curated template-exercise IDs do not collide with STARTER_TEMPLATES", () => {
+    const starterTeIds = new Set(
+      STARTER_TEMPLATES.flatMap((t) => t.exercises.map((e) => e.id))
+    );
+    const collisions = CURATED_TEMPLATES.flatMap((t) =>
+      t.exercises.filter((e) => starterTeIds.has(e.id)).map((e) => e.id)
+    );
+    expect(collisions).toEqual([]);
+  });
+
+  it("curated template IDs do not collide with STARTER_TEMPLATES ids", () => {
+    const starterTplIds = new Set(STARTER_TEMPLATES.map((t) => t.id));
+    const collisions = CURATED_TEMPLATES.filter((t) => starterTplIds.has(t.id)).map((t) => t.id);
+    expect(collisions).toEqual([]);
+  });
+
+  it("CURATED_PROGRAMS schedule template_ids all reference CURATED_TEMPLATES", () => {
+    const curatedTplIds = new Set(CURATED_TEMPLATES.map((t) => t.id));
+    for (const prog of CURATED_PROGRAMS) {
+      for (const entry of prog.schedule) {
+        expect(curatedTplIds.has(entry.template_id)).toBe(true);
+      }
+    }
+  });
+});
+
+// ── Shared mock database factory ─────────────────────────────────────────────
+
+function makeDb() {
+  // Tracks rows by table for assertion helpers.
+  const rows: Record<string, any[]> = {
+    workout_templates: [],
+    template_exercises: [],
+    programs: [],
+    program_days: [],
+    program_schedule: [],
+    error_log: [],
+    app_settings: [],
+    exercises: [],
+  };
+
+  const runAsync = jest.fn(
+    // eslint-disable-next-line complexity -- mock branches mirror SQL surface
+    async (sql: string, params?: any[]) => {
+    const s = sql.trim().toUpperCase();
+    if (s.startsWith("INSERT OR IGNORE INTO WORKOUT_TEMPLATES")) {
+      const [id, name] = params ?? [];
+      if (!rows.workout_templates.find((r) => r.id === id)) {
+        rows.workout_templates.push({ id, name, is_curated: 1, is_starter: 0 });
+      }
+    } else if (s.startsWith("INSERT OR IGNORE INTO TEMPLATE_EXERCISES")) {
+      const [id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds, set_types] = params ?? [];
+      if (!rows.template_exercises.find((r) => r.id === id)) {
+        rows.template_exercises.push({ id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds, set_types });
+      }
+    } else if (s.startsWith("INSERT OR IGNORE INTO PROGRAMS")) {
+      const [id, name, description] = params ?? [];
+      if (!rows.programs.find((r) => r.id === id)) {
+        rows.programs.push({ id, name, description, is_curated: 1, is_starter: 0 });
+      }
+    } else if (s.startsWith("INSERT OR IGNORE INTO PROGRAM_DAYS")) {
+      const [id, program_id, template_id, position, label] = params ?? [];
+      if (!rows.program_days.find((r) => r.id === id)) {
+        rows.program_days.push({ id, program_id, template_id, position, label });
+      }
+    } else if (s.startsWith("INSERT OR IGNORE INTO PROGRAM_SCHEDULE")) {
+      const [program_id, day_of_week, template_id] = params ?? [];
+      if (!rows.program_schedule.find((r) => r.program_id === program_id && r.day_of_week === day_of_week)) {
+        rows.program_schedule.push({ program_id, day_of_week, template_id });
+      }
+    } else if (s.startsWith("INSERT INTO ERROR_LOG")) {
+      // SQL: INSERT INTO error_log (id, message, component, fatal, timestamp)
+      //      VALUES (?, ?, 'seed.curated', 0, ?)
+      // Only 3 placeholders — `component` and `fatal` are SQL literals.
+      // params: [id, message, timestamp]
+      const [id, message, timestamp] = params ?? [];
+      rows.error_log.push({ id, message, component: "seed.curated", fatal: 0, timestamp });
+    } else if (s.startsWith("INSERT OR REPLACE INTO APP_SETTINGS")) {
+      const [key, value] = params ?? [];
+      const existing = rows.app_settings.find((r) => r.key === key);
+      if (existing) existing.value = value;
+      else rows.app_settings.push({ key, value });
+    } else if (s.startsWith("INSERT OR IGNORE INTO APP_SETTINGS")) {
+      const [key, value] = params ?? [];
+      if (!rows.app_settings.find((r) => r.key === key)) {
+        rows.app_settings.push({ key, value });
+      }
+    } else if (s.startsWith("UPDATE TEMPLATE_EXERCISES SET")) {
+      // gated update — only apply if template is not curated
+      const id = params?.[params.length - 1];
+      const row = rows.template_exercises.find((r) => r.id === id);
+      if (row) {
+        const tpl = rows.workout_templates.find((t) => t.id === row.template_id);
+        if (!tpl || !tpl.is_curated) {
+          // Apply update (simplified — update position at minimum)
+          const [, , position] = params ?? [];
+          row.position = position;
+        }
+      }
+    }
+    return { changes: 1 };
+  });
+
+  const getFirstAsync = jest.fn(async (sql: string, params?: any[]) => {
+    const s = sql.trim().toUpperCase();
+    if (s.includes("FROM EXERCISES WHERE ID")) {
+      const id = params?.[0];
+      return rows.exercises.find((e) => e.id === id) ?? null;
+    }
+    if (s.includes("APP_SETTINGS") && s.includes("KEY")) {
+      const key = params?.[0] ?? sql.match(/'([^']+)'/)?.[1];
+      const row = rows.app_settings.find((r) => r.key === key);
+      return row ?? null;
+    }
+    if (s.includes("COUNT(*)") && s.includes("IS_VOLTRA")) {
+      const isVoltra = s.includes("IS_VOLTRA = 1");
+      return { count: rows.exercises.filter((e) => e.is_voltra === (isVoltra ? 1 : 0)).length };
+    }
+    return null;
+  });
+
+  const getAllAsync = jest.fn(async () => []);
+  const prepareAsync = jest.fn().mockResolvedValue({
+    executeAsync: jest.fn().mockResolvedValue(undefined),
+    finalizeAsync: jest.fn().mockResolvedValue(undefined),
+  });
+  const withTransactionAsync = jest.fn(async (cb: () => Promise<void>) => cb());
+
+  return {
+    runAsync,
+    getFirstAsync,
+    getAllAsync,
+    prepareAsync,
+    withTransactionAsync,
+    // helpers to inspect state
+    _rows: rows,
+    _addExercise: (id: string) => rows.exercises.push({ id }),
+  };
+}
+
+// ── AC9: Runtime orphan handling ──────────────────────────────────────────────
+
+describe("AC9 — runtime orphan exercise handling", () => {
+  it("skips orphan exercises, writes error_log, does not throw, completes other rows", async () => {
+    const db = makeDb();
+
+    // Seed all real exercises (so non-orphan rows pass)
+    const realExercises = seedExercises();
+    for (const ex of realExercises) db._addExercise(ex.id);
+
+    // Inject an orphan into CURATED_TEMPLATES for this test only
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { CURATED_TEMPLATES: curatedTpls } = require("../../../lib/curated-programs");
+    const origExercises = curatedTpls[0].exercises;
+    const orphanId = "NONEXISTENT-EXERCISE-ID-99";
+    curatedTpls[0].exercises = [
+      { id: "orphan-te-test-001", exercise_id: orphanId, target_sets: 3, target_reps: "5-8", rest_seconds: 90 },
+      ...origExercises,
+    ];
+
+    let threw = false;
+    try {
+      // Call upsertCuratedTemplates directly by importing seed module
+      const seedModule = require("../../../lib/db/seed");
+      // Expose via full seed run with mocked starters short-circuit
+      db.getFirstAsync.mockImplementationOnce(async () => ({ count: 100 })); // voltra count
+      db.getFirstAsync.mockImplementationOnce(async () => ({ count: 100 })); // non-voltra count
+      db.getFirstAsync.mockImplementationOnce(async () => ({ value: "6" })); // starter_version already 6
+      await seedModule.seed(db);
+    } catch {
+      threw = true;
+    } finally {
+      // Restore original exercises
+      curatedTpls[0].exercises = origExercises;
+      jest.resetModules();
+    }
+
+    // (a) No exception
+    expect(threw).toBe(false);
+
+    // (b) One error_log row with correct fields
+    const errorRows = db._rows.error_log.filter((r: any) => r.component === "seed.curated");
+    expect(errorRows.length).toBeGreaterThanOrEqual(1);
+    const errRow = errorRows[0];
+    expect(errRow.fatal).toBe(0);
+    expect(errRow.message).toContain(orphanId);
+
+    // (c) Seed completed for the other (non-orphan) curated rows
+    const nonOrphanTeRows = db._rows.template_exercises.filter(
+      (r: any) => r.template_id === curatedTpls[0].id && r.exercise_id !== orphanId
+    );
+    expect(nonOrphanTeRows.length).toBeGreaterThan(0);
+  });
+});
+
+// ── AC10: Idempotency ────────────────────────────────────────────────────────
+
+describe("AC10 — seed idempotency", () => {
+  it("running seed twice does not create duplicate programs/templates/schedule rows", async () => {
+    jest.resetModules();
+    const db = makeDb();
+    const realExercises = seedExercises();
+    for (const ex of realExercises) db._addExercise(ex.id);
+
+    const seedModule = require("../../../lib/db/seed");
+
+    // First run — version not set
+    db.getFirstAsync
+      .mockResolvedValueOnce({ count: 100 })
+      .mockResolvedValueOnce({ count: 100 })
+      .mockResolvedValueOnce(null); // starter_version null
+    await seedModule.seed(db);
+
+    const progCountAfterFirst = db._rows.programs.length;
+    const tplCountAfterFirst = db._rows.workout_templates.length;
+    const schedCountAfterFirst = db._rows.program_schedule.length;
+
+    // Second run — version = 6
+    db.getFirstAsync
+      .mockResolvedValueOnce({ count: 100 })
+      .mockResolvedValueOnce({ count: 100 })
+      .mockResolvedValueOnce({ value: "6" }); // starter_version already current
+    await seedModule.seed(db);
+
+    // Row counts must be stable
+    expect(db._rows.programs.length).toBe(progCountAfterFirst);
+    expect(db._rows.workout_templates.length).toBe(tplCountAfterFirst);
+    expect(db._rows.program_schedule.length).toBe(schedCountAfterFirst);
+  });
+});
+
+// ── AC11: User-edit preservation (gated UPDATE) ───────────────────────────────
+
+describe("AC11 — curated template_exercises user-edit preservation", () => {
+  it("curated template_exercises are NOT overwritten by subsequent seed runs", async () => {
+    jest.resetModules();
+    const db = makeDb();
+    const realExercises = seedExercises();
+    for (const ex of realExercises) db._addExercise(ex.id);
+
+    const seedModule = require("../../../lib/db/seed");
+
+    // First seed run inserts curated rows
+    db.getFirstAsync
+      .mockResolvedValueOnce({ count: 100 })
+      .mockResolvedValueOnce({ count: 100 })
+      .mockResolvedValueOnce(null); // version null
+    await seedModule.seed(db);
+
+    // Simulate user edit: change target_sets on a curated template_exercise
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { CURATED_TEMPLATES: curatedTpls } = require("../../../lib/curated-programs");
+    const editedTeId = curatedTpls[0].exercises[0].id;
+    const teRow = db._rows.template_exercises.find((r: any) => r.id === editedTeId);
+    expect(teRow).toBeDefined();
+    teRow.target_sets = 999; // user edit
+    const editedTplId = teRow.template_id;
+    // Mark template as curated in the mock db so the UPDATE gate fires
+    const tplRow = db._rows.workout_templates.find((r: any) => r.id === editedTplId);
+    expect(tplRow).toBeDefined();
+    tplRow.is_curated = 1;
+
+    // Second seed run (simulated STARTER_VERSION bump 6 → 7)
+    db.getFirstAsync
+      .mockResolvedValueOnce({ count: 100 })
+      .mockResolvedValueOnce({ count: 100 })
+      .mockResolvedValueOnce({ value: "5" }); // version below current → triggers update
+    await seedModule.seed(db);
+
+    // Curated row must be unchanged
+    const teAfter = db._rows.template_exercises.find((r: any) => r.id === editedTeId);
+    expect(teAfter?.target_sets).toBe(999);
+  });
+});
+
+// ── AC2: Upgrade scenario ─────────────────────────────────────────────────────
+
+describe("AC2 — upgrade from STARTER_VERSION=5 to 6", () => {
+  it("RR appears on upgrade and starter template_exercises still get gated update", async () => {
+    jest.resetModules();
+    const db = makeDb();
+    const realExercises = seedExercises();
+    for (const ex of realExercises) db._addExercise(ex.id);
+
+    const seedModule = require("../../../lib/db/seed");
+
+    // Pre-populate a starter template row to simulate existing user data
+    const starterTeId = STARTER_TEMPLATES[0].exercises[0].id;
+    db._rows.template_exercises.push({
+      id: starterTeId,
+      template_id: STARTER_TEMPLATES[0].id,
+      exercise_id: STARTER_TEMPLATES[0].exercises[0].exercise_id,
+      position: 99, // wrong position — UPDATE should repair it
+      target_sets: 3,
+      target_reps: "8-12",
+      rest_seconds: 90,
+      set_types: "[]",
+    });
+    db._rows.workout_templates.push({
+      id: STARTER_TEMPLATES[0].id,
+      name: STARTER_TEMPLATES[0].name,
+      is_starter: 1,
+      is_curated: 0,
+    });
+
+    // Seed with STARTER_VERSION=5 (upgrading)
+    db.getFirstAsync
+      .mockResolvedValueOnce({ count: 100 })
+      .mockResolvedValueOnce({ count: 100 })
+      .mockResolvedValueOnce({ value: "5" }); // below current
+    await seedModule.seed(db);
+
+    // (i) RR program row was seeded
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { CURATED_PROGRAMS: curatedProgs } = require("../../../lib/curated-programs");
+    const rrProg = db._rows.programs.find((r: any) => r.id === curatedProgs[0].id);
+    expect(rrProg).toBeDefined();
+
+    // (ii) Starter template_exercises UPDATE ran (repairs corrupted position)
+    // The mock UPDATE handler updates position for non-curated templates
+    const starterTeAfter = db._rows.template_exercises.find((r: any) => r.id === starterTeId);
+    // Position 0 is the correct position for the first exercise
+    expect(starterTeAfter?.position).toBe(0);
+  });
+});

--- a/__tests__/lib/db/seed-starter-templates.test.ts
+++ b/__tests__/lib/db/seed-starter-templates.test.ts
@@ -1,4 +1,5 @@
 import { STARTER_TEMPLATES, STARTER_PROGRAMS } from "../../../lib/starter-templates";
+import { CURATED_TEMPLATES } from "../../../lib/curated-programs";
 import { seedExercises } from "../../../lib/seed";
 
 // ---- Data Integrity Tests ----
@@ -95,8 +96,14 @@ describe("Seed — upsertTemplates repair logic", () => {
     const totalStarterExercises = STARTER_TEMPLATES.reduce(
       (sum, tpl) => sum + tpl.exercises.length, 0
     );
+    // BLD-1000: curated templates also issue INSERT against template_exercises.
+    // The UPDATE repair, however, is gated on `is_curated=0` so curated rows
+    // do not contribute to UPDATE call count.
+    const totalCuratedExercises = CURATED_TEMPLATES.reduce(
+      (sum, tpl) => sum + tpl.exercises.length, 0
+    );
 
-    expect(insertCalls.length).toBe(totalStarterExercises);
+    expect(insertCalls.length).toBe(totalStarterExercises + totalCuratedExercises);
     expect(updateCalls.length).toBe(totalStarterExercises);
   });
 

--- a/app/program/[id].tsx
+++ b/app/program/[id].tsx
@@ -13,6 +13,13 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { useProgramDetail, dayName } from "@/hooks/useProgramDetail";
 import { WeeklySchedule } from "@/components/program/WeeklySchedule";
 import { ProgramHistory } from "@/components/program/ProgramHistory";
+import {
+  CuratedChip,
+  CuratedCaption,
+  AttributionFooter,
+  useCuratedCaption,
+} from "@/components/program/CuratedExtras";
+import { CURATED_ATTRIBUTION } from "../../lib/curated-programs";
 
 export default function ProgramDetail() {
   const colors = useThemeColors();
@@ -33,6 +40,8 @@ export default function ProgramDetail() {
     }, [load])
   );
 
+  const { visible: captionVisible, dismiss: dismissCaption } = useCuratedCaption();
+
   if (!program) {
     return (
       <>
@@ -46,6 +55,13 @@ export default function ProgramDetail() {
 
   const currentIdx = days.findIndex((d) => d.id === program.current_day_id);
   const starter = !!program.is_starter;
+  const curated = !!program.is_curated;
+  // BLD-1000: curated programs are user-editable in place — they get the
+  // same action set as a custom program (Set Active / Edit). They are NOT
+  // user-deletable in v1: `softDeleteProgram` rejects curated rows so the
+  // delete icon is suppressed below. Attribution footer is rendered when
+  // `curated` is true. The first-launch caption lives in ProgramsList.
+  const attribution = curated ? CURATED_ATTRIBUTION[program.id] : undefined;
 
   return (
     <>
@@ -65,6 +81,16 @@ export default function ProgramDetail() {
               >
                 STARTER
               </Chip>
+            )}
+            {curated && <CuratedChip />}
+            {curated && (
+              <CuratedCaption
+                visible={captionVisible}
+                onDismiss={dismissCaption}
+                surface={colors.surface}
+                outline={colors.outline}
+                onSurfaceVariant={colors.onSurfaceVariant}
+              />
             )}
 
             {program.description ? (
@@ -108,6 +134,27 @@ export default function ProgramDetail() {
                   style={styles.actionBtn}
                   accessibilityLabel="Duplicate to edit"
                   label="Duplicate to Edit"
+                />
+              </View>
+            ) : curated ? (
+              // BLD-1000: curated programs are editable in place but not
+              // user-deletable in v1. Same actions as custom minus delete.
+              <View style={styles.actions}>
+                <Button
+                  variant={program.is_active ? "outline" : "default"}
+                  onPress={toggle}
+                  disabled={loading}
+                  style={styles.actionBtn}
+                  accessibilityLabel={program.is_active ? "Deactivate program" : "Set program as active"}
+                >
+                  {program.is_active ? "Deactivate" : "Set Active"}
+                </Button>
+                <Button
+                  variant="outline"
+                  onPress={() => router.push(`/program/create?programId=${program.id}`)}
+                  style={styles.actionBtn}
+                  accessibilityLabel="Edit program"
+                  label="Edit"
                 />
               </View>
             ) : (
@@ -221,6 +268,11 @@ export default function ProgramDetail() {
               schedEntry={schedEntry}
             />
             <ProgramHistory history={history} colors={colors} router={router} />
+            <AttributionFooter
+              attribution={attribution}
+              primary={colors.primary}
+              onSurfaceVariant={colors.onSurfaceVariant}
+            />
           </>
         }
       />

--- a/components/home/ProgramsList.tsx
+++ b/components/home/ProgramsList.tsx
@@ -1,6 +1,7 @@
-import React from "react";
-import { StyleSheet, View } from "react-native";
+import React, { useMemo, useState } from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
 import { Button } from "@/components/ui/button";
+import { Chip } from "@/components/ui/chip";
 import { Text } from "@/components/ui/text";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useRouter } from "expo-router";
@@ -18,8 +19,53 @@ type Props = {
   onOptions: (p: Program) => void;
 };
 
+// BLD-1001: filter modes for the Programs surface chip row.
+//   `all`     — every program (default).
+//   `curated` — programs flagged is_starter=1 OR is_curated=1 (everything
+//               that ships pre-seeded).
+//   `mine`    — user-created programs (both flags 0).
+// Selection is intentionally session-scoped (component-local `useState`):
+// it resets to `all` on app restart, per the BLD-986 plan / AC3.
+export type ProgramsFilter = "all" | "curated" | "mine";
+
 export function ProgramsList({ colors, programs, dayCounts, onPress, onDelete, onOptions }: Props) {
   const router = useRouter();
+  const [filter, setFilter] = useState<ProgramsFilter>("all");
+
+  const filtered = useMemo(() => {
+    if (filter === "all") return programs;
+    if (filter === "curated") {
+      return programs.filter((p) => p.is_starter === true || p.is_curated === true);
+    }
+    // `mine`: user-created (both flags falsy).
+    return programs.filter((p) => !p.is_starter && !p.is_curated);
+  }, [programs, filter]);
+
+  const renderChip = (value: ProgramsFilter, label: string) => {
+    const selected = filter === value;
+    return (
+      <Chip
+        key={value}
+        compact
+        selected={selected}
+        onPress={() => setFilter(value)}
+        // AC5/AC7: Chip uses selected={true} to apply background fill +
+        // bold weight together (not hue alone). Border on unselected chips
+        // gives the chip row visible structure on light themes.
+        style={
+          selected
+            ? undefined
+            : { borderWidth: 1, borderColor: colors.outline }
+        }
+        accessibilityLabel={`${label} programs filter${selected ? ", selected" : ""}`}
+        accessibilityRole="button"
+        accessibilityState={{ selected }}
+      >
+        {label}
+      </Chip>
+    );
+  };
+
   return (
     <View style={styles.section}>
       <View style={styles.sectionHeader}>
@@ -28,27 +74,71 @@ export function ProgramsList({ colors, programs, dayCounts, onPress, onDelete, o
           <View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}><MaterialCommunityIcons name="plus" size={16} color={colors.primary} /><Text style={{ color: colors.primary, fontSize: fontSizes.sm }}>Create</Text></View>
         </Button>
       </View>
-      {programs.length === 0 ? (
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.chipRow}
+        accessibilityLabel="Programs filter"
+      >
+        {renderChip("all", "All")}
+        {renderChip("curated", "Curated")}
+        {renderChip("mine", "Mine")}
+      </ScrollView>
+
+      {filtered.length === 0 ? (
         <View style={styles.empty}>
-          <Text style={{ color: colors.onSurfaceVariant }} accessibilityRole="text" accessibilityLabel="No programs yet. Create your first program.">Create your first program</Text>
-          <Button variant="outline" onPress={() => router.push("/program/create")} style={styles.emptyBtn} accessibilityLabel="Create your first program" label="Create Program" />
+          {filter === "curated" ? (
+            // AC: degenerate empty path — curated rows are undeletable in v1.
+            <Text
+              style={{ color: colors.onSurfaceVariant }}
+              accessibilityRole="text"
+              accessibilityLabel="No curated programs available. Future CableSnap updates may add more."
+            >
+              No curated programs available. Future CableSnap updates may add more.
+            </Text>
+          ) : filter === "mine" ? (
+            <>
+              <Text
+                style={{ color: colors.onSurfaceVariant }}
+                accessibilityRole="text"
+                accessibilityLabel="No programs yet. Create your first program."
+              >
+                Create your first program
+              </Text>
+              <Button variant="outline" onPress={() => router.push("/program/create")} style={styles.emptyBtn} accessibilityLabel="Create your first program" label="Create Program" />
+            </>
+          ) : (
+            <>
+              <Text style={{ color: colors.onSurfaceVariant }} accessibilityRole="text" accessibilityLabel="No programs yet. Create your first program.">Create your first program</Text>
+              <Button variant="outline" onPress={() => router.push("/program/create")} style={styles.emptyBtn} accessibilityLabel="Create your first program" label="Create Program" />
+            </>
+          )}
         </View>
       ) : (
         <View style={styles.flowList}>
-          {programs.map((item) => {
+          {filtered.map((item) => {
             const badges: { label: string; type: "active" | "starter" | "recommended" }[] = [];
             if (item.is_active) badges.push({ label: "ACTIVE", type: "active" });
-            const metaBadges: MetaBadge[] = [item.is_starter ? difficultyBadge("intermediate") : { icon: "signal-cellular-2", label: "Custom" }, { icon: "calendar-blank-outline", label: `${dayCounts[item.id] ?? 0} days` }];
+            const isPreseeded = item.is_starter || item.is_curated;
+            const metaBadges: MetaBadge[] = [
+              isPreseeded ? difficultyBadge("intermediate") : { icon: "signal-cellular-2", label: "Custom" },
+              { icon: "calendar-blank-outline", label: `${dayCounts[item.id] ?? 0} days` },
+            ];
             if (item.is_starter) metaBadges.push({ icon: "star-outline", label: "Starter" });
-            const menuItems: FlowCardMenuItem[] = item.is_starter
+            if (item.is_curated) metaBadges.push({ icon: "bookmark-outline", label: "Curated" });
+            // BLD-1001: curated programs are undeletable in v1 (matches starter
+            // behavior). Users hide them via the `Mine` filter chip above.
+            const menuItems: FlowCardMenuItem[] = isPreseeded
               ? [{ label: "Duplicate", icon: "content-copy", onPress: () => onOptions(item) }]
               : [
                   { label: "Duplicate", icon: "content-copy", onPress: () => onOptions(item) },
                   { label: "Delete", icon: "trash-can-outline", onPress: () => onDelete(item), destructive: true },
                 ];
+            const kindLabel = item.is_curated ? "Curated program" : item.is_starter ? "Starter program" : "Program";
             return (
               <FlowCard key={item.id} name={item.name} onPress={() => onPress(item.id)}
-                accessibilityLabel={`${item.is_starter ? "Starter program" : "Program"}: ${item.name}, ${dayCounts[item.id] ?? 0} days${item.is_active ? ", active" : ""}`}
+                accessibilityLabel={`${kindLabel}: ${item.name}, ${dayCounts[item.id] ?? 0} days${item.is_active ? ", active" : ""}`}
                 accessibilityHint="Long press for options"
                 badges={badges} meta={metaBadges}
                 menuItems={menuItems} />
@@ -66,4 +156,6 @@ const styles = StyleSheet.create({
   sectionHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginBottom: 8 },
   empty: { alignItems: "center", paddingVertical: 16 },
   emptyBtn: { marginTop: 8 },
+  chipRow: { flexDirection: "row", gap: 8, paddingVertical: 6, paddingRight: 8 },
+  chip: { borderWidth: 1 },
 });

--- a/components/home/TemplatesList.tsx
+++ b/components/home/TemplatesList.tsx
@@ -54,10 +54,13 @@ export function buildMenuItems(
   onDelete: (t: WorkoutTemplate) => void,
   onExport: (id: string) => void
 ): FlowCardMenuItem[] {
+  // Starters can be duplicated and exported but not edited/deleted.
   if (isStarter) return [
     { label: "Duplicate", icon: "content-copy", onPress: () => onOptions(item) },
     { label: "Export", icon: "export-variant", onPress: () => onExport(item.id) },
   ];
+  // BLD-1000: curated templates (is_curated=1) are non-deletable/non-editable like starters.
+  if (item.is_curated) return [{ label: "Duplicate", icon: "content-copy", onPress: () => onOptions(item) }];
   return [
     { label: "Edit", icon: "pencil", onPress: () => onEdit(item.id) },
     { label: "Duplicate", icon: "content-copy", onPress: () => onOptions(item) },

--- a/components/program/CuratedExtras.tsx
+++ b/components/program/CuratedExtras.tsx
@@ -1,0 +1,132 @@
+/**
+ * BLD-1000: Curated-program-only UI fragments lifted out of `app/program/[id].tsx`
+ * to keep the main file under its decomposition line-budget.
+ *
+ * Exports:
+ *   - `CuratedChip`        : the "CURATED" chip shown in the header.
+ *   - `useCuratedCaption`  : load / dismiss the one-shot intro caption.
+ *   - `CuratedCaption`     : the dismissible intro card itself.
+ *   - `AttributionFooter`  : tappable CC-BY-SA 3.0 source link.
+ */
+import React, { useCallback, useEffect, useState } from "react";
+import { Linking, StyleSheet, TouchableOpacity, View } from "react-native";
+import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
+import { Chip } from "@/components/ui/chip";
+import { Text } from "@/components/ui/text";
+import { fontSizes } from "@/constants/design-tokens";
+import { getAppSetting, setAppSetting } from "../../lib/db";
+
+export type CuratedAttribution = { label: string; url: string; license: string };
+
+const CAPTION_KEY = "curated_intro_dismissed";
+
+export function CuratedChip() {
+  return (
+    <Chip
+      compact
+      style={styles.chip}
+      accessibilityLabel="Curated program from the community. Editable in place."
+    >
+      CURATED
+    </Chip>
+  );
+}
+
+export function useCuratedCaption() {
+  const [dismissed, setDismissed] = useState(true);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    getAppSetting(CAPTION_KEY)
+      .then((v) => {
+        setDismissed(v === "1");
+        setLoaded(true);
+      })
+      .catch(() => {
+        setDismissed(false);
+        setLoaded(true);
+      });
+  }, []);
+
+  const dismiss = useCallback(async () => {
+    setDismissed(true);
+    try {
+      await setAppSetting(CAPTION_KEY, "1");
+    } catch {
+      /* persist failed; local dismiss still applies */
+    }
+  }, []);
+
+  return { visible: loaded && !dismissed, dismiss };
+}
+
+export function CuratedCaption({
+  visible, onDismiss, surface, outline, onSurfaceVariant,
+}: {
+  visible: boolean;
+  onDismiss: () => void;
+  surface: string;
+  outline: string;
+  onSurfaceVariant: string;
+}) {
+  if (!visible) return null;
+  return (
+    <View style={[styles.captionCard, { backgroundColor: surface, borderColor: outline }]}>
+      <Text style={[styles.captionText, { color: onSurfaceVariant }]} maxFontSizeMultiplier={1.5}>
+        Curated programs are added by CableSnap. Edit freely or hide them via the filter on the Programs screen.
+      </Text>
+      <TouchableOpacity
+        onPress={onDismiss}
+        hitSlop={8}
+        accessibilityLabel="Dismiss curated programs info"
+        accessibilityRole="button"
+        style={styles.captionDismiss}
+      >
+        <MaterialCommunityIcons name="close" size={18} color={onSurfaceVariant} />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+export function AttributionFooter({
+  attribution, primary, onSurfaceVariant,
+}: {
+  attribution: CuratedAttribution | undefined;
+  primary: string;
+  onSurfaceVariant: string;
+}) {
+  if (!attribution) return null;
+  return (
+    <TouchableOpacity
+      onPress={() => void Linking.openURL(attribution.url)}
+      accessibilityLabel={`Source: ${attribution.label} (${attribution.license}). Opens in browser.`}
+      accessibilityRole="link"
+      style={styles.attributionRow}
+    >
+      <Text style={[styles.attributionText, { color: onSurfaceVariant }]} maxFontSizeMultiplier={1.5}>
+        Adapted from{" "}
+        <Text style={{ color: primary, textDecorationLine: "underline" }} maxFontSizeMultiplier={1.5}>
+          {attribution.label}
+        </Text>{" "}
+        ({attribution.license}).
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: { alignSelf: "flex-start", marginBottom: 12 },
+  captionCard: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+  },
+  captionText: { flex: 1, fontSize: fontSizes.sm, lineHeight: 18 },
+  captionDismiss: { paddingTop: 1 },
+  attributionRow: { marginTop: 16, paddingBottom: 8 },
+  attributionText: { fontSize: fontSizes.xs, lineHeight: 16 },
+});

--- a/lib/curated-programs.ts
+++ b/lib/curated-programs.ts
@@ -1,0 +1,169 @@
+/**
+ * Curated Programs Library — BLD-1000 v1.
+ *
+ * Static, license-clean catalog of named, proven training programs shipped
+ * with CableSnap. v1 is RR-only (r/bodyweightfitness Recommended Routine).
+ *
+ * Curated programs:
+ *   - Are seeded into `workout_templates` and `programs` with `is_curated=1`
+ *     by `lib/db/seed.ts:upsertCuratedTemplates`/`upsertCuratedPrograms`.
+ *   - Are NOT user-deletable in v1 (soft-delete guard in
+ *     `lib/programs.ts:softDeleteProgram` checks `is_curated=0`). Users hide
+ *     them via the `Mine` filter chip on the Programs surface.
+ *   - Are user-editable in place. Subsequent seed runs do NOT issue the
+ *     BLD-467 canonical-repair UPDATE on curated rows (the gate at
+ *     `lib/db/seed.ts:upsertTemplates` excludes curated rows), so user
+ *     changes to `target_sets` / `target_reps` / `rest_seconds` / `set_types`
+ *     persist across cold launches and across future `STARTER_VERSION` bumps.
+ *
+ * License attribution
+ *   The Recommended Routine is adapted from the r/bodyweightfitness wiki:
+ *     https://www.reddit.com/r/bodyweightfitness/wiki/kb/recommended_routine
+ *   The original wiki text is licensed CC-BY-SA 3.0. Movement names and
+ *   structural data (sets/reps/exercises) are not copyrightable. The
+ *   description prose below is paraphrased — no block is verbatim from the
+ *   wiki. The detail screen renders an attribution footer with a tappable
+ *   source link when a program has `is_curated=1`. See `app/program/[id].tsx`.
+ *
+ * Bundle hygiene
+ *   Target ≤ 8 KB gzipped for this module in v1. RR alone is well within
+ *   that envelope. Future programs (5×5, GZCLP, etc.) are out of scope —
+ *   parked to v2.
+ */
+import type { StarterTemplate } from "./starter-templates";
+
+/**
+ * A curated program shipped by CableSnap.
+ *
+ * Distinct from `StarterProgram` because curated programs additionally seed
+ * `program_schedule` rows (one per `schedule[]` entry) so the user sees the
+ * program's recommended weekday placement on first launch. Starters do not
+ * write `program_schedule` (they have no day-of-week mapping). Keeping the
+ * types separate ensures starter behavior is unchanged.
+ */
+export type CuratedProgram = {
+  id: string;
+  name: string;
+  description: string;
+  /** Each entry binds a calendar day (0=Sun..6=Sat) to a workout template. */
+  schedule: { day_of_week: number; template_id: string }[];
+  /** Mirrors `StarterProgram.days` — drives `program_days` row insertion. */
+  days: { id: string; label: string; template_id: string }[];
+  /** Source URL surfaced in the program detail screen attribution footer. */
+  source_url: string;
+  /** Source attribution name (paired with CC-BY-SA 3.0 marker in UI). */
+  source_name: string;
+};
+
+// ─── Recommended Routine (RR) ───────────────────────────────────────────────
+// Six bedrock progressions, full-body, 3 days/week. The wiki recommends
+// Monday / Wednesday / Friday placement; the user can reschedule freely.
+//
+// Movement IDs map to bodyweight exercises seeded in `lib/seed-community.ts`:
+//   squat:        mw-bw-027 (Bodyweight Squat)
+//   hinge/glutes: mw-bw-033 (Glute Bridge)
+//   push:         mw-bw-001 (Push-Up)
+//   vertical pull: mw-bw-049 (Negative Pull-Up) — accessible entry point
+//   horizontal pull: mw-bw-008 (Inverted Row)
+//   anti-extension: mw-bw-017 (Plank)
+//
+// The build-time test `__tests__/lib/db/seed-curated.test.ts` enforces that
+// every exercise_id below resolves in the seed exercise list. The runtime
+// defense in `upsertCuratedTemplates` skips any row whose exercise_id has
+// gone missing and writes one warning to `error_log`.
+
+const RR_TEMPLATE_ID = "curated-rr-tpl-1";
+const RR_PROGRAM_ID = "curated-rr-prog-1";
+
+export const CURATED_TEMPLATES: StarterTemplate[] = [
+  {
+    id: RR_TEMPLATE_ID,
+    name: "Recommended Routine",
+    difficulty: "beginner",
+    duration: "~45 min",
+    exercises: [
+      // Squat progression — start with bodyweight squat, advance to split-squat
+      // (mw-bw-028) or pistol squat (mw-bw-037) as strength allows. The user
+      // edits this row in place to swap in the next progression.
+      {
+        id: "curated-rr-te-1-squat",
+        exercise_id: "mw-bw-027",
+        target_sets: 3,
+        target_reps: "5-8",
+        rest_seconds: 90,
+      },
+      // Hip hinge / posterior chain — start with glute bridge, advance to
+      // single-leg glute bridge (mw-bw-034) for added unilateral demand.
+      {
+        id: "curated-rr-te-2-hinge",
+        exercise_id: "mw-bw-033",
+        target_sets: 3,
+        target_reps: "10-12",
+        rest_seconds: 90,
+      },
+      // Horizontal push — push-up. Knee push-up (mw-bw-046) is the
+      // accessible entry; one-arm push-up (mw-bw-047) is the long-term goal.
+      {
+        id: "curated-rr-te-3-push",
+        exercise_id: "mw-bw-001",
+        target_sets: 3,
+        target_reps: "5-8",
+        rest_seconds: 90,
+      },
+      // Vertical pull — negative pull-up is the realistic starting point
+      // for users who cannot yet do a full pull-up (mw-bw-011). Scapular
+      // pull-up (mw-bw-048) and dead hang (mw-bw-042) are earlier rungs.
+      {
+        id: "curated-rr-te-4-vertical-pull",
+        exercise_id: "mw-bw-049",
+        target_sets: 3,
+        target_reps: "3-5",
+        rest_seconds: 90,
+      },
+      // Horizontal pull — inverted row. Incline row (mw-bw-050) is the
+      // easier entry; elevated-feet inverted row (mw-bw-051) is harder.
+      {
+        id: "curated-rr-te-5-horizontal-pull",
+        exercise_id: "mw-bw-008",
+        target_sets: 3,
+        target_reps: "5-8",
+        rest_seconds: 90,
+      },
+      // Anti-extension core — plank for time. Knee plank (mw-bw-054) is
+      // the accessible entry; side plank (mw-bw-018) is a complementary
+      // anti-lateral-flexion variant.
+      {
+        id: "curated-rr-te-6-anti-extension",
+        exercise_id: "mw-bw-017",
+        target_sets: 3,
+        target_reps: "30-60s",
+        rest_seconds: 60,
+      },
+    ],
+  },
+];
+
+export const CURATED_PROGRAMS: CuratedProgram[] = [
+  {
+    id: RR_PROGRAM_ID,
+    name: "r/bodyweightfitness Recommended Routine",
+    // Paraphrased — not verbatim from the wiki. See file header §License.
+    description:
+      "A full-body bodyweight routine built around six fundamental movement patterns: squat, hip hinge, horizontal push, vertical pull, horizontal pull, and an anti-extension core hold. Run three non-consecutive days per week. Each movement has an ordered list of progressions — start at the variation you can perform with good form, edit the exercise on this template when you are ready to advance.",
+    days: [
+      { id: "curated-rr-day-1", label: "Day A", template_id: RR_TEMPLATE_ID },
+      { id: "curated-rr-day-2", label: "Day B", template_id: RR_TEMPLATE_ID },
+      { id: "curated-rr-day-3", label: "Day C", template_id: RR_TEMPLATE_ID },
+    ],
+    schedule: [
+      // Mon / Wed / Fri default placement. Day-of-week index follows JS
+      // Date.getDay() — 1=Mon, 3=Wed, 5=Fri.
+      { day_of_week: 1, template_id: RR_TEMPLATE_ID },
+      { day_of_week: 3, template_id: RR_TEMPLATE_ID },
+      { day_of_week: 5, template_id: RR_TEMPLATE_ID },
+    ],
+    source_url:
+      "https://www.reddit.com/r/bodyweightfitness/wiki/kb/recommended_routine",
+    source_name: "r/bodyweightfitness Recommended Routine",
+  },
+];

--- a/lib/curated-programs.ts
+++ b/lib/curated-programs.ts
@@ -156,11 +156,11 @@ export const CURATED_PROGRAMS: CuratedProgram[] = [
       { id: "curated-rr-day-3", label: "Day C", template_id: RR_TEMPLATE_ID },
     ],
     schedule: [
-      // Mon / Wed / Fri default placement. Day-of-week index follows JS
-      // Date.getDay() — 1=Mon, 3=Wed, 5=Fri.
-      { day_of_week: 1, template_id: RR_TEMPLATE_ID },
-      { day_of_week: 3, template_id: RR_TEMPLATE_ID },
-      { day_of_week: 5, template_id: RR_TEMPLATE_ID },
+      // Mon / Wed / Fri default placement. App convention: 0=Mon…6=Sun
+      // (see lib/notifications.ts — "our day_of_week: 0=Mon..6=Sun").
+      { day_of_week: 0, template_id: RR_TEMPLATE_ID },
+      { day_of_week: 2, template_id: RR_TEMPLATE_ID },
+      { day_of_week: 4, template_id: RR_TEMPLATE_ID },
     ],
     source_url:
       "https://www.reddit.com/r/bodyweightfitness/wiki/kb/recommended_routine",

--- a/lib/curated-programs.ts
+++ b/lib/curated-programs.ts
@@ -167,3 +167,21 @@ export const CURATED_PROGRAMS: CuratedProgram[] = [
     source_name: "r/bodyweightfitness Recommended Routine",
   },
 ];
+
+/**
+ * Map of curated program id -> attribution metadata. The detail screen renders
+ * a tappable footer (CC-BY-SA 3.0) when the active program has `is_curated=1`.
+ */
+export const CURATED_ATTRIBUTION: Record<
+  string,
+  { label: string; url: string; license: string }
+> = Object.fromEntries(
+  CURATED_PROGRAMS.map((p) => [
+    p.id,
+    {
+      label: p.source_name,
+      url: p.source_url,
+      license: "CC-BY-SA 3.0",
+    },
+  ])
+);

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -591,15 +591,15 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
     }
     case "workout_templates": {
       const r = await database.runAsync(
-        "INSERT OR IGNORE INTO workout_templates (id, name, created_at, updated_at, is_starter, source) VALUES (?, ?, ?, ?, ?, ?)",
-        [row.id, row.name, row.created_at, row.updated_at, row.is_starter ?? 0, row.source ?? null]
+        "INSERT OR IGNORE INTO workout_templates (id, name, created_at, updated_at, is_starter, is_curated, source) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.name, row.created_at, row.updated_at, row.is_starter ?? 0, row.is_curated ?? 0, row.source ?? null]
       );
       return r.changes > 0;
     }
     case "programs": {
       const r = await database.runAsync(
-        "INSERT OR IGNORE INTO programs (id, name, description, is_active, current_day_id, created_at, updated_at, deleted_at, is_starter) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        [row.id, row.name, row.description ?? "", row.is_active ?? 0, row.current_day_id ?? null, row.created_at, row.updated_at, row.deleted_at ?? null, row.is_starter ?? 0]
+        "INSERT OR IGNORE INTO programs (id, name, description, is_active, current_day_id, created_at, updated_at, deleted_at, is_starter, is_curated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.name, row.description ?? "", row.is_active ?? 0, row.current_day_id ?? null, row.created_at, row.updated_at, row.deleted_at ?? null, row.is_starter ?? 0, row.is_curated ?? 0]
       );
       return r.changes > 0;
     }

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -37,9 +37,13 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   // workout_templates table
   await addColumnIfMissing(database, "workout_templates", "is_starter", "INTEGER DEFAULT 0");
   await addColumnIfMissing(database, "workout_templates", "source", "TEXT DEFAULT NULL");
+  // BLD-1000: curated programs library — additive migration. See schema.ts.
+  await addColumnIfMissing(database, "workout_templates", "is_curated", "INTEGER DEFAULT 0");
 
   // programs table
   await addColumnIfMissing(database, "programs", "is_starter", "INTEGER DEFAULT 0");
+  // BLD-1000: curated programs library.
+  await addColumnIfMissing(database, "programs", "is_curated", "INTEGER DEFAULT 0");
 
   // template_exercises table
   await addColumnIfMissing(database, "template_exercises", "link_id", "TEXT DEFAULT NULL");

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -42,6 +42,12 @@ export const workoutTemplates = sqliteTable("workout_templates", {
   updated_at: integer("updated_at").notNull(),
   is_starter: integer("is_starter").default(0),
   source: text("source"),
+  // BLD-1000: curated programs library. is_curated=1 marks rows shipped by
+  // CableSnap (e.g., r/bodyweightfitness Recommended Routine). Distinct from
+  // is_starter — curated rows go through a separate seed path that does NOT
+  // issue the BLD-467 canonical-repair UPDATE; user edits persist across
+  // STARTER_VERSION bumps. See lib/db/seed.ts:upsertCuratedTemplates.
+  is_curated: integer("is_curated").default(0),
 });
 
 export const templateExercises = sqliteTable("template_exercises", {
@@ -220,6 +226,8 @@ export const programs = sqliteTable("programs", {
   updated_at: integer("updated_at").notNull(),
   deleted_at: integer("deleted_at"),
   is_starter: integer("is_starter").default(0),
+  // BLD-1000: curated programs library. See workoutTemplates.is_curated above.
+  is_curated: integer("is_curated").default(0),
 });
 
 export const programDays = sqliteTable("program_days", {

--- a/lib/db/seed.ts
+++ b/lib/db/seed.ts
@@ -6,6 +6,8 @@ import {
   STARTER_PROGRAMS,
   STARTER_VERSION,
 } from "../starter-templates";
+import { CURATED_TEMPLATES, CURATED_PROGRAMS } from "../curated-programs";
+import { uuid } from "../uuid";
 
 async function countSeeded(database: SQLite.SQLiteDatabase, isVoltra: boolean): Promise<number> {
   const result = await database.getFirstAsync<{ count: number }>(
@@ -54,6 +56,8 @@ export async function seed(database: SQLite.SQLiteDatabase): Promise<void> {
   // Backfill exercises referenced by starter templates that upgrading users
   // may be missing (e.g., community exercises added after initial install).
   await backfillStarterExercises(database, exercises);
+  // BLD-1000: same backfill for curated-program-referenced exercises.
+  await backfillCuratedExercises(database, exercises);
 
   // BLD-913: backfill progression data for existing seeded exercises that
   // were inserted before progression columns existed. Only updates non-custom
@@ -130,8 +134,21 @@ async function upsertTemplates(database: SQLite.SQLiteDatabase): Promise<void> {
         "INSERT OR IGNORE INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds, set_types) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         [ex.id, tpl.id, ex.exercise_id, i, ex.target_sets, ex.target_reps, ex.rest_seconds, JSON.stringify(ex.set_types ?? [])]
       );
+      // BLD-1000: gate the canonical-repair UPDATE on `is_curated=0`.
+      // `template_exercises` has no `is_curated` column (verified at
+      // `lib/db/schema.ts:47-61`), so we gate via parent `workout_templates`.
+      // Curated rows are insert-once — user edits to target_sets / reps /
+      // rest_seconds / set_types persist across cold launches and across
+      // future STARTER_VERSION bumps. Starter rows continue to receive the
+      // BLD-467 canonical repair so corrupted starter data is fixed on launch.
+      // The gate is a no-op today (starter and curated id namespaces are
+      // disjoint: `starter-tpl-*` vs. `curated-rr-*`) but documents intent
+      // and protects against future id collisions.
       await database.runAsync(
-        "UPDATE template_exercises SET template_id = ?, exercise_id = ?, position = ?, target_sets = ?, target_reps = ?, rest_seconds = ?, set_types = ? WHERE id = ?",
+        `UPDATE template_exercises SET template_id = ?, exercise_id = ?, position = ?, target_sets = ?, target_reps = ?, rest_seconds = ?, set_types = ?
+         WHERE id = ? AND template_id IN (
+           SELECT id FROM workout_templates WHERE COALESCE(is_curated, 0) = 0
+         )`,
         [tpl.id, ex.exercise_id, i, ex.target_sets, ex.target_reps, ex.rest_seconds, JSON.stringify(ex.set_types ?? []), ex.id]
       );
     }
@@ -155,6 +172,132 @@ async function upsertPrograms(database: SQLite.SQLiteDatabase): Promise<void> {
         [day.id, prog.id, day.template_id, i, day.label]
       );
     }
+  }
+}
+
+/**
+ * BLD-1000: seed curated workout templates (e.g., r/bodyweightfitness RR).
+ *
+ * Mirrors `upsertTemplates` but with two critical differences:
+ *  1. Rows are inserted with `is_curated = 1` and `is_starter = 0`.
+ *  2. NO canonical-repair UPDATE is issued. Curated rows are insert-once;
+ *     user edits to `target_sets` / `target_reps` / `rest_seconds` /
+ *     `set_types` persist across cold launches and `STARTER_VERSION` bumps.
+ *     If we ever need to repair a shipped curated row, we ship a one-shot
+ *     migration — not a per-launch repair.
+ *
+ * Defensive orphan-id handling: before inserting each `template_exercises`
+ * row, we look up the `exercise_id` in the `exercises` table. If missing, we
+ * skip the insert and write one `error_log` entry (`component='seed.curated'`,
+ * `fatal=0`). This is new code in BLD-1000 — the starter path remains "blind
+ * insert" because every starter exercise is guaranteed by the build-time test.
+ * Curated rows have a build-time CI gate too, but the runtime defense protects
+ * against drift if future curated content references an exercise that gets
+ * removed from the seed list.
+ */
+async function upsertCuratedTemplates(database: SQLite.SQLiteDatabase): Promise<void> {
+  for (const tpl of CURATED_TEMPLATES) {
+    await database.runAsync(
+      "INSERT OR IGNORE INTO workout_templates (id, name, created_at, updated_at, is_starter, is_curated) VALUES (?, ?, 0, 0, 0, 1)",
+      [tpl.id, tpl.name]
+    );
+    for (let i = 0; i < tpl.exercises.length; i++) {
+      const ex = tpl.exercises[i];
+      // BLD-1000 AC9: orphan-exercise-id runtime defense. Skip the insert
+      // and write one warning to error_log if the exercise no longer exists.
+      const found = await database.getFirstAsync<{ id: string }>(
+        "SELECT id FROM exercises WHERE id = ? AND deleted_at IS NULL",
+        [ex.exercise_id]
+      );
+      if (!found) {
+        await database.runAsync(
+          `INSERT INTO error_log (id, message, component, fatal, timestamp)
+           VALUES (?, ?, 'seed.curated', 0, ?)`,
+          [
+            uuid(),
+            `Curated template ${tpl.id} references missing exercise_id ${ex.exercise_id} (template_exercise ${ex.id}); skipping insert.`,
+            Date.now(),
+          ]
+        );
+        continue;
+      }
+      await database.runAsync(
+        "INSERT OR IGNORE INTO template_exercises (id, template_id, exercise_id, position, target_sets, target_reps, rest_seconds, set_types) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [ex.id, tpl.id, ex.exercise_id, i, ex.target_sets, ex.target_reps, ex.rest_seconds, JSON.stringify(ex.set_types ?? [])]
+      );
+      // NO repair UPDATE. User edits persist.
+    }
+  }
+}
+
+/**
+ * BLD-1000: seed curated programs (e.g., RR).
+ *
+ * Like `upsertCuratedTemplates`, this is insert-once: no repair UPDATE on
+ * `programs` itself, no repair on `program_days` rows. Additionally inserts
+ * `program_schedule` rows from the curated program's `schedule[]` so the
+ * weekday placement is visible on first launch. The PRIMARY KEY on
+ * `(program_id, day_of_week)` (`schema.ts:250`) makes schedule inserts
+ * idempotent — user edits to schedule rows persist across re-seeds.
+ */
+async function upsertCuratedPrograms(database: SQLite.SQLiteDatabase): Promise<void> {
+  for (const prog of CURATED_PROGRAMS) {
+    await database.runAsync(
+      "INSERT OR IGNORE INTO programs (id, name, description, is_active, current_day_id, created_at, updated_at, is_starter, is_curated) VALUES (?, ?, ?, 0, NULL, 0, 0, 0, 1)",
+      [prog.id, prog.name, prog.description]
+    );
+    for (let i = 0; i < prog.days.length; i++) {
+      const day = prog.days[i];
+      await database.runAsync(
+        "INSERT OR IGNORE INTO program_days (id, program_id, template_id, position, label) VALUES (?, ?, ?, ?, ?)",
+        [day.id, prog.id, day.template_id, i, day.label]
+      );
+    }
+    for (const slot of prog.schedule) {
+      await database.runAsync(
+        "INSERT OR IGNORE INTO program_schedule (program_id, day_of_week, template_id) VALUES (?, ?, ?)",
+        [prog.id, slot.day_of_week, slot.template_id]
+      );
+    }
+  }
+}
+
+/**
+ * BLD-1000: backfill exercises referenced by curated templates that may not
+ * yet be in the user's `exercises` table (e.g., if curated content references
+ * a community exercise added in a later release).
+ */
+async function backfillCuratedExercises(
+  database: SQLite.SQLiteDatabase,
+  allExercises: Exercise[]
+): Promise<void> {
+  const neededIds = new Set<string>();
+  for (const tpl of CURATED_TEMPLATES) {
+    for (const ex of tpl.exercises) {
+      neededIds.add(ex.exercise_id);
+    }
+  }
+  const exerciseMap = new Map<string, Exercise>();
+  for (const ex of allExercises) {
+    if (neededIds.has(ex.id)) exerciseMap.set(ex.id, ex);
+  }
+  for (const id of neededIds) {
+    const ex = exerciseMap.get(id);
+    if (!ex) continue;
+    await database.runAsync(
+      `INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty, is_custom, attachment, is_voltra, progression_group, progression_order)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        ex.id, ex.name, ex.category,
+        JSON.stringify(ex.primary_muscles), JSON.stringify(ex.secondary_muscles),
+        ex.equipment, ex.instructions, ex.difficulty,
+        ex.is_custom ? 1 : 0,
+        ex.attachment ?? "handle",
+        ex.is_voltra ? 1 : 0,
+        ex.progression_group ?? null,
+        ex.progression_order ?? null,
+      ]
+    );
   }
 }
 
@@ -202,6 +345,17 @@ async function seedStarters(database: SQLite.SQLiteDatabase): Promise<void> {
 
   await database.withTransactionAsync(async () => {
     await upsertPrograms(database);
+  });
+
+  // BLD-1000: curated templates and programs run in separate transactions
+  // for the same isolation reason. They are insert-once (no repair UPDATE)
+  // and write to error_log on orphan exercise_id references.
+  await database.withTransactionAsync(async () => {
+    await upsertCuratedTemplates(database);
+  });
+
+  await database.withTransactionAsync(async () => {
+    await upsertCuratedPrograms(database);
   });
 
   if (!row || Number(row.value) < STARTER_VERSION) {

--- a/lib/db/tables.ts
+++ b/lib/db/tables.ts
@@ -88,7 +88,8 @@ export async function createCoreTables(database: SQLite.SQLiteDatabase): Promise
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
       is_starter INTEGER DEFAULT 0,
-      source TEXT
+      source TEXT,
+      is_curated INTEGER DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS template_exercises (
@@ -228,7 +229,8 @@ export async function createCoreTables(database: SQLite.SQLiteDatabase): Promise
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
       deleted_at INTEGER DEFAULT NULL,
-      is_starter INTEGER DEFAULT 0
+      is_starter INTEGER DEFAULT 0,
+      is_curated INTEGER DEFAULT 0
     );
 
     CREATE TABLE IF NOT EXISTS program_days (

--- a/lib/db/templates.ts
+++ b/lib/db/templates.ts
@@ -90,7 +90,7 @@ export async function getTemplates(): Promise<WorkoutTemplate[]> {
     .select()
     .from(workoutTemplates)
     .orderBy(asc(workoutTemplates.is_starter), desc(workoutTemplates.created_at));
-  return rows.map((r) => ({ ...r, is_starter: r.is_starter === 1, source: (r.source ?? null) as TemplateSource }));
+  return rows.map((r) => ({ ...r, is_starter: r.is_starter === 1, is_curated: r.is_curated === 1, source: (r.source ?? null) as TemplateSource }));
 }
 
 export async function getTemplateById(
@@ -103,7 +103,7 @@ export async function getTemplateById(
     .where(eq(workoutTemplates.id, id))
     .get();
   if (!raw) return null;
-  const tpl: WorkoutTemplate = { ...raw, is_starter: raw.is_starter === 1, source: (raw.source ?? null) as TemplateSource };
+  const tpl: WorkoutTemplate = { ...raw, is_starter: raw.is_starter === 1, is_curated: raw.is_curated === 1, source: (raw.source ?? null) as TemplateSource };
 
   const rows = await db
     .select({
@@ -299,6 +299,15 @@ export async function duplicateProgram(id: string): Promise<string> {
     }
   }
 
+  // BLD-1000: fetch schedule rows so we can copy them into the new program.
+  const scheduleRows = await db
+    .select({
+      day_of_week: programSchedule.day_of_week,
+      template_id: programSchedule.template_id,
+    })
+    .from(programSchedule)
+    .where(eq(programSchedule.program_id, id));
+
   await withTransaction(async () => {
     await db.insert(programs).values({
       id: newId,
@@ -319,6 +328,16 @@ export async function duplicateProgram(id: string): Promise<string> {
         template_id: tplId,
         position: day.position,
         label: day.label,
+      });
+    }
+
+    // BLD-1000: copy weekly schedule, remapping template_id through templateCopies.
+    for (const row of scheduleRows) {
+      const tplId = templateCopies.get(row.template_id) ?? row.template_id;
+      await db.insert(programSchedule).values({
+        program_id: newId,
+        day_of_week: row.day_of_week,
+        template_id: tplId,
       });
     }
   });

--- a/lib/db/templates.ts
+++ b/lib/db/templates.ts
@@ -188,11 +188,12 @@ export async function updateTemplateName(
 export async function deleteTemplate(id: string): Promise<void> {
   const db = await getDrizzle();
   const tpl = await db
-    .select({ is_starter: workoutTemplates.is_starter })
+    .select({ is_starter: workoutTemplates.is_starter, is_curated: workoutTemplates.is_curated })
     .from(workoutTemplates)
     .where(eq(workoutTemplates.id, id))
     .get();
-  if (tpl?.is_starter === 1) return;
+  // BLD-1000: guard both starter AND curated templates from deletion.
+  if (tpl?.is_starter === 1 || tpl?.is_curated === 1) return;
 
   await withTransaction(async () => {
     await db.delete(programSchedule).where(eq(programSchedule.template_id, id));
@@ -287,11 +288,12 @@ export async function duplicateProgram(id: string): Promise<string> {
   for (const day of days) {
     if (day.template_id && !templateCopies.has(day.template_id)) {
       const tpl = await db
-        .select({ is_starter: workoutTemplates.is_starter })
+        .select({ is_starter: workoutTemplates.is_starter, is_curated: workoutTemplates.is_curated })
         .from(workoutTemplates)
         .where(eq(workoutTemplates.id, day.template_id))
         .get();
-      if (tpl?.is_starter === 1) {
+      // BLD-1000: also copy curated templates so the duplicate is independent.
+      if (tpl?.is_starter === 1 || tpl?.is_curated === 1) {
         templateCopies.set(day.template_id, await duplicateTemplate(day.template_id));
       }
     }

--- a/lib/programs.ts
+++ b/lib/programs.ts
@@ -36,14 +36,20 @@ export async function getPrograms(): Promise<Program[]> {
     description: string;
     is_active: number;
     is_starter: number;
+    is_curated: number;
     current_day_id: string | null;
     created_at: number;
     updated_at: number;
     deleted_at: number | null;
   }>(
-    "SELECT * FROM programs WHERE deleted_at IS NULL ORDER BY is_active DESC, is_starter ASC, updated_at DESC"
+    "SELECT * FROM programs WHERE deleted_at IS NULL ORDER BY is_active DESC, is_starter ASC, is_curated ASC, updated_at DESC"
   );
-  return rows.map((r) => ({ ...r, is_active: r.is_active === 1, is_starter: r.is_starter === 1 }));
+  return rows.map((r) => ({
+    ...r,
+    is_active: r.is_active === 1,
+    is_starter: r.is_starter === 1,
+    is_curated: r.is_curated === 1,
+  }));
 }
 
 export async function getProgramById(id: string): Promise<Program | null> {
@@ -54,13 +60,19 @@ export async function getProgramById(id: string): Promise<Program | null> {
     description: string;
     is_active: number;
     is_starter: number;
+    is_curated: number;
     current_day_id: string | null;
     created_at: number;
     updated_at: number;
     deleted_at: number | null;
   }>("SELECT * FROM programs WHERE id = ? AND deleted_at IS NULL", [id]);
   if (!row) return null;
-  return { ...row, is_active: row.is_active === 1, is_starter: row.is_starter === 1 };
+  return {
+    ...row,
+    is_active: row.is_active === 1,
+    is_starter: row.is_starter === 1,
+    is_curated: row.is_curated === 1,
+  };
 }
 
 export async function updateProgram(
@@ -77,13 +89,21 @@ export async function updateProgram(
 
 export async function softDeleteProgram(id: string): Promise<void> {
   const database = await getDatabase();
-  const prog = await database.getFirstAsync<{ is_starter: number }>(
-    "SELECT is_starter FROM programs WHERE id = ?",
+  // BLD-1000: extend the BLD-1 soft-delete guard to cover curated programs.
+  // Curated rows must remain present across STARTER_VERSION bumps (the
+  // re-seed path is INSERT-OR-IGNORE keyed on the static curated id, so
+  // soft-deleting then bumping would leave a tombstoned row that the seeder
+  // refuses to overwrite — and on top of that the user's edits would be
+  // permanently inaccessible). Users who do not want a curated program in
+  // their list use the `Mine` filter chip on the Programs surface to hide
+  // it. Deletable-curated semantics are parked to v2.
+  const prog = await database.getFirstAsync<{ is_starter: number; is_curated: number }>(
+    "SELECT is_starter, is_curated FROM programs WHERE id = ?",
     [id]
   );
-  if (prog?.is_starter === 1) return;
+  if (prog?.is_starter === 1 || prog?.is_curated === 1) return;
   await database.runAsync(
-    "UPDATE programs SET deleted_at = ?, is_active = 0, updated_at = ? WHERE id = ? AND is_starter = 0",
+    "UPDATE programs SET deleted_at = ?, is_active = 0, updated_at = ? WHERE id = ? AND is_starter = 0 AND COALESCE(is_curated, 0) = 0",
     [Date.now(), Date.now(), id]
   );
 }
@@ -96,13 +116,19 @@ export async function getActiveProgram(): Promise<Program | null> {
     description: string;
     is_active: number;
     is_starter: number;
+    is_curated: number;
     current_day_id: string | null;
     created_at: number;
     updated_at: number;
     deleted_at: number | null;
   }>("SELECT * FROM programs WHERE is_active = 1 AND deleted_at IS NULL LIMIT 1");
   if (!row) return null;
-  return { ...row, is_active: true, is_starter: row.is_starter === 1 };
+  return {
+    ...row,
+    is_active: true,
+    is_starter: row.is_starter === 1,
+    is_curated: row.is_curated === 1,
+  };
 }
 
 export async function activateProgram(id: string): Promise<void> {

--- a/lib/starter-templates.ts
+++ b/lib/starter-templates.ts
@@ -25,7 +25,7 @@ export type StarterProgram = {
   days: { id: string; label: string; template_id: string }[];
 };
 
-export const STARTER_VERSION = 5;
+export const STARTER_VERSION = 6;
 
 export const STARTER_TEMPLATES: StarterTemplate[] = [
   {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -224,6 +224,8 @@ export type WorkoutTemplate = {
   created_at: number;
   updated_at: number;
   is_starter?: boolean;
+  /** BLD-1000: true for curated-library templates shipped by the app. */
+  is_curated?: boolean;
   source?: TemplateSource;
   exercises?: TemplateExercise[];
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -469,6 +469,7 @@ export type Program = {
   description: string;
   is_active: boolean;
   is_starter?: boolean;
+  is_curated?: boolean;
   current_day_id: string | null;
   created_at: number;
   updated_at: number;


### PR DESCRIPTION
## Summary

Ships v1 of the Curated Programs Library seeding the r/bodyweightfitness Recommended Routine (RR) as a ready-to-use, community-sourced program. RR is a full-body bodyweight session 3×/week (Mon/Wed/Fri default). Descriptions are paraphrased — not copied verbatim from the wiki. All other programs (5×5/GZCLP/PPL/etc.) are parked to v2.

## Changes

### Schema
- `is_curated INTEGER DEFAULT 0` added to `workout_templates` and `programs` (drizzle schema, raw `CREATE TABLE`, additive migration via `addColumnIfMissing`)
- `Program.is_curated?: boolean` added to `lib/types.ts`

### Catalog (`lib/curated-programs.ts`)
- `CuratedProgram` type, `CURATED_TEMPLATES` (1 template, 6 exercises mapped to `mw-bw-*` seed IDs), `CURATED_PROGRAMS` (1 program, Mon/Wed/Fri schedule), `CURATED_ATTRIBUTION` export for detail screen footer

### Seed (`lib/db/seed.ts`)
- `upsertCuratedTemplates` / `upsertCuratedPrograms`: insert-once, no canonical-repair UPDATE, orphan exercise_id defense → `error_log` (`component='seed.curated'`, `fatal=0`)
- BLD-467 canonical-repair UPDATE on `template_exercises` gated on `is_curated=0` via parent-template subquery — curated user edits persist across STARTER_VERSION bumps
- `STARTER_VERSION` bumped 5 → 6 to trigger re-seed on existing installs
- `softDeleteProgram` extended: guard is now `is_starter=0 AND is_curated=0`
- `is_curated` surfaced through `getPrograms`, `getProgramById`, `getActiveProgram`

### UI
- **Programs surface** (`components/home/ProgramsList.tsx`): `[All / Curated / Mine]` filter chips (session-scoped, only shown when curated rows present), first-launch dismissible hint, `CURATED` meta badge, no Delete in card menu for curated rows
- **Program detail** (`app/program/[id].tsx`): `CURATED` chip, dismissible intro caption, Set Active / Edit actions (no Delete), CC-BY-SA 3.0 attribution footer linking to source; extracted to `components/program/CuratedExtras.tsx` to stay under FTA 350-line budget

### Tests
- `__tests__/lib/db/seed-curated.test.ts` — 9 cases: AC8 build integrity (orphan/dup/collision), AC9 runtime orphan defense, AC10 idempotency, AC11 user-edit preservation, AC2 upgrade 5→6
- Updated `__tests__/lib/db/seed-starter-templates.test.ts` INSERT count assertion to include curated rows (UPDATE count remains starter-only)
- `scripts/audit-tests.sh` ceiling bumped 2100 → 2200 for the 9 new test cases

## Testing

- `npx tsc --noEmit` — clean (0 errors)
- `npm test` — 3004/3004 pass
- `npm run lint` — 0 new errors in changed files (23 pre-existing errors unchanged)
- FTA decomposition limit: `app/program/[id].tsx` is 336 lines (limit 350)

## Acceptance Criteria Coverage

| AC | Status | Notes |
|----|--------|-------|
| AC1 new install | ✅ | RR seeded via upsertCuratedTemplates/Programs on STARTER_VERSION bump |
| AC2 upgrade | ✅ | seed-curated.test.ts AC2 test; STARTER_VERSION 5→6 |
| AC3 filter chips | ✅ | ProgramsList.tsx All/Curated/Mine, session-scoped |
| AC4 attribution | ✅ | CuratedExtras.tsx → AttributionFooter, tappable CC-BY-SA link |
| AC5 first-launch | ✅ | useCuratedCaption hook + CuratedCaption in detail screen |
| AC8 exercise IDs | ✅ | seed-curated.test.ts AC8 suite (5 assertions) |
| AC9 orphan defense | ✅ | seed-curated.test.ts AC9 test + error_log write |
| AC10 idempotency | ✅ | seed-curated.test.ts AC10 test |
| AC11 user-edit persist | ✅ | Gated UPDATE + AC11 test |
| AC13 no new packages | ✅ | Only Linking from react-native (already a dep) |
| AC16 paraphrased | ✅ | Descriptions are original prose, not wiki verbatim |

## Issue

Resolves BLD-1000 (parent: BLD-986)