### PR TITLE
feat(gym): Per-Gym Cable Stack Calibration (BLD-1060)

### DIFF
--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -243,6 +243,9 @@ jest.mock('../../lib/db', () => ({
   updateExerciseNote: jest.fn().mockResolvedValue(undefined),
   getExerciseBackfillCandidate: jest.fn().mockResolvedValue(null),
   dismissExerciseBackfill: jest.fn().mockResolvedValue(undefined),
+  getActiveGymCount: jest.fn().mockResolvedValue(0),
+  getGymProfiles: jest.fn().mockResolvedValue([]),
+  getSessionsByGym: jest.fn().mockResolvedValue([]),
 }))
 
 jest.mock('../../lib/db/pr-dashboard', () => ({

--- a/__tests__/acceptance/body-progress.acceptance.test.tsx
+++ b/__tests__/acceptance/body-progress.acceptance.test.tsx
@@ -59,6 +59,9 @@ jest.mock('../../lib/db', () => ({
   upsertBodyWeight: jest.fn().mockResolvedValue(undefined),
   deleteBodyWeight: jest.fn().mockResolvedValue(undefined),
   updateBodySettings: jest.fn().mockResolvedValue(undefined),
+  getActiveGymCount: jest.fn().mockResolvedValue(0),
+  getGymProfiles: jest.fn().mockResolvedValue([]),
+  getSessionsByGym: jest.fn().mockResolvedValue([]),
 }))
 
 jest.mock('../../lib/db/pr-dashboard', () => ({

--- a/__tests__/acceptance/body-tracking.acceptance.test.tsx
+++ b/__tests__/acceptance/body-tracking.acceptance.test.tsx
@@ -54,6 +54,9 @@ jest.mock('../../lib/db', () => ({
   upsertBodyWeight: jest.fn().mockResolvedValue(undefined),
   deleteBodyWeight: jest.fn().mockResolvedValue(undefined),
   updateBodySettings: jest.fn().mockResolvedValue(undefined),
+  getActiveGymCount: jest.fn().mockResolvedValue(0),
+  getGymProfiles: jest.fn().mockResolvedValue([]),
+  getSessionsByGym: jest.fn().mockResolvedValue([]),
 }))
 
 jest.mock('../../lib/db/pr-dashboard', () => ({

--- a/__tests__/acceptance/weekly-summary.acceptance.test.tsx
+++ b/__tests__/acceptance/weekly-summary.acceptance.test.tsx
@@ -138,6 +138,9 @@ jest.mock('../../lib/db', () => ({
   deleteBodyWeight: jest.fn().mockResolvedValue(undefined),
   updateBodySettings: jest.fn().mockResolvedValue(undefined),
   getWeeklySummary: jest.fn().mockResolvedValue(mockSummaryData),
+  getActiveGymCount: jest.fn().mockResolvedValue(0),
+  getGymProfiles: jest.fn().mockResolvedValue([]),
+  getSessionsByGym: jest.fn().mockResolvedValue([]),
 }))
 
 jest.mock('../../lib/db/pr-dashboard', () => ({

--- a/__tests__/components/progress/MonthlyReportSegment.test.tsx
+++ b/__tests__/components/progress/MonthlyReportSegment.test.tsx
@@ -129,6 +129,9 @@ jest.mock('../../../lib/db', () => ({
     prs: [], nutrition: null, body: null, streak: 0,
   }),
   getMonthlyReport: jest.fn().mockResolvedValue(mockMonthlyData),
+  getActiveGymCount: jest.fn().mockResolvedValue(0),
+  getGymProfiles: jest.fn().mockResolvedValue([]),
+  getSessionsByGym: jest.fn().mockResolvedValue([]),
 }))
 
 jest.mock('../../../lib/units', () => ({

--- a/__tests__/components/progress/WorkoutSegment-gym-pill.test.tsx
+++ b/__tests__/components/progress/WorkoutSegment-gym-pill.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * BLD-1060 — Gym filter pill 390px overflow regression test.
+ *
+ * AC: PLAN-BLD-1059 rev 3 lines 226-228 + BLD-1055 learning:
+ * "assert full parent-to-child width chain so variable-length gym names do not
+ * push the gym filter row past 390px on RN Web."
+ *
+ * Risk addressed: filterPills uses flexDirection:row for horizontal pills. If
+ * flexWrap is removed or the paddingHorizontal budget is exceeded, long gym names
+ * (user-controlled) can push the row past the 390px viewport — the exact regression
+ * class as BLD-1055. This test locks the structural invariants so regressions
+ * trip a test before shipping.
+ */
+
+import React from "react";
+import { render, waitFor } from "@testing-library/react-native";
+
+// ── mock heavy deps before importing WorkoutSegment ──────────────────────────
+
+jest.mock("expo-router", () => {
+  const RealReact = require("react");
+  return {
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+    useFocusEffect: (cb: () => void) => {
+      // Run synchronously so state is set before first render assertions
+      RealReact.useEffect(() => { cb(); }, []);
+    },
+  };
+});
+
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => "Icon");
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#6750A4",
+    primaryContainer: "#EADDFF",
+    onPrimaryContainer: "#21005D",
+    surface: "#FFFBFE",
+    onSurface: "#1C1B1F",
+    onSurfaceVariant: "#49454F",
+    onPrimary: "#FFFFFF",
+    outlineVariant: "#CAC4D0",
+  }),
+}));
+jest.mock("@/lib/layout", () => ({
+  useLayout: () => ({ wide: false, atLeastMedium: false, width: 390, scale: 1.0 }),
+}));
+jest.mock("@/components/FloatingTabBar", () => ({
+  useFloatingTabBarHeight: () => 64,
+}));
+jest.mock("@/lib/errors", () => ({ logError: jest.fn() }));
+jest.mock("@/lib/interactions", () => ({ log: jest.fn() }));
+jest.mock("expo-localization", () => ({ getCalendars: () => [{ firstWeekday: 1 }] }));
+
+// Child components that render complex UI — stub them out
+jest.mock("@/components/WeeklySummary", () => "WeeklySummary");
+jest.mock("@/components/progress/CalendarView", () => "CalendarView");
+jest.mock("@/components/progress/WorkoutCards", () => ({
+  WorkoutChartCard: "WorkoutChartCard",
+  SessionsByGymCard: "SessionsByGymCard",
+  SessionsCard: "SessionsCard",
+}));
+jest.mock("@/components/progress/PRSummaryCard", () => ({
+  PRSummaryCard: "PRSummaryCard",
+}));
+jest.mock("@/components/progress/TrendCards", () => ({
+  RPETrendCard: "RPETrendCard",
+  RatingTrendCard: "RatingTrendCard",
+}));
+jest.mock("@/components/progress/StrengthLevelsCard", () => "StrengthLevelsCard");
+jest.mock("@/components/progress/ActiveGoalsCard", () => "ActiveGoalsCard");
+jest.mock("@/components/progress/WorkoutEmptyState", () => "WorkoutEmptyState");
+
+jest.mock("@/lib/db/pr-dashboard", () => ({
+  getPRStats: jest.fn().mockResolvedValue({ totalPRs: 0, prsThisMonth: 0 }),
+  getRecentPRsWithDelta: jest.fn().mockResolvedValue([]),
+}));
+
+// Return activeGymCount >= 2 so showGymUI = true and gymFilter renders
+jest.mock("@/lib/db", () => ({
+  getWeeklySessionCounts: jest.fn().mockResolvedValue([]),
+  getWeeklyVolume: jest.fn().mockResolvedValue([]),
+  getCompletedSessionsWithSetCount: jest.fn().mockResolvedValue([
+    { id: "s1", name: "Pull Day", started_at: Date.now(), duration_seconds: 3600, set_count: 5 },
+    { id: "s2", name: "Push Day", started_at: Date.now() - 86400000, duration_seconds: 2400, set_count: 6 },
+    { id: "s3", name: "Leg Day", started_at: Date.now() - 172800000, duration_seconds: 2700, set_count: 7 },
+  ]),
+  getBodySettings: jest.fn().mockResolvedValue({ weight_unit: "kg" }),
+  // 3 active gyms → showGymUI = true
+  getActiveGymCount: jest.fn().mockResolvedValue(3),
+  getGymProfiles: jest.fn().mockResolvedValue([
+    { id: "gym-1", name: "A Very Long Gym Name That Exceeds 24 Chars", is_default: 1, deleted_at: null },
+    { id: "gym-2", name: "Downtown Fitness Center", is_default: 0, deleted_at: null },
+    { id: "gym-3", name: "CrossFit Annex", is_default: 0, deleted_at: null },
+  ]),
+  getSessionsByGym: jest.fn().mockResolvedValue([
+    { gymId: "gym-1", gymName: "A Very Long Gym Name That Exceeds 24 Chars", count: 15 },
+    { gymId: "gym-2", gymName: "Downtown Fitness Center", count: 8 },
+    { gymId: "gym-3", gymName: "CrossFit Annex", count: 4 },
+  ]),
+}));
+
+import WorkoutSegment from "@/components/progress/WorkoutSegment";
+
+describe("WorkoutSegment — gym filter pill 390px width-chain regression (BLD-1060)", () => {
+  it("renders gym filter row when activeGymCount >= 2", async () => {
+    const { getByTestId } = render(<WorkoutSegment />);
+
+    await waitFor(() => {
+      expect(getByTestId("workout-gym-filter-row")).toBeTruthy();
+    });
+  });
+
+  it("filterPills uses flexWrap:wrap so long gym names wrap instead of overflowing 390px", async () => {
+    const { getByTestId } = render(<WorkoutSegment />);
+
+    await waitFor(() => {
+      expect(getByTestId("workout-gym-filter-pills")).toBeTruthy();
+    });
+
+    const pills = getByTestId("workout-gym-filter-pills");
+    const rawStyle = pills.props.style;
+    const flattened = Array.isArray(rawStyle)
+      ? Object.assign({}, ...rawStyle.filter(Boolean))
+      : (rawStyle ?? {});
+
+    // flexWrap:wrap is the overflow prevention for a row of variable-length pills.
+    // If this is removed, a 24+ char gym name pushes the row past 390px — BLD-1055 class.
+    expect(flattened.flexWrap).toBe("wrap");
+  });
+
+  it("filterRow paddingHorizontal stays within 390px viewport budget", async () => {
+    const { getByTestId } = render(<WorkoutSegment />);
+
+    await waitFor(() => {
+      expect(getByTestId("workout-gym-filter-row")).toBeTruthy();
+    });
+
+    const row = getByTestId("workout-gym-filter-row");
+    const rawStyle = row.props.style;
+    const flattened = Array.isArray(rawStyle)
+      ? Object.assign({}, ...rawStyle.filter(Boolean))
+      : (rawStyle ?? {});
+
+    // paddingHorizontal: 16 means the pill area is 390 - 32 = 358px.
+    // Must not exceed 20px per side or pills with long names may clip.
+    const ph = flattened.paddingHorizontal ?? (flattened.paddingLeft ?? 0);
+    expect(ph).toBeLessThanOrEqual(20);
+  });
+
+  it("filterPills uses flexDirection:row (pills lay out horizontally and wrap)", async () => {
+    const { getByTestId } = render(<WorkoutSegment />);
+
+    await waitFor(() => {
+      expect(getByTestId("workout-gym-filter-pills")).toBeTruthy();
+    });
+
+    const pills = getByTestId("workout-gym-filter-pills");
+    const rawStyle = pills.props.style;
+    const flattened = Array.isArray(rawStyle)
+      ? Object.assign({}, ...rawStyle.filter(Boolean))
+      : (rawStyle ?? {});
+
+    expect(flattened.flexDirection).toBe("row");
+  });
+
+  it("renders all gym options including extra-long names without crashing", async () => {
+    const { getByTestId, getAllByRole } = render(<WorkoutSegment />);
+
+    await waitFor(() => {
+      expect(getByTestId("workout-gym-filter-row")).toBeTruthy();
+    });
+
+    // 4 pills: "All gyms" + 3 gym options — all must render without error
+    const buttons = getAllByRole("button");
+    // At least the 4 gym filter buttons (+ toggle button = 5 total)
+    expect(buttons.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/__tests__/lib/cable-stack.test.ts
+++ b/__tests__/lib/cable-stack.test.ts
@@ -1,0 +1,90 @@
+/**
+ * BLD-1060: parseCalibrationBulkPaste unit tests.
+ *
+ * AC from PLAN-BLD-1059.md:
+ *   Input: "1=5\n2=foo\n0=10\n3=12.5\n3=15\n5=-2"
+ *   Expected: accepted {1=5, 3=15}, 4 rows skipped, toast "Added 2 markers. 4 rows skipped."
+ */
+import { parseCalibrationBulkPaste, buildBulkPasteToast, resolveMarker } from "../../lib/cable-stack";
+
+describe("parseCalibrationBulkPaste", () => {
+  it("resolveMarker returns the matching weight and null when missing", () => {
+    expect(
+      resolveMarker(
+        [
+          { id: "c1", stack_id: "s1", marker: 5, true_weight: 15 },
+          { id: "c2", stack_id: "s1", marker: 10, true_weight: 30 },
+        ],
+        10,
+      ),
+    ).toEqual({ weight: 30, unit: "" });
+    expect(resolveMarker([], 10)).toBeNull();
+  });
+
+  it("parses the exact AC scenario", () => {
+    const input = "1=5\n2=foo\n0=10\n3=12.5\n3=15\n5=-2";
+    const result = parseCalibrationBulkPaste(input);
+
+    // Accepted: marker 1 (weight 5) and marker 3 (last value wins: 15)
+    expect(result.accepted).toHaveLength(2);
+    expect(result.accepted[0]).toEqual({ marker: 1, trueWeight: 5 });
+    expect(result.accepted[1]).toEqual({ marker: 3, trueWeight: 15 });
+
+    // 4 skipped: "2=foo" (non_numeric_weight), "0=10" (marker_must_be_positive),
+    //            "3=12.5" (duplicate_marker), "5=-2" (weight_must_be_positive)
+    expect(result.skipped).toHaveLength(4);
+
+    const reasons = result.skipped.map((r) => r.reason);
+    expect(reasons).toContain("non_numeric_weight");
+    expect(reasons).toContain("marker_must_be_positive");
+    expect(reasons).toContain("duplicate_marker");
+    expect(reasons).toContain("weight_must_be_positive");
+  });
+
+  it("produces the correct toast for the AC scenario", () => {
+    const input = "1=5\n2=foo\n0=10\n3=12.5\n3=15\n5=-2";
+    const result = parseCalibrationBulkPaste(input);
+    expect(buildBulkPasteToast(result)).toBe("Added 2 markers. 4 rows skipped.");
+  });
+
+  it("returns empty for blank input", () => {
+    expect(parseCalibrationBulkPaste("")).toEqual({ accepted: [], skipped: [] });
+    expect(parseCalibrationBulkPaste("   ")).toEqual({ accepted: [], skipped: [] });
+  });
+
+  it("accepts valid decimal weights", () => {
+    const result = parseCalibrationBulkPaste("1=2.5\n2=10");
+    expect(result.accepted).toEqual([
+      { marker: 1, trueWeight: 2.5 },
+      { marker: 2, trueWeight: 10 },
+    ]);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  it("skips rows without = separator", () => {
+    const result = parseCalibrationBulkPaste("abc\n1=5");
+    expect(result.accepted).toHaveLength(1);
+    expect(result.skipped[0].reason).toBe("non_numeric_marker");
+  });
+
+  it("skips non-integer markers", () => {
+    const result = parseCalibrationBulkPaste("1.5=10");
+    expect(result.accepted).toHaveLength(0);
+    expect(result.skipped[0].reason).toBe("non_numeric_marker");
+  });
+
+  it("toast: all accepted", () => {
+    const result = parseCalibrationBulkPaste("1=5\n2=10");
+    expect(buildBulkPasteToast(result)).toBe("Added 2 markers.");
+  });
+
+  it("toast: all skipped", () => {
+    const result = parseCalibrationBulkPaste("0=5");
+    expect(buildBulkPasteToast(result)).toBe("No valid rows. 1 skipped.");
+  });
+
+  it("toast: single accepted, no skipped", () => {
+    const result = parseCalibrationBulkPaste("1=5");
+    expect(buildBulkPasteToast(result)).toBe("Added 1 marker.");
+  });
+});

--- a/__tests__/lib/db/add-sets-batch-bodyweight-variant.test.ts
+++ b/__tests__/lib/db/add-sets-batch-bodyweight-variant.test.ts
@@ -62,10 +62,9 @@ describe('addSetsBatch — bodyweight variant positional binding (BLD-768)', () 
 
     expect(mockExecuteAsync).toHaveBeenCalled();
     const args = mockExecuteAsync.mock.calls.at(-1)![0] as unknown[];
-    expect(args).toHaveLength(13);
-    // Slot order (post-BLD-771 column drop): id, session_id, exercise_id,
-    // set_number, link_id, round, tempo, set_type, exercise_position,
-    // attachment, mount_position, grip_type, grip_width.
+    expect(args).toHaveLength(17);
+    // Slot order: id, session_id, exercise_id, set_number, link_id, round, tempo, set_type, exercise_position,
+    // attachment, mount_position, grip_type, grip_width, stack_id, stack_marker, stack_unit_at_log, stack_name_at_log.
     expect(args[1]).toBe('sess-1');           // session_id
     expect(args[2]).toBe('ex-1');             // exercise_id
     expect(args[3]).toBe(1);                  // set_number

--- a/__tests__/lib/db/add-sets-batch-variant.test.ts
+++ b/__tests__/lib/db/add-sets-batch-variant.test.ts
@@ -71,10 +71,11 @@ describe('addSetsBatch — variant positional binding (BLD-771)', () => {
     // rather than the total count.
     expect(mockExecuteAsync).toHaveBeenCalled();
     const args = mockExecuteAsync.mock.calls.at(-1)![0] as unknown[];
-    expect(args).toHaveLength(13);
+    expect(args).toHaveLength(17);
     // Slot order is: id, session_id, exercise_id, set_number, link_id,
     // round, tempo, set_type, exercise_position,
-    // attachment, mount_position, grip_type, grip_width.
+    // attachment, mount_position, grip_type, grip_width,
+    // stack_id, stack_marker, stack_unit_at_log, stack_name_at_log.
     expect(args[1]).toBe('sess-1');           // session_id
     expect(args[2]).toBe('ex-1');             // exercise_id
     expect(args[3]).toBe(1);                  // set_number

--- a/__tests__/lib/db/calibration-immutability.test.ts
+++ b/__tests__/lib/db/calibration-immutability.test.ts
@@ -1,0 +1,154 @@
+/**
+ * BLD-1060 — Calibration immutability regression test.
+ *
+ * AC: PLAN-BLD-1059 rev 3 lines 197-200 — "historical sets keep their original
+ * weight + snapshotted stack/gym names after later edits."
+ *
+ * Risk addressed: a future refactor could accidentally add a retroactive UPDATE
+ * that rewrites snapshot fields (stack_name_at_log, stack_unit_at_log,
+ * stack_marker, gym_name_at_log) on historical rows when the user renames a
+ * stack or changes a calibration value. This test catches that by:
+ *   1. Inserting a calibrated set (marker 10 = 30 kg, stack "Dual Pulley", gym "Home Gym")
+ *   2. Updating the calibration (marker 10 → 50 kg) + renaming the stack
+ *   3. Re-reading the historical row and asserting the snapshots are byte-for-byte unchanged
+ *
+ * Uses node:sqlite (real engine) because mocking DB calls cannot prove
+ * row-level immutability — only a real SELECT can.
+ */
+
+import { DatabaseSync } from "node:sqlite";
+
+describe("BLD-1060 — calibration immutability", () => {
+  let db: DatabaseSync;
+
+  beforeAll(() => {
+    db = new DatabaseSync(":memory:");
+
+    db.exec(`
+      CREATE TABLE gym_profiles (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        is_default INTEGER NOT NULL DEFAULT 0,
+        deleted_at INTEGER
+      );
+
+      CREATE TABLE cable_stacks (
+        id TEXT PRIMARY KEY NOT NULL,
+        gym_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        unit TEXT NOT NULL DEFAULT 'kg',
+        deleted_at INTEGER
+      );
+
+      CREATE TABLE stack_calibrations (
+        id TEXT PRIMARY KEY NOT NULL,
+        stack_id TEXT NOT NULL,
+        marker INTEGER NOT NULL,
+        true_weight REAL NOT NULL,
+        UNIQUE(stack_id, marker)
+      );
+
+      CREATE TABLE workout_sessions (
+        id TEXT PRIMARY KEY NOT NULL,
+        started_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        gym_id TEXT,
+        gym_name_at_log TEXT
+      );
+
+      CREATE TABLE workout_sets (
+        id TEXT PRIMARY KEY NOT NULL,
+        session_id TEXT NOT NULL,
+        exercise_id TEXT NOT NULL,
+        set_number INTEGER NOT NULL DEFAULT 1,
+        weight REAL NOT NULL DEFAULT 0,
+        reps INTEGER NOT NULL DEFAULT 0,
+        completed INTEGER NOT NULL DEFAULT 0,
+        stack_id TEXT,
+        stack_marker INTEGER,
+        stack_unit_at_log TEXT,
+        stack_name_at_log TEXT
+      );
+    `);
+
+    // Seed: gym + stack + calibration
+    db.exec(`
+      INSERT INTO gym_profiles (id, name, is_default) VALUES ('gym-1', 'Home Gym', 1);
+      INSERT INTO cable_stacks (id, gym_id, name, unit) VALUES ('stack-1', 'gym-1', 'Dual Pulley', 'kg');
+      INSERT INTO stack_calibrations (id, stack_id, marker, true_weight) VALUES ('cal-1', 'stack-1', 10, 30);
+    `);
+
+    // Log a session and a set — snapshot fields written at log time
+    db.exec(`
+      INSERT INTO workout_sessions (id, started_at, completed_at, gym_id, gym_name_at_log)
+        VALUES ('sess-1', 1700000000, 1700003600, 'gym-1', 'Home Gym');
+
+      INSERT INTO workout_sets (id, session_id, exercise_id, weight, reps, completed,
+                                 stack_id, stack_marker, stack_unit_at_log, stack_name_at_log)
+        VALUES ('set-1', 'sess-1', 'ex-bench', 30, 10, 1,
+                'stack-1', 10, 'kg', 'Dual Pulley');
+    `);
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  it("updating stack calibration does not change historical set snapshots", () => {
+    // Mutate: recalibrate marker 10 to 50 kg
+    db.prepare(
+      "UPDATE stack_calibrations SET true_weight = 50 WHERE stack_id = ? AND marker = ?"
+    ).run("stack-1", 10);
+
+    const row = db.prepare(
+      "SELECT weight, stack_marker, stack_unit_at_log, stack_name_at_log FROM workout_sets WHERE id = ?"
+    ).get("set-1") as {
+      weight: number;
+      stack_marker: number;
+      stack_unit_at_log: string;
+      stack_name_at_log: string;
+    };
+
+    // Snapshot fields must be byte-for-byte what was logged at session time
+    expect(row.weight).toBe(30);
+    expect(row.stack_marker).toBe(10);
+    expect(row.stack_unit_at_log).toBe("kg");
+    expect(row.stack_name_at_log).toBe("Dual Pulley");
+  });
+
+  it("renaming a cable stack does not rewrite historical set stack_name_at_log", () => {
+    // Mutate: rename the stack
+    db.prepare("UPDATE cable_stacks SET name = ? WHERE id = ?").run("Pulley Pro 2000", "stack-1");
+
+    const row = db.prepare(
+      "SELECT stack_name_at_log FROM workout_sets WHERE id = ?"
+    ).get("set-1") as { stack_name_at_log: string };
+
+    // At-log snapshot must still be the original name
+    expect(row.stack_name_at_log).toBe("Dual Pulley");
+  });
+
+  it("renaming a gym does not rewrite historical session gym_name_at_log", () => {
+    // Mutate: rename the gym
+    db.prepare("UPDATE gym_profiles SET name = ? WHERE id = ?").run("Downtown Gym", "gym-1");
+
+    const row = db.prepare(
+      "SELECT gym_name_at_log FROM workout_sessions WHERE id = ?"
+    ).get("sess-1") as { gym_name_at_log: string };
+
+    // Session was stamped with "Home Gym" — that must not change
+    expect(row.gym_name_at_log).toBe("Home Gym");
+  });
+
+  it("soft-deleting the stack does not affect historical set snapshot fields", () => {
+    db.prepare("UPDATE cable_stacks SET deleted_at = 1730000000 WHERE id = ?").run("stack-1");
+
+    const row = db.prepare(
+      "SELECT stack_id, stack_name_at_log, stack_unit_at_log FROM workout_sets WHERE id = ?"
+    ).get("set-1") as { stack_id: string; stack_name_at_log: string; stack_unit_at_log: string };
+
+    expect(row.stack_id).toBe("stack-1");
+    expect(row.stack_name_at_log).toBe("Dual Pulley");
+    expect(row.stack_unit_at_log).toBe("kg");
+  });
+});

--- a/__tests__/lib/db/e1rm-trends-gym.test.ts
+++ b/__tests__/lib/db/e1rm-trends-gym.test.ts
@@ -1,0 +1,41 @@
+const mockQuery = jest.fn();
+
+jest.mock("../../../lib/db/helpers", () => ({
+  query: (...args: unknown[]) => mockQuery(...args),
+}));
+
+import { getE1RMTrends, getE1RMTrendsByGym } from "../../../lib/db/e1rm-trends";
+
+describe("e1rm trend gym query branching", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery.mockResolvedValue([]);
+  });
+
+  it("uses the all-gyms SQL path when gymId is omitted", async () => {
+    await getE1RMTrends();
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).not.toContain("OR ? IS NULL");
+    expect(sql).not.toContain("wss.gym_id = ?");
+    expect(params).toHaveLength(3);
+  });
+
+  it("uses the gym-scoped SQL path when a gymId is provided", async () => {
+    await getE1RMTrends("gym-1");
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("wss.gym_id = ?");
+    expect(sql).not.toContain("OR ? IS NULL");
+    expect(params).toEqual(expect.arrayContaining(["gym-1"]));
+    expect(params).toHaveLength(5);
+  });
+
+  it("keeps the explicit gym wrapper wired to the gym-scoped query", async () => {
+    await getE1RMTrendsByGym("gym-2");
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("wss.gym_id = ?");
+    expect(params[0]).toBe("gym-2");
+  });
+});

--- a/__tests__/lib/db/e1rm-trends-query-plan.test.ts
+++ b/__tests__/lib/db/e1rm-trends-query-plan.test.ts
@@ -1,0 +1,188 @@
+/**
+ * BLD-1060 — EXPLAIN QUERY PLAN regression for idx_workout_sessions_gym_started_at.
+ *
+ * AC: PLAN-BLD-1059 rev 3 lines 223-224 — "EXPLAIN QUERY PLAN test asserts
+ * idx_workout_sessions_gym_started_at is used by the gym-scoped e1RM trend query."
+ *
+ * Risk addressed: if a future migration reorders the WHERE predicates in
+ * getE1RMTrendsByGym, or if the (gym_id, started_at) index is dropped or renamed,
+ * SQLite would fall back to a full table scan on workout_sessions. This test
+ * catches that regression by asserting the literal index name in the query plan.
+ *
+ * Engine: node:sqlite (Node v22+ built-in). Production uses expo-sqlite which is
+ * the same SQLite3 library; the query planner is identical. We use a real engine
+ * here because EXPLAIN QUERY PLAN cannot be meaningfully mocked.
+ *
+ * See __tests__/lib/db/grip-history-query-plan.test.ts for the identical pattern
+ * used on BLD-822 (idx_workout_sets_exercise).
+ */
+
+import { DatabaseSync } from "node:sqlite";
+
+describe("BLD-1060 — e1RM gym-scoped query plan", () => {
+  let db: DatabaseSync;
+
+  beforeAll(() => {
+    db = new DatabaseSync(":memory:");
+
+    // Mirror only the columns the query touches.
+    // Schema source: lib/db/schema.ts + lib/db/migrations.ts
+    db.exec(`
+      CREATE TABLE exercises (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL
+      );
+
+      CREATE TABLE workout_sessions (
+        id TEXT PRIMARY KEY NOT NULL,
+        started_at INTEGER NOT NULL,
+        completed_at INTEGER,
+        gym_id TEXT
+      );
+
+      CREATE TABLE workout_sets (
+        id TEXT PRIMARY KEY NOT NULL,
+        session_id TEXT NOT NULL,
+        exercise_id TEXT NOT NULL,
+        set_number INTEGER NOT NULL,
+        weight REAL NOT NULL DEFAULT 0,
+        reps INTEGER NOT NULL DEFAULT 0,
+        completed INTEGER NOT NULL DEFAULT 0,
+        set_type TEXT NOT NULL DEFAULT 'normal'
+      );
+
+      -- Production composite index from lib/db/migrations.ts:153
+      CREATE INDEX idx_workout_sessions_gym_started_at ON workout_sessions(gym_id, started_at);
+
+      -- Other production indexes so the planner has full statistics
+      CREATE INDEX idx_workout_sets_session ON workout_sets(session_id);
+      CREATE INDEX idx_workout_sets_exercise ON workout_sets(exercise_id);
+    `);
+
+    // Seed: 100 sessions across 2 gyms × 10 sets each = 1000 sets.
+    // Target gym has ~50 sessions — sufficient selectivity for the planner.
+    const now = Date.now();
+    const insertSession = db.prepare(
+      "INSERT INTO workout_sessions (id, started_at, completed_at, gym_id) VALUES (?, ?, ?, ?)"
+    );
+    const insertSet = db.prepare(
+      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, set_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    );
+    const insertExercise = db.prepare(
+      "INSERT INTO exercises (id, name) VALUES (?, ?)"
+    );
+
+    for (let ex = 0; ex < 20; ex++) {
+      insertExercise.run(`ex-${ex}`, `Exercise ${ex}`);
+    }
+
+    db.exec("BEGIN");
+    for (let s = 0; s < 100; s++) {
+      const sessionId = `sess-${s}`;
+      const gymId = s % 2 === 0 ? "gym-target" : "gym-other";
+      insertSession.run(sessionId, now - (100 - s) * 86400000, now - (100 - s) * 86400000 + 3600000, gymId);
+      for (let n = 1; n <= 10; n++) {
+        const exId = `ex-${n % 20}`;
+        insertSet.run(`set-${s}-${n}`, sessionId, exId, n, 60 + n, 8, 1, "normal");
+      }
+    }
+    db.exec("COMMIT");
+
+    // Populate sqlite_stat1 so the planner has accurate cardinality estimates.
+    db.exec("ANALYZE");
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  it("gym-scoped e1RM query uses idx_workout_sessions_gym_started_at (not a full SCAN)", () => {
+    // Production SQL verbatim from lib/db/e1rm-trends.ts:getE1RMTrendsByGym.
+    // Both inner subqueries share the same WHERE (gym_id = ? AND started_at >= ?),
+    // which is the leading-equality prefix that lets SQLite use the composite index.
+    const sql = `EXPLAIN QUERY PLAN
+      SELECT
+        cur.exercise_id,
+        COALESCE(e.name, 'Deleted Exercise') AS name,
+        cur.e1rm AS current_e1rm,
+        prev.e1rm AS previous_e1rm
+      FROM (
+        SELECT ws.exercise_id,
+               MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm,
+               COUNT(DISTINCT wss.id) AS session_count
+        FROM workout_sets ws
+        JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1
+          AND ws.set_type != 'warmup'
+          AND ws.weight > 0
+          AND ws.reps > 0
+          AND ws.reps <= 12
+          AND wss.completed_at IS NOT NULL
+          AND wss.gym_id = ?
+          AND wss.started_at >= ?
+        GROUP BY ws.exercise_id
+        HAVING session_count >= 3
+      ) cur
+      JOIN (
+        SELECT ws.exercise_id,
+               MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm
+        FROM workout_sets ws
+        JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1
+          AND ws.set_type != 'warmup'
+          AND ws.weight > 0
+          AND ws.reps > 0
+          AND ws.reps <= 12
+          AND wss.completed_at IS NOT NULL
+          AND wss.gym_id = ?
+          AND wss.started_at >= ? AND wss.started_at < ?
+        GROUP BY ws.exercise_id
+      ) prev ON cur.exercise_id = prev.exercise_id
+      LEFT JOIN exercises e ON cur.exercise_id = e.id
+      WHERE cur.e1rm > prev.e1rm
+      ORDER BY (cur.e1rm - prev.e1rm) DESC
+      LIMIT 5`;
+
+    const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
+    const sixtyDaysAgo = Date.now() - 60 * 24 * 60 * 60 * 1000;
+
+    const plan = db.prepare(sql).all(
+      "gym-target", thirtyDaysAgo,
+      "gym-target", sixtyDaysAgo, thirtyDaysAgo
+    ) as { detail: string }[];
+
+    const planText = plan.map((r) => r.detail).join("\n");
+
+    // ASSERTION 1: at least one scan of workout_sessions must use the composite index.
+    // SQLite formats this as:
+    //   "SEARCH wss USING INDEX idx_workout_sessions_gym_started_at (gym_id=? AND started_at>?)"
+    expect(planText).toMatch(/USING INDEX idx_workout_sessions_gym_started_at/);
+
+    // ASSERTION 2: workout_sessions must not be scanned without an index.
+    // A full SCAN here means the planner dropped the composite index — block on that.
+    const sessionLines = plan
+      .map((r) => r.detail)
+      .filter((d) => /\bwss\b|workout_sessions/.test(d));
+    for (const line of sessionLines) {
+      // Allow SEARCH (indexed) but not SCAN (unindexed full table read)
+      expect(line).not.toMatch(/^SCAN /);
+    }
+  });
+
+  it("plan is stable after ANALYZE re-run (planner stats refresh)", () => {
+    // Guard against the planner changing its strategy when statistics are refreshed.
+    db.exec("ANALYZE");
+
+    const sql = `EXPLAIN QUERY PLAN
+      SELECT ws.exercise_id
+      FROM workout_sets ws
+      JOIN workout_sessions wss ON ws.session_id = wss.id
+      WHERE wss.gym_id = ? AND wss.started_at >= ?
+      LIMIT 5`;
+
+    const plan = db.prepare(sql).all("gym-target", Date.now() - 86400000 * 30) as { detail: string }[];
+    const planText = plan.map((r) => r.detail).join("\n");
+
+    expect(planText).toMatch(/USING INDEX idx_workout_sessions_gym_started_at/);
+  });
+});

--- a/__tests__/lib/db/gym-profiles.test.ts
+++ b/__tests__/lib/db/gym-profiles.test.ts
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * BLD-1060: gym-profiles DB function tests.
+ *
+ * Tests:
+ *   1. setDefaultGym atomicity — both UPDATEs run inside withTransactionAsync
+ *   2. getActiveGymCount — counts distinct gyms with completed sessions
+ *   3. deleteGymProfile soft-delete — sets deleted_at, preserves record
+ */
+
+const mockDb: any = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  getFirstAsync: jest.fn().mockResolvedValue(null),
+  runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  prepareAsync: jest.fn().mockResolvedValue({
+    executeAsync: jest.fn().mockResolvedValue(undefined),
+    finalizeAsync: jest.fn().mockResolvedValue(undefined),
+  }),
+  withTransactionAsync: jest.fn(async (cb: (db: any) => Promise<void>) => cb(mockDb)),
+};
+
+jest.mock("expo-sqlite", () => ({
+  openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+}));
+
+jest.mock("../../../lib/uuid", () => ({
+  uuid: jest.fn(() => "stack-test-id"),
+}));
+
+import {
+  setDefaultGym,
+  getActiveGymCount,
+  deleteGymProfile,
+  createCableStack,
+} from "../../../lib/db/gym-profiles";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.getFirstAsync.mockResolvedValue(null);
+  mockDb.getAllAsync.mockResolvedValue([]);
+  mockDb.runAsync.mockResolvedValue({ changes: 1 });
+  mockDb.withTransactionAsync.mockImplementation(async (cb: (db: any) => Promise<void>) => cb(mockDb));
+});
+
+describe("setDefaultGym — atomicity", () => {
+  it("runs both UPDATEs inside withTransactionAsync", async () => {
+    await setDefaultGym("gym-abc");
+
+    expect(mockDb.withTransactionAsync).toHaveBeenCalled();
+
+    // runAsync must have been called at least twice inside the transaction
+    const runCalls: string[] = mockDb.runAsync.mock.calls.map((c: any[]) => c[0] as string);
+    const clearCall = runCalls.find((sql) => sql.includes("is_default = 0"));
+    const setCall = runCalls.find((sql) => sql.includes("is_default = 1") && sql.includes("WHERE id ="));
+    expect(clearCall).toBeDefined();
+    expect(setCall).toBeDefined();
+  });
+
+  it("sets the target gym id in the second UPDATE", async () => {
+    await setDefaultGym("gym-xyz");
+    const setCalls = mockDb.runAsync.mock.calls.filter(
+      (c: any[]) => (c[0] as string).includes("is_default = 1") && (c[0] as string).includes("WHERE id =")
+    );
+    expect(setCalls.length).toBeGreaterThanOrEqual(1);
+    // The gym id must appear as a param
+    expect(setCalls[0][1]).toContain("gym-xyz");
+  });
+});
+
+describe("getActiveGymCount", () => {
+  it("returns the count from the SQL query", async () => {
+    mockDb.getFirstAsync.mockResolvedValue({ count: 3 });
+    const result = await getActiveGymCount(90);
+    expect(result).toBe(3);
+  });
+
+  it("returns 0 when no active gyms", async () => {
+    mockDb.getFirstAsync.mockResolvedValue({ count: 0 });
+    const result = await getActiveGymCount(90);
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 when query returns null", async () => {
+    mockDb.getFirstAsync.mockResolvedValue(null);
+    const result = await getActiveGymCount(90);
+    expect(result).toBe(0);
+  });
+
+  it("passes a cutoff timestamp as a param", async () => {
+    mockDb.getFirstAsync.mockResolvedValue({ count: 1 });
+    const before = Date.now();
+    await getActiveGymCount(30);
+    const after = Date.now();
+    const call = mockDb.getFirstAsync.mock.calls[0];
+    const cutoffParam = call[1][0] as number;
+    const expectedMin = before - 30 * 24 * 60 * 60 * 1000;
+    const expectedMax = after - 30 * 24 * 60 * 60 * 1000;
+    expect(cutoffParam).toBeGreaterThanOrEqual(expectedMin);
+    expect(cutoffParam).toBeLessThanOrEqual(expectedMax);
+  });
+});
+
+describe("createCableStack", () => {
+  it("assigns the next position when none is provided", async () => {
+    mockDb.getFirstAsync
+      .mockResolvedValueOnce({ max_position: 2 })
+      .mockResolvedValueOnce({
+        id: "stack-test-id",
+        gym_id: "gym-1",
+        name: "Cable Cross",
+        unit: "kg",
+        position: 3,
+        created_at: 1,
+        updated_at: 1,
+        deleted_at: null,
+      });
+
+    const result = await createCableStack({ gym_id: "gym-1", name: "Cable Cross" });
+
+    expect(mockDb.runAsync).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO cable_stacks"),
+      expect.arrayContaining(["stack-test-id", "gym-1", "Cable Cross", "kg", 3]),
+    );
+    expect(result.position).toBe(3);
+  });
+});
+
+describe("deleteGymProfile — soft delete", () => {
+  it("calls UPDATE with deleted_at and preserves record (no hard delete)", async () => {
+    await deleteGymProfile("gym-123");
+
+    const runCalls: Array<[string, unknown[]]> = mockDb.runAsync.mock.calls;
+    // Must NOT contain a DELETE statement
+    const hardDelete = runCalls.find(([sql]) => sql.trim().toUpperCase().startsWith("DELETE"));
+    expect(hardDelete).toBeUndefined();
+
+    // Must contain an UPDATE setting deleted_at
+    const softDelete = runCalls.find(([sql]) => sql.includes("deleted_at") && sql.includes("UPDATE"));
+    expect(softDelete).toBeDefined();
+    expect(softDelete![1]).toContain("gym-123");
+  });
+
+  it("also clears is_default on soft delete", async () => {
+    await deleteGymProfile("gym-456");
+    const runCalls: Array<[string, unknown[]]> = mockDb.runAsync.mock.calls;
+    const updateCall = runCalls.find(([sql]) => sql.includes("deleted_at") && sql.includes("UPDATE"));
+    expect(updateCall![0]).toContain("is_default");
+  });
+});

--- a/__tests__/lib/db/import-export-bodyweight-variant.test.ts
+++ b/__tests__/lib/db/import-export-bodyweight-variant.test.ts
@@ -112,9 +112,9 @@ describe('import-export — bodyweight variant round-trip (BLD-768)', () => {
 
     const wsInsert = insertCalls.find((c) => c.sql.includes('INSERT OR IGNORE INTO workout_sets'));
     expect(wsInsert).toBeDefined();
-    // Column list ends with: ..., attachment, mount_position, grip_type, grip_width.
-    // Param indices (0-based, post-BLD-771 column drop): 16=attachment, 17=mount_position, 18=grip_type, 19=grip_width.
-    expect(wsInsert!.params).toHaveLength(20);
+    // Column list ends with: ..., attachment, mount_position, grip_type, grip_width, stack_id, stack_marker, stack_unit_at_log, stack_name_at_log.
+    // Param indices (0-based): 16=attachment, 17=mount_position, 18=grip_type, 19=grip_width, 20=stack_id, 21=stack_marker, 22=stack_unit_at_log, 23=stack_name_at_log.
+    expect(wsInsert!.params).toHaveLength(24);
     expect(wsInsert!.params[18]).toBe('overhand');
     expect(wsInsert!.params[19]).toBe('narrow');
   });

--- a/__tests__/lib/db/import-export-gym-roundtrip.test.ts
+++ b/__tests__/lib/db/import-export-gym-roundtrip.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const mockStmt = {
+  executeAsync: jest.fn().mockResolvedValue(undefined),
+  finalizeAsync: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockDb: any = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  getFirstAsync: jest.fn().mockResolvedValue(null),
+  runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  prepareAsync: jest.fn().mockResolvedValue(mockStmt),
+  withTransactionAsync: jest.fn(async (cb: (db: any) => Promise<void>) => cb(mockDb)),
+};
+
+jest.mock("expo-sqlite", () => ({
+  openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+}));
+
+import { exportAllData, importData } from "../../../lib/db/import-export";
+
+describe("import-export gym round-trip", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDb.getFirstAsync.mockResolvedValue({ cnt: 0 });
+    mockDb.runAsync.mockResolvedValue({ changes: 1 });
+  });
+
+  it("exports and re-imports gym tables plus session/set snapshot fields", async () => {
+    mockDb.getAllAsync.mockImplementation(async (sql: string) => {
+      if (sql.includes("gym_profiles")) {
+        return [{ id: "g1", name: "Home Gym", notes: "", is_default: 1, created_at: 1, updated_at: 1, deleted_at: null }];
+      }
+      if (sql.includes("cable_stacks")) {
+        return [{ id: "stack-1", gym_id: "g1", name: "Dual Pulley", unit: "kg", position: 2, created_at: 2, updated_at: 2, deleted_at: null }];
+      }
+      if (sql.includes("stack_calibrations")) {
+        return [{ id: "cal-1", stack_id: "stack-1", marker: 10, true_weight: 30 }];
+      }
+      if (sql.includes("workout_sessions")) {
+        return [{ id: "sess-1", template_id: null, name: "Pull Day", started_at: 3, completed_at: 4, duration_seconds: 1800, notes: "", program_day_id: null, rating: null, import_batch_id: null, gym_id: "g1", gym_name_at_log: "Home Gym" }];
+      }
+      if (sql.includes("workout_sets")) {
+        return [{ id: "set-1", session_id: "sess-1", exercise_id: "ex-1", set_number: 1, weight: 30, reps: 10, completed: 1, completed_at: 4, rpe: null, notes: "", link_id: null, round: null, tempo: null, set_type: "normal", duration_seconds: null, bodyweight_modifier_kg: null, attachment: null, mount_position: null, grip_type: null, grip_width: null, stack_id: "stack-1", stack_marker: 10, stack_unit_at_log: "kg", stack_name_at_log: "Dual Pulley" }];
+      }
+      return [];
+    });
+
+    const backup = await exportAllData();
+    const history = (backup.data as Record<string, Record<string, any[]>>).workout_history;
+
+    expect(history.gym_profiles[0].name).toBe("Home Gym");
+    expect(history.cable_stacks[0].position).toBe(2);
+    expect(history.stack_calibrations[0].true_weight).toBe(30);
+    expect(history.workout_sessions[0].gym_name_at_log).toBe("Home Gym");
+    expect(history.workout_sets[0].stack_name_at_log).toBe("Dual Pulley");
+
+    const insertCalls: Array<{ sql: string; params: unknown[] }> = [];
+    mockDb.runAsync.mockImplementation(async (sql: string, params: unknown[]) => {
+      insertCalls.push({ sql, params });
+      return { changes: 1 };
+    });
+
+    await importData(backup as unknown as Record<string, unknown>);
+
+    expect(insertCalls.find((call) => call.sql.includes("INSERT OR IGNORE INTO gym_profiles"))?.params).toEqual([
+      "g1", "Home Gym", "", 1, 1, 1, null,
+    ]);
+    expect(insertCalls.find((call) => call.sql.includes("INSERT OR IGNORE INTO cable_stacks"))?.params).toEqual([
+      "stack-1", "g1", "Dual Pulley", "kg", 2, 2, 2, null,
+    ]);
+    expect(insertCalls.find((call) => call.sql.includes("INSERT OR IGNORE INTO stack_calibrations"))?.params).toEqual([
+      "cal-1", "stack-1", 10, 30,
+    ]);
+
+    const sessionInsert = insertCalls.find((call) => call.sql.includes("INSERT OR IGNORE INTO workout_sessions"));
+    expect(sessionInsert?.params?.[10]).toBe("g1");
+    expect(sessionInsert?.params?.[11]).toBe("Home Gym");
+
+    const setInsert = insertCalls.find((call) => call.sql.includes("INSERT OR IGNORE INTO workout_sets"));
+    expect(setInsert?.params?.[20]).toBe("stack-1");
+    expect(setInsert?.params?.[21]).toBe(10);
+    expect(setInsert?.params?.[22]).toBe("kg");
+    expect(setInsert?.params?.[23]).toBe("Dual Pulley");
+  });
+});

--- a/__tests__/lib/db/import-export-gym-roundtrip.test.ts
+++ b/__tests__/lib/db/import-export-gym-roundtrip.test.ts
@@ -83,4 +83,52 @@ describe("import-export gym round-trip", () => {
     expect(setInsert?.params?.[22]).toBe("kg");
     expect(setInsert?.params?.[23]).toBe("Dual Pulley");
   });
+
+  it("round-trips soft-deleted rows with non-null deleted_at (plan §245 binding contract)", async () => {
+    // Plan line 245: "a row exported with deleted_at = 1730000000 imports
+    // with deleted_at = 1730000000". Verifies the INSERT OR IGNORE path
+    // preserves non-null deleted_at byte-for-byte.
+    mockDb.getAllAsync.mockImplementation(async (sql: string) => {
+      if (sql.includes("gym_profiles")) {
+        return [
+          { id: "g-live", name: "Active Gym", notes: "", is_default: 1, created_at: 1, updated_at: 1, deleted_at: null },
+          { id: "g-del", name: "Closed Gym", notes: "", is_default: 0, created_at: 2, updated_at: 3, deleted_at: 1730000000 },
+        ];
+      }
+      if (sql.includes("cable_stacks")) {
+        return [
+          { id: "stack-live", gym_id: "g-live", name: "Active Stack", unit: "kg", position: 1, created_at: 4, updated_at: 4, deleted_at: null },
+          { id: "stack-del", gym_id: "g-del", name: "Old Stack", unit: "lb", position: 1, created_at: 5, updated_at: 6, deleted_at: 1730000000 },
+        ];
+      }
+      if (sql.includes("stack_calibrations")) return [];
+      if (sql.includes("workout_sessions")) return [];
+      if (sql.includes("workout_sets")) return [];
+      return [];
+    });
+
+    const backup = await exportAllData();
+    const history = (backup.data as Record<string, Record<string, any[]>>).workout_history;
+
+    // Backup must preserve the non-null deleted_at
+    expect(history.gym_profiles.find((r: any) => r.id === "g-del")?.deleted_at).toBe(1730000000);
+    expect(history.cable_stacks.find((r: any) => r.id === "stack-del")?.deleted_at).toBe(1730000000);
+
+    const insertCalls: Array<{ sql: string; params: unknown[] }> = [];
+    mockDb.runAsync.mockImplementation(async (sql: string, params: unknown[]) => {
+      insertCalls.push({ sql, params });
+      return { changes: 1 };
+    });
+
+    await importData(backup as unknown as Record<string, unknown>);
+
+    // INSERT OR IGNORE must pass deleted_at: 1730000000 for the soft-deleted rows
+    const gymInserts = insertCalls.filter((c) => c.sql.includes("INSERT OR IGNORE INTO gym_profiles"));
+    const deletedGymInsert = gymInserts.find((c) => (c.params as unknown[]).includes("g-del"));
+    expect(deletedGymInsert?.params).toContain(1730000000);
+
+    const stackInserts = insertCalls.filter((c) => c.sql.includes("INSERT OR IGNORE INTO cable_stacks"));
+    const deletedStackInsert = stackInserts.find((c) => (c.params as unknown[]).includes("stack-del"));
+    expect(deletedStackInsert?.params).toContain(1730000000);
+  });
 });

--- a/__tests__/lib/db/import-export.test.ts
+++ b/__tests__/lib/db/import-export.test.ts
@@ -71,6 +71,9 @@ describe("exportAllData", () => {
       template_exercises: [],
     });
     expect(result.data.workout_history).toEqual({
+      gym_profiles: [],
+      cable_stacks: [],
+      stack_calibrations: [],
       workout_sessions: [],
       workout_sets: [],
     });

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -151,6 +151,24 @@ export default function Settings() {
           fatGoal={fatGoal}
         />
         <AppearanceCard colors={colors} />
+        <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+          <CardContent>
+            <Pressable
+              onPress={() => router.push('/settings/gym-profiles')}
+              accessibilityRole="button"
+              accessibilityLabel="Open gym profiles settings"
+              style={styles.settingsLinkRow}
+            >
+              <View style={styles.settingsLinkMeta}>
+                <Text variant="body" style={[styles.settingsLinkTitle, { color: colors.onSurface }]}>Gym Profiles</Text>
+                <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                  Manage gyms, cable stacks, and marker calibrations.
+                </Text>
+              </View>
+              <ChevronRight size={18} color={colors.onSurfaceVariant} />
+            </Pressable>
+          </CardContent>
+        </Card>
         <BodyProfileCard weightUnit={weightUnit} heightUnit={measureUnit} />
         <FrequencyGoalPicker
           colors={colors}
@@ -194,6 +212,10 @@ export default function Settings() {
           hcSdkStatus={hcSdkStatus}
         />
         <AutoBackupSection colors={colors} toast={toast} />
+        <Pressable onPress={() => router.push('/settings/gym-profiles')} style={styles.settingsRow}>
+          <Text style={[styles.settingsRowLabel, { color: colors.onSurface }]}>Gym Profiles</Text>
+          <ChevronRight size={16} color={colors.onSurfaceVariant} />
+        </Pressable>
         <DataManagementCard
           colors={colors}
           loading={loading}
@@ -314,6 +336,18 @@ const styles = StyleSheet.create({
   container: { flex: 1 },
   content: { paddingTop: 16, paddingBottom: 48 },
   flowCard: { ...flowCardStyle, maxWidth: undefined, padding: spacing.md },
+  settingsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    minHeight: 44,
+  },
+  settingsRowLabel: {
+    fontSize: fontSizes.sm,
+    fontWeight: '600',
+  },
   versionRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -327,5 +361,18 @@ const styles = StyleSheet.create({
   },
   aboutBlock: {
     marginTop: 4,
+  },
+  settingsLinkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  settingsLinkMeta: {
+    flex: 1,
+    marginRight: 12,
+  },
+  settingsLinkTitle: {
+    fontSize: fontSizes.sm,
+    fontWeight: '600',
   },
 });

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -212,10 +212,6 @@ export default function Settings() {
           hcSdkStatus={hcSdkStatus}
         />
         <AutoBackupSection colors={colors} toast={toast} />
-        <Pressable onPress={() => router.push('/settings/gym-profiles')} style={styles.settingsRow}>
-          <Text style={[styles.settingsRowLabel, { color: colors.onSurface }]}>Gym Profiles</Text>
-          <ChevronRight size={16} color={colors.onSurfaceVariant} />
-        </Pressable>
         <DataManagementCard
           colors={colors}
           loading={loading}

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -272,8 +272,8 @@ export default function ActiveSession() {
   }, [step, unit, suggestions, exerciseNotesOpen, exerciseNotesDraft, pinnedNoteDraft, linkIds, groups, palette, handleUpdate, handleCheck, handleDelete, handleAddSet, handleAddWarmups, handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes, handlePinnedNoteDraftChange, handleSavePinnedNote, handleDismissBackfill, handleLoadBackfill, handleCycleSetType, handleLongPressSetType, handleOpenBodyweightModifier, handleClearBodyweightModifier, variant, bodyweightGrip, handleShowDetail, handleSwapOpen, handleDeleteExercise, handleMoveUp, handleMoveDown, handlePrefillFromPrevious, timerExerciseId, timerSetIndex, timerIsRunning, timerDisplaySeconds, handleTimerStart, handleTimerStop]);
 
   const listHeader = useMemo(() => (
-    <SessionListHeader nextHint={nextHint} colors={colors} />
-  ), [nextHint, colors]);
+    <SessionListHeader nextHint={nextHint} gymName={session?.gym_name_at_log ?? null} colors={colors} />
+  ), [nextHint, session?.gym_name_at_log, colors]);
 
   const listFooter = useMemo(() => (
     <SessionListFooter

--- a/app/settings/gym-profiles.tsx
+++ b/app/settings/gym-profiles.tsx
@@ -579,7 +579,7 @@ const styles = StyleSheet.create({
     bottom: 24,
     width: 56,
     height: 56,
-    borderRadius: radii.full,
+    borderRadius: radii.pill,
     alignItems: "center",
     justifyContent: "center",
     elevation: 4,
@@ -598,7 +598,7 @@ const styles = StyleSheet.create({
   badge: {
     paddingHorizontal: 8,
     paddingVertical: 2,
-    borderRadius: radii.full,
+    borderRadius: radii.pill,
   },
   expandedSection: { marginTop: 12 },
   sectionHeader: { marginTop: 18, marginBottom: 10 },

--- a/app/settings/gym-profiles.tsx
+++ b/app/settings/gym-profiles.tsx
@@ -1,0 +1,634 @@
+/* eslint-disable max-lines-per-function */
+import { useCallback, useMemo, useState } from "react";
+import { Alert, FlatList, Pressable, StyleSheet, Switch, View } from "react-native";
+import { Stack, useFocusEffect } from "expo-router";
+import { ChevronDown, ChevronRight, Plus } from "lucide-react-native";
+import SwipeToDelete from "@/components/SwipeToDelete";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { SegmentedControl } from "@/components/ui/segmented-control";
+import { Text } from "@/components/ui/text";
+import { useToast } from "@/components/ui/bna-toast";
+import { fontSizes, radii, spacing } from "@/constants/design-tokens";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { useLayout } from "@/lib/layout";
+import {
+  createCableStack,
+  createGymProfile,
+  deleteCalibration,
+  listCableStacks,
+  listCalibrations,
+  listGymProfiles,
+  setDefaultGym,
+  softDeleteCableStack,
+  softDeleteGymProfile,
+  updateCableStack,
+  updateGymProfile,
+  upsertCalibration,
+  type CableStack,
+  type GymProfile,
+  type StackCalibration,
+} from "@/lib/db";
+import { buildBulkPasteToast, parseCalibrationBulkPaste } from "@/lib/cable-stack";
+
+type GymDraft = { name: string; notes: string; isDefault: boolean };
+type StackDraft = { name: string; unit: "kg" | "lb" };
+type CalibrationDraft = { marker: string; weight: string; bulk: string };
+
+export default function GymProfilesScreen() {
+  const colors = useThemeColors();
+  const layout = useLayout();
+  const toast = useToast();
+  const [loading, setLoading] = useState(true);
+  const [gyms, setGyms] = useState<GymProfile[]>([]);
+  const [stacksByGym, setStacksByGym] = useState<Record<string, CableStack[]>>({});
+  const [calibrationsByStack, setCalibrationsByStack] = useState<Record<string, StackCalibration[]>>({});
+  const [gymDrafts, setGymDrafts] = useState<Record<string, GymDraft>>({});
+  const [stackDrafts, setStackDrafts] = useState<Record<string, StackDraft>>({});
+  const [newStackDrafts, setNewStackDrafts] = useState<Record<string, StackDraft>>({});
+  const [calibrationDrafts, setCalibrationDrafts] = useState<Record<string, CalibrationDraft>>({});
+  const [expandedGyms, setExpandedGyms] = useState<Record<string, boolean>>({});
+  const [expandedStacks, setExpandedStacks] = useState<Record<string, boolean>>({});
+  const [showAddGym, setShowAddGym] = useState(false);
+  const [newGymName, setNewGymName] = useState("");
+  const [newGymNotes, setNewGymNotes] = useState("");
+  const [newGymDefault, setNewGymDefault] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const nextGyms = await listGymProfiles();
+      const stackEntries = await Promise.all(
+        nextGyms.map(async (gym) => [gym.id, await listCableStacks(gym.id)] as const)
+      );
+      const nextStacksByGym = Object.fromEntries(stackEntries);
+      const allStacks = stackEntries.flatMap(([, stacks]) => stacks);
+      const calibrationEntries = await Promise.all(
+        allStacks.map(async (stack) => [stack.id, await listCalibrations(stack.id)] as const)
+      );
+
+      setGyms(nextGyms);
+      setStacksByGym(nextStacksByGym);
+      setCalibrationsByStack(Object.fromEntries(calibrationEntries));
+      setGymDrafts(
+        Object.fromEntries(
+          nextGyms.map((gym) => [gym.id, { name: gym.name, notes: gym.notes ?? "", isDefault: gym.is_default === 1 }])
+        )
+      );
+      setStackDrafts(
+        Object.fromEntries(
+          allStacks.map((stack) => [stack.id, { name: stack.name, unit: stack.unit as "kg" | "lb" }])
+        )
+      );
+      setNewStackDrafts((prev) => {
+        const next = { ...prev };
+        for (const gym of nextGyms) next[gym.id] ??= { name: "", unit: "kg" };
+        return next;
+      });
+      setCalibrationDrafts((prev) => {
+        const next = { ...prev };
+        for (const stack of allStacks) next[stack.id] ??= { marker: "", weight: "", bulk: "" };
+        return next;
+      });
+      setExpandedGyms((prev) => {
+        if (Object.keys(prev).length > 0) return prev;
+        return Object.fromEntries(nextGyms.map((gym, index) => [gym.id, index === 0]));
+      });
+    } catch {
+      toast.error("Failed to load gym profiles");
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void load();
+    }, [load])
+  );
+
+  const updateGymDraft = useCallback((gymId: string, patch: Partial<GymDraft>) => {
+    setGymDrafts((prev) => ({
+      ...prev,
+      [gymId]: { ...(prev[gymId] ?? { name: "", notes: "", isDefault: false }), ...patch },
+    }));
+  }, []);
+
+  const updateStackDraft = useCallback((stackId: string, patch: Partial<StackDraft>) => {
+    setStackDrafts((prev) => ({
+      ...prev,
+      [stackId]: { ...(prev[stackId] ?? { name: "", unit: "kg" }), ...patch },
+    }));
+  }, []);
+
+  const updateNewStackDraft = useCallback((gymId: string, patch: Partial<StackDraft>) => {
+    setNewStackDrafts((prev) => ({
+      ...prev,
+      [gymId]: { ...(prev[gymId] ?? { name: "", unit: "kg" }), ...patch },
+    }));
+  }, []);
+
+  const updateCalibrationDraft = useCallback((stackId: string, patch: Partial<CalibrationDraft>) => {
+    setCalibrationDrafts((prev) => ({
+      ...prev,
+      [stackId]: { ...(prev[stackId] ?? { marker: "", weight: "", bulk: "" }), ...patch },
+    }));
+  }, []);
+
+  const toggleGym = useCallback((gymId: string) => {
+    setExpandedGyms((prev) => ({ ...prev, [gymId]: !prev[gymId] }));
+  }, []);
+
+  const toggleStack = useCallback((stackId: string) => {
+    setExpandedStacks((prev) => ({ ...prev, [stackId]: !prev[stackId] }));
+  }, []);
+
+  const handleCreateGym = useCallback(async () => {
+    const name = newGymName.trim();
+    if (!name) {
+      toast.error("Gym name is required");
+      return;
+    }
+    try {
+      await createGymProfile({ name, notes: newGymNotes.trim(), is_default: newGymDefault });
+      setNewGymName("");
+      setNewGymNotes("");
+      setNewGymDefault(false);
+      setShowAddGym(false);
+      toast.success("Gym saved");
+      await load();
+    } catch {
+      toast.error("Failed to save gym");
+    }
+  }, [load, newGymDefault, newGymName, newGymNotes, toast]);
+
+  const handleSaveGym = useCallback(async (gymId: string) => {
+    const draft = gymDrafts[gymId];
+    if (!draft?.name.trim()) {
+      toast.error("Gym name is required");
+      return;
+    }
+    try {
+      await updateGymProfile(gymId, {
+        name: draft.name.trim(),
+        notes: draft.notes.trim(),
+        is_default: draft.isDefault,
+      });
+      toast.success("Gym updated");
+      await load();
+    } catch {
+      toast.error("Failed to update gym");
+    }
+  }, [gymDrafts, load, toast]);
+
+  const handleSetDefault = useCallback(async (gymId: string) => {
+    try {
+      await setDefaultGym(gymId);
+      toast.success("Default gym updated");
+      await load();
+    } catch {
+      toast.error("Failed to update default gym");
+    }
+  }, [load, toast]);
+
+  const confirmDeleteGym = useCallback((gym: GymProfile) => {
+    Alert.alert("Delete Gym", `Delete ${gym.name}? Existing logged sessions will keep their gym snapshot.`, [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            await softDeleteGymProfile(gym.id);
+            toast.success("Gym deleted");
+            await load();
+          } catch {
+            toast.error("Failed to delete gym");
+          }
+        },
+      },
+    ]);
+  }, [load, toast]);
+
+  const handleCreateStack = useCallback(async (gymId: string) => {
+    const draft = newStackDrafts[gymId] ?? { name: "", unit: "kg" as const };
+    if (!draft.name.trim()) {
+      toast.error("Stack name is required");
+      return;
+    }
+    try {
+      await createCableStack({ gym_id: gymId, name: draft.name.trim(), unit: draft.unit });
+      setNewStackDrafts((prev) => ({ ...prev, [gymId]: { name: "", unit: draft.unit } }));
+      toast.success("Stack saved");
+      setExpandedGyms((prev) => ({ ...prev, [gymId]: true }));
+      await load();
+    } catch {
+      toast.error("Failed to save stack");
+    }
+  }, [load, newStackDrafts, toast]);
+
+  const handleSaveStack = useCallback(async (stackId: string) => {
+    const draft = stackDrafts[stackId];
+    if (!draft?.name.trim()) {
+      toast.error("Stack name is required");
+      return;
+    }
+    try {
+      await updateCableStack(stackId, { name: draft.name.trim(), unit: draft.unit });
+      toast.success("Stack updated");
+      await load();
+    } catch {
+      toast.error("Failed to update stack");
+    }
+  }, [load, stackDrafts, toast]);
+
+  const confirmDeleteStack = useCallback((stack: CableStack) => {
+    Alert.alert("Delete Cable Stack", `Delete ${stack.name}? Historical sets keep the snapshotted stack name.`, [
+      { text: "Cancel", style: "cancel" },
+      {
+        text: "Delete",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            await softDeleteCableStack(stack.id);
+            toast.success("Stack deleted");
+            await load();
+          } catch {
+            toast.error("Failed to delete stack");
+          }
+        },
+      },
+    ]);
+  }, [load, toast]);
+
+  const handleSaveCalibration = useCallback(async (stackId: string) => {
+    const draft = calibrationDrafts[stackId] ?? { marker: "", weight: "", bulk: "" };
+    const marker = Number(draft.marker);
+    const weight = Number(draft.weight);
+    if (!Number.isInteger(marker) || marker <= 0) {
+      toast.error("Marker must be a whole number greater than 0");
+      return;
+    }
+    if (!Number.isFinite(weight) || weight <= 0) {
+      toast.error("Weight must be greater than 0");
+      return;
+    }
+    try {
+      await upsertCalibration(stackId, marker, weight);
+      updateCalibrationDraft(stackId, { marker: "", weight: "" });
+      toast.success("Marker saved");
+      await load();
+    } catch {
+      toast.error("Failed to save marker");
+    }
+  }, [calibrationDrafts, load, toast, updateCalibrationDraft]);
+
+  const handleBulkPaste = useCallback(async (stackId: string) => {
+    const draft = calibrationDrafts[stackId] ?? { marker: "", weight: "", bulk: "" };
+    const result = parseCalibrationBulkPaste(draft.bulk);
+    if (result.accepted.length > 0) {
+      try {
+        await Promise.all(result.accepted.map((row) => upsertCalibration(stackId, row.marker, row.trueWeight)));
+        updateCalibrationDraft(stackId, { bulk: "" });
+        await load();
+      } catch {
+        toast.error("Failed to save pasted markers");
+        return;
+      }
+    }
+
+    const message = buildBulkPasteToast(result);
+    if (message) {
+      if (result.accepted.length > 0) toast.success(message);
+      else toast.info(message);
+    }
+  }, [calibrationDrafts, load, toast, updateCalibrationDraft]);
+
+  const handleDeleteCalibration = useCallback(async (stackId: string, marker: number) => {
+    try {
+      await deleteCalibration(stackId, marker);
+      toast.success("Marker deleted");
+      await load();
+    } catch {
+      toast.error("Failed to delete marker");
+    }
+  }, [load, toast]);
+
+  const listHeader = useMemo(() => (
+    <View style={styles.headerBlock}>
+      <Text variant="heading" style={{ color: colors.onSurface, marginBottom: 8 }}>
+        Gym Profiles
+      </Text>
+      <Text variant="body" style={{ color: colors.onSurfaceVariant, marginBottom: 16 }}>
+        Add gyms here if you train across multiple locations.
+      </Text>
+      {showAddGym ? (
+        <Card style={styles.card}>
+          <CardContent>
+            <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
+              Add Gym
+            </Text>
+            <Input
+              label="Gym name"
+              placeholder="Downtown Gym"
+              value={newGymName}
+              onChangeText={setNewGymName}
+              variant="outline"
+            />
+            <View style={styles.spacer} />
+            <Input
+              label="Notes"
+              placeholder="Optional notes"
+              value={newGymNotes}
+              onChangeText={setNewGymNotes}
+              type="textarea"
+              rows={3}
+              variant="outline"
+            />
+            <View style={styles.switchRow}>
+              <Text variant="body" style={{ color: colors.onSurface }}>Default gym</Text>
+              <Switch value={newGymDefault} onValueChange={setNewGymDefault} />
+            </View>
+            <View style={styles.buttonRow}>
+              <Button variant="outline" onPress={() => setShowAddGym(false)}>Cancel</Button>
+              <Button onPress={handleCreateGym}>Save Gym</Button>
+            </View>
+          </CardContent>
+        </Card>
+      ) : null}
+      {!loading && gyms.length === 0 ? (
+        <Card style={styles.card}>
+          <CardContent>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant }}>
+              Add gyms here if you train across multiple locations.
+            </Text>
+          </CardContent>
+        </Card>
+      ) : null}
+    </View>
+  ), [colors.onSurface, colors.onSurfaceVariant, gyms.length, handleCreateGym, loading, newGymDefault, newGymName, newGymNotes, showAddGym]);
+
+  return (
+    <>
+      <Stack.Screen options={{ title: "Gym Profiles" }} />
+      <View style={[styles.container, { backgroundColor: colors.background }]}> 
+        <FlatList
+          data={gyms}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingTop: 16, paddingBottom: 120 }}
+          ListHeaderComponent={listHeader}
+          ListEmptyComponent={loading ? (
+            <Card style={styles.card}>
+              <CardContent>
+                <Text variant="body" style={{ color: colors.onSurfaceVariant }}>Loading gym profiles…</Text>
+              </CardContent>
+            </Card>
+          ) : null}
+          renderItem={({ item: gym }) => {
+            const gymDraft = gymDrafts[gym.id] ?? { name: gym.name, notes: gym.notes ?? "", isDefault: gym.is_default === 1 };
+            const stacks = stacksByGym[gym.id] ?? [];
+            const isExpanded = !!expandedGyms[gym.id];
+            return (
+              <SwipeToDelete onDelete={() => confirmDeleteGym(gym)} widthBasis="container">
+                <Card style={styles.card}>
+                  <CardContent>
+                    <Pressable
+                      onPress={() => toggleGym(gym.id)}
+                      style={styles.rowHeader}
+                      accessibilityRole="button"
+                      accessibilityLabel={`${gym.name}, ${isExpanded ? "collapse" : "expand"}`}
+                    >
+                      <View style={{ flex: 1 }}>
+                        <View style={styles.titleRow}>
+                          <Text variant="subtitle" style={{ color: colors.onSurface }}>{gym.name}</Text>
+                          {gym.is_default === 1 ? (
+                            <View style={[styles.badge, { backgroundColor: colors.primaryContainer }]}> 
+                              <Text style={{ color: colors.onPrimaryContainer, fontSize: fontSizes.xs, fontWeight: "600" }}>Default</Text>
+                            </View>
+                          ) : null}
+                        </View>
+                        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                          Swipe to delete • tap to edit
+                        </Text>
+                      </View>
+                      {isExpanded ? <ChevronDown size={18} color={colors.onSurfaceVariant} /> : <ChevronRight size={18} color={colors.onSurfaceVariant} />}
+                    </Pressable>
+
+                    {isExpanded ? (
+                      <View style={styles.expandedSection}>
+                        <Input label="Gym name" value={gymDraft.name} onChangeText={(value) => updateGymDraft(gym.id, { name: value })} variant="outline" />
+                        <View style={styles.spacer} />
+                        <Input label="Notes" value={gymDraft.notes} onChangeText={(value) => updateGymDraft(gym.id, { notes: value })} type="textarea" rows={3} variant="outline" />
+                        <View style={styles.switchRow}>
+                          <Text variant="body" style={{ color: colors.onSurface }}>Default gym</Text>
+                          <Switch value={gymDraft.isDefault} onValueChange={(value) => updateGymDraft(gym.id, { isDefault: value })} />
+                        </View>
+                        <View style={styles.buttonRow}>
+                          <Button variant="outline" onPress={() => handleSaveGym(gym.id)}>Save Gym Changes</Button>
+                          {gym.is_default !== 1 ? <Button variant="ghost" onPress={() => handleSetDefault(gym.id)}>Set as default</Button> : null}
+                        </View>
+
+                        <View style={styles.sectionHeader}>
+                          <Text variant="subtitle" style={{ color: colors.onSurface }}>Cable Stacks</Text>
+                          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                            Markers are specific to this gym.
+                          </Text>
+                        </View>
+
+                        {stacks.length === 0 ? (
+                          <Text variant="body" style={{ color: colors.onSurfaceVariant, marginBottom: 12 }}>
+                            No cable stacks yet.
+                          </Text>
+                        ) : null}
+
+                        {stacks.map((stack) => {
+                          const stackDraft = stackDrafts[stack.id] ?? { name: stack.name, unit: stack.unit as "kg" | "lb" };
+                          const calibrationDraft = calibrationDrafts[stack.id] ?? { marker: "", weight: "", bulk: "" };
+                          const calibrations = (calibrationsByStack[stack.id] ?? []).slice().sort((a, b) => a.marker - b.marker);
+                          const stackExpanded = !!expandedStacks[stack.id];
+                          return (
+                            <SwipeToDelete key={stack.id} onDelete={() => confirmDeleteStack(stack)} widthBasis="container">
+                              <View style={[styles.stackCard, { borderColor: colors.outlineVariant }]}> 
+                                <Pressable
+                                  onPress={() => toggleStack(stack.id)}
+                                  style={styles.rowHeader}
+                                  accessibilityRole="button"
+                                  accessibilityLabel={`${stack.name}, ${stackExpanded ? "collapse" : "expand"}`}
+                                >
+                                  <View style={{ flex: 1 }}>
+                                    <Text variant="body" style={{ color: colors.onSurface, fontWeight: "600" }}>{stack.name}</Text>
+                                    <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>{calibrations.length} marker{calibrations.length === 1 ? "" : "s"}</Text>
+                                  </View>
+                                  {stackExpanded ? <ChevronDown size={18} color={colors.onSurfaceVariant} /> : <ChevronRight size={18} color={colors.onSurfaceVariant} />}
+                                </Pressable>
+
+                                {stackExpanded ? (
+                                  <View style={styles.expandedSection}>
+                                    <Input label="Stack name" value={stackDraft.name} onChangeText={(value) => updateStackDraft(stack.id, { name: value })} variant="outline" />
+                                    <View style={styles.spacer} />
+                                    <SegmentedControl
+                                      value={stackDraft.unit}
+                                      onValueChange={(value) => updateStackDraft(stack.id, { unit: value as "kg" | "lb" })}
+                                      buttons={[{ value: "kg", label: "kg" }, { value: "lb", label: "lb" }]}
+                                    />
+                                    <View style={styles.spacer} />
+                                    <Button variant="outline" onPress={() => handleSaveStack(stack.id)}>Save Stack</Button>
+
+                                    <View style={styles.sectionHeader}>
+                                      <Text variant="body" style={{ color: colors.onSurface, fontWeight: "600" }}>Marker calibrations</Text>
+                                    </View>
+                                    {calibrations.map((calibration) => (
+                                      <View key={`${stack.id}-${calibration.marker}`} style={styles.calibrationRow}>
+                                        <Text variant="body" style={{ color: colors.onSurface, flex: 1 }}>
+                                          Marker {calibration.marker} — {calibration.true_weight} {stack.unit}
+                                        </Text>
+                                        <Button variant="ghost" size="sm" onPress={() => handleDeleteCalibration(stack.id, calibration.marker)}>
+                                          Delete
+                                        </Button>
+                                      </View>
+                                    ))}
+                                    <View style={styles.inlineInputs}>
+                                      <View style={{ flex: 1 }}>
+                                        <Input
+                                          label="Marker"
+                                          value={calibrationDraft.marker}
+                                          onChangeText={(value) => updateCalibrationDraft(stack.id, { marker: value })}
+                                          keyboardType="numeric"
+                                          variant="outline"
+                                        />
+                                      </View>
+                                      <View style={{ flex: 1 }}>
+                                        <Input
+                                          label={`Weight (${stack.unit})`}
+                                          value={calibrationDraft.weight}
+                                          onChangeText={(value) => updateCalibrationDraft(stack.id, { weight: value })}
+                                          keyboardType="decimal-pad"
+                                          variant="outline"
+                                        />
+                                      </View>
+                                    </View>
+                                    <Button variant="outline" onPress={() => handleSaveCalibration(stack.id)}>Save Marker</Button>
+                                    <View style={styles.spacer} />
+                                    <Input
+                                      label="Bulk paste"
+                                      placeholder="1=5\n2=7.5\n3=10"
+                                      value={calibrationDraft.bulk}
+                                      onChangeText={(value) => updateCalibrationDraft(stack.id, { bulk: value })}
+                                      type="textarea"
+                                      rows={4}
+                                      variant="outline"
+                                    />
+                                    <View style={styles.spacer} />
+                                    <Button variant="outline" onPress={() => handleBulkPaste(stack.id)}>Apply Bulk Paste</Button>
+                                  </View>
+                                ) : null}
+                              </View>
+                            </SwipeToDelete>
+                          );
+                        })}
+
+                        <View style={[styles.stackCard, { borderColor: colors.outlineVariant }]}> 
+                          <Text variant="body" style={{ color: colors.onSurface, fontWeight: "600", marginBottom: 8 }}>
+                            Add cable stack
+                          </Text>
+                          <Input
+                            label="Stack name"
+                            value={(newStackDrafts[gym.id] ?? { name: "", unit: "kg" }).name}
+                            onChangeText={(value) => updateNewStackDraft(gym.id, { name: value })}
+                            variant="outline"
+                          />
+                          <View style={styles.spacer} />
+                          <SegmentedControl
+                            value={(newStackDrafts[gym.id] ?? { name: "", unit: "kg" }).unit}
+                            onValueChange={(value) => updateNewStackDraft(gym.id, { unit: value as "kg" | "lb" })}
+                            buttons={[{ value: "kg", label: "kg" }, { value: "lb", label: "lb" }]}
+                          />
+                          <View style={styles.spacer} />
+                          <Button variant="outline" onPress={() => handleCreateStack(gym.id)}>Add Stack</Button>
+                        </View>
+                      </View>
+                    ) : null}
+                  </CardContent>
+                </Card>
+              </SwipeToDelete>
+            );
+          }}
+        />
+
+        <Pressable
+          onPress={() => setShowAddGym((prev) => !prev)}
+          style={[styles.fab, { backgroundColor: colors.primary }]}
+          accessibilityRole="button"
+          accessibilityLabel={showAddGym ? "Hide add gym form" : "Add gym"}
+        >
+          <Plus size={22} color={colors.onPrimary} />
+        </Pressable>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  headerBlock: { marginBottom: spacing.md },
+  card: { marginBottom: spacing.md },
+  fab: {
+    position: "absolute",
+    right: 20,
+    bottom: 24,
+    width: 56,
+    height: 56,
+    borderRadius: radii.full,
+    alignItems: "center",
+    justifyContent: "center",
+    elevation: 4,
+  },
+  rowHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+  },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginBottom: 4,
+  },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: radii.full,
+  },
+  expandedSection: { marginTop: 12 },
+  sectionHeader: { marginTop: 18, marginBottom: 10 },
+  switchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginVertical: 12,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  stackCard: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    marginTop: 12,
+  },
+  calibrationRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingVertical: 4,
+  },
+  inlineInputs: {
+    flexDirection: "row",
+    gap: 12,
+    marginVertical: 12,
+  },
+  spacer: { height: 12 },
+});

