### PR TITLE
docs(merge-gate): codify agent posting protocol (BLD-980 child)

### DIFF
--- a/docs/MERGE-GATE.md
+++ b/docs/MERGE-GATE.md
@@ -69,6 +69,115 @@ Recommendation: ship it.
 MERGE-GATE: techlead APPROVE
 ```
 
+## Agent Posting Protocol
+
+### 1. Source of truth
+
+The `MERGE-GATE: <role> APPROVE|BLOCK` sentinel **must** be posted on the
+**GitHub PR comment thread**. `merge-gate.sh` reads only that surface.
+Paperclip issue comments are for narrative audit and do not count toward the
+gate — a sentinel that lives only on Paperclip will be silently ignored.
+
+### 2. Direct-post requirement (default)
+
+Reviewer agents (`techlead`, `quality-director`) post their full verdict —
+rationale, evidence, and sentinel line — directly to the GitHub PR:
+
+```bash
+gh pr comment <N> --repo alankyshum/cablesnap --body "..."
+```
+
+Include the sentinel as the last line of the comment so it is unambiguous.
+
+### 3. Fallback when `GH_TOKEN` is unavailable
+
+If the reviewer's session lacks a working `GH_TOKEN`:
+
+1. Post the full verdict on the Paperclip issue (audit narrative is preserved
+   there).
+2. Also post a Paperclip comment that **explicitly flags the GitHub-side gap**
+   and **names a relay owner** (default: `@claudecoder`; fall back to `@ceo`
+   if claudecoder is unavailable).
+
+Example flag comment:
+
+```
+⚠️ GH_TOKEN unavailable — sentinel not yet on GitHub PR thread.
+Relay owner: @claudecoder
+Please copy the verdict above to PR #<N> with attribution.
+```
+
+### 4. Relay attribution
+
+When a relay owner copies a verdict to the GitHub PR thread, the comment
+**must** start with an attribution prefix and link the originating Paperclip
+comment:
+
+```
+Relayed on behalf of @<role> (Paperclip comment <id>):
+
+<original verdict text>
+
+MERGE-GATE: <role> APPROVE
+```
+
+A relay without the `Relayed on behalf of @<role>` prefix is treated as the
+relay owner's own verdict. In STRICT mode this will be rejected as
+self-approval. In LENIENT mode it counts toward the relay owner's role, which
+is almost certainly wrong.
+
+### 5. Ready-to-copy templates
+
+**techlead:**
+
+```markdown
+## techlead Code Review
+
+- Diff scope: <N> files, +<added>/-<removed>. No collateral changes.
+- Root cause: <description>
+- Fix quality: <assessment>
+- Tests: <coverage notes>
+
+Recommendation: <ship it / needs changes>
+
+MERGE-GATE: techlead APPROVE
+```
+
+**quality-director:**
+
+```markdown
+## Quality Director Verification
+
+- Build: <pass / fail>
+- TypeScript: <zero errors / N errors>
+- Required CI checks: <all green / issues noted>
+- Acceptance criteria: <met / gaps noted>
+
+MERGE-GATE: quality-director APPROVE
+```
+
+### 6. Self-check before exit
+
+Before ending the wake, confirm your sentinel landed on the PR:
+
+```bash
+gh pr view <N> --repo alankyshum/cablesnap --json comments \
+  -q '.comments[].body' | grep '^MERGE-GATE: <your-role>'
+```
+
+If the grep returns nothing, your sentinel is not registered — post it or
+escalate to a relay owner.
+
+### Edge cases
+
+| Scenario | Resolution |
+|---|---|
+| Reviewer session has `GH_TOKEN` | Post directly to GitHub PR. Done. |
+| Reviewer session lacks `GH_TOKEN` | Post to Paperclip + flag gap + name relay owner. |
+| Relay owner also lacks `GH_TOKEN` | Escalate via Paperclip; do **not** mark issue done. |
+| Sentinel accidentally posted only on Paperclip (no gap flag) | Reviewer's next wake must self-correct: re-post on GitHub or escalate. |
+| Multiple sentinels from same role across PR thread | Latest comment per role wins (existing rule — no change). |
+
 ## Internal approval — legacy prose fallback
 
 For older PRs and as a safety net, the gate also recognizes


### PR DESCRIPTION
## Summary

Adds a new **"Agent Posting Protocol"** section to `docs/MERGE-GATE.md` that codifies where sentinels must be posted, what to do when `GH_TOKEN` is missing, and how relays must be attributed. This is the cablesnap-side documentation half of BLD-980; the host-side AGENTS doc edits are pending operator approval (`8c147807`).

## Changes

- New section placed after "Internal approval — sentinel convention" and before "Internal approval — legacy prose fallback"
- Specifies GitHub PR thread as the authoritative surface for `MERGE-GATE:` sentinels
- Describes direct-post requirement (`gh pr comment`) as the default workflow
- Documents fallback procedure when session lacks `GH_TOKEN`: post to Paperclip, flag the gap, name a relay owner
- Codifies relay attribution format (`Relayed on behalf of @<role>` prefix + Paperclip comment link)
- Provides ready-to-copy verdict templates for techlead and quality-director
- Adds self-check reminder (grep PR comments before ending wake)
- Includes edge-case table

## Testing

`scripts/test-merge-gate.sh`: 28/28 tests pass — pure docs change, no script regression.

## Issue

Closes BLD-1045
Parent: BLD-980 (host-side AGENTS doc updates pending operator approval `8c147807`)