### PR TITLE
ci(release): gate scheduled-release on CHANGELOG.md + backfill v0.26.20–v0.26.22 (BLD-1027)

### DIFF
--- a/.github/workflows/bundle-gate.yml
+++ b/.github/workflows/bundle-gate.yml
@@ -24,6 +24,8 @@ on:
       - 'assets/exercise-illustrations/**'
       - 'scripts/verify-scenario-hook-not-in-bundle.sh'
       - 'scripts/verify-exercise-illustrations-size.sh'
+      - 'CHANGELOG.md'
+      - 'scripts/check-changelog-parity.sh'
       - '.github/workflows/bundle-gate.yml'
       - 'package.json'
       - 'package-lock.json'
@@ -59,6 +61,14 @@ jobs:
 
       - name: Run bundle gate
         run: bash scripts/verify-scenario-hook-not-in-bundle.sh
+
+      - name: Verify CHANGELOG ↔ app.config.ts parity (BLD-1027)
+        # Drift alarm: scheduled-release.yml previously bumped versionCode
+        # without touching CHANGELOG.md, so v0.26.20–v0.26.22 shipped with no
+        # curated release notes (BLD-1026). This step asserts the top
+        # `## v<X.Y.Z>` header + `<!-- versionCode: N -->` marker match
+        # app.config.ts on every PR + on every push to main.
+        run: bash scripts/check-changelog-parity.sh
 
       - name: Verify exercise illustration bundle size (BLD-561)
         run: bash scripts/verify-exercise-illustrations-size.sh

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -85,8 +85,54 @@ jobs:
           echo "No new commits since ${{ steps.latest_tag.outputs.tag }}. Skipping release."
           exit 0
 
