### PR TITLE
fix(home): prevent workout card crop on tablet flex-wrap rows (BLD-1033)

### DIFF
--- a/__tests__/components/home/RecentWorkoutsList.test.tsx
+++ b/__tests__/components/home/RecentWorkoutsList.test.tsx
@@ -86,19 +86,19 @@ describe("RecentWorkoutsList", () => {
     );
 
     // Walk the JSON tree looking for a node with alignSelf: 'flex-start'
-    type JsonNode = { props?: { style?: unknown }; children?: JsonNode[] | null };
-    function hasAlignSelfFlexStart(node: JsonNode | null): boolean {
-      if (!node) return false;
+    type JsonNode = { props?: { style?: unknown }; children?: JsonNode[] | string[] | null };
+    function hasAlignSelfFlexStart(node: JsonNode | string | null): boolean {
+      if (!node || typeof node === "string") return false;
       if (node.props?.style) {
         const flat = StyleSheet.flatten(node.props.style);
         if (flat?.alignSelf === "flex-start") return true;
       }
       if (Array.isArray(node.children)) {
-        return node.children.some((child) => hasAlignSelfFlexStart(child));
+        return (node.children as Array<JsonNode | string>).some((child) => hasAlignSelfFlexStart(child));
       }
       return false;
     }
 
-    expect(hasAlignSelfFlexStart(toJSON() as JsonNode)).toBe(true);
+    expect(hasAlignSelfFlexStart(toJSON() as JsonNode | string | null)).toBe(true);
   });
 });

