### PR TITLE
fix(progress): Body view FlatList content hidden by floating navbar (BLD-990)

### DIFF
--- a/__tests__/app/source-checks-batch.test.ts
+++ b/__tests__/app/source-checks-batch.test.ts
@@ -802,6 +802,7 @@ describe("Tab screens use useFloatingTabBarHeight (BLD-212)", () => {
     { label: "progress (WorkoutSegment)", file: "components/progress/WorkoutSegment.tsx" },
     { label: "progress (NutritionSegment)", file: "components/progress/NutritionSegment.tsx" },
     { label: "progress (MonthlyReportSegment)", file: "components/progress/MonthlyReportSegment.tsx" },
+    { label: "progress (BodySegment)", file: "components/progress/BodySegment.tsx" },
     { label: "settings.tsx", file: "app/(tabs)/settings.tsx" },
   ];
 

--- a/components/progress/BodySegment.tsx
+++ b/components/progress/BodySegment.tsx
@@ -13,6 +13,7 @@ import type { BodyWeight } from "../../lib/types";
 import { toDisplay } from "../../lib/units";
 import { radii } from "../../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { useFloatingTabBarHeight } from "@/components/FloatingTabBar";
 import { useBodyMetrics } from "@/hooks/useBodyMetrics";
 import WeightLogModal from "./WeightLogModal";
 import {
@@ -108,7 +109,7 @@ function BodyModal({
 
 export default function BodySegment() {
   const colors = useThemeColors();
-
+  const tabBarHeight = useFloatingTabBarHeight();
   const {
     settings,
     latest,
@@ -202,6 +203,7 @@ export default function BodySegment() {
         renderItem={renderEntry}
         onEndReached={loadMore}
         onEndReachedThreshold={0.5}
+        contentContainerStyle={{ paddingBottom: tabBarHeight + 16 }}
         ListHeaderComponent={
           <>
             {latest && (
@@ -246,7 +248,7 @@ export default function BodySegment() {
       <FAB
         icon="plus"
         onPress={() => setModal(true)}
-        style={[styles.fab, { backgroundColor: colors.primary }]}
+        style={[styles.fab, { backgroundColor: colors.primary, bottom: tabBarHeight + 16 }]}
         color={colors.onPrimary}
         accessibilityLabel="Log body weight"
       />
@@ -275,7 +277,6 @@ const styles = StyleSheet.create({
   fab: {
     position: "absolute",
     right: 16,
-    bottom: 16,
     width: 56,
     height: 56,
     borderRadius: radii.pill,


### PR DESCRIPTION
## Summary

Body view FlatList entries were obscured by the floating bottom navbar. This adds the same floating tab bar padding pattern used by other Progress sub-tabs (Muscles, Workouts, Nutrition, Monthly).

## Changes

- `components/progress/BodySegment.tsx`: import `useFloatingTabBarHeight`, add `contentContainerStyle={{ paddingBottom: tabBarHeight + 16 }}` to FlatList, set FAB `bottom: tabBarHeight + 16`
- `__tests__/app/source-checks-batch.test.ts`: extend 'Tab screens use useFloatingTabBarHeight' test to cover BodySegment.tsx

## Testing

- TypeScript: no errors
- Source-checks-batch test passes (Tab screens use useFloatingTabBarHeight)
- Pattern matches MuscleVolumeSegment, WorkoutSegment, NutritionSegment, MonthlyReportSegment

## Issue

Resolves BLD-990