+      # BLD-1027: CHANGELOG.md gate. The `publish-release` skill marks
+      # CHANGELOG.md as the *single source of truth* for release notes (in-app
+      # What's New, GitHub Release body, F-Droid sidecars). Before BLD-1027
+      # this workflow happily bumped versionCode every 12h without touching
+      # CHANGELOG.md, so v0.26.20–v0.26.22 escaped the gate with raw `git log`
+      # release notes and no F-Droid sidecars (see BLD-1026 diagnosis).
+      #
+      # Now: a populated `## Unreleased` section is *required* for the
+      # workflow to ship. If it's missing or empty, no-op the release with a
+      # clear notice — same pattern as the "no new commits" exit above. The
+      # only escape hatch is to either curate the section or cancel the run.
+      - name: Gate on CHANGELOG.md `## Unreleased` section
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
+        id: changelog_gate
+        run: |
+          set -euo pipefail
+          if [ ! -f CHANGELOG.md ]; then
+            echo "::error::CHANGELOG.md is missing — cannot release without curated notes."
+            exit 1
+          fi
+          # Extract body of the `## Unreleased` section: everything between
+          # `## Unreleased` and the next `## ` header. macOS/BSD-safe awk.
+          BODY=$(awk '
+            /^##[[:space:]]+Unreleased[[:space:]]*$/ { in_u = 1; next }
+            in_u && /^## / { exit }
+            in_u { print }
+          ' CHANGELOG.md)
+          # Strip whitespace + the placeholder sentinel used between releases.
+          STRIPPED=$(printf '%s\n' "$BODY" \
+            | sed -E 's/_No user-facing changes yet\._//I' \
+            | tr -d '[:space:]')
+          if [ -z "$STRIPPED" ]; then
+            echo "::notice::CHANGELOG.md has no curated '## Unreleased' content — skipping scheduled release."
+            echo "::notice::Add bullets to the '## Unreleased' section in CHANGELOG.md to ship the next version."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Curated '## Unreleased' content found — proceeding with release."
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+
+      - name: Stop here if CHANGELOG gate said skip
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release != 'true'
+        run: |
+          echo "CHANGELOG gate said skip. Exiting workflow successfully (no-op)."
+          exit 0
+
       - name: Compute next version
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         id: next_version
         run: |
           TAG="${{ steps.latest_tag.outputs.tag }}"
@@ -110,7 +156,7 @@ jobs:
           echo "Next version: $NEXT"
 
       - name: Compute next version code
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         id: next_vcode
         run: |
           CURRENT=$(grep 'CurrentVersionCode:' fdroid/metadata/com.persoack.cablesnap.yml | awk '{print $2}')
@@ -119,7 +165,7 @@ jobs:
           echo "Next version code: $NEXT"
 
       - name: Bump version in package.json
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         run: |
           VERSION="${{ steps.next_version.outputs.version }}"
           node -e "
@@ -130,7 +176,7 @@ jobs:
           "
 
       - name: Bump version in app.config.ts
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         run: |
           VERSION="${{ steps.next_version.outputs.version }}"
           VCODE="${{ steps.next_vcode.outputs.version_code }}"
@@ -138,28 +184,101 @@ jobs:
           sed -i "s/versionCode: [0-9]*/versionCode: $VCODE/" app.config.ts
 
       - name: Bump version in F-Droid metadata
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         run: |
           VERSION="${{ steps.next_version.outputs.version }}"
           VCODE="${{ steps.next_vcode.outputs.version_code }}"
           sed -i "s/CurrentVersion: .*/CurrentVersion: $VERSION/" fdroid/metadata/com.persoack.cablesnap.yml
           sed -i "s/CurrentVersionCode: .*/CurrentVersionCode: $VCODE/" fdroid/metadata/com.persoack.cablesnap.yml
 
+      # BLD-1027: Promote `## Unreleased` → `## vX.Y.Z — DATE` with the
+      # `<!-- versionCode: N -->` marker. This keeps CHANGELOG.md in sync
+      # with the version bumped above and recreates a fresh placeholder
+      # `## Unreleased` for the next cycle. macOS/BSD-safe awk.
+      - name: Promote `## Unreleased` to versioned section in CHANGELOG.md
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.next_version.outputs.version }}"
+          VCODE="${{ steps.next_vcode.outputs.version_code }}"
+          DATE=$(date -u +%Y-%m-%d)
+          NEW_HEADER="## v$VERSION — $DATE"
+          MARKER="<!-- versionCode: $VCODE -->"
+          PLACEHOLDER=$'## Unreleased\n\n_No user-facing changes yet._\n'
+
+          awk -v new_header="$NEW_HEADER" \
+              -v marker="$MARKER" \
+              -v placeholder="$PLACEHOLDER" '
+            BEGIN { promoted = 0 }
+            /^##[[:space:]]+Unreleased[[:space:]]*$/ && promoted == 0 {
+              printf "%s\n", placeholder
+              print new_header
+              print marker
+              promoted = 1
+              next
+            }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.md.tmp
+          mv CHANGELOG.md.tmp CHANGELOG.md
+          echo "Promoted '## Unreleased' to '$NEW_HEADER' (versionCode $VCODE)"
+          # Sanity: top `## v<semver>` header must now match.
+          TOP=$(awk '/^## v[0-9]+\.[0-9]+\.[0-9]+/ { print; exit }' CHANGELOG.md)
+          echo "Top entry: $TOP"
+
+      # Setup Node + deps before changelog regen *and* the Android build —
+      # `npm run changelog:gen` (BLD-571) needs tsx, the Android build needs
+      # node_modules for `expo prebuild`. Keeping these here means we can
+      # commit the regenerated artifacts atomically with the version bump.
+      - name: Set up Node.js
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
+        run: npm ci
+
+      - name: Regenerate changelog artifacts (lib/changelog.generated.ts + F-Droid sidecars)
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          npm run changelog:gen
+          # Sanity: the new versionCode sidecar must exist.
+          VCODE="${{ steps.next_vcode.outputs.version_code }}"
+          SIDECAR="fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/${VCODE}.txt"
+          if [ ! -s "$SIDECAR" ]; then
+            echo "::error::Expected F-Droid sidecar $SIDECAR to be written by changelog:gen but it is missing or empty."
+            exit 1
+          fi
+          echo "Wrote $SIDECAR ($(wc -c < "$SIDECAR") bytes)"
+
       - name: Generate release notes
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         id: release_notes
         run: |