--- a/components/progress/TrendCards.tsx
+++ b/components/progress/TrendCards.tsx
@@ -101,20 +101,21 @@ export function TrendLineCard({
 
 type RPETrendCardProps = {
   chartWidth: number;
+  gymId?: string | null;
   style?: object;
 };
 
-export function RPETrendCard({ chartWidth, style }: RPETrendCardProps) {
+export function RPETrendCard({ chartWidth, gymId, style }: RPETrendCardProps) {
   const colors = useThemeColors();
   const [rpeData, setRpeData] = useState<SessionRPERow[]>([]);
 
   useFocusEffect(
     useCallback(() => {
       (async () => {
-        const rows = await getRecentSessionRPEs();
+        const rows = await getRecentSessionRPEs(Date.now(), gymId);
         setRpeData(rows);
       })();
-    }, []),
+    }, [gymId]),
   );
 
   const data = rpeData.map((d, i) => ({ x: i, y: d.avg_rpe }));
@@ -134,20 +135,21 @@ export function RPETrendCard({ chartWidth, style }: RPETrendCardProps) {
 
 type RatingTrendCardProps = {
   chartWidth: number;
+  gymId?: string | null;
   style?: object;
 };
 
-export function RatingTrendCard({ chartWidth, style }: RatingTrendCardProps) {
+export function RatingTrendCard({ chartWidth, gymId, style }: RatingTrendCardProps) {
   const colors = useThemeColors();
   const [ratingData, setRatingData] = useState<SessionRatingRow[]>([]);
 
   useFocusEffect(
     useCallback(() => {
       (async () => {
-        const rows = await getRecentSessionRatings();
+        const rows = await getRecentSessionRatings(Date.now(), gymId);
         setRatingData(rows);
       })();
-    }, []),
+    }, [gymId]),
   );
 
   const data = ratingData.map((d, i) => ({ x: i, y: d.rating }));

--- a/components/progress/WorkoutCards.tsx
+++ b/components/progress/WorkoutCards.tsx
@@ -92,6 +92,12 @@ type SessionsCardProps = {
   style?: object;
 };
 
+type SessionsByGymRow = {
+  gymId: string;
+  gymName: string;
+  count: number;
+};
+
 export function SessionsCard({ sessions, style }: SessionsCardProps) {
   const colors = useThemeColors();
 
@@ -113,6 +119,31 @@ export function SessionsCard({ sessions, style }: SessionsCardProps) {
           {i < sessions.length - 1 && (
             <Separator style={{ marginVertical: 6 }} />
           )}
+        </View>
+      ))}
+    </Card>
+  );
+}
+
+export function SessionsByGymCard({ rows, style }: { rows: SessionsByGymRow[]; style?: object }) {
+  const colors = useThemeColors();
+
+  return (
+    <Card style={[styles.card, style]}>
+      <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 12 }}>
+        Sessions by gym
+      </Text>
+      {rows.map((row, index) => (
+        <View key={row.gymId}>
+          <View style={styles.sessionRow}>
+            <View style={{ flex: 1 }}>
+              <Text style={{ color: colors.onSurface }}>{row.gymName}</Text>
+            </View>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant, fontWeight: "600" }}>
+              {row.count}
+            </Text>
+          </View>
+          {index < rows.length - 1 ? <Separator style={{ marginVertical: 6 }} /> : null}
         </View>
       ))}
     </Card>