--- a/__tests__/components/home/RecentWorkoutsList.test.tsx
+++ b/__tests__/components/home/RecentWorkoutsList.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * BLD-1033: Recent Workout cards cropped on tablet rows
+ *
+ * Regression test: Animated.View wrapper must have alignSelf:'flex-start' so
+ * each card sizes to its own content rather than stretching to the tallest
+ * sibling in the flex-wrap row.
+ */
+
+jest.mock("expo-router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock("../../../hooks/useColorScheme", () => ({ useColorScheme: () => "light" }));
+
+import React from "react";
+import { render } from "@testing-library/react-native";
+import RecentWorkoutsList from "../../../components/home/RecentWorkoutsList";
+import type { ThemeColors } from "../../../hooks/useThemeColors";
+import type { WorkoutSession } from "../../../lib/types";
+
+const mockColors: Partial<ThemeColors> = {
+  surface: "#FFFFFF",
+  onSurface: "#1A2138",
+  onSurfaceVariant: "#6B7280",
+  onBackground: "#1A2138",
+};
+
+const shortSession: WorkoutSession = {
+  id: "s1",
+  name: "Push",
+  started_at: "2026-05-01T10:00:00Z",
+  duration_seconds: 3600,
+  template_id: null,
+  notes: null,
+  rpe: null,
+  mood: null,
+  body_weight_kg: null,
+};
+
+const longNameSession: WorkoutSession = {
+  id: "s2",
+  name: "Full Body Hypertrophy — Upper Lower Split Day A",
+  started_at: "2026-05-02T10:00:00Z",
+  duration_seconds: 5400,
+  template_id: null,
+  notes: null,
+  rpe: null,
+  mood: null,
+  body_weight_kg: null,
+};
+
+describe("RecentWorkoutsList", () => {
+  it("renders session names", () => {
+    const { getByText } = render(
+      <RecentWorkoutsList
+        colors={mockColors as ThemeColors}
+        sessions={[shortSession, longNameSession]}
+        setCounts={{ s1: 5, s2: 8 }}
+        avgRPEs={{ s1: null, s2: 7.5 }}
+      />,
+    );
+
+    expect(getByText("Push")).toBeTruthy();
+    expect(getByText("Full Body Hypertrophy — Upper Lower Split Day A")).toBeTruthy();
+  });
+
+  it("renders empty state when no sessions", () => {
+    const { getByText } = render(
+      <RecentWorkoutsList
+        colors={mockColors as ThemeColors}
+        sessions={[]}
+        setCounts={{}}
+        avgRPEs={{}}
+      />,
+    );
+
+    expect(getByText(/No workouts yet/)).toBeTruthy();
+  });
+
+  it("animatedCard wrapper has alignSelf flex-start to prevent tablet row crop (BLD-1033)", () => {
+    const { StyleSheet } = require("react-native");
+    const { toJSON } = render(
+      <RecentWorkoutsList
+        colors={mockColors as ThemeColors}
+        sessions={[shortSession, longNameSession]}
+        setCounts={{ s1: 5, s2: 8 }}
+        avgRPEs={{ s1: null, s2: null }}
+      />,
+    );
+
+    // Walk the JSON tree looking for a node with alignSelf: 'flex-start'
+    type JsonNode = { props?: { style?: unknown }; children?: JsonNode[] | null };
+    function hasAlignSelfFlexStart(node: JsonNode | null): boolean {
+      if (!node) return false;
+      if (node.props?.style) {
+        const flat = StyleSheet.flatten(node.props.style);
+        if (flat?.alignSelf === "flex-start") return true;
+      }
+      if (Array.isArray(node.children)) {
+        return node.children.some((child) => hasAlignSelfFlexStart(child));
+      }
+      return false;
+    }
+
+    expect(hasAlignSelfFlexStart(toJSON() as JsonNode)).toBe(true);
+  });
+});

--- a/__tests__/components/home/RecentWorkoutsList.test.tsx
+++ b/__tests__/components/home/RecentWorkoutsList.test.tsx
@@ -25,25 +25,29 @@ const mockColors: Partial<ThemeColors> = {
 const shortSession: WorkoutSession = {
   id: "s1",
   name: "Push",
-  started_at: "2026-05-01T10:00:00Z",
+  started_at: 1746352800000,
+  clock_started_at: null,
+  completed_at: 1746356400000,
   duration_seconds: 3600,
   template_id: null,
-  notes: null,
-  rpe: null,
-  mood: null,
-  body_weight_kg: null,
+  notes: "",
+  rating: null,
+  edited_at: null,
+  import_batch_id: null,
 };
 
 const longNameSession: WorkoutSession = {
   id: "s2",
   name: "Full Body Hypertrophy — Upper Lower Split Day A",
-  started_at: "2026-05-02T10:00:00Z",
+  started_at: 1746439200000,
+  clock_started_at: null,
+  completed_at: 1746444600000,
   duration_seconds: 5400,
   template_id: null,
-  notes: null,
-  rpe: null,
-  mood: null,
-  body_weight_kg: null,
+  notes: "",
+  rating: null,
+  edited_at: null,
+  import_batch_id: null,
 };
 
 describe("RecentWorkoutsList", () => {

--- a/components/home/RecentWorkoutsList.tsx
+++ b/components/home/RecentWorkoutsList.tsx
@@ -37,7 +37,7 @@ export default function RecentWorkoutsList({ colors, sessions, setCounts, avgRPE
             const rpe = avgRPEs[item.id];
             const rpeStr = rpe != null ? ` · RPE ${Math.round(rpe * 10) / 10}` : "";
             return (
-              <Animated.View key={item.id} entering={FadeInDown.delay(index * 60).duration(300)}>
+              <Animated.View key={item.id} entering={FadeInDown.delay(index * 60).duration(300)} style={styles.animatedCard}>
                 <Pressable
                   style={[styles.flowCard, { backgroundColor: colors.surface, borderRadius: 12, padding: 18 }]}
                   onPress={() => router.push(`/session/detail/${item.id}`)}
@@ -68,8 +68,9 @@ export default function RecentWorkoutsList({ colors, sessions, setCounts, avgRPE
 const styles = StyleSheet.create({
   section: { marginBottom: 20 },
   sectionHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginBottom: 8 },
-  flowList: { flexDirection: "row", flexWrap: "wrap", gap: 12, alignItems: "flex-start" },
-  flowCard: { marginBottom: 8, ...flowCardStyle, flexGrow: 0 },
+  flowList: { flexDirection: "row", flexWrap: "wrap", gap: 12 },
+  animatedCard: { ...flowCardStyle, alignSelf: "flex-start" },
+  flowCard: { marginBottom: 8 },
   empty: { alignItems: "center", paddingVertical: 16 },
   recentRow: { flexDirection: "row", alignItems: "center" },
   rpeTag: { borderRadius: 12, paddingHorizontal: 8, paddingVertical: 2, marginLeft: 8 },


### PR DESCRIPTION
## Summary

On tablet/foldable widths where Recent Workouts lays out 2+ cards per row, cards with long (2-line) workout names were visually cropped at the bottom. The root cause: `Animated.View` is the actual flex item in the `flowList` container, but the flex sizing props (`minWidth`, `flexGrow`, `flexShrink`, `flexBasis`) and height-constraining behavior were only applied to the inner `Pressable`. Without `alignSelf: 'flex-start'` on the wrapper, `Animated.View` stretched to fill the full cross-axis height of its flex-wrap row.

## Changes

- `animatedCard` style added: spreads `flowCardStyle` + `alignSelf: 'flex-start'`
- `flowCard` style simplified to `marginBottom: 8` only (visual spacing)
- `flowList` style: removed redundant `alignItems: 'flex-start'` (now per-item)
- Added `__tests__/components/home/RecentWorkoutsList.test.tsx` with regression test

## Testing

- `npx tsc --noEmit` — zero errors
- Unit tests pass (3/3): renders sessions, empty state, and regression test verifying `alignSelf: 'flex-start'` on the wrapper node
- Existing dashboard acceptance tests unaffected

## Issue

Resolves BLD-1033 (GitHub #460)