-          TAG="${{ steps.latest_tag.outputs.tag }}"
+          # BLD-1027: read release-notes body from CHANGELOG.md (single source
+          # of truth — see publish-release SKILL Step 7). Replaces the
+          # synthesised `git log` output that shipped in v0.26.20–v0.26.22.
+          # macOS/BSD-safe awk: extract from the first `## v$VERSION` header
+          # up to (but not including) the next `## ` header.
+          set -euo pipefail
           VERSION="${{ steps.next_version.outputs.version }}"
+          BODY=$(awk -v v="$VERSION" '
+            $0 ~ "^## v"v"([^0-9]|$)" { in_section=1; next }
+            in_section && /^## / { exit }
+            in_section { print }
+          ' CHANGELOG.md)
+          if [ -z "$(printf '%s' "$BODY" | tr -d '[:space:]')" ]; then
+            echo "::error::CHANGELOG.md has an empty body for v$VERSION — refusing to ship."
+            exit 1
+          fi
           {
             echo 'notes<<NOTES_EOF'
             echo "## What's New"
             echo ""
-            if [ -z "$TAG" ]; then
-              git log --oneline | head -20
-            else
-              git log --oneline "$TAG"..HEAD
-            fi
+            echo "$BODY"
             echo ""
             echo "## Install"
             echo ""
@@ -180,12 +299,15 @@ jobs:
       # fingerprint verification — still run, so the signing path can be
       # exercised and independently verified before merge.
       - name: Commit and push
-        if: steps.check_commits.outputs.has_new_commits == 'true' && github.ref == 'refs/heads/main'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref == 'refs/heads/main'
         run: |
           VERSION="${{ steps.next_version.outputs.version }}"
           git config user.name "CableSnap Release Bot"
           git config user.email "release-bot@cablesnap.app"
-          git add package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml
+          git add package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml \
+            CHANGELOG.md \
+            lib/changelog.generated.ts \
+            fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/
           if git diff --cached --quiet; then
             echo "Version files already at v$VERSION — skipping commit."
           else
@@ -214,7 +336,7 @@ jobs:
           fi
 
       - name: Dry-run notice (non-main ref)
-        if: steps.check_commits.outputs.has_new_commits == 'true' && github.ref != 'refs/heads/main'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref != 'refs/heads/main'
         run: |
           echo "::notice::Dry-run mode — ref is ${{ github.ref }}, not refs/heads/main."
           echo "::notice::Skipping 'Commit and push' and 'Create GitHub Release'; signed APK will be uploaded as a workflow artifact for review."
@@ -222,29 +344,22 @@ jobs:
       # --- Build APK BEFORE creating release (immutable releases block later uploads) ---
 
       - name: Set up JDK 17
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Set up Android SDK
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         uses: android-actions/setup-android@v3
 
-      - name: Set up Node.js
-        if: steps.check_commits.outputs.has_new_commits == 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install dependencies
-        if: steps.check_commits.outputs.has_new_commits == 'true'
-        run: npm ci
+      # Node.js + npm install already happened earlier (before changelog
+      # promotion + regen). The cached node_modules are reused here for
+      # `expo prebuild` and the Android build.
 
       - name: Generate native project
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         env:
           # Sentry Expo config plugin reads these at prebuild time to generate
           # android/sentry.properties. Missing values are handled gracefully
@@ -256,7 +371,7 @@ jobs:
         run: npx expo prebuild --clean --platform android
 
       - name: Boost Gradle JVM heap
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         run: |
           # expo prebuild --clean regenerates android/gradle.properties with
           # org.gradle.jvmargs=-Xmx2048m, which is borderline for
@@ -273,7 +388,7 @@ jobs:
           grep '^org.gradle.jvmargs=' "$PROPS"
 
       - name: Decode release keystore and write keystore.properties
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -296,7 +411,7 @@ jobs:
           echo "Wrote android/keystore.properties (storeFile=release.keystore, alias=$ANDROID_KEY_ALIAS)"
 
       - name: Build APK
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         env:
           # Sentry Android Gradle plugin reads these to upload debug symbols +
           # source maps during assembleRelease. Missing SENTRY_AUTH_TOKEN is
@@ -337,7 +452,7 @@ jobs:
           ls -lh cablesnap.apk cablesnap-fdroid.apk cablesnap-wear.apk
 
       - name: AC10b — verify F-Droid APK contains zero GMS Wearable classes
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         run: |
           # Plan AC10b: the F-Droid flavor APK MUST NOT carry any
           # com/google/android/gms/wearable/* classes. We verify by listing
@@ -365,7 +480,7 @@ jobs:
           echo "AC10b OK — F-Droid APK is GMS-Wearable-free."
 
       - name: Verify APK signature matches committed fingerprint
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         run: |
           set -euo pipefail
           BUILD_TOOLS_DIR=$(ls -d "$ANDROID_HOME"/build-tools/*/ 2>/dev/null | sort -V | tail -1)
@@ -435,7 +550,7 @@ jobs:
       # --- Emulator smoke test: verify APK launches without crashing ---
 
       - name: Android emulator smoke test
-        if: steps.check_commits.outputs.has_new_commits == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
           api-level: 34
@@ -455,7 +570,7 @@ jobs:
       # --- Create release WITH APK attached atomically ---
 
       - name: Upload dry-run signed APK + apksigner log (non-main ref)
-        if: always() && steps.check_commits.outputs.has_new_commits == 'true' && github.ref != 'refs/heads/main'
+        if: always() && steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref != 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: dry-run-signed-apk
@@ -468,7 +583,7 @@ jobs:
           retention-days: 14
 
       - name: Create GitHub Release with APK
-        if: steps.check_commits.outputs.has_new_commits == 'true' && github.ref == 'refs/heads/main'
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           RELEASE_NOTES: ${{ steps.release_notes.outputs.notes }}

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -97,7 +97,7 @@ jobs:
       # clear notice — same pattern as the "no new commits" exit above. The
       # only escape hatch is to either curate the section or cancel the run.
       - name: Gate on CHANGELOG.md `## Unreleased` section
-        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
+        if: steps.check_commits.outputs.has_new_commits == 'true'
         id: changelog_gate
         run: |
           set -euo pipefail

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -26,6 +26,22 @@ if [ -f "scripts/check-license.sh" ]; then
   fi
 fi
 
+# ─── CHANGELOG ↔ app.config.ts parity gate (BLD-1027) ──────────
+# Blocks push if the top `## v<X.Y.Z>` header in CHANGELOG.md (or its
+# `<!-- versionCode: N -->` marker) doesn't match `version` /
+# `android.versionCode` in app.config.ts. Same drift class that let
+# v0.26.20–v0.26.22 ship without CHANGELOG entries (BLD-1026).
+if [ -f "scripts/check-changelog-parity.sh" ]; then
+  echo "📝 Verifying CHANGELOG ↔ app.config.ts parity..."
+  if ! bash scripts/check-changelog-parity.sh; then
+    echo ""
+    echo "Update CHANGELOG.md (top '## vX.Y.Z' header + '<!-- versionCode: N -->' marker)"
+    echo "to match app.config.ts before pushing."
+    echo "To skip this check (governance escape hatch only): git push --no-verify"
+    exit 1
+  fi
+fi
+
 # ─── Exercise Illustration Bundle Gate (BLD-561) ────────────────
 # Blocks push if assets/exercise-illustrations/**/*.webp exceeds the hard-fail
 # bundle budget (R2 plan: target ≤8MB, hard fail >12MB).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,20 @@ The `<!-- versionCode: N -->` marker is optional but required for F-Droid
 sidecar emission. The `publish-release` skill prepends a new section (with
 marker) at release time.
 
-## v0.26.19 — 2026-05-01
-<!-- versionCode: 76 -->
-- Fixed Android crash on app open caused by WearOS module class-loading failure on devices without Google Play Services.
-- Replaced direct WearOS Wearable API import with Class.forName() reflection to prevent NoClassDefFoundError at startup.
-- Removed WearOSModule from Expo autolinker to prevent F-Droid build crashes.
-- Added Android emulator smoke test to CI pipeline to catch launch crashes before release.
-
 ## Unreleased
 
+_No user-facing changes yet._
+
+## v0.26.22 — 2026-05-03
+<!-- versionCode: 92 -->
+- Internal/CI: regression-catcher fixture migrated to wrapper-fixture pattern (BLD-1023).
+
+## v0.26.21 — 2026-05-03
+<!-- versionCode: 91 -->
+- Internal/CI: routine release — no user-facing changes.
+
+## v0.26.20 — 2026-05-02
+<!-- versionCode: 90 -->
 ### Added
 - Hydration tracking — log water in ml or fl oz from the Nutrition tab; configurable daily goal and preset volumes in Settings.
 - Workout templates now remember the training mode you pick per Voltra exercise; sessions started from the template open in the saved mode automatically.
@@ -38,6 +43,16 @@ marker) at release time.
 
 ### Removed
 - Removed the **Eccentric** training mode chip and tempo tracking. Existing eccentric sets in your history are preserved as standard sets; other Voltra modes (Band, Damper, Isokinetic, Isometric, Custom, Rowing) are unchanged.
+
+### Internal/CI
+- Merge gate: comment-fallback approvals for lenient branch protection.
+
+## v0.26.19 — 2026-05-01
+<!-- versionCode: 76 -->
+- Fixed Android crash on app open caused by WearOS module class-loading failure on devices without Google Play Services.
+- Replaced direct WearOS Wearable API import with Class.forName() reflection to prevent NoClassDefFoundError at startup.
+- Removed WearOSModule from Expo autolinker to prevent F-Droid build crashes.
+- Added Android emulator smoke test to CI pipeline to catch launch crashes before release.
 
 ## v0.26.12 — 2026-04-26
 <!-- versionCode: 65 -->

--- a/__tests__/scripts/check-changelog-parity.test.ts
+++ b/__tests__/scripts/check-changelog-parity.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Tests for scripts/check-changelog-parity.sh (BLD-1027).
+ *
+ * Builds a tiny fake repo (CHANGELOG.md + app.config.ts) per case, runs the
+ * shell script with `repo_root` overridden via cwd, and asserts the exit code
+ * + stderr output. This is the drift alarm wired into pre-push and
+ * bundle-gate.yml — same class of failure that let v0.26.20–v0.26.22 ship
+ * without curated CHANGELOG entries (BLD-1026).
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  cpSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const SCRIPT = resolve(__dirname, "..", "..", "scripts", "check-changelog-parity.sh");
+
+function makeRepo(changelog: string, version: string, versionCode: number): string {
+  const root = mkdtempSync(join(tmpdir(), "parity-"));
+  mkdirSync(join(root, "scripts"), { recursive: true });
+  cpSync(SCRIPT, join(root, "scripts", "check-changelog-parity.sh"));
+  writeFileSync(join(root, "CHANGELOG.md"), changelog, "utf8");
+  writeFileSync(
+    join(root, "app.config.ts"),
+    `export default () => ({\n  version: "${version}",\n  android: {\n    versionCode: ${versionCode},\n  },\n});\n`,
+    "utf8"
+  );
+  return root;
+}
+
+function run(root: string) {
+  return spawnSync("bash", [join(root, "scripts", "check-changelog-parity.sh")], {
+    cwd: root,
+    encoding: "utf8",
+  });
+}
+
+describe("check-changelog-parity.sh", () => {
+  const goodChangelog = [
+    "# Changelog",
+    "",
+    "## Unreleased",
+    "",
+    "_No user-facing changes yet._",
+    "",
+    "## v1.2.3 — 2026-05-03",
+    "<!-- versionCode: 42 -->",
+    "- A change.",
+    "",
+    "## v1.2.2 — 2026-05-02",
+    "<!-- versionCode: 41 -->",
+    "- An older change.",
+    "",
+  ].join("\n");
+
+  let roots: string[] = [];
+  afterEach(() => {
+    for (const r of roots) rmSync(r, { recursive: true, force: true });
+    roots = [];
+  });
+
+  it("exits 0 when CHANGELOG top entry matches app.config.ts", () => {
+    const root = makeRepo(goodChangelog, "1.2.3", 42);
+    roots.push(root);
+    const r = run(root);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("parity OK");
+  });
+
+  it("fails when CHANGELOG version is ahead of app.config.ts", () => {
+    const root = makeRepo(goodChangelog, "1.2.2", 41);
+    roots.push(root);
+    const r = run(root);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/version drift/);
+  });
+
+  it("fails when versionCode marker disagrees with app.config.ts", () => {
+    const root = makeRepo(goodChangelog, "1.2.3", 99);
+    roots.push(root);
+    const r = run(root);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/versionCode drift/);
+  });
+
+  it("fails when the top entry has no versionCode marker", () => {
+    const noMarker = goodChangelog.replace("<!-- versionCode: 42 -->\n", "");
+    const root = makeRepo(noMarker, "1.2.3", 42);
+    roots.push(root);
+    const r = run(root);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/versionCode: N/);
+  });
+
+  it("fails when CHANGELOG.md has no `## v<semver>` headers at all", () => {
+    const empty = "# Changelog\n\n## Unreleased\n\n_No user-facing changes yet._\n";
+    const root = makeRepo(empty, "1.2.3", 42);
+    roots.push(root);
+    const r = run(root);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/no '## v<semver>' header/);
+  });
+
+  it("ignores `## Unreleased` and matches against the first versioned entry", () => {
+    // Ensures the awk loop doesn't latch onto `## Unreleased` as a candidate.
+    const withDirtyUnreleased = [
+      "# Changelog",
+      "",
+      "## Unreleased",
+      "<!-- versionCode: 999 -->",
+      "- a stray marker that must NOT be picked up",
+      "",
+      "## v1.2.3 — 2026-05-03",
+      "<!-- versionCode: 42 -->",
+      "- the real top entry.",
+      "",
+    ].join("\n");
+    const root = makeRepo(withDirtyUnreleased, "1.2.3", 42);
+    roots.push(root);
+    const r = run(root);
+    expect(r.status).toBe(0);
+  });
+});

