### PR TITLE
chore(test-infra): raise test-count ceiling 2100→2500 (BLD-1009)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -182,7 +182,7 @@ Alternatively, move non-route code out of `app/` entirely (into `components/`, `
 
 > **Runtime measurement methodology** lives in [`docs/QA-BUDGET.md`](../docs/QA-BUDGET.md) — read it before measuring per-suite wall-clock times (TL;DR: use `./scripts/measure-suite.sh` or `npm test`; never bare `npx jest`).
 
-The test suite has a **budget of 1800 test cases**. Before adding tests, agents MUST:
+The test suite has a **budget of 2500 test cases** (env-overridable via `MAX_TESTS`). Before adding tests, agents MUST:
 
 1. Run `./scripts/audit-tests.sh` to check the current count
 2. If over budget, consolidate overlapping tests before adding new ones

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -57,7 +57,7 @@ if [ -f "scripts/check-curation-gate.ts" ] && [ -f "assets/exercise-illustration
 fi
 
 # ─── Test Budget Gate ────────────────────────────────────────────
-# Blocks push if test count exceeds budget (1800 test cases)
+# Blocks push if test count exceeds budget (default 2500 test cases; see scripts/audit-tests.sh)
 # Scopes duplicate/overlap checks to changed test files only (BLD-812)
 if [ -f "scripts/audit-tests.sh" ]; then
   echo "🧪 Running test audit..."

--- a/docs/QA-BUDGET.md
+++ b/docs/QA-BUDGET.md
@@ -5,7 +5,8 @@ use when measuring per-suite wall-clock runtime.
 
 ## Test budget policy
 
-The Jest test suite has a **hard cap of 1800 test cases**, enforced by
+The Jest test suite has a **hard cap of 2500 test cases** (env-overridable
+via `MAX_TESTS`), enforced by
 [`scripts/audit-tests.sh`](../scripts/audit-tests.sh) and the
 [`.husky/pre-push`](../.husky/pre-push) hook. Agents must run the audit before
 adding tests and consolidate overlapping coverage when over budget. Full rules

--- a/scripts/audit-tests.sh
+++ b/scripts/audit-tests.sh
@@ -7,7 +7,7 @@
 #   --detail                 show extended mock-overlap matrix
 #   --skip-runtime           skip the npm test runtime check (fast audit)
 #   RUNTIME_BUDGET_SECONDS   override runtime ceiling (default: 150)
-#   MAX_TESTS                override count ceiling (default: 1800)
+#   MAX_TESTS                override count ceiling (default: 2500)
 #   SKIP_RUNTIME=1           same as --skip-runtime
 
 set -euo pipefail
@@ -16,8 +16,8 @@ PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TEST_DIR="$PROJECT_ROOT/__tests__"
 
 # ─── Configuration ───────────────────────────────────────────────
-MAX_TESTS="${MAX_TESTS:-2100}"                          # hard ceiling — fail if exceeded
-WARN_TESTS="${WARN_TESTS:-2000}"                        # warning threshold
+MAX_TESTS="${MAX_TESTS:-2500}"                          # hard ceiling — fail if exceeded
+WARN_TESTS="${WARN_TESTS:-2400}"                        # warning threshold
 RUNTIME_BUDGET_SECONDS="${RUNTIME_BUDGET_SECONDS:-150}" # wall-time ceiling for `npm test`
 RUNTIME_WARN_SECONDS="${RUNTIME_WARN_SECONDS:-120}"     # warning threshold
 # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes BLD-1009.

## Change
- `scripts/audit-tests.sh`: default `MAX_TESTS` **2100 → 2500**, `WARN_TESTS` **2000 → 2400**
- Synced documented numbers in `.husky/pre-push`, `docs/QA-BUDGET.md`, `.claude/CLAUDE.md`
- `MAX_TESTS` / `WARN_TESTS` remain env-overridable

## Why option 1 (raise) over options 2 (split) and 3 (warn-only)

The actual safety hole is that `--no-verify` disables **every** pre-push gate (license, illustration bundle, curation, FTA, test audit) — not just the count check. A plain raise fixes this today with minimum churn. Splitting by directory adds maintenance for marginal benefit; demoting to a warning weakens the regression guard. We can revisit splitting if a single category starts dominating growth.

2500 = current 2197 + ~14% headroom. The env override remains a one-line escape hatch.

## Acceptance criteria
- ✅ Clean branch with ≤2500 tests pushes without `--no-verify` (this branch did so)
- ✅ Genuine regressions (bulk test deletion) still trip the floor

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>