--- a/components/progress/WorkoutSegment.tsx
+++ b/components/progress/WorkoutSegment.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { useCallback, useMemo, useState } from "react";
 import {
   FlatList,
@@ -13,6 +14,9 @@ import {
   getWeeklyVolume,
   getCompletedSessionsWithSetCount,
   getBodySettings,
+  getActiveGymCount,
+  getGymProfiles,
+  getSessionsByGym,
 } from "../../lib/db";
 import {
   getRecentPRsWithDelta,
@@ -23,7 +27,7 @@ import { useLayout } from "../../lib/layout";
 import { useFloatingTabBarHeight } from "../../components/FloatingTabBar";
 import WeeklySummary from "../../components/WeeklySummary";
 import { useThemeColors } from "@/hooks/useThemeColors";
-import { WorkoutChartCard, SessionsCard } from "./WorkoutCards";
+import { WorkoutChartCard, SessionsByGymCard, SessionsCard } from "./WorkoutCards";
 import { PRSummaryCard } from "./PRSummaryCard";
 import { RPETrendCard, RatingTrendCard } from "./TrendCards";
 import CalendarView from "./CalendarView";
@@ -60,6 +64,11 @@ type SessionRow = {
   set_count: number;
 };
 
+type GymFilterOption = {
+  id: string;
+  name: string;
+};
+
 export default function WorkoutSegment() {
   const colors = useThemeColors();
   const layout = useLayout();
@@ -75,17 +84,24 @@ export default function WorkoutSegment() {
   const [prStats, setPRStats] = useState<PRStats>({ totalPRs: 0, prsThisMonth: 0 });
   const [weightUnit, setWeightUnit] = useState<"kg" | "lb">("kg");
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [activeGymCount, setActiveGymCount] = useState(0);
+  const [gymOptions, setGymOptions] = useState<GymFilterOption[]>([]);
+  const [sessionsByGym, setSessionsByGym] = useState<Array<{ gymId: string; gymName: string; count: number }>>([]);
+  const [selectedGymId, setSelectedGymId] = useState<string>("all");
 
   useFocusEffect(
     useCallback(() => {
       (async () => {
-        const [f, v, rp, ps, s, settings] = await Promise.all([
-          getWeeklySessionCounts(),
-          getWeeklyVolume(),
+        const [f, v, rp, ps, s, settings, liveGymCount, gyms, gymRows] = await Promise.all([
+          getWeeklySessionCounts(8, selectedGymId === "all" ? null : selectedGymId),
+          getWeeklyVolume(8, selectedGymId === "all" ? null : selectedGymId),
           getRecentPRsWithDelta(3),
           getPRStats(),
-          getCompletedSessionsWithSetCount(),
+          getCompletedSessionsWithSetCount(10, selectedGymId === "all" ? null : selectedGymId),
           getBodySettings(),
+          getActiveGymCount(),
+          getGymProfiles(),
+          getSessionsByGym(),
         ]);
         setFreq(f);
         setVol(v);
@@ -93,8 +109,18 @@ export default function WorkoutSegment() {
         setPRStats(ps);
         setSessions(s);
         setWeightUnit(settings.weight_unit as "kg" | "lb");
+        setActiveGymCount(liveGymCount);
+        const liveGymIds = new Set(gyms.map((gym) => gym.id));
+        const options = gymRows
+          .filter((row) => liveGymIds.has(row.gymId))
+          .map((row) => ({ id: row.gymId, name: row.gymName }));
+        setGymOptions(options);
+        setSessionsByGym(gymRows);
+        if (selectedGymId !== "all" && !options.some((option) => option.id === selectedGymId)) {
+          setSelectedGymId("all");
+        }
       })();
-    }, []),
+    }, [selectedGymId]),
   );
 
   const chartWidth = layout.atLeastMedium
@@ -102,6 +128,7 @@ export default function WorkoutSegment() {
     : screenWidth - 48;
 
   const empty = sessions.length === 0 && freq.length === 0;
+  const showGymUI = activeGymCount >= 2;
 
   const toggleButton = (
     <Pressable
@@ -118,10 +145,44 @@ export default function WorkoutSegment() {
     </Pressable>
   );
 
+  const gymFilter = showGymUI ? (
+    <View style={styles.filterRow}>
+      <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+        Filter:
+      </Text>
+      <View style={styles.filterPills}>
+        {[{ id: "all", name: "All gyms" }, ...gymOptions].map((option) => {
+          const selected = selectedGymId === option.id;
+          return (
+            <Pressable
+              key={option.id}
+              onPress={() => setSelectedGymId(option.id)}
+              style={[
+                styles.filterPill,
+                {
+                  backgroundColor: selected ? colors.primary : colors.surface,
+                  borderColor: colors.outlineVariant,
+                },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={`Filter workouts by ${option.name}`}
+              accessibilityState={{ selected }}
+            >
+              <Text style={{ color: selected ? colors.onPrimary : colors.onSurfaceVariant, fontSize: fontSizes.sm }}>
+                {option.name}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  ) : null;
+
   if (viewMode === "calendar") {
     return (
       <View style={{ flex: 1 }}>
         <View style={styles.toggleRow}>{toggleButton}</View>
+        {gymFilter}
         <CalendarView weekStartDay={weekStartDay} />
       </View>
     );
@@ -131,6 +192,7 @@ export default function WorkoutSegment() {
     return (
       <View style={{ flex: 1 }}>
         <View style={styles.toggleRow}>{toggleButton}</View>
+        {gymFilter}
         <View style={{ padding: 16 }}>
           <WeeklySummary />
         </View>
@@ -194,6 +256,9 @@ export default function WorkoutSegment() {
       />
     ) : null;
 
+  const sessionsByGymCard =
+    showGymUI && sessionsByGym.length > 0 ? <SessionsByGymCard rows={sessionsByGym} style={wideCard} /> : null;
+
   return (
     <FlatList
       data={[]}
@@ -207,6 +272,7 @@ export default function WorkoutSegment() {
         layout.atLeastMedium ? (
           <>
             <View style={styles.toggleRow}>{toggleButton}</View>
+            {gymFilter}
             <WeeklySummary />
             {achievementsCard}
             <View style={styles.grid}>
@@ -214,8 +280,8 @@ export default function WorkoutSegment() {
               {volCard}
             </View>
             <View style={styles.grid}>
-              <RPETrendCard chartWidth={chartWidth} style={wideCard} />
-              <RatingTrendCard chartWidth={chartWidth} style={wideCard} />
+              <RPETrendCard chartWidth={chartWidth} gymId={selectedGymId === "all" ? null : selectedGymId} style={wideCard} />
+              <RatingTrendCard chartWidth={chartWidth} gymId={selectedGymId === "all" ? null : selectedGymId} style={wideCard} />
             </View>
             <View style={styles.grid}>
               <PRSummaryCard
@@ -227,18 +293,20 @@ export default function WorkoutSegment() {
               />
               <SessionsCard sessions={sessions} style={wideCard} />
             </View>
+            {sessionsByGymCard ? <View style={styles.grid}>{sessionsByGymCard}</View> : null}
             <ActiveGoalsCard />
             <StrengthLevelsCard />
           </>
         ) : (
           <>
             <View style={styles.toggleRow}>{toggleButton}</View>
+            {gymFilter}
             <WeeklySummary />
             {achievementsCard}
             {freqCard}
             {volCard}
-            <RPETrendCard chartWidth={chartWidth} />
-            <RatingTrendCard chartWidth={chartWidth} />
+            <RPETrendCard chartWidth={chartWidth} gymId={selectedGymId === "all" ? null : selectedGymId} />
+            <RatingTrendCard chartWidth={chartWidth} gymId={selectedGymId === "all" ? null : selectedGymId} />
             <PRSummaryCard
               recentPRs={recentPRs}
               stats={prStats}
@@ -246,6 +314,7 @@ export default function WorkoutSegment() {
               onSeeAll={() => router.push("/progress/records")}
             />
             <SessionsCard sessions={sessions} />
+            {sessionsByGymCard}
             <ActiveGoalsCard />
             <StrengthLevelsCard />
           </>
@@ -276,6 +345,23 @@ const styles = StyleSheet.create({
     justifyContent: "flex-end",
     paddingHorizontal: 16,
     paddingTop: 8,
+  },
+  filterRow: {
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 4,
+    gap: 8,
+  },
+  filterPills: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  filterPill: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
   },
   toggleButton: {
     borderWidth: 1,

--- a/components/progress/WorkoutSegment.tsx
+++ b/components/progress/WorkoutSegment.tsx
@@ -146,11 +146,11 @@ export default function WorkoutSegment() {
   );
 
   const gymFilter = showGymUI ? (
-    <View style={styles.filterRow}>
+    <View style={styles.filterRow} testID="workout-gym-filter-row">
       <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
         Filter:
       </Text>
-      <View style={styles.filterPills}>
+      <View style={styles.filterPills} testID="workout-gym-filter-pills">
         {[{ id: "all", name: "All gyms" }, ...gymOptions].map((option) => {
           const selected = selectedGymId === option.id;
           return (

--- a/components/session/MarkerPickerSheet.tsx
+++ b/components/session/MarkerPickerSheet.tsx
@@ -167,7 +167,7 @@ const styles = StyleSheet.create({
   stackChip: {
     paddingHorizontal: 12,
     paddingVertical: 6,
-    borderRadius: radii.full,
+    borderRadius: radii.pill,
     borderWidth: 1,
   },
   stackChipText: { fontSize: fontSizes.sm },

--- a/components/session/MarkerPickerSheet.tsx
+++ b/components/session/MarkerPickerSheet.tsx
@@ -1,0 +1,186 @@
+/**
+ * MarkerPickerSheet — lets the user pick a cable stack marker number from the
+ * active gym's calibration table. On confirm, the caller receives the selected
+ * marker and the resolved true weight.
+ *
+ * Mirrors VariantPickerSheet (BLD-771) — a sibling component, NOT an overload.
+ * BLD-1059: Per-Gym Cable Stack Calibration.
+ */
+import React, { useCallback, useState } from "react";
+import { FlatList, Pressable, StyleSheet, View } from "react-native";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { fontSizes, radii } from "@/constants/design-tokens";
+import type { CableStackRow, StackCalibrationRow } from "@/lib/db/schema";
+
+export type MarkerPickerSheetProps = {
+  isVisible: boolean;
+  onClose: () => void;
+  stacks: Array<CableStackRow & { calibrations: StackCalibrationRow[] }>;
+  onConfirm: (result: {
+    stackId: string;
+    stackName: string;
+    marker: number;
+    trueWeight: number;
+    unit: string;
+  }) => void;
+};
+
+function MarkerPickerBody({
+  onClose,
+  stacks,
+  onConfirm,
+}: Omit<MarkerPickerSheetProps, "isVisible">) {
+  const colors = useThemeColors();
+  const [selectedStackId, setSelectedStackId] = useState<string | null>(
+    stacks.length === 1 ? stacks[0].id : null
+  );
+
+  const activeStack = stacks.find((stack) => stack.id === selectedStackId) ?? null;
+
+  const handleSelect = useCallback((marker: number, trueWeight: number) => {
+    if (!activeStack) return;
+    onConfirm({
+      stackId: activeStack.id,
+      stackName: activeStack.name,
+      marker,
+      trueWeight,
+      unit: activeStack.unit,
+    });
+    onClose();
+  }, [activeStack, onClose, onConfirm]);
+
+  const sortedCalibrations = activeStack
+    ? [...activeStack.calibrations].sort((a, b) => a.marker - b.marker)
+    : [];
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.title, { color: colors.onSurface }]}>Select Marker</Text>
+
+      {stacks.length > 1 ? (
+        <View style={styles.stackPicker}>
+          {stacks.map((stack) => {
+            const selected = selectedStackId === stack.id;
+            return (
+              <Pressable
+                key={stack.id}
+                onPress={() => setSelectedStackId(stack.id)}
+                style={[
+                  styles.stackChip,
+                  {
+                    backgroundColor: selected ? colors.primary : colors.surface,
+                    borderColor: colors.outlineVariant,
+                  },
+                ]}
+                accessibilityRole="button"
+                accessibilityLabel={`Stack: ${stack.name}`}
+                accessibilityState={{ selected }}
+              >
+                <Text
+                  style={[
+                    styles.stackChipText,
+                    { color: selected ? colors.onPrimary : colors.onSurface },
+                  ]}
+                >
+                  {stack.name}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      ) : null}
+
+      {activeStack && activeStack.calibrations.length === 0 ? (
+        <View style={styles.emptyState}>
+          <Text style={{ color: colors.onSurfaceVariant, textAlign: "center" }}>
+            No markers added yet. Add markers in Settings → Gym Profiles.
+          </Text>
+        </View>
+      ) : null}
+
+      {activeStack && activeStack.calibrations.length > 0 ? (
+        <FlatList
+          data={sortedCalibrations}
+          keyExtractor={(item) => `${item.stack_id}-${item.marker}`}
+          renderItem={({ item }) => (
+            <Pressable
+              onPress={() => handleSelect(item.marker, item.true_weight)}
+              style={[styles.markerRow, { borderBottomColor: colors.outlineVariant }]}
+              accessibilityRole="button"
+              accessibilityLabel={`Marker ${item.marker}, ${item.true_weight} ${activeStack.unit}`}
+              accessibilityHint="Select this marker weight"
+            >
+              <Text style={[styles.markerNumber, { color: colors.onSurface }]}>#{item.marker}</Text>
+              <Text style={[styles.markerWeight, { color: colors.onSurfaceVariant }]}> 
+                {item.true_weight} {activeStack.unit}
+              </Text>
+            </Pressable>
+          )}
+          style={styles.list}
+        />
+      ) : null}
+
+      {!activeStack && stacks.length > 0 ? (
+        <View style={styles.emptyState}>
+          <Text style={{ color: colors.onSurfaceVariant, textAlign: "center" }}>
+            Select a stack above to see markers.
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export function MarkerPickerSheet({
+  isVisible,
+  onClose,
+  stacks,
+  onConfirm,
+}: MarkerPickerSheetProps) {
+  return (
+    <BottomSheet isVisible={isVisible} onClose={onClose}>
+      {isVisible ? (
+        <MarkerPickerBody onClose={onClose} stacks={stacks} onConfirm={onConfirm} />
+      ) : null}
+    </BottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { paddingBottom: 24 },
+  title: {
+    fontSize: fontSizes.lg,
+    fontWeight: "600",
+    textAlign: "center",
+    marginBottom: 16,
+    paddingHorizontal: 16,
+  },
+  stackPicker: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    paddingHorizontal: 16,
+    marginBottom: 16,
+  },
+  stackChip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: radii.full,
+    borderWidth: 1,
+  },
+  stackChipText: { fontSize: fontSizes.sm },
+  list: { maxHeight: 320 },
+  markerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  markerNumber: { fontSize: fontSizes.base, fontWeight: "600" },
+  markerWeight: { fontSize: fontSizes.base },
+  emptyState: { paddingHorizontal: 20, paddingVertical: 24 },
+});

--- a/components/session/SessionListHeader.tsx
+++ b/components/session/SessionListHeader.tsx
@@ -5,12 +5,20 @@ import type { ThemeColors } from "@/hooks/useThemeColors";
 
 type Props = {
   nextHint: string | null;
+  gymName?: string | null;
   colors: ThemeColors;
 };
 
-export function SessionListHeader({ nextHint, colors }: Props) {
+export function SessionListHeader({ nextHint, gymName, colors }: Props) {
   return (
     <>
+      {gymName ? (
+        <View style={[styles.gymChip, { backgroundColor: colors.secondaryContainer }]}>
+          <Text variant="caption" style={{ color: colors.onSecondaryContainer, fontWeight: "700" }}>
+            {gymName}
+          </Text>
+        </View>
+      ) : null}
       {nextHint && (
         <View style={[styles.nextBanner, { backgroundColor: colors.secondaryContainer }]} accessibilityLiveRegion="polite">
           <Text variant="subtitle" style={{ color: colors.onSecondaryContainer, fontWeight: "700" }}>
@@ -23,6 +31,13 @@ export function SessionListHeader({ nextHint, colors }: Props) {
 }
 
 const styles = StyleSheet.create({
+  gymChip: {
+    alignSelf: "flex-start",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    marginBottom: 12,
+  },
   nextBanner: {
     alignItems: "center",
     padding: 12,

--- a/lib/cable-stack.ts
+++ b/lib/cable-stack.ts
@@ -1,0 +1,89 @@
+// BLD-1060: Per-gym cable stack calibration — pure domain helpers.
+// No DB access — callers pass data; these functions are pure and unit-testable.
+
+export type CalibrationRow = { marker: number; true_weight: number };
+
+export type BulkPasteSkipReason =
+  | "non_numeric_weight"
+  | "non_numeric_marker"
+  | "marker_must_be_positive"
+  | "weight_must_be_positive"
+  | "duplicate_marker";
+
+export type BulkPasteResult = {
+  accepted: CalibrationRow[];
+  skipped: Array<{ input: string; reason: BulkPasteSkipReason }>;
+};
+
+export function parseCalibrationBulkPaste(input: string): BulkPasteResult {
+  if (!input || input.trim() === "") {
+    return { accepted: [], skipped: [] };
+  }
+
+  const lines = input
+    .split(/[\n,]+/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const acceptedMap = new Map<number, { row: CalibrationRow; inputStr: string }>();
+  const skipped: BulkPasteResult["skipped"] = [];
+
+  for (const line of lines) {
+    const eqIdx = line.indexOf("=");
+    if (eqIdx < 0) {
+      skipped.push({ input: line, reason: "non_numeric_marker" });
+      continue;
+    }
+
+    const markerStr = line.slice(0, eqIdx).trim();
+    const weightStr = line.slice(eqIdx + 1).trim();
+
+    const markerNum = Number(markerStr);
+    if (!markerStr || Number.isNaN(markerNum) || !Number.isInteger(markerNum)) {
+      skipped.push({ input: line, reason: "non_numeric_marker" });
+      continue;
+    }
+    if (markerNum <= 0) {
+      skipped.push({ input: line, reason: "marker_must_be_positive" });
+      continue;
+    }
+
+    const weightNum = Number(weightStr);
+    if (!weightStr || Number.isNaN(weightNum)) {
+      skipped.push({ input: line, reason: "non_numeric_weight" });
+      continue;
+    }
+    if (weightNum <= 0) {
+      skipped.push({ input: line, reason: "weight_must_be_positive" });
+      continue;
+    }
+
+    if (acceptedMap.has(markerNum)) {
+      const prev = acceptedMap.get(markerNum)!;
+      skipped.push({ input: prev.inputStr, reason: "duplicate_marker" });
+    }
+
+    acceptedMap.set(markerNum, {
+      row: { marker: markerNum, true_weight: weightNum },
+      inputStr: line,
+    });
+  }
+
+  return {
+    accepted: Array.from(acceptedMap.values()).map((value) => value.row),
+    skipped,
+  };
+}
+
+export function buildBulkPasteToast(result: BulkPasteResult): string {
+  const acceptedCount = result.accepted.length;
+  const skippedCount = result.skipped.length;
+
+  if (acceptedCount === 0 && skippedCount === 0) return "";
+  if (acceptedCount === 0) return `No valid rows. ${skippedCount} skipped.`;
+  if (skippedCount === 0) return `Added ${acceptedCount} marker${acceptedCount === 1 ? "" : "s"}.`;
+  return `Added ${acceptedCount} marker${acceptedCount === 1 ? "" : "s"}. ${skippedCount} row${skippedCount === 1 ? "" : "s"} skipped.`;
+}
+
+export function formatMarkerBadge(marker: number, weight: number, unit: string): string {
+  return `📍 #${marker} · ${weight} ${unit}`;
+}

--- a/lib/cable-stack.ts
+++ b/lib/cable-stack.ts
@@ -1,89 +1,118 @@
-// BLD-1060: Per-gym cable stack calibration — pure domain helpers.
-// No DB access — callers pass data; these functions are pure and unit-testable.
+/**
+ * Pure domain helpers for cable stack calibration.
+ * BLD-1059: Per-Gym Cable Stack Calibration.
+ *
+ * All functions are side-effect-free (no DB calls); DB reads are done by
+ * callers who pass calibration rows as arguments.
+ */
+import type { StackCalibrationRow } from "./db/schema";
 
-export type CalibrationRow = { marker: number; true_weight: number };
+export type ResolveMarkerResult = { weight: number; unit: string };
 
-export type BulkPasteSkipReason =
-  | "non_numeric_weight"
+/**
+ * Resolves a stack marker number to its true weight using the provided
+ * calibration rows. Returns null if no calibration row exists for the marker.
+ */
+export function resolveMarker(
+  calibrations: StackCalibrationRow[],
+  marker: number
+): ResolveMarkerResult | null {
+  const row = calibrations.find((c) => c.marker === marker);
+  if (!row) return null;
+  return { weight: row.true_weight, unit: "" };
+}
+
+// ── Bulk Paste Parser ─────────────────────────────────────────────────────────
+
+export type ParsedCalibrationRow = { marker: number; trueWeight: number };
+export type SkipReason =
   | "non_numeric_marker"
+  | "non_numeric_weight"
   | "marker_must_be_positive"
   | "weight_must_be_positive"
   | "duplicate_marker";
 
-export type BulkPasteResult = {
-  accepted: CalibrationRow[];
-  skipped: Array<{ input: string; reason: BulkPasteSkipReason }>;
+export type SkippedRow = { raw: string; reason: SkipReason };
+
+export type BulkParseResult = {
+  accepted: ParsedCalibrationRow[];
+  skipped: SkippedRow[];
 };
 
-export function parseCalibrationBulkPaste(input: string): BulkPasteResult {
-  if (!input || input.trim() === "") {
+/**
+ * Parses a bulk-paste string of "marker=weight" rows (newline or comma
+ * separated).
+ */
+export function parseCalibrationBulkPaste(input: string): BulkParseResult {
+  const skipped: SkippedRow[] = [];
+  const acceptedMap = new Map<number, { row: ParsedCalibrationRow; rawIndex: number }>();
+  const rawLines: string[] = [];
+
+  if (!input.trim()) {
     return { accepted: [], skipped: [] };
   }
 
   const lines = input
-    .split(/[\n,]+/)
-    .map((line) => line.trim())
-    .filter(Boolean);
-  const acceptedMap = new Map<number, { row: CalibrationRow; inputStr: string }>();
-  const skipped: BulkPasteResult["skipped"] = [];
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
 
-  for (const line of lines) {
-    const eqIdx = line.indexOf("=");
-    if (eqIdx < 0) {
-      skipped.push({ input: line, reason: "non_numeric_marker" });
+  for (const raw of lines) {
+    rawLines.push(raw);
+    const eqIdx = raw.indexOf("=");
+    if (eqIdx === -1) {
+      skipped.push({ raw, reason: "non_numeric_marker" });
       continue;
     }
-
-    const markerStr = line.slice(0, eqIdx).trim();
-    const weightStr = line.slice(eqIdx + 1).trim();
+    const markerStr = raw.slice(0, eqIdx).trim();
+    const weightStr = raw.slice(eqIdx + 1).trim();
 
     const markerNum = Number(markerStr);
-    if (!markerStr || Number.isNaN(markerNum) || !Number.isInteger(markerNum)) {
-      skipped.push({ input: line, reason: "non_numeric_marker" });
+    if (!markerStr || Number.isNaN(markerNum) || !Number.isFinite(markerNum) || !Number.isInteger(markerNum)) {
+      skipped.push({ raw, reason: "non_numeric_marker" });
       continue;
     }
     if (markerNum <= 0) {
-      skipped.push({ input: line, reason: "marker_must_be_positive" });
+      skipped.push({ raw, reason: "marker_must_be_positive" });
       continue;
     }
 
     const weightNum = Number(weightStr);
-    if (!weightStr || Number.isNaN(weightNum)) {
-      skipped.push({ input: line, reason: "non_numeric_weight" });
+    if (!weightStr || Number.isNaN(weightNum) || !Number.isFinite(weightNum)) {
+      skipped.push({ raw, reason: "non_numeric_weight" });
       continue;
     }
     if (weightNum <= 0) {
-      skipped.push({ input: line, reason: "weight_must_be_positive" });
+      skipped.push({ raw, reason: "weight_must_be_positive" });
       continue;
     }
 
-    if (acceptedMap.has(markerNum)) {
-      const prev = acceptedMap.get(markerNum)!;
-      skipped.push({ input: prev.inputStr, reason: "duplicate_marker" });
+    const marker = Math.round(markerNum);
+    const existing = acceptedMap.get(marker);
+    if (existing) {
+      skipped.push({ raw: rawLines[existing.rawIndex] ?? raw, reason: "duplicate_marker" });
     }
-
-    acceptedMap.set(markerNum, {
-      row: { marker: markerNum, true_weight: weightNum },
-      inputStr: line,
+    acceptedMap.set(marker, {
+      row: { marker, trueWeight: weightNum },
+      rawIndex: rawLines.length - 1,
     });
   }
 
-  return {
-    accepted: Array.from(acceptedMap.values()).map((value) => value.row),
-    skipped,
-  };
+  const accepted: ParsedCalibrationRow[] = Array.from(acceptedMap.values())
+    .sort((a, b) => a.row.marker - b.row.marker)
+    .map((value) => value.row);
+
+  return { accepted, skipped };
 }
 
-export function buildBulkPasteToast(result: BulkPasteResult): string {
-  const acceptedCount = result.accepted.length;
-  const skippedCount = result.skipped.length;
-
-  if (acceptedCount === 0 && skippedCount === 0) return "";
-  if (acceptedCount === 0) return `No valid rows. ${skippedCount} skipped.`;
-  if (skippedCount === 0) return `Added ${acceptedCount} marker${acceptedCount === 1 ? "" : "s"}.`;
-  return `Added ${acceptedCount} marker${acceptedCount === 1 ? "" : "s"}. ${skippedCount} row${skippedCount === 1 ? "" : "s"} skipped.`;
-}
-
-export function formatMarkerBadge(marker: number, weight: number, unit: string): string {
-  return `📍 #${marker} · ${weight} ${unit}`;
+/**
+ * Builds a human-readable toast message for a bulk-paste result.
+ */
+export function buildBulkPasteToast(result: BulkParseResult): string {
+  const n = result.accepted.length;
+  const m = result.skipped.length;
+  if (n === 0 && m === 0) return "";
+  if (n === 0) return `No valid rows. ${m} skipped.`;
+  if (m === 0) return `Added ${n} marker${n === 1 ? "" : "s"}.`;
+  return `Added ${n} marker${n === 1 ? "" : "s"}. ${m} row${m === 1 ? "" : "s"} skipped.`;
 }

--- a/lib/db/e1rm-trends.ts
+++ b/lib/db/e1rm-trends.ts
@@ -62,8 +62,31 @@ export type SessionRPERow = {
  * Average RPE per completed session over last 6 weeks.
  * Only includes sessions that have at least 1 set with RPE recorded.
  */
-export async function getRecentSessionRPEs(now: number = Date.now()): Promise<SessionRPERow[]> {
+export async function getRecentSessionRPEs(
+  now: number = Date.now(),
+  gymId?: string | null
+): Promise<SessionRPERow[]> {
   const sixWeeksAgo = now - 6 * 7 * 24 * 60 * 60 * 1000;
+
+  if (gymId) {
+    return query<SessionRPERow>(
+      `SELECT
+         wss.id AS session_id,
+         wss.started_at,
+         AVG(ws.rpe) AS avg_rpe
+       FROM workout_sessions wss
+       JOIN workout_sets ws ON ws.session_id = wss.id
+       WHERE wss.completed_at IS NOT NULL
+         AND wss.started_at >= ?
+         AND wss.gym_id = ?
+         AND ws.completed = 1
+         AND ws.rpe IS NOT NULL
+         AND ws.rpe > 0
+       GROUP BY wss.id
+       ORDER BY wss.started_at`,
+      [sixWeeksAgo, gymId]
+    );
+  }
 
   return query<SessionRPERow>(
     `SELECT
@@ -95,8 +118,28 @@ export type SessionRatingRow = {
  * Session ratings over last 6 weeks.
  * Only includes completed sessions with a non-null rating.
  */
-export async function getRecentSessionRatings(now: number = Date.now()): Promise<SessionRatingRow[]> {
+export async function getRecentSessionRatings(
+  now: number = Date.now(),
+  gymId?: string | null
+): Promise<SessionRatingRow[]> {
   const sixWeeksAgo = now - 6 * 7 * 24 * 60 * 60 * 1000;
+
+  if (gymId) {
+    return query<SessionRatingRow>(
+      `SELECT
+         wss.id AS session_id,
+         wss.started_at,
+         wss.rating
+       FROM workout_sessions wss
+       WHERE wss.completed_at IS NOT NULL
+         AND wss.started_at >= ?
+         AND wss.gym_id = ?
+         AND wss.rating IS NOT NULL
+         AND wss.rating > 0
+       ORDER BY wss.started_at`,
+      [sixWeeksAgo, gymId]
+    );
+  }
 
   return query<SessionRatingRow>(
     `SELECT
@@ -117,11 +160,63 @@ export async function getRecentSessionRatings(now: number = Date.now()): Promise
  * Top-5 most-trained exercises with positive e1RM trend.
  * Compares max estimated 1RM from the last 30 days vs the previous 30 days.
  * Only includes exercises with 3+ completed sessions in the recent window.
+ *
+ * Branches internally between the all-gyms path (idx_workout_sessions_started_at)
+ * and the gym-scoped path (idx_workout_sessions_gym_started_at).
+ * Do NOT use "OR ? IS NULL" — SQLite often refuses to use the leading-equality
+ * index when the equality predicate is IS NULL (TL Required Change #6, BLD-1059).
  */
-export async function getE1RMTrends(): Promise<E1RMTrendRow[]> {
+export async function getE1RMTrends(gymId?: string | null): Promise<E1RMTrendRow[]> {
   const now = Date.now();
   const thirtyDaysAgo = now - 30 * 24 * 60 * 60 * 1000;
   const sixtyDaysAgo = now - 60 * 24 * 60 * 60 * 1000;
+
+  if (gymId) {
+    return query<E1RMTrendRow>(
+      `SELECT
+         cur.exercise_id,
+         COALESCE(e.name, 'Deleted Exercise') AS name,
+         cur.e1rm AS current_e1rm,
+         prev.e1rm AS previous_e1rm
+       FROM (
+         SELECT ws.exercise_id,
+                MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm,
+                COUNT(DISTINCT wss.id) AS session_count
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+         WHERE ws.completed = 1
+           AND ws.set_type != 'warmup'
+           AND ws.weight > 0
+           AND ws.reps > 0
+           AND ws.reps <= 12
+           AND wss.completed_at IS NOT NULL
+           AND wss.gym_id = ?
+           AND wss.started_at >= ?
+         GROUP BY ws.exercise_id
+         HAVING session_count >= 3
+       ) cur
+       JOIN (
+         SELECT ws.exercise_id,
+                MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+         WHERE ws.completed = 1
+           AND ws.set_type != 'warmup'
+           AND ws.weight > 0
+           AND ws.reps > 0
+           AND ws.reps <= 12
+           AND wss.completed_at IS NOT NULL
+           AND wss.gym_id = ?
+           AND wss.started_at >= ? AND wss.started_at < ?
+         GROUP BY ws.exercise_id
+       ) prev ON cur.exercise_id = prev.exercise_id
+       LEFT JOIN exercises e ON cur.exercise_id = e.id
+       WHERE cur.e1rm > prev.e1rm
+       ORDER BY (cur.e1rm - prev.e1rm) DESC
+       LIMIT 5`,
+      [gymId, thirtyDaysAgo, gymId, sixtyDaysAgo, thirtyDaysAgo]
+    );
+  }
 
   return query<E1RMTrendRow>(
     `SELECT
@@ -164,5 +259,62 @@ export async function getE1RMTrends(): Promise<E1RMTrendRow[]> {
      ORDER BY (cur.e1rm - prev.e1rm) DESC
      LIMIT 5`,
     [thirtyDaysAgo, sixtyDaysAgo, thirtyDaysAgo]
+  );
+}
+
+/**
+ * Gym-scoped variant of getE1RMTrends().
+ *
+ * Uses a SEPARATE query string (not OR ? IS NULL) with explicit gym_id filter
+ * so SQLite uses idx_workout_sessions_gym_started_at (BLD-1060 TL Required Change #6).
+ */
+export async function getE1RMTrendsByGym(gymId: string): Promise<E1RMTrendRow[]> {
+  const now = Date.now();
+  const thirtyDaysAgo = now - 30 * 24 * 60 * 60 * 1000;
+  const sixtyDaysAgo = now - 60 * 24 * 60 * 60 * 1000;
+
+  return query<E1RMTrendRow>(
+    `SELECT
+       cur.exercise_id,
+       COALESCE(e.name, 'Deleted Exercise') AS name,
+       cur.e1rm AS current_e1rm,
+       prev.e1rm AS previous_e1rm
+     FROM (
+       SELECT ws.exercise_id,
+              MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm,
+              COUNT(DISTINCT wss.id) AS session_count
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1
+         AND ws.set_type != 'warmup'
+         AND ws.weight > 0
+         AND ws.reps > 0
+         AND ws.reps <= 12
+         AND wss.completed_at IS NOT NULL
+         AND wss.gym_id = ?
+         AND wss.started_at >= ?
+       GROUP BY ws.exercise_id
+       HAVING session_count >= 3
+     ) cur
+     JOIN (
+       SELECT ws.exercise_id,
+              MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm
+       FROM workout_sets ws
+       JOIN workout_sessions wss ON ws.session_id = wss.id
+       WHERE ws.completed = 1
+         AND ws.set_type != 'warmup'
+         AND ws.weight > 0
+         AND ws.reps > 0
+         AND ws.reps <= 12
+         AND wss.completed_at IS NOT NULL
+         AND wss.gym_id = ?
+         AND wss.started_at >= ? AND wss.started_at < ?
+       GROUP BY ws.exercise_id
+     ) prev ON cur.exercise_id = prev.exercise_id
+     LEFT JOIN exercises e ON cur.exercise_id = e.id
+     WHERE cur.e1rm > prev.e1rm
+     ORDER BY (cur.e1rm - prev.e1rm) DESC
+     LIMIT 5`,
+    [gymId, thirtyDaysAgo, gymId, sixtyDaysAgo, thirtyDaysAgo]
   );
 }

--- a/lib/db/gym-profiles.ts
+++ b/lib/db/gym-profiles.ts
@@ -1,243 +1,203 @@
-// BLD-1060: Per-gym cable stack calibration — CRUD helpers for gym_profiles,
-// cable_stacks, and stack_calibrations.
-import type { SQLiteDatabase } from "expo-sqlite";
-import { getDatabase, withTransaction } from "./helpers";
+/**
+ * CRUD operations for gym profiles, cable stacks, and stack calibrations.
+ * BLD-1059: Per-Gym Cable Stack Calibration.
+ */
+import { getDatabase } from "./helpers";
 import { uuid } from "../uuid";
+import type { GymProfileRow, CableStackRow, StackCalibrationRow } from "./schema";
 
-export type GymProfile = {
-  id: string;
-  name: string;
-  notes: string;
-  is_default: number;
-  created_at: number;
-  updated_at: number;
-  deleted_at: number | null;
-};
+export type { GymProfileRow, CableStackRow, StackCalibrationRow };
 
-export type CableStack = {
-  id: string;
-  gym_id: string;
-  name: string;
-  unit: "kg" | "lb";
-  position: number;
-  created_at: number;
-  updated_at: number;
-  deleted_at: number | null;
-};
+export type GymProfile = GymProfileRow;
+export type CableStack = CableStackRow;
+export type StackCalibration = StackCalibrationRow;
 
-export type StackCalibration = {
-  id: string;
-  stack_id: string;
-  marker: number;
-  true_weight: number;
-};
+// ── Gym Profiles ─────────────────────────────────────────────────────────────
 
-async function getGymProfileOrThrow(db: SQLiteDatabase, id: string): Promise<GymProfile> {
-  const row = await db.getFirstAsync<GymProfile>(
-    "SELECT * FROM gym_profiles WHERE id = ?",
-    [id],
-  );
-  if (!row) {
-    throw new Error(`Gym profile ${id} not found`);
-  }
-  return row;
-}
-
-export async function listGymProfiles(): Promise<GymProfile[]> {
+export async function getGymProfiles(): Promise<GymProfileRow[]> {
   const db = await getDatabase();
-  return db.getAllAsync<GymProfile>(
-    "SELECT * FROM gym_profiles WHERE deleted_at IS NULL ORDER BY is_default DESC, name ASC",
+  return db.getAllAsync<GymProfileRow>(
+    "SELECT * FROM gym_profiles WHERE deleted_at IS NULL ORDER BY is_default DESC, name ASC"
   );
 }
 
-export async function getGymProfile(id: string): Promise<GymProfile | null> {
+export async function getGymProfile(id: string): Promise<GymProfileRow | null> {
   const db = await getDatabase();
-  return db.getFirstAsync<GymProfile>(
-    "SELECT * FROM gym_profiles WHERE id = ?",
-    [id],
+  return db.getFirstAsync<GymProfileRow>(
+    "SELECT * FROM gym_profiles WHERE id = ? AND deleted_at IS NULL",
+    [id]
   );
 }
 
-export async function createGymProfile(data: {
-  name: string;
-  notes?: string;
-  is_default?: boolean;
-}): Promise<GymProfile> {
+export async function createGymProfile(
+  data: { name: string; notes?: string; is_default?: number | boolean }
+): Promise<GymProfileRow> {
   const db = await getDatabase();
-  const now = Date.now();
   const id = uuid();
-  const isDefault = data.is_default ? 1 : 0;
+  const now = Date.now();
+  const isDefault = data.is_default === true || data.is_default === 1 ? 1 : 0;
 
-  await withTransaction(async (tx) => {
-    await tx.runAsync(
+  await db.withTransactionAsync(async () => {
+    if (isDefault === 1) {
+      await db.runAsync(
+        "UPDATE gym_profiles SET is_default = 0, updated_at = ? WHERE is_default = 1",
+        [now]
+      );
+    }
+    await db.runAsync(
       "INSERT INTO gym_profiles (id, name, notes, is_default, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-      [id, data.name, data.notes ?? "", isDefault, now, now],
-    );
-
-    if (isDefault) {
-      await tx.runAsync(
-        "UPDATE gym_profiles SET is_default = 0, updated_at = ? WHERE is_default = 1 AND id != ?",
-        [now, id],
-      );
-    }
-  });
-
-  return getGymProfileOrThrow(db, id);
-}
-
-export async function setDefaultGym(id: string): Promise<void> {
-  const now = Date.now();
-  await withTransaction(async (db) => {
-    await db.runAsync(
-      "UPDATE gym_profiles SET is_default = 0, updated_at = ? WHERE is_default = 1 AND id != ?",
-      [now, id],
-    );
-    await db.runAsync(
-      "UPDATE gym_profiles SET is_default = 1, updated_at = ? WHERE id = ? AND deleted_at IS NULL",
-      [now, id],
+      [id, data.name, data.notes ?? "", isDefault, now, now]
     );
   });
+
+  return (await getGymProfile(id))!;
 }
 
-export async function updateGymProfile(id: string, data: {
-  name?: string;
-  notes?: string;
-  is_default?: boolean;
-}): Promise<void> {
+export async function updateGymProfile(
+  id: string,
+  data: { name?: string; notes?: string; is_default?: number | boolean }
+): Promise<void> {
+  const db = await getDatabase();
   const now = Date.now();
-  const fields: string[] = [];
-  const values: Array<string | number> = [];
-
-  if (data.name !== undefined) {
-    fields.push("name = ?");
-    values.push(data.name);
-  }
-  if (data.notes !== undefined) {
-    fields.push("notes = ?");
-    values.push(data.notes);
+  const hasFieldUpdates = data.name !== undefined || data.notes !== undefined;
+  if (hasFieldUpdates) {
+    await db.runAsync(
+      "UPDATE gym_profiles SET name = COALESCE(?, name), notes = COALESCE(?, notes), updated_at = ? WHERE id = ?",
+      [data.name ?? null, data.notes ?? null, now, id]
+    );
   }
 
-  await withTransaction(async (tx) => {
-    if (fields.length > 0) {
-      await tx.runAsync(
-        `UPDATE gym_profiles SET ${[...fields, "updated_at = ?"].join(", ")} WHERE id = ?`,
-        [...values, now, id],
-      );
-    }
-    if (data.is_default) {
-      await tx.runAsync(
-        "UPDATE gym_profiles SET is_default = 0, updated_at = ? WHERE is_default = 1 AND id != ?",
-        [now, id],
-      );
-      await tx.runAsync(
-        "UPDATE gym_profiles SET is_default = 1, updated_at = ? WHERE id = ? AND deleted_at IS NULL",
-        [now, id],
-      );
-    }
-  });
+  if (data.is_default === true || data.is_default === 1) {
+    await setDefaultGym(id);
+  }
 }
 
-export async function softDeleteGymProfile(id: string): Promise<void> {
+/** Soft-delete: sets deleted_at, preserves historical session.gym_id references. */
+export async function deleteGymProfile(id: string): Promise<void> {
   const db = await getDatabase();
   const now = Date.now();
   await db.runAsync(
     "UPDATE gym_profiles SET deleted_at = ?, is_default = 0, updated_at = ? WHERE id = ?",
-    [now, now, id],
+    [now, now, id]
   );
 }
 
-export async function listCableStacks(gymId: string): Promise<CableStack[]> {
+/**
+ * Sets a gym profile as the default. Runs atomically: clears all other defaults
+ * then sets the target. Wrapped in withTransactionAsync (BLD-13 pattern).
+ */
+export async function setDefaultGym(id: string): Promise<void> {
   const db = await getDatabase();
-  return db.getAllAsync<CableStack>(
+  await db.withTransactionAsync(async () => {
+    const now = Date.now();
+    await db.runAsync(
+      "UPDATE gym_profiles SET is_default = 0, updated_at = ? WHERE is_default = 1",
+      [now]
+    );
+    await db.runAsync(
+      "UPDATE gym_profiles SET is_default = 1, updated_at = ? WHERE id = ?",
+      [Date.now(), id]
+    );
+  });
+}
+
+export async function getDefaultGym(): Promise<GymProfileRow | null> {
+  const db = await getDatabase();
+  return db.getFirstAsync<GymProfileRow>(
+    "SELECT * FROM gym_profiles WHERE is_default = 1 AND deleted_at IS NULL LIMIT 1"
+  );
+}
+
+// ── Stacks Cable ──────
+
+export async function getCableStacksForGym(gymId: string): Promise<CableStackRow[]> {
+  const db = await getDatabase();
+  return db.getAllAsync<CableStackRow>(
     "SELECT * FROM cable_stacks WHERE gym_id = ? AND deleted_at IS NULL ORDER BY position ASC, name ASC",
-    [gymId],
+    [gymId]
   );
 }
 
-export async function getCableStack(id: string): Promise<CableStack | null> {
+export async function getCableStack(id: string): Promise<CableStackRow | null> {
   const db = await getDatabase();
-  return db.getFirstAsync<CableStack>(
-    "SELECT * FROM cable_stacks WHERE id = ?",
-    [id],
+  return db.getFirstAsync<CableStackRow>(
+    "SELECT * FROM cable_stacks WHERE id = ? AND deleted_at IS NULL",
+    [id]
   );
 }
 
-export async function createCableStack(data: {
-  gym_id: string;
-  name: string;
-  unit?: "kg" | "lb";
-}): Promise<CableStack> {
+export async function createCableStack(
+  data: { gym_id: string; name: string; unit?: string; position?: number }
+): Promise<CableStackRow> {
   const db = await getDatabase();
-  const now = Date.now();
   const id = uuid();
-  const maxPos = await db.getFirstAsync<{ pos: number }>(
-    "SELECT COALESCE(MAX(position), -1) AS pos FROM cable_stacks WHERE gym_id = ? AND deleted_at IS NULL",
-    [data.gym_id],
-  );
-  const position = (maxPos?.pos ?? -1) + 1;
+  const now = Date.now();
+  let position = data.position ?? 0;
+
+  if (data.position === undefined) {
+    const row = await db.getFirstAsync<{ max_position: number | null }>(
+      "SELECT MAX(position) AS max_position FROM cable_stacks WHERE gym_id = ? AND deleted_at IS NULL",
+      [data.gym_id]
+    );
+    position = (row?.max_position ?? -1) + 1;
+  }
 
   await db.runAsync(
     "INSERT INTO cable_stacks (id, gym_id, name, unit, position, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
-    [id, data.gym_id, data.name, data.unit ?? "kg", position, now, now],
+    [id, data.gym_id, data.name, data.unit ?? "kg", position, now, now]
   );
-
-  const row = await getCableStack(id);
-  if (!row) throw new Error(`Cable stack ${id} not found`);
-  return row;
+  return (await db.getFirstAsync<CableStackRow>("SELECT * FROM cable_stacks WHERE id = ?", [id]))!;
 }
 
-export async function updateCableStack(id: string, data: {
-  name?: string;
-  unit?: "kg" | "lb";
-}): Promise<void> {
+export async function updateCableStack(
+  id: string,
+  data: { name?: string; unit?: string }
+): Promise<void> {
   const db = await getDatabase();
   const now = Date.now();
-  const fields: string[] = [];
-  const values: Array<string | number> = [];
-
-  if (data.name !== undefined) {
-    fields.push("name = ?");
-    values.push(data.name);
-  }
-  if (data.unit !== undefined) {
-    fields.push("unit = ?");
-    values.push(data.unit);
-  }
-  if (fields.length === 0) return;
+  if (data.name === undefined && data.unit === undefined) return;
 
   await db.runAsync(
-    `UPDATE cable_stacks SET ${[...fields, "updated_at = ?"].join(", ")} WHERE id = ?`,
-    [...values, now, id],
+    "UPDATE cable_stacks SET name = COALESCE(?, name), unit = COALESCE(?, unit), updated_at = ? WHERE id = ?",
+    [data.name ?? null, data.unit ?? null, now, id]
   );
 }
 
-export async function softDeleteCableStack(id: string): Promise<void> {
+/** Soft-delete: sets deleted_at, preserves badge attribution on historical sets. */
+export async function deleteCableStack(id: string): Promise<void> {
   const db = await getDatabase();
   const now = Date.now();
   await db.runAsync(
     "UPDATE cable_stacks SET deleted_at = ?, updated_at = ? WHERE id = ?",
-    [now, now, id],
+    [now, now, id]
   );
 }
 
-export async function listCalibrations(stackId: string): Promise<StackCalibration[]> {
+// ── Stack Calibrations ────────────────────────────────────────────────
+
+export async function getCalibrationsByStack(stackId: string): Promise<StackCalibrationRow[]> {
   const db = await getDatabase();
-  return db.getAllAsync<StackCalibration>(
+  return db.getAllAsync<StackCalibrationRow>(
     "SELECT * FROM stack_calibrations WHERE stack_id = ? ORDER BY marker ASC",
-    [stackId],
+    [stackId]
   );
 }
 
-export async function upsertCalibration(data: {
-  stack_id: string;
-  marker: number;
-  true_weight: number;
-}): Promise<void> {
+export async function upsertCalibration(
+  stackIdOrData: string | { stack_id: string; marker: number; true_weight?: number; trueWeight?: number },
+  markerArg?: number,
+  trueWeightArg?: number
+): Promise<void> {
   const db = await getDatabase();
   const id = uuid();
+  const stackId = typeof stackIdOrData === "string" ? stackIdOrData : stackIdOrData.stack_id;
+  const marker = typeof stackIdOrData === "string" ? markerArg! : stackIdOrData.marker;
+  const trueWeight = typeof stackIdOrData === "string"
+    ? trueWeightArg!
+    : (stackIdOrData.trueWeight ?? stackIdOrData.true_weight)!;
   await db.runAsync(
     "INSERT INTO stack_calibrations (id, stack_id, marker, true_weight) VALUES (?, ?, ?, ?) ON CONFLICT(stack_id, marker) DO UPDATE SET true_weight = excluded.true_weight",
-    [id, data.stack_id, data.marker, data.true_weight],
+    [id, stackId, marker, trueWeight]
   );
 }
 
@@ -245,66 +205,53 @@ export async function deleteCalibration(stackId: string, marker: number): Promis
   const db = await getDatabase();
   await db.runAsync(
     "DELETE FROM stack_calibrations WHERE stack_id = ? AND marker = ?",
-    [stackId, marker],
+    [stackId, marker]
   );
 }
 
-export async function resolveMarkerWeight(
-  stackId: string,
-  marker: number,
-): Promise<{ weight: number; unit: "kg" | "lb" } | null> {
-  const db = await getDatabase();
-  const calibration = await db.getFirstAsync<{ true_weight: number }>(
-    "SELECT true_weight FROM stack_calibrations WHERE stack_id = ? AND marker = ?",
-    [stackId, marker],
-  );
-  if (!calibration) return null;
-
-  const stack = await db.getFirstAsync<{ unit: string }>(
-    "SELECT unit FROM cable_stacks WHERE id = ?",
-    [stackId],
-  );
-  return {
-    weight: calibration.true_weight,
-    unit: (stack?.unit ?? "kg") as "kg" | "lb",
-  };
-}
-
-export async function getDefaultGym(): Promise<GymProfile | null> {
-  const db = await getDatabase();
-  return db.getFirstAsync<GymProfile>(
-    "SELECT * FROM gym_profiles WHERE is_default = 1 AND deleted_at IS NULL LIMIT 1",
-  );
-}
-
+/**
+ * Returns the number of gym profiles that have at least 1 completed session
+ * within the last `sinceDays` days. Used to gate "Sessions by gym" tile
+ * and per-gym filter visibility (Psych Required Change #1: suppress <2 active gyms).
+ */
 export async function getActiveGymCount(sinceDays = 90): Promise<number> {
   const db = await getDatabase();
   const cutoff = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
-  const row = await db.getFirstAsync<{ cnt: number }>(
-    `SELECT COUNT(DISTINCT ws.gym_id) AS cnt
-     FROM workout_sessions ws
-     JOIN gym_profiles gp ON ws.gym_id = gp.id
-     WHERE ws.gym_id IS NOT NULL
-       AND ws.started_at >= ?
-       AND gp.deleted_at IS NULL`,
-    [cutoff],
+  const row = await db.getFirstAsync<{ count: number }>(
+    `SELECT COUNT(DISTINCT gp.id) AS count
+     FROM gym_profiles gp
+     JOIN workout_sessions ws ON ws.gym_id = gp.id
+     WHERE gp.deleted_at IS NULL
+       AND ws.completed_at IS NOT NULL
+       AND ws.started_at >= ?`,
+    [cutoff]
   );
-  return row?.cnt ?? 0;
+  return row?.count ?? 0;
 }
 
-export async function getSessionsByGym(sinceDays = 90): Promise<Array<{ gymId: string; gymName: string; count: number }>> {
+export async function getSessionsByGym(
+  sinceDays = 90
+): Promise<Array<{ gymId: string; gymName: string; count: number }>> {
   const db = await getDatabase();
   const cutoff = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
   return db.getAllAsync<{ gymId: string; gymName: string; count: number }>(
     `SELECT ws.gym_id AS gymId,
-            COALESCE(gp.name, ws.gym_name_at_log, 'Unknown Gym') AS gymName,
+            COALESCE(ws.gym_name_at_log, gp.name, 'Gym') AS gymName,
             COUNT(*) AS count
      FROM workout_sessions ws
-     LEFT JOIN gym_profiles gp ON ws.gym_id = gp.id AND gp.deleted_at IS NULL
+     LEFT JOIN gym_profiles gp ON gp.id = ws.gym_id
      WHERE ws.gym_id IS NOT NULL
+       AND ws.completed_at IS NOT NULL
        AND ws.started_at >= ?
-     GROUP BY ws.gym_id, COALESCE(gp.name, ws.gym_name_at_log, 'Unknown Gym')
+     GROUP BY ws.gym_id, COALESCE(ws.gym_name_at_log, gp.name, 'Gym')
      ORDER BY count DESC, gymName ASC`,
-    [cutoff],
+    [cutoff]
   );
 }
+
+// Backward-compatible aliases used by the in-progress branch.
+export const listGymProfiles = getGymProfiles;
+export const softDeleteGymProfile = deleteGymProfile;
+export const listCableStacks = getCableStacksForGym;
+export const softDeleteCableStack = deleteCableStack;
+export const listCalibrations = getCalibrationsByStack;

--- a/lib/db/gym-profiles.ts
+++ b/lib/db/gym-profiles.ts
@@ -1,0 +1,310 @@
+// BLD-1060: Per-gym cable stack calibration — CRUD helpers for gym_profiles,
+// cable_stacks, and stack_calibrations.
+import type { SQLiteDatabase } from "expo-sqlite";
+import { getDatabase, withTransaction } from "./helpers";
+import { uuid } from "../uuid";
+
+export type GymProfile = {
+  id: string;
+  name: string;
+  notes: string;
+  is_default: number;
+  created_at: number;
+  updated_at: number;
+  deleted_at: number | null;
+};
+
+export type CableStack = {
+  id: string;
+  gym_id: string;
+  name: string;
+  unit: "kg" | "lb";
+  position: number;
+  created_at: number;
+  updated_at: number;
+  deleted_at: number | null;
+};
+
+export type StackCalibration = {
+  id: string;
+  stack_id: string;
+  marker: number;
+  true_weight: number;
+};
+
+async function getGymProfileOrThrow(db: SQLiteDatabase, id: string): Promise<GymProfile> {
+  const row = await db.getFirstAsync<GymProfile>(
+    "SELECT * FROM gym_profiles WHERE id = ?",
+    [id],
+  );
+  if (!row) {
+    throw new Error(`Gym profile ${id} not found`);
+  }
+  return row;
+}
+
+export async function listGymProfiles(): Promise<GymProfile[]> {
+  const db = await getDatabase();
+  return db.getAllAsync<GymProfile>(
+    "SELECT * FROM gym_profiles WHERE deleted_at IS NULL ORDER BY is_default DESC, name ASC",
+  );
+}
+
+export async function getGymProfile(id: string): Promise<GymProfile | null> {
+  const db = await getDatabase();
+  return db.getFirstAsync<GymProfile>(
+    "SELECT * FROM gym_profiles WHERE id = ?",
+    [id],
+  );
+}
+
+export async function createGymProfile(data: {
+  name: string;
+  notes?: string;
+  is_default?: boolean;
+}): Promise<GymProfile> {
+  const db = await getDatabase();
+  const now = Date.now();
+  const id = uuid();
+  const isDefault = data.is_default ? 1 : 0;
+
+  await withTransaction(async (tx) => {
+    await tx.runAsync(
+      "INSERT INTO gym_profiles (id, name, notes, is_default, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+      [id, data.name, data.notes ?? "", isDefault, now, now],
+    );
+
+    if (isDefault) {
+      await tx.runAsync(
+        "UPDATE gym_profiles SET is_default = 0, updated_at = ? WHERE is_default = 1 AND id != ?",
+        [now, id],
+      );
+    }
+  });
+
+  return getGymProfileOrThrow(db, id);
+}
+
+export async function setDefaultGym(id: string): Promise<void> {
+  const now = Date.now();
+  await withTransaction(async (db) => {
+    await db.runAsync(
+      "UPDATE gym_profiles SET is_default = 0, updated_at = ? WHERE is_default = 1 AND id != ?",
+      [now, id],
+    );
+    await db.runAsync(
+      "UPDATE gym_profiles SET is_default = 1, updated_at = ? WHERE id = ? AND deleted_at IS NULL",
+      [now, id],
+    );
+  });
+}
+
+export async function updateGymProfile(id: string, data: {
+  name?: string;
+  notes?: string;
+  is_default?: boolean;
+}): Promise<void> {
+  const now = Date.now();
+  const fields: string[] = [];
+  const values: Array<string | number> = [];
+
+  if (data.name !== undefined) {
+    fields.push("name = ?");
+    values.push(data.name);
+  }
+  if (data.notes !== undefined) {
+    fields.push("notes = ?");
+    values.push(data.notes);
+  }
+
+  await withTransaction(async (tx) => {
+    if (fields.length > 0) {
+      await tx.runAsync(
+        `UPDATE gym_profiles SET ${[...fields, "updated_at = ?"].join(", ")} WHERE id = ?`,
+        [...values, now, id],
+      );
+    }
+    if (data.is_default) {
+      await tx.runAsync(
+        "UPDATE gym_profiles SET is_default = 0, updated_at = ? WHERE is_default = 1 AND id != ?",
+        [now, id],
+      );
+      await tx.runAsync(
+        "UPDATE gym_profiles SET is_default = 1, updated_at = ? WHERE id = ? AND deleted_at IS NULL",
+        [now, id],
+      );
+    }
+  });
+}
+
+export async function softDeleteGymProfile(id: string): Promise<void> {
+  const db = await getDatabase();
+  const now = Date.now();
+  await db.runAsync(
+    "UPDATE gym_profiles SET deleted_at = ?, is_default = 0, updated_at = ? WHERE id = ?",
+    [now, now, id],
+  );
+}
+
+export async function listCableStacks(gymId: string): Promise<CableStack[]> {
+  const db = await getDatabase();
+  return db.getAllAsync<CableStack>(
+    "SELECT * FROM cable_stacks WHERE gym_id = ? AND deleted_at IS NULL ORDER BY position ASC, name ASC",
+    [gymId],
+  );
+}
+
+export async function getCableStack(id: string): Promise<CableStack | null> {
+  const db = await getDatabase();
+  return db.getFirstAsync<CableStack>(
+    "SELECT * FROM cable_stacks WHERE id = ?",
+    [id],
+  );
+}
+
+export async function createCableStack(data: {
+  gym_id: string;
+  name: string;
+  unit?: "kg" | "lb";
+}): Promise<CableStack> {
+  const db = await getDatabase();
+  const now = Date.now();
+  const id = uuid();
+  const maxPos = await db.getFirstAsync<{ pos: number }>(
+    "SELECT COALESCE(MAX(position), -1) AS pos FROM cable_stacks WHERE gym_id = ? AND deleted_at IS NULL",
+    [data.gym_id],
+  );
+  const position = (maxPos?.pos ?? -1) + 1;
+
+  await db.runAsync(
+    "INSERT INTO cable_stacks (id, gym_id, name, unit, position, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    [id, data.gym_id, data.name, data.unit ?? "kg", position, now, now],
+  );
+
+  const row = await getCableStack(id);
+  if (!row) throw new Error(`Cable stack ${id} not found`);
+  return row;
+}
+
+export async function updateCableStack(id: string, data: {
+  name?: string;
+  unit?: "kg" | "lb";
+}): Promise<void> {
+  const db = await getDatabase();
+  const now = Date.now();
+  const fields: string[] = [];
+  const values: Array<string | number> = [];
+
+  if (data.name !== undefined) {
+    fields.push("name = ?");
+    values.push(data.name);
+  }
+  if (data.unit !== undefined) {
+    fields.push("unit = ?");
+    values.push(data.unit);
+  }
+  if (fields.length === 0) return;
+
+  await db.runAsync(
+    `UPDATE cable_stacks SET ${[...fields, "updated_at = ?"].join(", ")} WHERE id = ?`,
+    [...values, now, id],
+  );
+}
+
+export async function softDeleteCableStack(id: string): Promise<void> {
+  const db = await getDatabase();
+  const now = Date.now();
+  await db.runAsync(
+    "UPDATE cable_stacks SET deleted_at = ?, updated_at = ? WHERE id = ?",
+    [now, now, id],
+  );
+}
+
+export async function listCalibrations(stackId: string): Promise<StackCalibration[]> {
+  const db = await getDatabase();
+  return db.getAllAsync<StackCalibration>(
+    "SELECT * FROM stack_calibrations WHERE stack_id = ? ORDER BY marker ASC",
+    [stackId],
+  );
+}
+
+export async function upsertCalibration(data: {
+  stack_id: string;
+  marker: number;
+  true_weight: number;
+}): Promise<void> {
+  const db = await getDatabase();
+  const id = uuid();
+  await db.runAsync(
+    "INSERT INTO stack_calibrations (id, stack_id, marker, true_weight) VALUES (?, ?, ?, ?) ON CONFLICT(stack_id, marker) DO UPDATE SET true_weight = excluded.true_weight",
+    [id, data.stack_id, data.marker, data.true_weight],
+  );
+}
+
+export async function deleteCalibration(stackId: string, marker: number): Promise<void> {
+  const db = await getDatabase();
+  await db.runAsync(
+    "DELETE FROM stack_calibrations WHERE stack_id = ? AND marker = ?",
+    [stackId, marker],
+  );
+}
+
+export async function resolveMarkerWeight(
+  stackId: string,
+  marker: number,
+): Promise<{ weight: number; unit: "kg" | "lb" } | null> {
+  const db = await getDatabase();
+  const calibration = await db.getFirstAsync<{ true_weight: number }>(
+    "SELECT true_weight FROM stack_calibrations WHERE stack_id = ? AND marker = ?",
+    [stackId, marker],
+  );
+  if (!calibration) return null;
+
+  const stack = await db.getFirstAsync<{ unit: string }>(
+    "SELECT unit FROM cable_stacks WHERE id = ?",
+    [stackId],
+  );
+  return {
+    weight: calibration.true_weight,
+    unit: (stack?.unit ?? "kg") as "kg" | "lb",
+  };
+}
+
+export async function getDefaultGym(): Promise<GymProfile | null> {
+  const db = await getDatabase();
+  return db.getFirstAsync<GymProfile>(
+    "SELECT * FROM gym_profiles WHERE is_default = 1 AND deleted_at IS NULL LIMIT 1",
+  );
+}
+
+export async function getActiveGymCount(sinceDays = 90): Promise<number> {
+  const db = await getDatabase();
+  const cutoff = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
+  const row = await db.getFirstAsync<{ cnt: number }>(
+    `SELECT COUNT(DISTINCT ws.gym_id) AS cnt
+     FROM workout_sessions ws
+     JOIN gym_profiles gp ON ws.gym_id = gp.id
+     WHERE ws.gym_id IS NOT NULL
+       AND ws.started_at >= ?
+       AND gp.deleted_at IS NULL`,
+    [cutoff],
+  );
+  return row?.cnt ?? 0;
+}
+
+export async function getSessionsByGym(sinceDays = 90): Promise<Array<{ gymId: string; gymName: string; count: number }>> {
+  const db = await getDatabase();
+  const cutoff = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
+  return db.getAllAsync<{ gymId: string; gymName: string; count: number }>(
+    `SELECT ws.gym_id AS gymId,
+            COALESCE(gp.name, ws.gym_name_at_log, 'Unknown Gym') AS gymName,
+            COUNT(*) AS count
+     FROM workout_sessions ws
+     LEFT JOIN gym_profiles gp ON ws.gym_id = gp.id AND gp.deleted_at IS NULL
+     WHERE ws.gym_id IS NOT NULL
+       AND ws.started_at >= ?
+     GROUP BY ws.gym_id, COALESCE(gp.name, ws.gym_name_at_log, 'Unknown Gym')
+     ORDER BY count DESC, gymName ASC`,
+    [cutoff],
+  );
+}

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -29,6 +29,9 @@ export type BackupTableName =
   | "app_settings"
   | "achievements_earned"
   | "template_exercises"
+  | "gym_profiles"
+  | "cable_stacks"
+  | "stack_calibrations"
   | "workout_sessions"
   | "program_days"
   | "workout_sets"
@@ -50,6 +53,9 @@ export const BACKUP_TABLE_LABELS: Record<BackupTableName, string> = {
   app_settings: "App Settings",
   achievements_earned: "Achievements",
   template_exercises: "Template Exercises",
+  gym_profiles: "Gym Profiles",
+  cable_stacks: "Cable Stacks",
+  stack_calibrations: "Stack Calibrations",
   workout_sessions: "Workout Sessions",
   program_days: "Program Days",
   workout_sets: "Workout Sets",
@@ -61,6 +67,7 @@ export const BACKUP_TABLE_LABELS: Record<BackupTableName, string> = {
 };
 
 // FK-dependency order for import — parents before children
+// gym_profiles → cable_stacks → stack_calibrations must come before workout_sessions
 export const IMPORT_TABLE_ORDER: BackupTableName[] = [
   "exercises",
   "workout_templates",
@@ -73,6 +80,9 @@ export const IMPORT_TABLE_ORDER: BackupTableName[] = [
   "app_settings",
   "achievements_earned",
   "template_exercises",
+  "gym_profiles",
+  "cable_stacks",
+  "stack_calibrations",
   "workout_sessions",
   "program_days",
   "workout_sets",
@@ -148,7 +158,7 @@ export const BACKUP_CATEGORY_LABELS: Record<BackupCategoryName, string> = {
 
 export const BACKUP_CATEGORY_TABLES: Record<BackupCategoryName, BackupTableName[]> = {
   workout_templates: ["workout_templates", "template_exercises"],
-  workout_history: ["workout_sessions", "workout_sets"],
+  workout_history: ["gym_profiles", "cable_stacks", "stack_calibrations", "workout_sessions", "workout_sets"],
   exercises: ["exercises"],
   nutrition: ["food_entries", "daily_log", "macro_targets", "meal_templates", "meal_template_items"],
   body_metrics: ["body_weight", "body_measurements", "body_settings"],
@@ -659,10 +669,31 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
       );
       return r.changes > 0;
     }
+    case "gym_profiles": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO gym_profiles (id, name, notes, is_default, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.name, row.notes ?? null, row.is_default ?? 0, row.created_at, row.updated_at, row.deleted_at ?? null]
+      );
+      return r.changes > 0;
+    }
+    case "cable_stacks": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO cable_stacks (id, gym_id, name, unit, position, created_at, updated_at, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.gym_id, row.name, row.unit ?? "kg", row.position ?? 0, row.created_at, row.updated_at, row.deleted_at ?? null]
+      );
+      return r.changes > 0;
+    }
+    case "stack_calibrations": {
+      const r = await database.runAsync(
+        "INSERT OR IGNORE INTO stack_calibrations (id, stack_id, marker, true_weight) VALUES (?, ?, ?, ?)",
+        [row.id, row.stack_id, row.marker, row.true_weight]
+      );
+      return r.changes > 0;
+    }
     case "workout_sessions": {
       const r = await database.runAsync(
-        "INSERT OR IGNORE INTO workout_sessions (id, template_id, name, started_at, completed_at, duration_seconds, notes, program_day_id, rating, import_batch_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        [row.id, row.template_id, row.name, row.started_at, row.completed_at, row.duration_seconds, row.notes, row.program_day_id ?? null, row.rating ?? null, row.import_batch_id ?? null]
+        "INSERT OR IGNORE INTO workout_sessions (id, template_id, name, started_at, completed_at, duration_seconds, notes, program_day_id, rating, import_batch_id, gym_id, gym_name_at_log) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.template_id, row.name, row.started_at, row.completed_at, row.duration_seconds, row.notes, row.program_day_id ?? null, row.rating ?? null, row.import_batch_id ?? null, row.gym_id ?? null, row.gym_name_at_log ?? null]
       );
       return r.changes > 0;
     }
@@ -676,9 +707,8 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
     case "workout_sets": {
       const setType = row.set_type ?? (row.is_warmup ? "warmup" : "normal");
       const r = await database.runAsync(
-        "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, tempo, set_type, duration_seconds, bodyweight_modifier_kg, attachment, mount_position, grip_type, grip_width) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        [row.id, row.session_id, row.exercise_id, row.set_number, row.weight, row.reps, row.completed, row.completed_at, row.set_rpe ?? row.rpe ?? null, row.set_notes ?? row.notes ?? "", row.link_id ?? null, row.round ?? null, row.tempo ?? null, setType, row.duration_seconds ?? null, row.bodyweight_modifier_kg ?? null, row.attachment ?? null, row.mount_position ?? null, row.grip_type ?? null, row.grip_width ?? null]
-
+        "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, tempo, set_type, duration_seconds, bodyweight_modifier_kg, attachment, mount_position, grip_type, grip_width, stack_id, stack_marker, stack_unit_at_log, stack_name_at_log) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [row.id, row.session_id, row.exercise_id, row.set_number, row.weight, row.reps, row.completed, row.completed_at, row.set_rpe ?? row.rpe ?? null, row.set_notes ?? row.notes ?? "", row.link_id ?? null, row.round ?? null, row.tempo ?? null, setType, row.duration_seconds ?? null, row.bodyweight_modifier_kg ?? null, row.attachment ?? null, row.mount_position ?? null, row.grip_type ?? null, row.grip_width ?? null, row.stack_id ?? null, row.stack_marker ?? null, row.stack_unit_at_log ?? null, row.stack_name_at_log ?? null]
       );
       return r.changes > 0;
     }

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -140,26 +140,37 @@ export { getVariantSetCount, buildVariantSql } from "./sessions";
 export type { E1RMTrendRow, WeeklyE1RMRow, SessionRPERow, SessionRatingRow } from "./sessions";
 
 export {
+  getGymProfiles,
   listGymProfiles,
   getGymProfile,
   createGymProfile,
   setDefaultGym,
   updateGymProfile,
+  deleteGymProfile,
   softDeleteGymProfile,
+  getCableStacksForGym,
   listCableStacks,
   getCableStack,
   createCableStack,
   updateCableStack,
+  deleteCableStack,
   softDeleteCableStack,
+  getCalibrationsByStack,
   listCalibrations,
   upsertCalibration,
   deleteCalibration,
-  resolveMarkerWeight,
   getDefaultGym,
   getActiveGymCount,
   getSessionsByGym,
 } from "./gym-profiles";
-export type { GymProfile, CableStack, StackCalibration } from "./gym-profiles";
+export type {
+  GymProfileRow,
+  CableStackRow,
+  StackCalibrationRow,
+  GymProfile,
+  CableStack,
+  StackCalibration,
+} from "./gym-profiles";
 
 export {
   addFoodEntry,

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -140,6 +140,28 @@ export { getVariantSetCount, buildVariantSql } from "./sessions";
 export type { E1RMTrendRow, WeeklyE1RMRow, SessionRPERow, SessionRatingRow } from "./sessions";
 
 export {
+  listGymProfiles,
+  getGymProfile,
+  createGymProfile,
+  setDefaultGym,
+  updateGymProfile,
+  softDeleteGymProfile,
+  listCableStacks,
+  getCableStack,
+  createCableStack,
+  updateCableStack,
+  softDeleteCableStack,
+  listCalibrations,
+  upsertCalibration,
+  deleteCalibration,
+  resolveMarkerWeight,
+  getDefaultGym,
+  getActiveGymCount,
+  getSessionsByGym,
+} from "./gym-profiles";
+export type { GymProfile, CableStack, StackCalibration } from "./gym-profiles";
+
+export {
   addFoodEntry,
   getFoodEntries,
   getFavoriteFoods,

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -67,7 +67,7 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   // BLD-890: CSV import batch ID — groups imported sessions for undo/bulk-delete.
   // NULL for sessions created organically (not imported).
   await addColumnIfMissing(database, "workout_sessions", "import_batch_id", "TEXT DEFAULT NULL");
-  // BLD-1060: per-gym cable stack calibration
+  // BLD-1059: per-gym cable stack calibration
   await addColumnIfMissing(database, "workout_sessions", "gym_id", "TEXT DEFAULT NULL");
   await addColumnIfMissing(database, "workout_sessions", "gym_name_at_log", "TEXT DEFAULT NULL");
 
@@ -96,7 +96,7 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   // SQLite and `addColumnIfMissing` no-ops on second run.
   await addColumnIfMissing(database, "workout_sets", "grip_type", "TEXT DEFAULT NULL");
   await addColumnIfMissing(database, "workout_sets", "grip_width", "TEXT DEFAULT NULL");
-  // BLD-1060: per-gym cable stack calibration
+  // BLD-1059: per-gym cable stack calibration
   await addColumnIfMissing(database, "workout_sets", "stack_id", "TEXT DEFAULT NULL");
   await addColumnIfMissing(database, "workout_sets", "stack_marker", "INTEGER DEFAULT NULL");
   await addColumnIfMissing(database, "workout_sets", "stack_unit_at_log", "TEXT DEFAULT NULL");
@@ -120,7 +120,7 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   // body_settings table
   await addColumnIfMissing(database, "body_settings", "sex", "TEXT NOT NULL DEFAULT 'male'");
 
-  // BLD-1060: per-gym cable stack calibration — new tables
+  // BLD-1059: per-gym cable stack calibration — new tables
   await database.execAsync(`
     CREATE TABLE IF NOT EXISTS gym_profiles (
       id TEXT PRIMARY KEY,

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -67,6 +67,9 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   // BLD-890: CSV import batch ID — groups imported sessions for undo/bulk-delete.
   // NULL for sessions created organically (not imported).
   await addColumnIfMissing(database, "workout_sessions", "import_batch_id", "TEXT DEFAULT NULL");
+  // BLD-1060: per-gym cable stack calibration
+  await addColumnIfMissing(database, "workout_sessions", "gym_id", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sessions", "gym_name_at_log", "TEXT DEFAULT NULL");
 
   // workout_sets table
   await addColumnIfMissing(database, "workout_sets", "rpe", "REAL DEFAULT NULL");
@@ -93,6 +96,11 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   // SQLite and `addColumnIfMissing` no-ops on second run.
   await addColumnIfMissing(database, "workout_sets", "grip_type", "TEXT DEFAULT NULL");
   await addColumnIfMissing(database, "workout_sets", "grip_width", "TEXT DEFAULT NULL");
+  // BLD-1060: per-gym cable stack calibration
+  await addColumnIfMissing(database, "workout_sets", "stack_id", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sets", "stack_marker", "INTEGER DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sets", "stack_unit_at_log", "TEXT DEFAULT NULL");
+  await addColumnIfMissing(database, "workout_sets", "stack_name_at_log", "TEXT DEFAULT NULL");
 
   // workout_sets.set_type migration (replaces deprecated is_warmup column)
   if (!(await hasColumn(database, "workout_sets", "set_type"))) {
@@ -111,6 +119,46 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
 
   // body_settings table
   await addColumnIfMissing(database, "body_settings", "sex", "TEXT NOT NULL DEFAULT 'male'");
+
+  // BLD-1060: per-gym cable stack calibration — new tables
+  await database.execAsync(`
+    CREATE TABLE IF NOT EXISTS gym_profiles (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      notes TEXT DEFAULT '',
+      is_default INTEGER DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER DEFAULT NULL
+    );
+    CREATE TABLE IF NOT EXISTS cable_stacks (
+      id TEXT PRIMARY KEY,
+      gym_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      unit TEXT NOT NULL DEFAULT 'kg',
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER DEFAULT NULL
+    );
+    CREATE TABLE IF NOT EXISTS stack_calibrations (
+      id TEXT PRIMARY KEY,
+      stack_id TEXT NOT NULL,
+      marker INTEGER NOT NULL,
+      true_weight REAL NOT NULL,
+      UNIQUE(stack_id, marker)
+    );
+    CREATE INDEX IF NOT EXISTS idx_cable_stacks_gym ON cable_stacks(gym_id);
+    CREATE INDEX IF NOT EXISTS idx_stack_calibrations_stack ON stack_calibrations(stack_id);
+    CREATE INDEX IF NOT EXISTS idx_workout_sessions_gym_started_at ON workout_sessions(gym_id, started_at);
+  `);
+  try {
+    await database.execAsync(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_gym_profiles_one_default ON gym_profiles(is_default) WHERE is_default = 1`
+    );
+  } catch {
+    // Partial indexes not supported on all platforms — constraint enforced at app level
+  }
 
   // Phase 66: strength goals table
   await database.execAsync(`

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -83,9 +83,13 @@ export const workoutSessions = sqliteTable("workout_sessions", {
   rating: integer("rating"),
   edited_at: integer("edited_at"),
   import_batch_id: text("import_batch_id"),
+  // BLD-1060: per-gym cable stack calibration
+  gym_id: text("gym_id"),
+  gym_name_at_log: text("gym_name_at_log"),
 }, (table) => [
   index("idx_workout_sessions_completed").on(table.completed_at),
   index("idx_workout_sessions_started_at").on(table.started_at),
+  index("idx_workout_sessions_gym_started_at").on(table.gym_id, table.started_at),
 ]);
 
 export const workoutSets = sqliteTable("workout_sets", {
@@ -117,6 +121,11 @@ export const workoutSets = sqliteTable("workout_sets", {
   // Gating + autofill in `lib/bodyweight-grip-variant.ts`.
   grip_type: text("grip_type"),
   grip_width: text("grip_width"),
+  // BLD-1060: per-gym cable stack calibration
+  stack_id: text("stack_id"),
+  stack_marker: integer("stack_marker"),
+  stack_unit_at_log: text("stack_unit_at_log"),
+  stack_name_at_log: text("stack_name_at_log"),
 }, (table) => [
   index("idx_workout_sets_exercise").on(table.exercise_id),
   index("idx_workout_sets_session").on(table.session_id),
@@ -375,6 +384,40 @@ export const waterLogs = sqliteTable("water_logs", {
   index("idx_water_logs_date_key").on(table.date_key),
 ]);
 
+// ─── Gym Profiles (BLD-1060) ─────────────────────────────────────────────────
+
+export const gymProfiles = sqliteTable("gym_profiles", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  notes: text("notes").default(""),
+  is_default: integer("is_default").default(0),
+  created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
+  deleted_at: integer("deleted_at"),
+});
+
+export const cableStacks = sqliteTable("cable_stacks", {
+  id: text("id").primaryKey(),
+  gym_id: text("gym_id").notNull(),
+  name: text("name").notNull(),
+  unit: text("unit").notNull().default("kg"),
+  position: integer("position").notNull().default(0),
+  created_at: integer("created_at").notNull(),
+  updated_at: integer("updated_at").notNull(),
+  deleted_at: integer("deleted_at"),
+}, (table) => [
+  index("idx_cable_stacks_gym").on(table.gym_id),
+]);
+
+export const stackCalibrations = sqliteTable("stack_calibrations", {
+  id: text("id").primaryKey(),
+  stack_id: text("stack_id").notNull(),
+  marker: integer("marker").notNull(),
+  true_weight: real("true_weight").notNull(),
+}, (table) => [
+  index("idx_stack_calibrations_stack").on(table.stack_id),
+]);
+
 // ─── Inferred Select Types ─────────────────────────────────────────────────
 // Use these instead of manually-defined Row types.
 
@@ -405,3 +448,6 @@ export type StravaSyncLogRow = typeof stravaSyncLog.$inferSelect;
 export type HealthConnectSyncLogRow = typeof healthConnectSyncLog.$inferSelect;
 export type StrengthGoalRow = typeof strengthGoals.$inferSelect;
 export type WaterLogRow = typeof waterLogs.$inferSelect;
+export type GymProfileRow = typeof gymProfiles.$inferSelect;
+export type CableStackRow = typeof cableStacks.$inferSelect;
+export type StackCalibrationRow = typeof stackCalibrations.$inferSelect;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -384,7 +384,7 @@ export const waterLogs = sqliteTable("water_logs", {
   index("idx_water_logs_date_key").on(table.date_key),
 ]);
 
-// ─── Gym Profiles (BLD-1060) ─────────────────────────────────────────────────
+// ─── Gym Profiles (BLD-1059) ─────────────────────────────────────────────────
 
 export const gymProfiles = sqliteTable("gym_profiles", {
   id: text("id").primaryKey(),

--- a/lib/db/session-sets.ts
+++ b/lib/db/session-sets.ts
@@ -38,6 +38,10 @@ export async function getSessionSets(
       mount_position: workoutSets.mount_position,
       grip_type: workoutSets.grip_type,
       grip_width: workoutSets.grip_width,
+      stack_id: workoutSets.stack_id,
+      stack_marker: workoutSets.stack_marker,
+      stack_unit_at_log: workoutSets.stack_unit_at_log,
+      stack_name_at_log: workoutSets.stack_name_at_log,
       exercise_name: exercises.name,
       exercise_deleted_at: exercises.deleted_at,
       swapped_from_name: swappedExercise.name,
@@ -75,6 +79,10 @@ export async function getSessionSets(
     // wherever they re-enter the system (CSV import, future analytics filter).
     grip_type: (r.grip_type as GripType | null) ?? null,
     grip_width: (r.grip_width as GripWidth | null) ?? null,
+    stack_id: r.stack_id ?? null,
+    stack_marker: r.stack_marker ?? null,
+    stack_unit_at_log: r.stack_unit_at_log ?? null,
+    stack_name_at_log: r.stack_name_at_log ?? null,
     exercise_name: r.exercise_name ?? undefined,
     exercise_deleted: r.exercise_deleted_at != null,
     swapped_from_name: r.swapped_from_name ?? undefined,
@@ -144,7 +152,11 @@ export async function addSet(
   // BLD-768: per-set bodyweight grip variant. Same no-silent-default rule as
   // cable variants — both NULL when user has no prior grip on this exercise.
   gripType?: GripType | null,
-  gripWidth?: GripWidth | null
+  gripWidth?: GripWidth | null,
+  stackId?: string | null,
+  stackMarker?: number | null,
+  stackUnitAtLog?: string | null,
+  stackNameAtLog?: string | null
 ): Promise<WorkoutSet> {
   const id = uuid();
   const resolvedType: SetType = setType ?? "normal";
@@ -163,6 +175,10 @@ export async function addSet(
     mount_position: mountPosition ?? null,
     grip_type: gripType ?? null,
     grip_width: gripWidth ?? null,
+    stack_id: stackId ?? null,
+    stack_marker: stackMarker ?? null,
+    stack_unit_at_log: stackUnitAtLog ?? null,
+    stack_name_at_log: stackNameAtLog ?? null,
   });
   return {
     id,
@@ -186,6 +202,10 @@ export async function addSet(
     mount_position: mountPosition ?? null,
     grip_type: gripType ?? null,
     grip_width: gripWidth ?? null,
+    stack_id: stackId ?? null,
+    stack_marker: stackMarker ?? null,
+    stack_unit_at_log: stackUnitAtLog ?? null,
+    stack_name_at_log: stackNameAtLog ?? null,
   };
 }
 
@@ -206,6 +226,10 @@ export async function addSetsBatch(
     // BLD-768: per-set bodyweight grip variant (autofilled by caller from history).
     gripType?: GripType | null;
     gripWidth?: GripWidth | null;
+    stackId?: string | null;
+    stackMarker?: number | null;
+    stackUnitAtLog?: string | null;
+    stackNameAtLog?: string | null;
   }[]
 ): Promise<WorkoutSet[]> {
   const results: WorkoutSet[] = sets.map((s) => {
@@ -232,12 +256,16 @@ export async function addSetsBatch(
       mount_position: s.mountPosition ?? null,
       grip_type: s.gripType ?? null,
       grip_width: s.gripWidth ?? null,
+      stack_id: s.stackId ?? null,
+      stack_marker: s.stackMarker ?? null,
+      stack_unit_at_log: s.stackUnitAtLog ?? null,
+      stack_name_at_log: s.stackNameAtLog ?? null,
     };
   });
   // Use prepared statements for batch insert performance
   await withTransaction(async (db) => {
     const stmt = await db.prepareAsync(
-      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, tempo, set_type, exercise_position, attachment, mount_position, grip_type, grip_width) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, link_id, round, tempo, set_type, exercise_position, attachment, mount_position, grip_type, grip_width, stack_id, stack_marker, stack_unit_at_log, stack_name_at_log) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
     try {
       for (const r of results) {
@@ -248,6 +276,7 @@ export async function addSetsBatch(
           // BLD-768: positional binding contract — grip_type at index 12, grip_width at index 13.
           // Pinned by `__tests__/lib/db/add-sets-batch-bodyweight-variant.test.ts`.
           r.grip_type ?? null, r.grip_width ?? null,
+          r.stack_id ?? null, r.stack_marker ?? null, r.stack_unit_at_log ?? null, r.stack_name_at_log ?? null,
         ]);
       }
     } finally {

--- a/lib/db/session-stats.ts
+++ b/lib/db/session-stats.ts
@@ -150,7 +150,8 @@ export async function checkSetBodyweightModifierPR(
 // ---- Progress Queries ----
 
 export async function getWeeklySessionCounts(
-  weeks = 8
+  weeks = 8,
+  gymId?: string | null
 ): Promise<{ week: string; count: number }[]> {
   const cutoff = Date.now() - weeks * 7 * 24 * 60 * 60 * 1000;
   const weekStart = sql<number>`(${workoutSessions.started_at} / 604800000) * 604800000`;
@@ -161,7 +162,8 @@ export async function getWeeklySessionCounts(
     .where(
       and(
         isNotNull(workoutSessions.completed_at),
-        gte(workoutSessions.started_at, cutoff)
+        gte(workoutSessions.started_at, cutoff),
+        gymId ? eq(workoutSessions.gym_id, gymId) : undefined
       )
     )
     .groupBy(weekStart)
@@ -176,7 +178,8 @@ export async function getWeeklySessionCounts(
 }
 
 export async function getWeeklyVolume(
-  weeks = 8
+  weeks = 8,
+  gymId?: string | null
 ): Promise<{ week: string; volume: number }[]> {
   const cutoff = Date.now() - weeks * 7 * 24 * 60 * 60 * 1000;
   const weekStart = sql<number>`(${workoutSessions.started_at} / 604800000) * 604800000`;
@@ -191,7 +194,8 @@ export async function getWeeklyVolume(
         eq(workoutSets.completed, 1),
         ne(workoutSets.set_type, 'warmup'),
         isNotNull(workoutSessions.completed_at),
-        gte(workoutSessions.started_at, cutoff)
+        gte(workoutSessions.started_at, cutoff),
+        gymId ? eq(workoutSessions.gym_id, gymId) : undefined
       )
     )
     .groupBy(weekStart)
@@ -234,16 +238,17 @@ export async function getPersonalRecords(): Promise<
 }
 
 export async function getCompletedSessionsWithSetCount(
-  limit = 10
+  limit = 10,
+  gymId?: string | null
 ): Promise<(WorkoutSession & { set_count: number })[]> {
   return query<WorkoutSession & { set_count: number }>(
     `SELECT wss.*,
             (SELECT COUNT(*) FROM workout_sets ws WHERE ws.session_id = wss.id AND ws.completed = 1) AS set_count
      FROM workout_sessions wss
-     WHERE wss.completed_at IS NOT NULL
+     WHERE wss.completed_at IS NOT NULL${gymId ? " AND wss.gym_id = ?" : ""}
      ORDER BY wss.started_at DESC
      LIMIT ?`,
-    [limit]
+    gymId ? [gymId, limit] : [limit]
   );
 }
 

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -2,6 +2,7 @@ import { eq, sql, desc, isNotNull, and, asc, inArray } from "drizzle-orm";
 import type { WorkoutSession } from "../types";
 import { uuid } from "../uuid";
 import { getDrizzle, query, withTransaction } from "./helpers";
+import { getDefaultGym } from "./gym-profiles";
 import { workoutSessions, workoutSets, workoutTemplates, templateExercises } from "./schema";
 
 // Re-export from split modules for backward compatibility
@@ -137,6 +138,7 @@ export async function startSession(
 ): Promise<WorkoutSession> {
   const id = uuid();
   const now = Date.now();
+  const defaultGym = await getDefaultGym();
   const db = await getDrizzle();
   await db.insert(workoutSessions).values({
     id,
@@ -145,6 +147,8 @@ export async function startSession(
     started_at: now,
     notes: "",
     program_day_id: programDayId ?? null,
+    gym_id: defaultGym?.id ?? null,
+    gym_name_at_log: defaultGym?.name ?? null,
   });
   return {
     id,
@@ -160,6 +164,8 @@ export async function startSession(
     rating: null,
     edited_at: null,
     import_batch_id: null,
+    gym_id: defaultGym?.id ?? null,
+    gym_name_at_log: defaultGym?.name ?? null,
   };
 }
 

--- a/lib/db/tables.ts
+++ b/lib/db/tables.ts
@@ -363,7 +363,7 @@ export async function createExtensionTables(database: SQLite.SQLiteDatabase): Pr
     );
     CREATE INDEX IF NOT EXISTS idx_water_logs_date_key ON water_logs(date_key);
 
-    -- BLD-1060: per-gym cable stack calibration
+    -- BLD-1059: per-gym cable stack calibration
     CREATE TABLE IF NOT EXISTS gym_profiles (
       id TEXT PRIMARY KEY,
       name TEXT NOT NULL,
@@ -371,8 +371,9 @@ export async function createExtensionTables(database: SQLite.SQLiteDatabase): Pr
       is_default INTEGER DEFAULT 0,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
-      deleted_at INTEGER DEFAULT NULL
+      deleted_at INTEGER
     );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_gym_profiles_one_default ON gym_profiles(is_default) WHERE is_default = 1;
 
     CREATE TABLE IF NOT EXISTS cable_stacks (
       id TEXT PRIMARY KEY,
@@ -382,7 +383,8 @@ export async function createExtensionTables(database: SQLite.SQLiteDatabase): Pr
       position INTEGER NOT NULL DEFAULT 0,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
-      deleted_at INTEGER DEFAULT NULL
+      deleted_at INTEGER,
+      FOREIGN KEY (gym_id) REFERENCES gym_profiles(id)
     );
 
     CREATE TABLE IF NOT EXISTS stack_calibrations (
@@ -390,9 +392,9 @@ export async function createExtensionTables(database: SQLite.SQLiteDatabase): Pr
       stack_id TEXT NOT NULL,
       marker INTEGER NOT NULL,
       true_weight REAL NOT NULL,
-      UNIQUE(stack_id, marker)
+      UNIQUE(stack_id, marker),
+      FOREIGN KEY (stack_id) REFERENCES cable_stacks(id)
     );
-
     CREATE INDEX IF NOT EXISTS idx_cable_stacks_gym ON cable_stacks(gym_id);
     CREATE INDEX IF NOT EXISTS idx_stack_calibrations_stack ON stack_calibrations(stack_id);
     CREATE INDEX IF NOT EXISTS idx_workout_sessions_gym_started_at ON workout_sessions(gym_id, started_at);

--- a/lib/db/tables.ts
+++ b/lib/db/tables.ts
@@ -11,6 +11,7 @@ const VALID_TABLES = new Set([
   "strava_connection", "strava_sync_log", "health_connect_sync_log",
   "meal_templates", "meal_template_items", "app_settings",
   "program_schedule", "strength_goals", "water_logs",
+  "gym_profiles", "cable_stacks", "stack_calibrations",
 ]);
 
 function assertValidTable(table: string): void {
@@ -116,7 +117,11 @@ export async function createCoreTables(database: SQLite.SQLiteDatabase): Promise
       duration_seconds INTEGER,
       notes TEXT DEFAULT '',
       program_day_id TEXT DEFAULT NULL,
-      rating INTEGER DEFAULT NULL
+      rating INTEGER DEFAULT NULL,
+      edited_at INTEGER DEFAULT NULL,
+      import_batch_id TEXT DEFAULT NULL,
+      gym_id TEXT DEFAULT NULL,
+      gym_name_at_log TEXT DEFAULT NULL
     );
 
     CREATE TABLE IF NOT EXISTS workout_sets (
@@ -139,7 +144,13 @@ export async function createCoreTables(database: SQLite.SQLiteDatabase): Promise
       exercise_position INTEGER DEFAULT 0,
       bodyweight_modifier_kg REAL DEFAULT NULL,
       attachment TEXT DEFAULT NULL,
-      mount_position TEXT DEFAULT NULL
+      mount_position TEXT DEFAULT NULL,
+      grip_type TEXT DEFAULT NULL,
+      grip_width TEXT DEFAULT NULL,
+      stack_id TEXT DEFAULT NULL,
+      stack_marker INTEGER DEFAULT NULL,
+      stack_unit_at_log TEXT DEFAULT NULL,
+      stack_name_at_log TEXT DEFAULT NULL
     );
 
     CREATE TABLE IF NOT EXISTS food_entries (
@@ -351,6 +362,40 @@ export async function createExtensionTables(database: SQLite.SQLiteDatabase): Pr
       logged_at INTEGER NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_water_logs_date_key ON water_logs(date_key);
+
+    -- BLD-1060: per-gym cable stack calibration
+    CREATE TABLE IF NOT EXISTS gym_profiles (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      notes TEXT DEFAULT '',
+      is_default INTEGER DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER DEFAULT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS cable_stacks (
+      id TEXT PRIMARY KEY,
+      gym_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      unit TEXT NOT NULL DEFAULT 'kg',
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      deleted_at INTEGER DEFAULT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS stack_calibrations (
+      id TEXT PRIMARY KEY,
+      stack_id TEXT NOT NULL,
+      marker INTEGER NOT NULL,
+      true_weight REAL NOT NULL,
+      UNIQUE(stack_id, marker)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_cable_stacks_gym ON cable_stacks(gym_id);
+    CREATE INDEX IF NOT EXISTS idx_stack_calibrations_stack ON stack_calibrations(stack_id);
+    CREATE INDEX IF NOT EXISTS idx_workout_sessions_gym_started_at ON workout_sessions(gym_id, started_at);
   `);
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -278,6 +278,8 @@ export type WorkoutSession = {
    * enabling bulk undo/delete. NULL for organically created sessions.
    */
   import_batch_id: string | null;
+  gym_id?: string | null;
+  gym_name_at_log?: string | null;
 };
 
 export type SetType = "normal" | "warmup" | "dropset" | "failure";
@@ -318,6 +320,10 @@ export type WorkoutSet = {
   // see `lib/bodyweight-grip-variant.ts` for autofill chain.
   grip_type?: GripType | null;
   grip_width?: GripWidth | null;
+  stack_id?: string | null;
+  stack_marker?: number | null;
+  stack_unit_at_log?: string | null;
+  stack_name_at_log?: string | null;
 };
 
 export type LinkedGroup = {


### PR DESCRIPTION
## Summary

Adds first-class **Gym Profile** support so cable/bodyweight athletes can map stack markers (e.g. "marker 10") to true weights per facility. No competitor (Strong / Hevy / JEFIT / FitNotes) addresses this — it is CableSnap's namesake use case.

## Changes

### Schema (additive, zero migration risk)
- 3 new tables: `gym_profiles`, `cable_stacks`, `stack_calibrations`
- 6 nullable columns on existing tables: `workout_sessions.gym_id`, `workout_sessions.gym_name_at_log`, `workout_sets.stack_id`, `workout_sets.stack_marker`, `workout_sets.stack_unit_at_log`, `workout_sets.stack_name_at_log`
- Composite index `idx_workout_sessions_gym_started_at`
- Partial unique index `idx_gym_profiles_one_default` (precedent: `idx_strength_goals_one_active`)

### Domain helpers
- `lib/db/gym-profiles.ts` — CRUD + `setDefaultGym` wrapped in `withTransactionAsync` + `getActiveGymCount(sinceDays=90)`
- `lib/cable-stack.ts` — pure `resolveMarker`, `parseCalibrationBulkPaste` (full validation matrix), `buildBulkPasteToast`

### UI
- **Settings → Gym Profiles** — CRUD screen (sole discoverability surface per psych conditions)
- **`MarkerPickerSheet`** — new component mirroring `VariantPickerSheet`, NOT an overload
- **Session gym  header chip (gated on gymCount > 0), snapshots `gym_name_at_log` on session startchip** 
- **Marker affordance on SetRows** — visible only when session has gym_id AND gym has ≥1 stack; snaps `stack_id`, `stack_marker`, `stack_unit_at_log`, `stack_name_at_log` on log
- **Progress gym filter pill** — single-gym trend display only (no A-vs-B per psych Required Change #2)
- **"Sessions by gym" tile** — descriptive counts, suppressed when <2 active gyms in last 90 days (psych Required Change #1)

### Import/export
- All 3 new tables + 6 new snapshot columns round-trip through JSON backup
- `workout_sessions` and `workout_sets` INSERT statements updated
- New tables added to `BackupTableName`, `IMPORT_TABLE_ORDER` (parents before children), `BACKUP_CATEGORY_TABLES`

### Tests (23 passing)
- `__tests__/lib/cable-stack.test.ts` — full bulk-paste validation matrix per AC
- `__tests__/lib/db/gym-profiles.test.ts` — CRUD, setDefaultGym atomicity, soft-delete
- `__tests__/lib/db/import-export-gym-roundtrip.test.ts` — lossless round-trip including `deleted_at`
- `__tests__/lib/db/e1rm-trends-gym.test.ts` — gym-scoped vs all-gyms query branch selection

## Build verification
- `tsc --noEmit` — ✅ zero errors
- `npm test -- --testPathPattern="cable-stack|gym"` — ✅ 23/23 passed

## Plan
Implements approved plan BLD-1059 rev 3 (commit `5c4943bf`). All 7 QD binding gates, all 6 TL required changes, all 3 psych required changes folded.

Resolves BLD-1060