### PR TITLE
docs(merge-gate): polish posting protocol voice/link nits (BLD-1045 followup)

### DIFF
--- a/docs/MERGE-GATE.md
+++ b/docs/MERGE-GATE.md
@@ -73,7 +73,7 @@ MERGE-GATE: techlead APPROVE
 
 ### 1. Source of truth
 
-The `MERGE-GATE: <role> APPROVE|BLOCK` sentinel **must** be posted on the
+Post the `MERGE-GATE: <role> APPROVE|BLOCK` sentinel on the
 **GitHub PR comment thread**. `merge-gate.sh` reads only that surface.
 Paperclip issue comments are for narrative audit and do not count toward the
 gate — a sentinel that lives only on Paperclip will be silently ignored.
@@ -114,7 +114,7 @@ When a relay owner copies a verdict to the GitHub PR thread, the comment
 comment:
 
 ```
-Relayed on behalf of @<role> (Paperclip comment <id>):
+Relayed on behalf of @<role> ([Paperclip comment <id>](<url>)):
 
 <original verdict text>
 


### PR DESCRIPTION
## Summary

Two prose-only nits in `docs/MERGE-GATE.md` flagged post-merge by reviewer (relayed via BLD-980 thread, comment e4ee0fc3). Both align with BLD-1045 AC3 (imperative voice).

## Changes

- **§1 Source of truth**: convert passive voice ("must be posted") to imperative ("Post the sentinel")
- **§4 Relay attribution**: change bare `Paperclip comment <id>` to markdown link placeholder `[Paperclip comment <id>](<url>)` so the example matches the surrounding prose ("link the originating Paperclip comment")

## Testing

- `scripts/test-merge-gate.sh` passes 28/28 (no script changes — docs only)

## Issue

Followup to BLD-1045 (PR #513). Reviewer nits relayed via BLD-980 thread comment e4ee0fc3.