--- a/fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/90.txt
+++ b/fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/90.txt
@@ -1,0 +1,10 @@
+### Added
+- Hydration tracking — log water in ml or fl oz from the Nutrition tab; configurable daily goal and preset volumes in Settings.
+- Workout templates now remember the training mode you pick per Voltra exercise; sessions started from the template open in the saved mode automatically.
+
+### Changed
+- Workout duration now starts when you log your first completed set, not the moment you tap Start (BLD-630).
+
+### Removed
+- Removed the **Eccentric** training mode
+…see in-app release notes

--- a/fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/91.txt
+++ b/fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/91.txt
@@ -1,0 +1,1 @@
+- Internal/CI: routine release — no user-facing changes.

--- a/fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/92.txt
+++ b/fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/92.txt
@@ -1,0 +1,1 @@
+- Internal/CI: regression-catcher fixture migrated to wrapper-fixture pattern (BLD-1023).

--- a/lib/changelog.generated.ts
+++ b/lib/changelog.generated.ts
@@ -10,6 +10,24 @@ export interface ReleaseEntry {
 
 export const CHANGELOG: ReleaseEntry[] = [
   {
+    "version": "0.26.22",
+    "date": "2026-05-03",
+    "versionCode": 92,
+    "body": "- Internal/CI: regression-catcher fixture migrated to wrapper-fixture pattern (BLD-1023)."
+  },
+  {
+    "version": "0.26.21",
+    "date": "2026-05-03",
+    "versionCode": 91,
+    "body": "- Internal/CI: routine release — no user-facing changes."
+  },
+  {
+    "version": "0.26.20",
+    "date": "2026-05-02",
+    "versionCode": 90,
+    "body": "### Added\n- Hydration tracking — log water in ml or fl oz from the Nutrition tab; configurable daily goal and preset volumes in Settings.\n- Workout templates now remember the training mode you pick per Voltra exercise; sessions started from the template open in the saved mode automatically.\n\n### Changed\n- Workout duration now starts when you log your first completed set, not the moment you tap Start (BLD-630).\n\n### Removed\n- Removed the **Eccentric** training mode chip and tempo tracking. Existing eccentric sets in your history are preserved as standard sets; other Voltra modes (Band, Damper, Isokinetic, Isometric, Custom, Rowing) are unchanged.\n\n### Internal/CI\n- Merge gate: comment-fallback approvals for lenient branch protection."
+  },
+  {
     "version": "0.26.19",
     "date": "2026-05-01",
     "versionCode": 76,

--- a/scripts/check-changelog-parity.sh
+++ b/scripts/check-changelog-parity.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# CHANGELOG.md ↔ app.config.ts parity gate (BLD-1027 / BLD-1026).
+#
+# Asserts that the top-most `## v<X.Y.Z>` header in CHANGELOG.md and its
+# `<!-- versionCode: N -->` marker match `version` and `android.versionCode`
+# in app.config.ts. This is the "scheduled-release shipped without a
+# CHANGELOG bump" drift alarm — same class of failure as v0.26.20–v0.26.22
+# (see BLD-1026 plan).
+#
+# Exit codes:
+#   0  CHANGELOG ↔ app.config.ts agree.
+#   1  drift detected (or required files missing / unparseable).
+#
+# Usage:
+#   bash scripts/check-changelog-parity.sh
+#
+# Wired into:
+#   - .husky/pre-push  (local drift alarm)
+#   - .github/workflows/bundle-gate.yml  (CI drift alarm)
+#
+# macOS/BSD-safe: no `head -n -1`, no GNU-only flags. Mirrors the
+# publish-release SKILL Step 7 awk extractor style.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+changelog="$repo_root/CHANGELOG.md"
+app_config="$repo_root/app.config.ts"
+
+fail() {
+  echo "::error::$*" >&2
+  echo "$*" >&2
+  exit 1
+}
+
+[ -f "$changelog" ] || fail "CHANGELOG.md not found at $changelog"
+[ -f "$app_config" ] || fail "app.config.ts not found at $app_config"
+
+# First `## v<semver>` header (skip `## Unreleased`).
+top_header=$(awk '/^## v[0-9]+\.[0-9]+\.[0-9]+/ { print; exit }' "$changelog")
+[ -n "$top_header" ] || fail "CHANGELOG.md has no '## v<semver>' header"
+
+changelog_version=$(echo "$top_header" \
+  | sed -E 's/^## v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+
+# `<!-- versionCode: N -->` marker inside the top entry's body — read until
+# the next `## ` header.
+changelog_vcode=$(awk '
+  /^## v[0-9]+\.[0-9]+\.[0-9]+/ { if (in_top) exit; in_top = 1; next }
+  in_top && match($0, /<!--[[:space:]]*versionCode:[[:space:]]*([0-9]+)[[:space:]]*-->/, m) {
+    print m[1]; exit
+  }
+' "$changelog" 2>/dev/null || true)
+
+# `awk match()` with an array is GNU-only. Fallback for BSD awk: grep+sed.
+if [ -z "$changelog_vcode" ]; then
+  # Extract the body of the top entry (between first `## v<semver>` and the
+  # next `## ` header), then grep for the marker.
+  body=$(awk '
+    /^## v[0-9]+\.[0-9]+\.[0-9]+/ { if (in_top) exit; in_top = 1; next }
+    in_top && /^## / { exit }
+    in_top { print }
+  ' "$changelog")
+  changelog_vcode=$( { echo "$body" \
+    | grep -oE '<!--[[:space:]]*versionCode:[[:space:]]*[0-9]+[[:space:]]*-->' \
+    || true; } \
+    | head -1 \
+    | sed -E 's/.*versionCode:[[:space:]]*([0-9]+).*/\1/')
+fi
+
+[ -n "$changelog_vcode" ] \
+  || fail "CHANGELOG top entry v$changelog_version has no <!-- versionCode: N --> marker"
+
+config_version=$(grep -E '^[[:space:]]*version:[[:space:]]*"' "$app_config" \
+  | head -1 \
+  | sed -E 's/.*version:[[:space:]]*"([^"]+)".*/\1/')
+
+config_vcode=$(grep -E '^[[:space:]]*versionCode:[[:space:]]*[0-9]+' "$app_config" \
+  | head -1 \
+  | sed -E 's/.*versionCode:[[:space:]]*([0-9]+).*/\1/')
+
+[ -n "$config_version" ] || fail "could not parse version from app.config.ts"
+[ -n "$config_vcode" ]   || fail "could not parse android.versionCode from app.config.ts"
+
+if [ "$changelog_version" != "$config_version" ]; then
+  fail "CHANGELOG ↔ app.config.ts version drift — CHANGELOG top: v$changelog_version, app.config.ts: v$config_version"
+fi
+
+if [ "$changelog_vcode" != "$config_vcode" ]; then
+  fail "CHANGELOG ↔ app.config.ts versionCode drift — CHANGELOG marker: $changelog_vcode, app.config.ts: $config_vcode"
+fi
+
+echo "✅ CHANGELOG.md ↔ app.config.ts parity OK (v$config_version, versionCode $config_vcode)"


### PR DESCRIPTION
## Summary

Stops `scheduled-release.yml` from shipping versionCode bumps with no `CHANGELOG.md` update, and backfills the three releases (v0.26.20, v0.26.21, v0.26.22) that already escaped the gate. Parent/diagnosis: BLD-1026.

## Pipeline changes (`.github/workflows/scheduled-release.yml`)

- New `Gate on CHANGELOG.md '## Unreleased' section` step. No-ops the workflow with a clear `::notice::` when there is no curated unreleased content (drift alarm, same pattern as the existing "no new commits" exit). Threaded via `should_release` output so every downstream step short-circuits cleanly.
- Promote `## Unreleased` → `## vX.Y.Z — DATE` with `<!-- versionCode: N -->` marker after the version bump (pure awk, macOS/BSD-safe).
- Move Node setup + `npm ci` ahead of release-notes generation so `npm run changelog:gen` can refresh `lib/changelog.generated.ts` + the F-Droid `<versionCode>.txt` sidecar before the release commit. Removes the now-duplicate setup-node block later in the file.
- Replace the synthesised `git log --oneline` release notes with the awk extractor from the `publish-release` SKILL Step 7 so GitHub Release bodies come from `CHANGELOG.md` (single source of truth).
- Release commit now stages `CHANGELOG.md`, `lib/changelog.generated.ts`, and the F-Droid sidecars alongside the version-bump files.

## Backfill

- **v0.26.20** — promoted the curated `## Unreleased` content (hydration tracking, Voltra mode memory on templates, workout-duration trigger, Eccentric mode removal) plus the merge-gate comment-fallback Internal/CI line.
- **v0.26.21** — routine release (no user-facing changes).
- **v0.26.22** — Internal/CI: regression-catcher wrapper-fixture migration (BLD-1023).
- Regenerated `lib/changelog.generated.ts` (10 entries) and committed `fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/{90,91,92}.txt`.

## Drift regression test (`scripts/check-changelog-parity.sh`)

- New shell script + jest unit tests asserting the top `## v<X.Y.Z>` header in `CHANGELOG.md` and its `<!-- versionCode: N -->` marker match `version` / `android.versionCode` in `app.config.ts`.
- Wired into `.husky/pre-push` (local) and `bundle-gate.yml` (CI). Triggers on PRs touching `CHANGELOG.md`, `app.config.ts`, or the parity script itself. `git push --no-verify` remains the governance escape hatch.

## Out of scope

- Editing already-published v0.26.20–v0.26.22 GitHub Release bodies (immutable, not worth the churn — see issue body).
- Manual `publish-release` skill changes — the skill is already correct; this PR fixes the CI gap.

## Verification

- `npm run changelog:gen` writes 10 entries + 6 sidecars (no warnings beyond pre-existing markerless legacy entries).
- `bash scripts/check-changelog-parity.sh` → parity OK (v0.26.22, versionCode 92).
- `npx jest __tests__/scripts/{generate-changelog,check-changelog-parity}.test.ts` → 21 passed.
- Both updated workflows parse as valid YAML.

Refs: BLD-1027, BLD-1026, BLD-571.