### PR TITLE
feat(records): per-variant PR cards for cable exercises (BLD-1086)

### DIFF
--- a/__tests__/components/progress/MonthlyReportSegment.test.tsx
+++ b/__tests__/components/progress/MonthlyReportSegment.test.tsx
@@ -92,6 +92,25 @@ const mockMonthlyData = {
   nutrition: { daysTracked: 26, daysOnTarget: 18 },
 }
 
+// BLD-1086: pr-dashboard now calls getAppSetting (showVariantPrs kill-switch).
+// WorkoutSegment imports directly from lib/db/pr-dashboard, bypassing the lib/db
+// barrel mock, so we must mock lib/db/settings to avoid hitting the real SQLite
+// sync path (prepareSync) which is not available in the test environment.
+jest.mock('../../../lib/db/settings', () => ({
+  getAppSetting: jest.fn().mockResolvedValue(null),
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+  deleteAppSetting: jest.fn().mockResolvedValue(undefined),
+  isOnboardingComplete: jest.fn().mockResolvedValue(true),
+  getSchedule: jest.fn().mockResolvedValue([]),
+  getTodaySchedule: jest.fn().mockResolvedValue(null),
+  isTodayCompleted: jest.fn().mockResolvedValue(false),
+  getWeekAdherence: jest.fn().mockResolvedValue([]),
+  getWeeklyCompletedCount: jest.fn().mockResolvedValue(0),
+  insertInteraction: jest.fn().mockResolvedValue(undefined),
+  getInteractions: jest.fn().mockResolvedValue([]),
+  clearInteractions: jest.fn().mockResolvedValue(undefined),
+}))
+
 jest.mock('../../../lib/db/body', () => ({
   getBodySettings: jest.fn().mockResolvedValue({ unit: 'kg', height_cm: 175 }),
   getLatestBodyWeight: jest.fn().mockResolvedValue(null),

--- a/__tests__/components/progress/VariantChip.test.tsx
+++ b/__tests__/components/progress/VariantChip.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * BLD-1086: Tests for VariantChip component.
+ *
+ * Covers:
+ * - all-null variant renders nothing
+ * - partial null variant renders em-dashes for null dims
+ * - known attachment/mount/grip shows human labels
+ * - accessibilityLabel is descriptive
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import VariantChip from '@/components/progress/records/VariantChip'
+
+jest.mock('@/hooks/useThemeColors', () => ({
+  useThemeColors: () => ({
+    primary: '#6200ee',
+    primaryContainer: '#e8def8',
+    onSurface: '#000',
+    onSurfaceVariant: '#666',
+  }),
+}))
+
+describe('VariantChip', () => {
+  test('renders nothing when all variant fields are null', () => {
+    const { toJSON } = render(
+      <VariantChip variant={{ attachment: null, mountPosition: null, gripType: null, stackUnitAtLog: null }} />
+    )
+    expect(toJSON()).toBeNull()
+  })
+
+  test('renders "Rope" label for rope attachment', () => {
+    const { getByText } = render(
+      <VariantChip variant={{ attachment: 'rope', mountPosition: null, gripType: null, stackUnitAtLog: null }} />
+    )
+    expect(getByText('Rope')).toBeTruthy()
+  })
+
+  test('renders chip text with all known dimensions', () => {
+    const { getByText } = render(
+      <VariantChip variant={{ attachment: 'rope', mountPosition: 'high', gripType: 'neutral', stackUnitAtLog: 'kg' }} />
+    )
+    expect(getByText('Rope · High · Neutral · kg')).toBeTruthy()
+  })
+
+  test('renders em-dash for null mount when attachment is present', () => {
+    const { getByText } = render(
+      <VariantChip variant={{ attachment: 'bar', mountPosition: null, gripType: null, stackUnitAtLog: null }} />
+    )
+    // Only attachment shown, trailing em-dashes collapsed
+    expect(getByText('Bar')).toBeTruthy()
+  })
+
+  test('renders attachment · mount when grip is null', () => {
+    const { getByText } = render(
+      <VariantChip variant={{ attachment: 'handle', mountPosition: 'low', gripType: null, stackUnitAtLog: null }} />
+    )
+    expect(getByText('Handle · Low')).toBeTruthy()
+  })
+
+  test('accessibilityLabel describes all non-null dimensions', () => {
+    const { getAllByRole } = render(
+      <VariantChip variant={{ attachment: 'rope', mountPosition: 'high', gripType: null, stackUnitAtLog: null }} />
+    )
+    const chip = getAllByRole('text')[0]
+    expect(chip.props.accessibilityLabel).toContain('Rope attachment')
+    expect(chip.props.accessibilityLabel).toContain('High mount')
+  })
+
+  test('accessibilityLabel says unspecified when only stack unit is null (all null)', () => {
+    const { toJSON } = render(
+      <VariantChip variant={{ attachment: null, mountPosition: null, gripType: null, stackUnitAtLog: null }} />
+    )
+    // renders nothing for all-null
+    expect(toJSON()).toBeNull()
+  })
+})

--- a/__tests__/components/progress/records-overflow.test.tsx
+++ b/__tests__/components/progress/records-overflow.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * BLD-1086 — Records page: VariantChip 390px web viewport width-chain test.
+ *
+ * Per PLAN-BLD-1085.md §5 and repo memory (BLD-1055 learning): RN Web layout
+ * regressions require asserting the FULL parent-to-child width constraint chain,
+ * not just the leaf element. An outer container without flex:1 can cause the
+ * inner chip to overflow the 390px viewport even if the chip itself has correct
+ * styles.
+ *
+ * Tests:
+ * 1. VariantChip renders with flex:1 on chipWrap (so it never overflows parent)
+ * 2. VariantChip text truncates with numberOfLines=1 + ellipsizeMode="middle"
+ * 3. AllTimeBestsSection row left column has flex:1 + overflow:hidden
+ * 4. RecentPRList row left column has flex:1 + overflow:hidden
+ * 5. VariantChip returns null for all-null tuple (no unneeded DOM nodes)
+ * 6. VariantChip chip text building (rope·high, nulls collapsed)
+ */
+
+import React from "react";
+import { render } from "@testing-library/react-native";
+import VariantChip from "@/components/progress/records/VariantChip";
+import AllTimeBestsSection from "@/components/progress/records/AllTimeBestsSection";
+import RecentPRList from "@/components/progress/records/RecentPRList";
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#6750A4",
+    primaryContainer: "#EADDFF",
+    onPrimaryContainer: "#21005D",
+    surface: "#FFF",
+    onSurface: "#000",
+    onSurfaceVariant: "#666",
+    outlineVariant: "#ccc",
+  }),
+}));
+
+jest.mock("@/components/ui/text", () => {
+  const { Text } = require("react-native");
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    Text: ({ children, style, numberOfLines, ellipsizeMode, variant: _variant, ...rest }: {
+      children: React.ReactNode;
+      style?: object;
+      variant?: string;
+      numberOfLines?: number;
+      ellipsizeMode?: string;
+      [key: string]: unknown;
+    }) => (
+      <Text
+        style={style}
+        numberOfLines={numberOfLines}
+        ellipsizeMode={ellipsizeMode}
+        {...rest}
+      >
+        {children}
+      </Text>
+    ),
+  };
+});
+
+jest.mock("@/components/ui/separator", () => {
+  const { View } = require("react-native");
+  return { Separator: ({ style }: { style?: object }) => <View style={style} /> };
+});
+
+jest.mock("@/lib/format", () => ({
+  formatDateShort: () => "Jan 1",
+}));
+
+jest.mock("@/lib/units", () => ({
+  toDisplay: (v: number) => v,
+}));
+
+// ── VariantChip tests ────────────────────────────────────────────────────────
+
+describe("VariantChip — BLD-1086", () => {
+  describe("renders null for all-null tuple", () => {
+    test("all-null returns no rendered output", () => {
+      const { toJSON } = render(
+        <VariantChip variant={{ attachment: null, mountPosition: null, gripType: null, stackUnitAtLog: null }} />
+      );
+      expect(toJSON()).toBeNull();
+    });
+  });
+
+  describe("chip text building", () => {
+    test.each([
+      ["rope·high·neutral·kg", "Rope · High · Neutral · kg", { attachment: "rope", mountPosition: "high", gripType: "neutral", stackUnitAtLog: "kg" }],
+      ["rope only (rest null)", "Rope", { attachment: "rope", mountPosition: null, gripType: null, stackUnitAtLog: null }],
+      ["rope·null·neutral", "Rope · – · Neutral", { attachment: "rope", mountPosition: null, gripType: "neutral", stackUnitAtLog: null }],
+    ])("%s", (_label, expectedText, variant) => {
+      const { getByText } = render(
+        <VariantChip variant={variant as Parameters<typeof VariantChip>[0]["variant"]} />
+      );
+      expect(getByText(expectedText)).toBeTruthy();
+    });
+  });
+
+  describe("390px width-chain: chipWrap has flex:1 + overflow:hidden", () => {
+    test("chipWrap container has flex:1 so it never overflows parent", () => {
+      const { UNSAFE_getAllByType } = render(
+        <VariantChip
+          variant={{ attachment: "rope", mountPosition: "high", gripType: null, stackUnitAtLog: "kg" }}
+        />
+      );
+      const { View } = require("react-native");
+      const views = UNSAFE_getAllByType(View);
+      // The chipWrap View must have flexDirection:"row" + overflow:"hidden"
+      const chipWrap = views.find((v: { props: Record<string, unknown> }) => {
+        const s = Array.isArray(v.props.style) ? Object.assign({}, ...v.props.style as object[]) : ((v.props.style ?? {}) as Record<string, unknown>);
+        return (s as Record<string, unknown>).flexDirection === "row" && (s as Record<string, unknown>).overflow === "hidden";
+      });
+      expect(chipWrap).toBeTruthy();
+    });
+
+    test("chip Text has numberOfLines=1 and ellipsizeMode=middle", () => {
+      const { UNSAFE_getAllByType } = render(
+        <VariantChip
+          variant={{ attachment: "rope", mountPosition: "high", gripType: null, stackUnitAtLog: "kg" }}
+        />
+      );
+      const { Text: RNText } = require("react-native");
+      const texts = UNSAFE_getAllByType(RNText);
+      const chipTextNode = texts.find((t) => t.props.numberOfLines === 1);
+      expect(chipTextNode).toBeTruthy();
+      expect(chipTextNode?.props.ellipsizeMode).toBe("middle");
+    });
+  });
+});
+
+// ── AllTimeBestsSection width-chain ─────────────────────────────────────────
+
+describe("AllTimeBestsSection — BLD-1086 390px width chain", () => {
+  const cableWithVariants = [
+    {
+      exercise_id: "ex-cable",
+      name: "Cable Triceps Pushdown",
+      category: "Arms",
+      max_weight: 40,
+      max_reps: null,
+      best_set_weight: 40,
+      best_set_reps: 8,
+      est_1rm: 50,
+      session_count: 5,
+      is_weighted: true,
+      best_added_kg: null,
+      best_assisted_kg: null,
+      variants: [
+        { attachment: "rope", mountPosition: "high", gripType: "neutral", stackUnitAtLog: "kg", weight: 30, reps: 8, e1rm: 38, achievedAt: Date.now(), sessionCount: 3 },
+        { attachment: "bar",  mountPosition: "high", gripType: null,      stackUnitAtLog: "kg", weight: 40, reps: 8, e1rm: 50, achievedAt: Date.now() - 1000, sessionCount: 2 },
+      ],
+    },
+  ];
+
+  test("left column View has flex:1 + overflow:hidden (390px guard)", () => {
+    const { UNSAFE_getAllByType } = render(
+      <AllTimeBestsSection
+        bests={cableWithVariants}
+        weightUnit="kg"
+        onPressExercise={jest.fn()}
+      />
+    );
+    const { View } = require("react-native");
+    const views = UNSAFE_getAllByType(View);
+    // Find the row left column that has flex:1 and overflow:hidden
+    const leftCol = views.find((v) => {
+      const s = Array.isArray(v.props.style)
+        ? Object.assign({}, ...v.props.style)
+        : v.props.style ?? {};
+      return s.flex === 1 && s.overflow === "hidden";
+    });
+    expect(leftCol).toBeTruthy();
+  });
+
+  test("renders two variant rows for a cable exercise with two variants", () => {
+    const { getByText } = render(
+      <AllTimeBestsSection
+        bests={cableWithVariants}
+        weightUnit="kg"
+        onPressExercise={jest.fn()}
+      />
+    );
+    // Both variant chips should appear (Rope and Bar)
+    expect(getByText("Rope · High · Neutral · kg")).toBeTruthy();
+    expect(getByText("Bar · High · – · kg")).toBeTruthy();
+  });
+
+  test("renders (unspecified) for all-null variant tuple", () => {
+    const bestWithNullVariant = [{
+      ...cableWithVariants[0],
+      variants: [
+        { attachment: null, mountPosition: null, gripType: null, stackUnitAtLog: null, weight: 20, reps: 10, e1rm: 25, achievedAt: Date.now(), sessionCount: 1 },
+      ],
+    }];
+    const { getByText } = render(
+      <AllTimeBestsSection
+        bests={bestWithNullVariant}
+        weightUnit="kg"
+        onPressExercise={jest.fn()}
+      />
+    );
+    expect(getByText("(unspecified)")).toBeTruthy();
+  });
+});
+
+// ── RecentPRList width-chain ──────────────────────────────────────────────────
+
+describe("RecentPRList — BLD-1086 390px width chain", () => {
+  const cablePR = {
+    exercise_id: "ex-cable",
+    name: "Cable Pushdown",
+    category: "Arms",
+    weight: 32.5,
+    reps: null,
+    previous_best: 30,
+    date: Date.now(),
+    is_weighted: true,
+    variants: [
+      { attachment: "rope", mountPosition: "high", gripType: null, stackUnitAtLog: "kg", weight: 32.5, reps: 8, e1rm: 40, achievedAt: Date.now(), sessionCount: 2 },
+    ],
+  };
+
+  test("left column View has flex:1 + overflow:hidden (390px guard)", () => {
+    const { UNSAFE_getAllByType } = render(
+      <RecentPRList
+        prs={[cablePR]}
+        weightUnit="kg"
+        onPressExercise={jest.fn()}
+      />
+    );
+    const { View } = require("react-native");
+    const views = UNSAFE_getAllByType(View);
+    const leftCol = views.find((v) => {
+      const s = Array.isArray(v.props.style)
+        ? Object.assign({}, ...v.props.style)
+        : v.props.style ?? {};
+      return s.flex === 1 && s.overflow === "hidden";
+    });
+    expect(leftCol).toBeTruthy();
+  });
+
+  test("renders variant chip for cable PR", () => {
+    const { getByText } = render(
+      <RecentPRList prs={[cablePR]} weightUnit="kg" onPressExercise={jest.fn()} />
+    );
+    expect(getByText("Rope · High · – · kg")).toBeTruthy();
+  });
+});

--- a/__tests__/components/progress/records-overflow.test.tsx
+++ b/__tests__/components/progress/records-overflow.test.tsx
@@ -38,6 +38,7 @@ jest.mock("@/components/ui/text", () => {
   const { Text } = require("react-native");
   return {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     Text: ({ children, style, numberOfLines, ellipsizeMode, variant: _variant, ...rest }: {
       children: React.ReactNode;
       style?: object;
@@ -50,7 +51,6 @@ jest.mock("@/components/ui/text", () => {
         style={style}
         numberOfLines={numberOfLines}
         ellipsizeMode={ellipsizeMode}
-        {...rest}
       >
         {children}
       </Text>

--- a/__tests__/lib/db/pr-dashboard.test.ts
+++ b/__tests__/lib/db/pr-dashboard.test.ts
@@ -11,6 +11,11 @@ jest.mock('../../../lib/db/helpers', () => ({
   queryOne: jest.fn(),
 }))
 
+// BLD-1086: showVariantPrs() calls getAppSetting which uses getDrizzle — mock to return "0" (variant off) by default
+jest.mock('../../../lib/db/settings', () => ({
+  getAppSetting: jest.fn().mockResolvedValue('0'),
+}))
+
 const helpers = require('../../../lib/db/helpers') as {
   getDrizzle: jest.Mock
   query: jest.Mock
@@ -234,5 +239,131 @@ describe('PR Dashboard Data Layer', () => {
 
     const result = await getAllTimeBests()
     expect(result).toEqual([])
+  })
+})
+
+// ── BLD-1086: Variant PR tests ──────────────────────────────────────────────
+
+describe('BLD-1086 Variant PRs', () => {
+  const settingsMock = require('../../../lib/db/settings') as { getAppSetting: jest.Mock }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    helpers.query.mockResolvedValue([])
+    // Enable variant PRs by default in this suite
+    settingsMock.getAppSetting.mockResolvedValue(null)
+  })
+
+  test('getRecentPRsWithDelta: kill-switch (show_variant_prs=0) falls back to exercise-level queries only', async () => {
+    settingsMock.getAppSetting.mockResolvedValue('0')
+
+    const now = Date.now()
+    helpers.query
+      .mockResolvedValueOnce([
+        { exercise_id: 'ex1', name: 'Cable Fly', category: 'Push', weight: 50, previous_best: 45, date: now },
+      ])
+      .mockResolvedValueOnce([])
+
+    const result = await getRecentPRsWithDelta(20)
+    // Should make only 2 queries (weighted + rep), no cable variant query
+    expect(helpers.query).toHaveBeenCalledTimes(2)
+    expect(result).toHaveLength(1)
+    expect(result[0].exercise_id).toBe('ex1')
+    // No variants on kill-switch path
+    expect(result[0].variants).toBeUndefined()
+  })
+
+  test('getRecentPRsWithDelta: variant mode makes 3 queries (non-cable weight, cable variant, rep)', async () => {
+    const now = Date.now()
+    helpers.query
+      .mockResolvedValueOnce([
+        // Non-cable weight PR
+        { exercise_id: 'ex-bench', name: 'Bench Press', category: 'Push', weight: 100, previous_best: 95, date: now },
+      ])
+      .mockResolvedValueOnce([
+        // Cable variant PR (2nd query)
+        {
+          exercise_id: 'ex-cable',
+          name: 'Cable Fly',
+          category: 'Push',
+          weight: 50,
+          previous_best: 45,
+          date: now - 1000,
+          attachment: 'rope',
+          mount_position: 'high',
+          grip_type: null,
+          stack_unit_at_log: null,
+        },
+      ])
+      .mockResolvedValueOnce([])  // rep PRs
+
+    const result = await getRecentPRsWithDelta(20)
+    expect(helpers.query).toHaveBeenCalledTimes(3)
+    expect(result).toHaveLength(2)
+    // Cable variant PR is second (older)
+    const cablePR = result.find((r) => r.exercise_id === 'ex-cable')
+    expect(cablePR).toBeDefined()
+    expect(cablePR?.variants).toBeDefined()
+    expect(cablePR?.variants).toHaveLength(1)
+    expect(cablePR?.variants?.[0].attachment).toBe('rope')
+    expect(cablePR?.variants?.[0].mountPosition).toBe('high')
+  })
+
+  test('getRecentPRsWithDelta: cable PR with all-null variant has variants array with null fields', async () => {
+    const now = Date.now()
+    helpers.query
+      .mockResolvedValueOnce([])  // non-cable weight
+      .mockResolvedValueOnce([
+        {
+          exercise_id: 'ex-cable',
+          name: 'Cable Row',
+          category: 'Pull',
+          weight: 80,
+          previous_best: 75,
+          date: now,
+          attachment: null,
+          mount_position: null,
+          grip_type: null,
+          stack_unit_at_log: null,
+        },
+      ])
+      .mockResolvedValueOnce([])  // rep PRs
+
+    const result = await getRecentPRsWithDelta(20)
+    expect(result).toHaveLength(1)
+    const v = result[0].variants?.[0]
+    expect(v?.attachment).toBeNull()
+    expect(v?.mountPosition).toBeNull()
+    expect(v?.gripType).toBeNull()
+    expect(v?.stackUnitAtLog).toBeNull()
+  })
+
+  test('getAllTimeBests: cable exercises get variants attached when variant mode enabled', async () => {
+    const benchId = 'ex-bench'
+    const cableId = 'ex-cable'
+
+    helpers.query
+      .mockResolvedValueOnce([
+        { exercise_id: benchId, name: 'Bench Press', category: 'Push', max_weight: 100, best_set_weight: 100, best_set_reps: 5, session_count: 10 },
+        { exercise_id: cableId, name: 'Cable Fly', category: 'Push', max_weight: 50, best_set_weight: 50, best_set_reps: 12, session_count: 5 },
+      ])
+      .mockResolvedValueOnce([])  // bodyweight
+      .mockResolvedValueOnce([])  // getWeightedBodyweightPRs
+      .mockResolvedValueOnce([{ id: cableId }])  // getCableExerciseIds returns cable exercise (rows with {id})
+      .mockResolvedValueOnce([
+        // bestPerVariant results for cable exercise
+        { attachment: 'rope', mount_position: 'high', grip_type: null, stack_unit_at_log: null, max_weight: 50, best_reps: 12, achieved_at: 1700000000000, session_count: 3 },
+        { attachment: 'bar', mount_position: 'low', grip_type: null, stack_unit_at_log: null, max_weight: 45, best_reps: 15, achieved_at: 1699999999000, session_count: 2 },
+      ])
+
+    const result = await getAllTimeBests()
+    const cable = result.find((r) => r.exercise_id === cableId)
+    expect(cable?.variants).toBeDefined()
+    expect(cable?.variants).toHaveLength(2)
+    expect(cable?.variants?.[0].attachment).toBe('rope')
+
+    // Non-cable exercise should have no variants
+    const bench = result.find((r) => r.exercise_id === benchId)
+    expect(bench?.variants).toBeUndefined()
   })
 })

--- a/__tests__/lib/db/variant-prs-correctness.test.ts
+++ b/__tests__/lib/db/variant-prs-correctness.test.ts
@@ -1,0 +1,239 @@
+/**
+ * BLD-1086 — Regression test for `bestPerVariant` SQL correctness.
+ *
+ * Asserts that the fixed ROW_NUMBER() form returns the reps + completed_at of
+ * the *max-weight* set (not an arbitrary row), which the previous bare-column
+ * form failed to guarantee under SQLite's two-MAX() rule:
+ * https://www.sqlite.org/lang_select.html#bareagg
+ *
+ * Scenario per CEO recovery comment on BLD-1086 / PR #520:
+ *   sets for (cable-pushdown, rope, high, neutral, kg):
+ *     (weight=100, reps= 5, ts=100)   ← actual PR — best e1RM ≈ 116.7
+ *     (weight= 50, reps=20, ts=200)   ← latest set, lighter
+ *     (weight= 80, reps= 8, ts=150)
+ *
+ *   expected: max_weight=100, best_reps=5, achieved_at=100
+ *
+ * Engine: node:sqlite (Node v22+ built-in). Same SQLite3 query planner as
+ * expo-sqlite (both ship SQLite ≥ 3.45). The bare-column bug class CANNOT be
+ * caught by mocked tests — this requires a real engine.
+ */
+
+import { DatabaseSync } from "node:sqlite";
+
+const BEST_PER_VARIANT_SQL = `
+  SELECT
+     ws.attachment,
+     ws.mount_position,
+     ws.grip_type,
+     ws.stack_unit_at_log,
+     MAX(ws.weight)                                   AS max_weight,
+     best.reps                                        AS best_reps,
+     best.completed_at                                AS achieved_at,
+     COUNT(DISTINCT ws.session_id)                    AS session_count
+   FROM workout_sets ws
+   INNER JOIN workout_sessions wss ON ws.session_id = wss.id
+   LEFT JOIN (
+     SELECT
+       ws_b.exercise_id,
+       ws_b.attachment,
+       ws_b.mount_position,
+       ws_b.grip_type,
+       ws_b.stack_unit_at_log,
+       ws_b.reps,
+       ws_b.completed_at,
+       ROW_NUMBER() OVER (
+         PARTITION BY ws_b.exercise_id,
+                      ws_b.attachment,
+                      ws_b.mount_position,
+                      ws_b.grip_type,
+                      ws_b.stack_unit_at_log
+         ORDER BY ws_b.weight DESC, ws_b.completed_at DESC
+       ) AS rn
+     FROM workout_sets ws_b
+     INNER JOIN workout_sessions wss_b ON ws_b.session_id = wss_b.id
+     WHERE ws_b.exercise_id = ?
+       AND ws_b.completed = 1
+       AND ws_b.weight IS NOT NULL AND ws_b.weight > 0
+       AND ws_b.set_type != 'warmup'
+       AND wss_b.completed_at IS NOT NULL
+   ) best ON best.rn = 1
+         AND best.exercise_id = ws.exercise_id
+         AND best.attachment IS ws.attachment
+         AND best.mount_position IS ws.mount_position
+         AND best.grip_type IS ws.grip_type
+         AND best.stack_unit_at_log IS ws.stack_unit_at_log
+   WHERE ws.exercise_id = ?
+     AND ws.completed = 1
+     AND ws.weight IS NOT NULL AND ws.weight > 0
+     AND ws.set_type != 'warmup'
+     AND wss.completed_at IS NOT NULL
+   GROUP BY ws.exercise_id,
+            ws.attachment,
+            ws.mount_position,
+            ws.grip_type,
+            ws.stack_unit_at_log
+   ORDER BY best.completed_at DESC
+`;
+
+type Row = {
+  attachment: string | null;
+  mount_position: string | null;
+  grip_type: string | null;
+  stack_unit_at_log: string | null;
+  max_weight: number;
+  best_reps: number;
+  achieved_at: number;
+  session_count: number;
+};
+
+function makeDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE workout_sessions (
+      id TEXT PRIMARY KEY,
+      completed_at INTEGER
+    );
+    CREATE TABLE workout_sets (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      exercise_id TEXT NOT NULL,
+      weight REAL,
+      reps INTEGER,
+      completed INTEGER NOT NULL DEFAULT 1,
+      set_type TEXT NOT NULL DEFAULT 'normal',
+      completed_at INTEGER,
+      attachment TEXT,
+      mount_position TEXT,
+      grip_type TEXT,
+      stack_unit_at_log TEXT
+    );
+  `);
+  return db;
+}
+
+function insertSet(
+  db: DatabaseSync,
+  id: string,
+  sessionId: string,
+  exerciseId: string,
+  weight: number,
+  reps: number,
+  ts: number,
+  variant: { att: string | null; mount: string | null; grip: string | null; unit: string | null },
+) {
+  db.prepare(
+    `INSERT OR IGNORE INTO workout_sessions (id, completed_at) VALUES (?, ?)`,
+  ).run(sessionId, ts + 1);
+  db.prepare(
+    `INSERT INTO workout_sets
+       (id, session_id, exercise_id, weight, reps, completed, set_type, completed_at,
+        attachment, mount_position, grip_type, stack_unit_at_log)
+     VALUES (?, ?, ?, ?, ?, 1, 'normal', ?, ?, ?, ?, ?)`,
+  ).run(id, sessionId, exerciseId, weight, reps, ts, variant.att, variant.mount, variant.grip, variant.unit);
+}
+
+describe("BLD-1086 — bestPerVariant SQL correctness (real SQLite engine)", () => {
+  test("PR-then-lighter scenario: bare-column bug regression — best_reps + achieved_at come from the max-weight set", () => {
+    const db = makeDb();
+    const ex = "cable-triceps-pushdown";
+    const v = { att: "rope", mount: "high", grip: "neutral", unit: "kg" };
+
+    // The actual PR — heaviest weight, mid-timestamp
+    insertSet(db, "s1", "sess-A", ex, 100, 5, 100, v);
+    // Later, lighter set with high reps. Under the buggy bare-column form,
+    // SQLite picks reps=20 / ts=200 from this row.
+    insertSet(db, "s2", "sess-B", ex, 50, 20, 200, v);
+    insertSet(db, "s3", "sess-C", ex, 80, 8, 150, v);
+
+    const rows = db.prepare(BEST_PER_VARIANT_SQL).all(ex, ex) as Row[];
+
+    expect(rows).toHaveLength(1);
+    const r = rows[0];
+    expect(r.max_weight).toBe(100);
+    expect(r.best_reps).toBe(5);          // ← would be 20 (or undefined) under bare-column bug
+    expect(r.achieved_at).toBe(100);      // ← would be 200 under MAX(completed_at) bug
+    expect(r.session_count).toBe(3);
+
+    // e1rm sanity (epley): 100 * (1 + 5/30) ≈ 116.67
+    const e1rm = r.max_weight * (1 + r.best_reps / 30);
+    expect(e1rm).toBeCloseTo(116.67, 1);
+
+    db.close();
+  });
+
+  test("four-bucket NULL matrix: (rope,high), (rope,null), (null,high), (null,null) are four distinct rows", () => {
+    const db = makeDb();
+    const ex = "cable-row";
+
+    insertSet(db, "a1", "s-a", ex, 30,  8, 1000, { att: "rope", mount: "high", grip: null, unit: "kg" });
+    insertSet(db, "b1", "s-b", ex, 28,  8, 2000, { att: "rope", mount: null,   grip: null, unit: "kg" });
+    insertSet(db, "c1", "s-c", ex, 25, 10, 3000, { att: null,   mount: "high", grip: null, unit: "kg" });
+    insertSet(db, "d1", "s-d", ex, 20, 12, 4000, { att: null,   mount: null,   grip: null, unit: null });
+
+    const rows = db.prepare(BEST_PER_VARIANT_SQL).all(ex, ex) as Row[];
+
+    expect(rows).toHaveLength(4);
+    const keys = rows.map((r) => `${r.attachment}|${r.mount_position}|${r.stack_unit_at_log}`);
+    expect(keys).toContain("rope|high|kg");
+    expect(keys).toContain("rope|null|kg");
+    expect(keys).toContain("null|high|kg");
+    expect(keys).toContain("null|null|null");
+
+    // Each row's best_reps/achieved_at line up with its single set
+    const ropeHigh = rows.find((r) => r.attachment === "rope" && r.mount_position === "high")!;
+    expect(ropeHigh.max_weight).toBe(30);
+    expect(ropeHigh.best_reps).toBe(8);
+    expect(ropeHigh.achieved_at).toBe(1000);
+
+    db.close();
+  });
+
+  test("ties on weight: deterministic — most recent completed_at wins", () => {
+    const db = makeDb();
+    const ex = "cable-curl";
+    const v = { att: "bar", mount: "low", grip: null, unit: "kg" };
+
+    insertSet(db, "t1", "s-1", ex, 40, 10, 100, v);
+    insertSet(db, "t2", "s-2", ex, 40,  6, 500, v);   // later wins on tie
+    insertSet(db, "t3", "s-3", ex, 40,  8, 300, v);
+
+    const [r] = db.prepare(BEST_PER_VARIANT_SQL).all(ex, ex) as Row[];
+
+    expect(r.max_weight).toBe(40);
+    expect(r.achieved_at).toBe(500);
+    expect(r.best_reps).toBe(6);
+    expect(r.session_count).toBe(3);
+
+    db.close();
+  });
+
+  test("excludes warmup sets and incomplete sessions", () => {
+    const db = makeDb();
+    const ex = "cable-fly";
+    const v = { att: "handle", mount: "mid", grip: null, unit: "kg" };
+
+    insertSet(db, "w1", "s-real", ex, 25, 12, 1000, v);
+    // warmup at higher weight — must be excluded
+    db.prepare(
+      `INSERT INTO workout_sets (id, session_id, exercise_id, weight, reps, completed, set_type, completed_at,
+                                 attachment, mount_position, grip_type, stack_unit_at_log)
+       VALUES ('w2', 's-real', ?, 50, 5, 1, 'warmup', 1500, ?, ?, ?, ?)`,
+    ).run(ex, v.att, v.mount, v.grip, v.unit);
+    // set in incomplete session — must be excluded
+    db.prepare(`INSERT INTO workout_sessions (id, completed_at) VALUES ('s-open', NULL)`).run();
+    db.prepare(
+      `INSERT INTO workout_sets (id, session_id, exercise_id, weight, reps, completed, set_type, completed_at,
+                                 attachment, mount_position, grip_type, stack_unit_at_log)
+       VALUES ('w3', 's-open', ?, 60, 5, 1, 'normal', 2000, ?, ?, ?, ?)`,
+    ).run(ex, v.att, v.mount, v.grip, v.unit);
+
+    const rows = db.prepare(BEST_PER_VARIANT_SQL).all(ex, ex) as Row[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].max_weight).toBe(25);
+    expect(rows[0].best_reps).toBe(12);
+
+    db.close();
+  });
+});

--- a/__tests__/lib/db/variant-prs-query-plan.test.ts
+++ b/__tests__/lib/db/variant-prs-query-plan.test.ts
@@ -129,37 +129,75 @@ describe("BLD-1086 — bestPerVariant query plan", () => {
   });
 
   test('GROUP BY variant query uses idx_workout_sets_variant_pr (not SCAN TABLE)', () => {
-    // This is the exact SQL shape from bestPerVariant in lib/db/pr-dashboard.ts
+    // This SQL shape mirrors the SHIPPING bestPerVariant query in
+    // lib/db/pr-dashboard.ts:127-184 (LEFT JOIN ROW_NUMBER() form). If that
+    // production query changes shape, this test must be updated in lock-step
+    // so the AC "EXPLAIN QUERY PLAN confirms idx_workout_sets_variant_pr is
+    // used by the new variant aggregation query" is checked against what
+    // actually ships, not a stale draft.
     const planRows = db.prepare(`
       EXPLAIN QUERY PLAN
       SELECT
-        ws.attachment,
-        ws.mount_position,
-        ws.grip_type,
-        ws.stack_unit_at_log,
-        MAX(ws.weight)          AS max_weight,
-        ws.reps                 AS best_reps,
-        MAX(wss.completed_at)   AS achieved_at,
-        COUNT(DISTINCT ws.session_id) AS session_count
-      FROM workout_sets ws
-      INNER JOIN workout_sessions wss ON ws.session_id = wss.id
-      WHERE ws.exercise_id = ?
-        AND ws.completed = 1
-        AND ws.weight IS NOT NULL AND ws.weight > 0
-        AND ws.set_type != 'warmup'
-        AND wss.completed_at IS NOT NULL
-      GROUP BY ws.exercise_id,
-               ws.attachment,
-               ws.mount_position,
-               ws.grip_type,
-               ws.stack_unit_at_log
-      ORDER BY achieved_at DESC
-    `).all('cable-triceps-pushdown') as { detail: string }[];
+         ws.attachment,
+         ws.mount_position,
+         ws.grip_type,
+         ws.stack_unit_at_log,
+         MAX(ws.weight)                                   AS max_weight,
+         best.reps                                        AS best_reps,
+         best.completed_at                                AS achieved_at,
+         COUNT(DISTINCT ws.session_id)                    AS session_count
+       FROM workout_sets ws
+       INNER JOIN workout_sessions wss ON ws.session_id = wss.id
+       LEFT JOIN (
+         SELECT
+           ws_b.exercise_id,
+           ws_b.attachment,
+           ws_b.mount_position,
+           ws_b.grip_type,
+           ws_b.stack_unit_at_log,
+           ws_b.reps,
+           ws_b.completed_at,
+           ROW_NUMBER() OVER (
+             PARTITION BY ws_b.exercise_id,
+                          ws_b.attachment,
+                          ws_b.mount_position,
+                          ws_b.grip_type,
+                          ws_b.stack_unit_at_log
+             ORDER BY ws_b.weight DESC, ws_b.completed_at DESC
+           ) AS rn
+         FROM workout_sets ws_b
+         INNER JOIN workout_sessions wss_b ON ws_b.session_id = wss_b.id
+         WHERE ws_b.exercise_id = ?
+           AND ws_b.completed = 1
+           AND ws_b.weight IS NOT NULL AND ws_b.weight > 0
+           AND ws_b.set_type != 'warmup'
+           AND wss_b.completed_at IS NOT NULL
+       ) best ON best.rn = 1
+             AND best.exercise_id = ws.exercise_id
+             AND best.attachment IS ws.attachment
+             AND best.mount_position IS ws.mount_position
+             AND best.grip_type IS ws.grip_type
+             AND best.stack_unit_at_log IS ws.stack_unit_at_log
+       WHERE ws.exercise_id = ?
+         AND ws.completed = 1
+         AND ws.weight IS NOT NULL AND ws.weight > 0
+         AND ws.set_type != 'warmup'
+         AND wss.completed_at IS NOT NULL
+       GROUP BY ws.exercise_id,
+                ws.attachment,
+                ws.mount_position,
+                ws.grip_type,
+                ws.stack_unit_at_log
+       ORDER BY best.completed_at DESC
+    `).all('cable-triceps-pushdown', 'cable-triceps-pushdown') as { detail: string }[];
 
     const planText = planRows.map((r) => r.detail ?? JSON.stringify(r)).join('\n');
 
-    // Must use the variant PR composite index, NOT a full table scan
+    // Both the outer aggregation over `ws` AND the inner ROW_NUMBER() scan over
+    // `ws_b` must use idx_workout_sets_variant_pr (its leading column is
+    // exercise_id, matching both equality filters).
     expect(planText).toMatch(/idx_workout_sets_variant_pr/i);
+    expect(planText).not.toMatch(/SCAN workout_sets(?! USING)/i);
     expect(planText).not.toMatch(/SCAN TABLE workout_sets(?! USING)/i);
   });
 

--- a/__tests__/lib/db/variant-prs-query-plan.test.ts
+++ b/__tests__/lib/db/variant-prs-query-plan.test.ts
@@ -1,0 +1,170 @@
+/**
+ * BLD-1086 — EXPLAIN QUERY PLAN test for idx_workout_sets_variant_pr.
+ *
+ * AC: PLAN-BLD-1085.md Phase 0b — "EXPLAIN QUERY PLAN for the new variant
+ * aggregation query reports `USING INDEX idx_workout_sets_variant_pr`".
+ *
+ * Risk addressed: if a future migration drops or renames `idx_workout_sets_variant_pr`,
+ * the GROUP BY aggregation in `bestPerVariant` will fall back to a full table scan,
+ * causing O(n) cost on every PR Dashboard load for cable exercises. This test
+ * asserts the literal index name in the query plan, surfacing any regression
+ * immediately.
+ *
+ * Engine: node:sqlite (Node v22+ built-in). Same SQLite3 query planner as
+ * expo-sqlite (both ship SQLite ≥ 3.45). EXPLAIN QUERY PLAN cannot be
+ * meaningfully mocked — this test requires a real SQLite engine.
+ *
+ * See also: __tests__/lib/db/e1rm-trends-query-plan.test.ts (same pattern for
+ * idx_workout_sessions_gym_started_at from BLD-1060).
+ */
+
+import { DatabaseSync } from "node:sqlite";
+
+describe("BLD-1086 — bestPerVariant query plan", () => {
+  let db: DatabaseSync;
+
+  beforeAll(() => {
+    db = new DatabaseSync(":memory:");
+
+    // Mirror the production schema columns touched by bestPerVariant.
+    // Source: lib/db/schema.ts + lib/db/migrations.ts
+    db.exec(`
+      CREATE TABLE exercises (
+        id TEXT PRIMARY KEY NOT NULL,
+        name TEXT NOT NULL,
+        equipment TEXT NOT NULL DEFAULT 'cable'
+      );
+
+      CREATE TABLE workout_sessions (
+        id TEXT PRIMARY KEY NOT NULL,
+        started_at INTEGER NOT NULL,
+        completed_at INTEGER
+      );
+
+      CREATE TABLE workout_sets (
+        id TEXT PRIMARY KEY NOT NULL,
+        session_id TEXT NOT NULL,
+        exercise_id TEXT NOT NULL,
+        weight REAL NOT NULL DEFAULT 0,
+        reps INTEGER NOT NULL DEFAULT 0,
+        completed INTEGER NOT NULL DEFAULT 0,
+        set_type TEXT NOT NULL DEFAULT 'normal',
+        completed_at INTEGER,
+        attachment TEXT,
+        mount_position TEXT,
+        grip_type TEXT,
+        stack_unit_at_log TEXT
+      );
+
+      -- Production indexes from lib/db/migrations.ts (existing)
+      CREATE INDEX idx_workout_sets_exercise ON workout_sets(exercise_id);
+      CREATE INDEX idx_workout_sets_session ON workout_sets(session_id);
+      CREATE INDEX idx_workout_sets_session_exercise ON workout_sets(session_id, exercise_id);
+
+      -- BLD-1086 Phase 0b: the composite index under test
+      CREATE INDEX idx_workout_sets_variant_pr
+        ON workout_sets (exercise_id, attachment, mount_position, grip_type, completed_at);
+    `);
+
+    // Seed 5,000 sets across 80 exercises, ~30 distinct variant tuples.
+    // This matches the plan's AC bench fixture.
+    const EXERCISES = 80;
+    const TARGET_EXERCISE = 'cable-triceps-pushdown';
+    const VARIANT_TUPLES: [string | null, string | null, string | null, string | null][] = [
+      ['rope', 'high', 'neutral', 'kg'],
+      ['rope', 'high', 'overhand', 'kg'],
+      ['rope', 'mid', null, 'kg'],
+      ['rope', null, null, 'kg'],
+      ['bar', 'high', null, 'kg'],
+      ['bar', 'low', null, 'kg'],
+      ['handle', 'mid', null, 'kg'],
+      ['handle', null, null, null],
+      [null, 'high', null, 'kg'],
+      [null, null, null, null],
+    ];
+
+    db.exec("BEGIN");
+
+    // Insert exercises
+    const insertEx = db.prepare("INSERT INTO exercises (id, name) VALUES (?, ?)");
+    for (let i = 0; i < EXERCISES; i++) {
+      insertEx.run(`ex-${i}`, `Exercise ${i}`);
+    }
+    insertEx.run(TARGET_EXERCISE, "Cable Triceps Pushdown");
+
+    const insertSession = db.prepare(
+      "INSERT INTO workout_sessions (id, started_at, completed_at) VALUES (?, ?, ?)"
+    );
+    const insertSet = db.prepare(
+      `INSERT INTO workout_sets
+         (id, session_id, exercise_id, weight, reps, completed, set_type, completed_at,
+          attachment, mount_position, grip_type, stack_unit_at_log)
+       VALUES (?, ?, ?, ?, ?, 1, 'normal', ?, ?, ?, ?, ?)`
+    );
+
+    let setIdx = 0;
+    const baseTime = Date.now() - 365 * 86400 * 1000;
+
+    // 100 sessions × ~50 sets = 5,000 sets
+    for (let s = 0; s < 100; s++) {
+      const sessionId = `sess-${s}`;
+      const sessionTime = baseTime + s * 86400 * 1000 * 3;
+      insertSession.run(sessionId, sessionTime, sessionTime + 3600_000);
+
+      for (let k = 0; k < 50; k++) {
+        const exId = k < 10 ? TARGET_EXERCISE : `ex-${k % EXERCISES}`;
+        const tuple = VARIANT_TUPLES[k % VARIANT_TUPLES.length];
+        const weight = 20 + (k % 30);
+        const reps = 6 + (k % 6);
+        insertSet.run(`set-${setIdx++}`, sessionId, exId, weight, reps, sessionTime, ...tuple);
+      }
+    }
+
+    db.exec("COMMIT");
+    db.exec("ANALYZE");
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  test('GROUP BY variant query uses idx_workout_sets_variant_pr (not SCAN TABLE)', () => {
+    // This is the exact SQL shape from bestPerVariant in lib/db/pr-dashboard.ts
+    const planRows = db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT
+        ws.attachment,
+        ws.mount_position,
+        ws.grip_type,
+        ws.stack_unit_at_log,
+        MAX(ws.weight)          AS max_weight,
+        ws.reps                 AS best_reps,
+        MAX(wss.completed_at)   AS achieved_at,
+        COUNT(DISTINCT ws.session_id) AS session_count
+      FROM workout_sets ws
+      INNER JOIN workout_sessions wss ON ws.session_id = wss.id
+      WHERE ws.exercise_id = ?
+        AND ws.completed = 1
+        AND ws.weight IS NOT NULL AND ws.weight > 0
+        AND ws.set_type != 'warmup'
+        AND wss.completed_at IS NOT NULL
+      GROUP BY ws.exercise_id,
+               ws.attachment,
+               ws.mount_position,
+               ws.grip_type,
+               ws.stack_unit_at_log
+      ORDER BY achieved_at DESC
+    `).all('cable-triceps-pushdown') as { detail: string }[];
+
+    const planText = planRows.map((r) => r.detail ?? JSON.stringify(r)).join('\n');
+
+    // Must use the variant PR composite index, NOT a full table scan
+    expect(planText).toMatch(/idx_workout_sets_variant_pr/i);
+    expect(planText).not.toMatch(/SCAN TABLE workout_sets(?! USING)/i);
+  });
+
+  test('5,000-set seed has expected row count', () => {
+    const { total } = db.prepare("SELECT COUNT(*) AS total FROM workout_sets").get() as { total: number };
+    expect(total).toBe(5000);
+  });
+});

--- a/__tests__/lib/db/variant-prs.test.ts
+++ b/__tests__/lib/db/variant-prs.test.ts
@@ -1,0 +1,237 @@
+/**
+ * BLD-1086 — Per-variant PR data layer unit tests.
+ *
+ * Tests:
+ * 1. bestPerVariant: four-bucket NULL grouping (null != non-null at every position)
+ * 2. bestPerVariant: non-cable exercises remain unchanged (byte-identity check on results)
+ * 3. showVariantPrs: kill-switch semantics
+ * 4. getCableExerciseIds: equipment gating
+ * 5. getAllTimeBests / getRecentPRsWithDelta: no-op for non-cable (regression guard)
+ */
+
+jest.mock('../../../lib/db/helpers', () => ({
+  getDrizzle: jest.fn(),
+  query: jest.fn(),
+  queryOne: jest.fn(),
+}))
+
+jest.mock('../../../lib/db/settings', () => ({
+  getAppSetting: jest.fn(),
+  setAppSetting: jest.fn(),
+}))
+
+const helpers = require('../../../lib/db/helpers') as {
+  getDrizzle: jest.Mock
+  query: jest.Mock
+  queryOne: jest.Mock
+}
+
+const settings = require('../../../lib/db/settings') as {
+  getAppSetting: jest.Mock
+}
+
+import {
+  bestPerVariant,
+  showVariantPrs,
+  getAllTimeBests,
+  getRecentPRsWithDelta,
+} from '../../../lib/db/pr-dashboard'
+
+describe('BLD-1086 — Per-Variant PR data layer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    helpers.query.mockResolvedValue([])
+    settings.getAppSetting.mockResolvedValue(null) // default: feature enabled
+  })
+
+  // ── showVariantPrs kill-switch ──────────────────────────────────────────
+
+  describe('showVariantPrs', () => {
+    test.each([
+      ['null (default) → true', null, true],
+      ['"1" → true', '1', true],
+      ['"0" → false (kill-switch)', '0', false],
+      ['"" → true', '', true],
+    ])('%s', async (_label, settingVal, expected) => {
+      settings.getAppSetting.mockResolvedValue(settingVal)
+      const result = await showVariantPrs()
+      expect(result).toBe(expected)
+    })
+  })
+
+  // ── bestPerVariant four-bucket NULL grouping ────────────────────────────
+
+  describe('bestPerVariant', () => {
+    test('returns empty array when no sets', async () => {
+      helpers.query.mockResolvedValue([])
+      const result = await bestPerVariant('ex-cable-1')
+      expect(result).toEqual([])
+    })
+
+    test('four-bucket NULL matrix: (rope,high), (rope,null), (null,high), (null,null) are four distinct rows', async () => {
+      // This is the CRITICAL test per the plan. Each combination must be a
+      // distinct row — NULL must NOT be collapsed with non-NULL.
+      const now = Date.now()
+      helpers.query.mockResolvedValue([
+        { attachment: 'rope',  mount_position: 'high', grip_type: null, stack_unit_at_log: 'kg', max_weight: 30, best_reps: 8,  achieved_at: now - 1000, session_count: 3 },
+        { attachment: 'rope',  mount_position: null,   grip_type: null, stack_unit_at_log: 'kg', max_weight: 28, best_reps: 8,  achieved_at: now - 2000, session_count: 1 },
+        { attachment: null,    mount_position: 'high', grip_type: null, stack_unit_at_log: 'kg', max_weight: 25, best_reps: 10, achieved_at: now - 3000, session_count: 2 },
+        { attachment: null,    mount_position: null,   grip_type: null, stack_unit_at_log: null,  max_weight: 20, best_reps: 12, achieved_at: now - 4000, session_count: 5 },
+      ])
+
+      const result = await bestPerVariant('ex-cable-1')
+
+      expect(result).toHaveLength(4)
+
+      // Each row is a distinct variant
+      const keys = result.map((r) => `${r.attachment}|${r.mountPosition}|${r.gripType}|${r.stackUnitAtLog}`)
+      expect(keys).toContain('rope|high|null|kg')
+      expect(keys).toContain('rope|null|null|kg')
+      expect(keys).toContain('null|high|null|kg')
+      expect(keys).toContain('null|null|null|null')
+    })
+
+    test('maps DB columns to VariantBest fields correctly', async () => {
+      const achievedAt = 1720000000000
+      helpers.query.mockResolvedValue([
+        { attachment: 'rope', mount_position: 'high', grip_type: 'neutral', stack_unit_at_log: 'kg',
+          max_weight: 32.5, best_reps: 8, achieved_at: achievedAt, session_count: 4 },
+      ])
+
+      const [row] = await bestPerVariant('ex-cable-1')
+
+      expect(row.attachment).toBe('rope')
+      expect(row.mountPosition).toBe('high')
+      expect(row.gripType).toBe('neutral')
+      expect(row.stackUnitAtLog).toBe('kg')
+      expect(row.weight).toBe(32.5)
+      expect(row.reps).toBe(8)
+      expect(row.achievedAt).toBe(achievedAt)
+      expect(row.sessionCount).toBe(4)
+      // e1rm = epley(32.5, 8) = 32.5 * (1 + 8/30) ≈ 41.2
+      expect(row.e1rm).toBeGreaterThan(0)
+    })
+
+    test('null DB fields coerce to null (not undefined)', async () => {
+      helpers.query.mockResolvedValue([
+        { attachment: null, mount_position: null, grip_type: null, stack_unit_at_log: null,
+          max_weight: 20, best_reps: 10, achieved_at: 1720000000000, session_count: 1 },
+      ])
+
+      const [row] = await bestPerVariant('ex-cable-1')
+
+      expect(row.attachment).toBeNull()
+      expect(row.mountPosition).toBeNull()
+      expect(row.gripType).toBeNull()
+      expect(row.stackUnitAtLog).toBeNull()
+    })
+
+    test('multiple variants with different grip_type are kept separate', async () => {
+      const now = Date.now()
+      helpers.query.mockResolvedValue([
+        { attachment: 'rope', mount_position: 'high', grip_type: 'overhand',  stack_unit_at_log: 'kg', max_weight: 30, best_reps: 8, achieved_at: now, session_count: 2 },
+        { attachment: 'rope', mount_position: 'high', grip_type: 'underhand', stack_unit_at_log: 'kg', max_weight: 28, best_reps: 8, achieved_at: now - 1000, session_count: 1 },
+      ])
+
+      const result = await bestPerVariant('ex-cable-1')
+      expect(result).toHaveLength(2)
+      expect(result.map((r) => r.gripType)).toContain('overhand')
+      expect(result.map((r) => r.gripType)).toContain('underhand')
+    })
+
+    test('stack_unit_at_log cross-gym separation: same attachment, different units = two rows', async () => {
+      const now = Date.now()
+      helpers.query.mockResolvedValue([
+        { attachment: 'rope', mount_position: 'high', grip_type: null, stack_unit_at_log: 'kg',           max_weight: 30, best_reps: 8, achieved_at: now,         session_count: 2 },
+        { attachment: 'rope', mount_position: 'high', grip_type: null, stack_unit_at_log: 'plate-marker', max_weight: 5,  best_reps: 8, achieved_at: now - 1000, session_count: 1 },
+      ])
+
+      const result = await bestPerVariant('ex-cable-1')
+      expect(result).toHaveLength(2)
+      expect(result.map((r) => r.stackUnitAtLog)).toContain('kg')
+      expect(result.map((r) => r.stackUnitAtLog)).toContain('plate-marker')
+    })
+  })
+
+  // ── getAllTimeBests: variants attached for cable, not for non-cable ──────
+
+  describe('getAllTimeBests variant attachment', () => {
+    test('non-cable exercises produce no variants field (byte-identity guard)', async () => {
+      // Enable variant feature
+      settings.getAppSetting.mockResolvedValue(null)
+
+      // Mock the getAllTimeBests queries — weighted non-cable, bodyweight, bw PRs
+      helpers.query
+        // weighted bests
+        .mockResolvedValueOnce([
+          { exercise_id: 'ex-bench', name: 'Bench Press', category: 'Push', max_weight: 100, best_set_weight: 100, best_set_reps: 5, session_count: 10 },
+        ])
+        // bodyweight bests
+        .mockResolvedValueOnce([])
+        // weighted BW PRs
+        .mockResolvedValueOnce([])
+        // showVariantPrs → getAppSetting
+        // getCableExerciseIds — returns empty (not cable)
+        .mockResolvedValueOnce([]) // cable exercises lookup returns empty
+
+      const results = await getAllTimeBests()
+
+      expect(results).toHaveLength(1)
+      // variants should NOT be set (or be empty) for non-cable
+      expect(results[0].variants).toBeUndefined()
+    })
+
+    test('kill-switch off: no variants on any exercise', async () => {
+      settings.getAppSetting.mockResolvedValue('0') // kill-switch off
+
+      helpers.query
+        .mockResolvedValueOnce([
+          { exercise_id: 'ex-cable', name: 'Cable Pushdown', category: 'Push', max_weight: 40, best_set_weight: 40, best_set_reps: 8, session_count: 5 },
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+
+      const results = await getAllTimeBests()
+      expect(results).toHaveLength(1)
+      expect(results[0].variants).toBeUndefined()
+    })
+  })
+
+  // ── getRecentPRsWithDelta: variants for cable ────────────────────────────
+
+  describe('getRecentPRsWithDelta variant attachment', () => {
+    test('non-cable exercises have no variants', async () => {
+      settings.getAppSetting.mockResolvedValue(null)
+      const now = Date.now()
+      helpers.query
+        // weight PRs
+        .mockResolvedValueOnce([
+          { exercise_id: 'ex-bench', name: 'Bench Press', category: 'Push', weight: 100, previous_best: 95, date: now },
+        ])
+        // rep PRs
+        .mockResolvedValueOnce([])
+        // getCableExerciseIds → empty (not cable)
+        .mockResolvedValueOnce([])
+
+      const results = await getRecentPRsWithDelta()
+
+      expect(results).toHaveLength(1)
+      expect(results[0].variants).toBeUndefined()
+    })
+
+    test('kill-switch off: no variants on any PR', async () => {
+      settings.getAppSetting.mockResolvedValue('0')
+      const now = Date.now()
+      helpers.query
+        .mockResolvedValueOnce([
+          { exercise_id: 'ex-cable', name: 'Cable Pushdown', category: 'Push', weight: 30, previous_best: 28, date: now },
+        ])
+        .mockResolvedValueOnce([])
+
+      const results = await getRecentPRsWithDelta()
+
+      expect(results).toHaveLength(1)
+      expect(results[0].variants).toBeUndefined()
+    })
+  })
+})

--- a/components/progress/StrengthLevelsCard.tsx
+++ b/components/progress/StrengthLevelsCard.tsx
@@ -10,11 +10,18 @@ import { toKg, toDisplay } from "@/lib/units";
 import { STRENGTH_LEVEL_COLORS } from "@/constants/theme";
 import { fontSizes } from "@/constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import {
+  ATTACHMENT_LABELS,
+  MOUNT_POSITION_LABELS,
+  GRIP_TYPE_LABELS,
+} from "@/lib/types";
 import type { Sex } from "@/lib/nutrition-calc";
 
 type LevelRow = StrengthResult & {
   name: string;
   e1rmKg: number;
+  // BLD-1086: variant provenance caption (cable exercises only). null = non-cable or no variant.
+  variantCaption: string | null;
 };
 
 const LEVEL_LABELS: Record<StrengthLevel, string> = {
@@ -24,6 +31,26 @@ const LEVEL_LABELS: Record<StrengthLevel, string> = {
   advanced: "Advanced",
   elite: "Elite",
 };
+
+/** Build "best achieved with: Rope · High" caption from variant provenance fields. */
+function buildVariantCaption(
+  attachment: string | null,
+  mount: string | null,
+  gripType: string | null,
+): string | null {
+  if (attachment === null && mount === null && gripType === null) return null;
+  const parts: string[] = [];
+  if (attachment !== null) {
+    parts.push((ATTACHMENT_LABELS as Record<string, string>)[attachment] ?? attachment);
+  }
+  if (mount !== null) {
+    parts.push((MOUNT_POSITION_LABELS as Record<string, string>)[mount] ?? mount);
+  }
+  if (gripType !== null) {
+    parts.push((GRIP_TYPE_LABELS as Record<string, string>)[gripType] ?? gripType);
+  }
+  return parts.length > 0 ? `best achieved with: ${parts.join(" · ")}` : null;
+}
 
 export default function StrengthLevelsCard({ style }: { style?: object }) {
   const colors = useThemeColors();
@@ -53,7 +80,12 @@ export default function StrengthLevelsCard({ style }: { style?: object }) {
             const e1rmKg = toKg(row.est_1rm, weightUnit);
             const result = getStrengthLevel(row.name, gender, bodyWeightKg, e1rmKg);
             if (result) {
-              levels.push({ ...result, name: row.name, e1rmKg });
+              const variantCaption = buildVariantCaption(
+                row.best_variant_attachment ?? null,
+                row.best_variant_mount ?? null,
+                row.best_variant_grip_type ?? null,
+              );
+              levels.push({ ...result, name: row.name, e1rmKg, variantCaption });
             }
           }
 
@@ -78,17 +110,28 @@ export default function StrengthLevelsCard({ style }: { style?: object }) {
           const nextHint = row.nextLevel && row.nextThresholdKg != null
             ? `→ ${LEVEL_LABELS[row.nextLevel]} at ${Math.round(row.e1rmKg > 0 ? toDisplay(row.nextThresholdKg, "kg") : 0)} kg`
             : null;
-          const a11yLabel = `${row.name}: ${LEVEL_LABELS[row.level]}${nextHint ? `. ${nextHint}` : ""}`;
+          const a11yLabel = [
+            `${row.name}: ${LEVEL_LABELS[row.level]}`,
+            nextHint ?? "",
+            row.variantCaption ?? "",
+          ].filter(Boolean).join(". ");
 
           return (
             <View key={row.name} style={styles.row} accessibilityLabel={a11yLabel}>
-              <Text
-                variant="body"
-                style={[styles.exerciseName, { color: colors.onSurface }]}
-                numberOfLines={1}
-              >
-                {row.name}
-              </Text>
+              <View style={styles.exerciseCol}>
+                <Text
+                  variant="body"
+                  style={[styles.exerciseName, { color: colors.onSurface }]}
+                  numberOfLines={1}
+                >
+                  {row.name}
+                </Text>
+                {row.variantCaption ? (
+                  <Text variant="caption" style={[styles.variantCaption, { color: colors.onSurfaceVariant }]}>
+                    {row.variantCaption}
+                  </Text>
+                ) : null}
+              </View>
               <View style={[styles.badge, { backgroundColor: badgeColor.bg }]}>
                 <Text style={[styles.badgeText, { color: badgeColor.text }]}>
                   {LEVEL_LABELS[row.level]}
@@ -112,10 +155,16 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     paddingVertical: 6,
   },
-  exerciseName: {
+  exerciseCol: {
     flex: 1,
     marginRight: 8,
+  },
+  exerciseName: {
     fontSize: fontSizes.sm,
+  },
+  variantCaption: {
+    fontSize: fontSizes.xs,
+    marginTop: 1,
   },
   badge: {
     borderRadius: 12,
@@ -127,3 +176,4 @@ const styles = StyleSheet.create({
     fontWeight: "600",
   },
 });
+

--- a/components/progress/records/AllTimeBestsSection.tsx
+++ b/components/progress/records/AllTimeBestsSection.tsx
@@ -4,7 +4,8 @@ import { Text } from "@/components/ui/text";
 import { Separator } from "@/components/ui/separator";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { toDisplay } from "@/lib/units";
-import type { AllTimeBest } from "@/lib/db/pr-dashboard";
+import VariantChip from "./VariantChip";
+import type { AllTimeBest, VariantBest } from "@/lib/db/pr-dashboard";
 
 type Props = {
   bests: AllTimeBest[];
@@ -20,6 +21,137 @@ function groupByCategory(bests: AllTimeBest[]): { category: string; data: AllTim
     else map.set(b.category, [b]);
   }
   return Array.from(map.entries()).map(([category, data]) => ({ category, data }));
+}
+
+type BestRowItem = {
+  key: string;
+  item: AllTimeBest;
+  variant?: VariantBest;
+};
+
+/** Expand a single AllTimeBest into one-per-variant rows for cable exercises. */
+function expandRows(best: AllTimeBest): BestRowItem[] {
+  if (best.variants && best.variants.length > 0) {
+    // Sort by e1rm DESC for All-Time Bests
+    const sorted = [...best.variants].sort((a, b) => b.e1rm - a.e1rm);
+    return sorted.map((v, i) => ({
+      key: `${best.exercise_id}-v${i}`,
+      item: best,
+      variant: v,
+    }));
+  }
+  return [{ key: best.exercise_id, item: best }];
+}
+
+function isAllNull(v: VariantBest): boolean {
+  return v.attachment === null && v.mountPosition === null &&
+    v.gripType === null && v.stackUnitAtLog === null;
+}
+
+type BestRowProps = {
+  row: BestRowItem;
+  showSeparator: boolean;
+  weightUnit: "kg" | "lb";
+  onPress: () => void;
+};
+
+function buildBestRowA11y(
+  item: AllTimeBest,
+  variant: VariantBest | undefined,
+  displayWeight: number | null,
+  displayE1rm: number | null,
+  displayReps: number | null,
+  sessionCount: number,
+  isUnspecified: boolean,
+  weightUnit: "kg" | "lb",
+): string {
+  if (!item.is_weighted) return `${item.name}: ${displayReps ?? 0} reps, ${sessionCount} sessions`;
+  const variantPart = variant
+    ? (isUnspecified ? "(unspecified variant)" : `variant: ${variant.attachment ?? "–"} ${variant.mountPosition ?? "–"}`)
+    : "";
+  const weightPart = displayWeight != null ? `${toDisplay(displayWeight, weightUnit)} ${weightUnit}` : "";
+  const e1rmPart = displayE1rm ? `estimated one rep max ${Math.round(toDisplay(displayE1rm, weightUnit))} ${weightUnit}` : "";
+  const sessionPart = `${sessionCount} session${sessionCount !== 1 ? "s" : ""}`;
+  return [item.name, variantPart, weightPart, e1rmPart, sessionPart].filter(Boolean).join(", ");
+}
+
+function BestRowValueDisplay({ item, displayWeight, displayE1rm, displayReps, weightUnit, colors }: {
+  item: AllTimeBest;
+  displayWeight: number | null;
+  displayE1rm: number | null;
+  displayReps: number | null;
+  weightUnit: "kg" | "lb";
+  colors: ReturnType<typeof useThemeColors>;
+}) {
+  if (!item.is_weighted) {
+    return (
+      <Text style={{ color: colors.onSurface, fontWeight: "600" }}>
+        {displayReps} reps
+      </Text>
+    );
+  }
+  return (
+    <>
+      <Text style={{ color: colors.onSurface, fontWeight: "600" }}>
+        {displayWeight != null ? toDisplay(displayWeight, weightUnit) : "-"} {weightUnit}
+      </Text>
+      {displayE1rm != null ? (
+        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+          e1RM: {Math.round(toDisplay(displayE1rm, weightUnit))} {weightUnit}
+        </Text>
+      ) : null}
+    </>
+  );
+}
+
+function BestRow({ row, showSeparator, weightUnit, onPress }: BestRowProps) {
+  const colors = useThemeColors();
+  const { item, variant } = row;
+  const displayWeight = variant ? variant.weight : item.max_weight;
+  const displayE1rm = variant ? variant.e1rm : item.est_1rm;
+  const displayReps = variant ? null : item.max_reps;
+  const sessionCount = variant ? variant.sessionCount : item.session_count;
+  const isUnspecified = variant ? isAllNull(variant) : false;
+
+  const a11yLabel = buildBestRowA11y(item, variant, displayWeight, displayE1rm, displayReps, sessionCount, isUnspecified, weightUnit);
+
+  return (
+    <React.Fragment>
+      <Pressable
+        style={styles.bestRow}
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={a11yLabel}
+      >
+        <View style={{ flex: 1, overflow: "hidden" }}>
+          <Text style={{ color: colors.onSurface }}>{item.name}</Text>
+          {variant ? (
+            isUnspecified ? (
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                (unspecified)
+              </Text>
+            ) : (
+              <VariantChip variant={variant} />
+            )
+          ) : null}
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+            {sessionCount} session{sessionCount !== 1 ? "s" : ""}
+          </Text>
+        </View>
+        <View style={styles.valueCol}>
+          <BestRowValueDisplay
+            item={item}
+            displayWeight={displayWeight}
+            displayE1rm={displayE1rm}
+            displayReps={displayReps}
+            weightUnit={weightUnit}
+            colors={colors}
+          />
+        </View>
+      </Pressable>
+      {showSeparator && <Separator style={{ marginVertical: 2 }} />}
+    </React.Fragment>
+  );
 }
 
 export default function AllTimeBestsSection({ bests, weightUnit, onPressExercise }: Props) {
@@ -47,47 +179,14 @@ export default function AllTimeBestsSection({ bests, weightUnit, onPressExercise
           >
             {section.category}
           </Text>
-          {section.data.map((item, i) => (
-            <React.Fragment key={item.exercise_id}>
-              <Pressable
-                style={styles.bestRow}
-                onPress={() => onPressExercise(item.exercise_id)}
-                accessibilityRole="button"
-                accessibilityLabel={
-                  item.is_weighted
-                    ? `${item.name}: ${item.max_weight != null ? toDisplay(item.max_weight, weightUnit) : '-'} ${weightUnit}${item.est_1rm ? `, estimated one rep max ${Math.round(toDisplay(item.est_1rm, weightUnit))} ${weightUnit}` : ''}, ${item.session_count} sessions`
-                    : `${item.name}: ${item.max_reps} reps, ${item.session_count} sessions`
-                }
-              >
-                <View style={{ flex: 1 }}>
-                  <Text style={{ color: colors.onSurface }}>{item.name}</Text>
-                  <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-                    {item.session_count} session{item.session_count !== 1 ? "s" : ""}
-                  </Text>
-                </View>
-                <View style={styles.valueCol}>
-                  {item.is_weighted ? (
-                    <>
-                      <Text style={{ color: colors.onSurface, fontWeight: "600" }}>
-                        {item.max_weight != null ? toDisplay(item.max_weight, weightUnit) : "-"} {weightUnit}
-                      </Text>
-                      {item.est_1rm != null ? (
-                        <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-                          e1RM: {Math.round(toDisplay(item.est_1rm, weightUnit))} {weightUnit}
-                        </Text>
-                      ) : null}
-                    </>
-                  ) : (
-                    <Text style={{ color: colors.onSurface, fontWeight: "600" }}>
-                      {item.max_reps} reps
-                    </Text>
-                  )}
-                </View>
-              </Pressable>
-              {i < section.data.length - 1 && (
-                <Separator style={{ marginVertical: 2 }} />
-              )}
-            </React.Fragment>
+          {section.data.flatMap((item) => expandRows(item)).map((row, i, arr) => (
+            <BestRow
+              key={row.key}
+              row={row}
+              showSeparator={i < arr.length - 1}
+              weightUnit={weightUnit}
+              onPress={() => onPressExercise(row.item.exercise_id)}
+            />
           ))}
         </View>
       ))}
@@ -121,3 +220,4 @@ const styles = StyleSheet.create({
     alignItems: "flex-end",
   },
 });
+

--- a/components/progress/records/RecentPRList.tsx
+++ b/components/progress/records/RecentPRList.tsx
@@ -5,6 +5,7 @@ import { Separator } from "@/components/ui/separator";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { formatDateShort } from "@/lib/format";
 import { toDisplay } from "@/lib/units";
+import VariantChip from "./VariantChip";
 import type { RecentPR } from "@/lib/db/pr-dashboard";
 
 type Props = {
@@ -35,47 +36,89 @@ function formatValue(pr: RecentPR, unit: "kg" | "lb"): string {
   return "-";
 }
 
-export default function RecentPRList({ prs, weightUnit, onPressExercise }: Props) {
-  const colors = useThemeColors();
+type PrRowProps = {
+  pr: RecentPR;
+  showSeparator: boolean;
+  weightUnit: "kg" | "lb";
+  onPress: () => void;
+};
 
+function PrRow({ pr, showSeparator, weightUnit, onPress }: PrRowProps) {
+  const colors = useThemeColors();
+  const variant = pr.variants?.[0];
+  const isUnspecified = variant
+    ? (variant.attachment === null && variant.mountPosition === null &&
+       variant.gripType === null && variant.stackUnitAtLog === null)
+    : false;
+  const value = formatValue(pr, weightUnit);
+  const delta = formatDelta(pr, weightUnit);
+  const variantLabel = variant && !isUnspecified
+    ? `, variant: ${variant.attachment ?? "unspecified"}`
+    : "";
+  const a11yLabel = `${pr.name}${variantLabel}: ${value}, ${delta}, ${formatDateShort(pr.date)}`;
+
+  return (
+    <React.Fragment>
+      <Pressable
+        style={styles.prRow}
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={a11yLabel}
+      >
+        <View style={[styles.nameCol, { overflow: "hidden" }]}>
+          <Text style={{ color: colors.onSurface }}>{pr.name}</Text>
+          {variant && !isUnspecified ? (
+            <VariantChip variant={{
+              attachment: variant.attachment,
+              mountPosition: variant.mountPosition,
+              gripType: variant.gripType,
+              stackUnitAtLog: variant.stackUnitAtLog,
+            }} />
+          ) : variant && isUnspecified ? (
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+              (unspecified)
+            </Text>
+          ) : null}
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+            {formatDateShort(pr.date)}
+          </Text>
+        </View>
+        <View style={styles.valueCol}>
+          <Text style={{ color: colors.onSurface, fontWeight: "600" }}>
+            {value}
+          </Text>
+          {delta ? (
+            <Text variant="caption" style={{ color: colors.primary, fontWeight: "600" }}>
+              {delta}
+            </Text>
+          ) : null}
+        </View>
+      </Pressable>
+      {showSeparator && <Separator style={{ marginVertical: 2 }} />}
+    </React.Fragment>
+  );
+}
+
+export default function RecentPRList({ prs, weightUnit, onPressExercise }: Props) {
   if (prs.length === 0) return null;
 
   return (
     <View style={styles.container}>
       <Text
         variant="subtitle"
-        style={[styles.sectionTitle, { color: colors.onSurface }]}
+        style={[styles.sectionTitle]}
         accessibilityRole="header"
       >
         Recent PRs
       </Text>
       {prs.map((pr, i) => (
-        <React.Fragment key={`${pr.exercise_id}-${pr.date}`}>
-          <Pressable
-            style={styles.prRow}
-            onPress={() => onPressExercise(pr.exercise_id)}
-            accessibilityRole="button"
-            accessibilityLabel={`${pr.name}: ${formatValue(pr, weightUnit)}, ${formatDelta(pr, weightUnit)}, ${formatDateShort(pr.date)}`}
-          >
-            <View style={{ flex: 1 }}>
-              <Text style={{ color: colors.onSurface }}>{pr.name}</Text>
-              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-                {formatDateShort(pr.date)}
-              </Text>
-            </View>
-            <View style={styles.valueCol}>
-              <Text style={{ color: colors.onSurface, fontWeight: "600" }}>
-                {formatValue(pr, weightUnit)}
-              </Text>
-              {formatDelta(pr, weightUnit) ? (
-                <Text variant="caption" style={{ color: colors.primary, fontWeight: "600" }}>
-                  {formatDelta(pr, weightUnit)}
-                </Text>
-              ) : null}
-            </View>
-          </Pressable>
-          {i < prs.length - 1 && <Separator style={{ marginVertical: 2 }} />}
-        </React.Fragment>
+        <PrRow
+          key={`${pr.exercise_id}-${pr.date}-${pr.variants?.[0]?.attachment ?? ""}`}
+          pr={pr}
+          showSeparator={i < prs.length - 1}
+          weightUnit={weightUnit}
+          onPress={() => onPressExercise(pr.exercise_id)}
+        />
       ))}
     </View>
   );
@@ -93,6 +136,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingVertical: 12,
     minHeight: 48,
+  },
+  nameCol: {
+    flex: 1,
   },
   valueCol: {
     alignItems: "flex-end",

--- a/components/progress/records/RecentPRList.tsx
+++ b/components/progress/records/RecentPRList.tsx
@@ -6,7 +6,12 @@ import { useThemeColors } from "@/hooks/useThemeColors";
 import { formatDateShort } from "@/lib/format";
 import { toDisplay } from "@/lib/units";
 import VariantChip from "./VariantChip";
-import type { RecentPR } from "@/lib/db/pr-dashboard";
+import type { RecentPR, VariantBest } from "@/lib/db/pr-dashboard";
+
+function isAllNull(v: VariantBest): boolean {
+  return v.attachment === null && v.mountPosition === null &&
+    v.gripType === null && v.stackUnitAtLog === null;
+}
 
 type Props = {
   prs: RecentPR[];
@@ -46,10 +51,7 @@ type PrRowProps = {
 function PrRow({ pr, showSeparator, weightUnit, onPress }: PrRowProps) {
   const colors = useThemeColors();
   const variant = pr.variants?.[0];
-  const isUnspecified = variant
-    ? (variant.attachment === null && variant.mountPosition === null &&
-       variant.gripType === null && variant.stackUnitAtLog === null)
-    : false;
+  const isUnspecified = variant ? isAllNull(variant) : false;
   const value = formatValue(pr, weightUnit);
   const delta = formatDelta(pr, weightUnit);
   const variantLabel = variant && !isUnspecified
@@ -67,17 +69,14 @@ function PrRow({ pr, showSeparator, weightUnit, onPress }: PrRowProps) {
       >
         <View style={[styles.nameCol, { overflow: "hidden" }]}>
           <Text style={{ color: colors.onSurface }}>{pr.name}</Text>
-          {variant && !isUnspecified ? (
-            <VariantChip variant={{
-              attachment: variant.attachment,
-              mountPosition: variant.mountPosition,
-              gripType: variant.gripType,
-              stackUnitAtLog: variant.stackUnitAtLog,
-            }} />
-          ) : variant && isUnspecified ? (
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-              (unspecified)
-            </Text>
+          {variant ? (
+            isUnspecified ? (
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                (unspecified)
+              </Text>
+            ) : (
+              <VariantChip variant={variant} />
+            )
           ) : null}
           <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
             {formatDateShort(pr.date)}

--- a/components/progress/records/VariantChip.tsx
+++ b/components/progress/records/VariantChip.tsx
@@ -1,0 +1,128 @@
+/**
+ * BLD-1086: Variant chip for per-variant PR cards.
+ *
+ * Renders a horizontal row of variant dimension labels below the exercise name.
+ * Null dimensions are rendered as em-dash (–). If ALL four dimensions are null
+ * the chip renders nothing (caller should show "(unspecified)" caption instead).
+ *
+ * 390px web-viewport: chip text wraps within its container; max 28 chars before
+ * ellipsizing in the middle. Parent-to-child width constraint is enforced by
+ * flex:1 on the container — do not set a fixed width here.
+ *
+ * accessibilityLabel is the full human-readable sentence:
+ *   "Variant: Rope attachment, high mount, neutral grip, kilograms."
+ */
+
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import {
+  ATTACHMENT_LABELS,
+  MOUNT_POSITION_LABELS,
+  GRIP_TYPE_LABELS,
+} from "@/lib/types";
+
+export type VariantTuple = {
+  attachment: string | null;
+  mountPosition: string | null;
+  gripType: string | null;
+  stackUnitAtLog: string | null;
+};
+
+function labelFor(
+  value: string | null,
+  dict: Record<string, string>
+): string {
+  if (value === null) return "–";
+  return dict[value] ?? value;
+}
+
+function stackUnitLabel(unit: string | null): string {
+  if (unit === null) return "–";
+  if (unit === "kg") return "kg";
+  if (unit === "lb") return "lb";
+  return unit;
+}
+
+function isAllNull(v: VariantTuple): boolean {
+  return v.attachment === null && v.mountPosition === null && v.gripType === null && v.stackUnitAtLog === null;
+}
+
+function buildChipText(v: VariantTuple): string {
+  const parts = [
+    labelFor(v.attachment, ATTACHMENT_LABELS as Record<string, string>),
+    labelFor(v.mountPosition, MOUNT_POSITION_LABELS as Record<string, string>),
+    labelFor(v.gripType, GRIP_TYPE_LABELS as Record<string, string>),
+    stackUnitLabel(v.stackUnitAtLog),
+  ];
+  // Collapse trailing em-dashes if all subsequent dims are null
+  let end = parts.length - 1;
+  while (end > 0 && parts[end] === "–") end--;
+  return parts.slice(0, end + 1).join(" · ");
+}
+
+function buildAccessibilityLabel(v: VariantTuple): string {
+  const parts: string[] = [];
+  if (v.attachment !== null) {
+    parts.push(`${labelFor(v.attachment, ATTACHMENT_LABELS as Record<string, string>)} attachment`);
+  }
+  if (v.mountPosition !== null) {
+    parts.push(`${labelFor(v.mountPosition, MOUNT_POSITION_LABELS as Record<string, string>)} mount`);
+  }
+  if (v.gripType !== null) {
+    parts.push(`${labelFor(v.gripType, GRIP_TYPE_LABELS as Record<string, string>)} grip`);
+  }
+  if (v.stackUnitAtLog !== null) {
+    parts.push(stackUnitLabel(v.stackUnitAtLog));
+  }
+  if (parts.length === 0) return "Variant: unspecified.";
+  return `Variant: ${parts.join(", ")}.`;
+}
+
+type Props = {
+  variant: VariantTuple;
+};
+
+export default function VariantChip({ variant }: Props) {
+  const colors = useThemeColors();
+
+  if (isAllNull(variant)) return null;
+
+  const chipText = buildChipText(variant);
+  const a11yLabel = buildAccessibilityLabel(variant);
+
+  return (
+    <View
+      style={styles.chipWrap}
+      accessible
+      accessibilityLabel={a11yLabel}
+      accessibilityRole="text"
+    >
+      <Text
+        variant="caption"
+        numberOfLines={1}
+        ellipsizeMode="middle"
+        style={[styles.chipText, { color: colors.primary, backgroundColor: colors.primaryContainer }]}
+      >
+        {chipText}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  chipWrap: {
+    flexDirection: "row",
+    overflow: "hidden",
+    marginTop: 3,
+  },
+  chipText: {
+    flex: 1,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    fontSize: 11,
+    overflow: "hidden",
+  },
+});

--- a/lib/db/exercise-history.ts
+++ b/lib/db/exercise-history.ts
@@ -2,25 +2,13 @@ import { eq, ne, and, sql, desc, asc, isNotNull, isNull, inArray, max, sum, coun
 import { query, queryOne, getDrizzle } from "./helpers";
 import { workoutSets, workoutSessions, exercises } from "./schema";
 import { mapRow } from "./exercises";
-import type { Exercise, Attachment, MountPosition } from "../types";
-
-/**
- * BLD-788: variant scope for analytics queries.
- *
- * Each field is independent:
- *   - `attachment === undefined` → no constraint on attachment dimension.
- *   - `attachment === null`      → match rows where attachment IS NULL.
- *   - `attachment === <value>`   → match rows where attachment = <value>.
- *
- * Same shape for `mount_position`. The default ("All variants") passes an
- * empty object — both fields undefined.
- *
- * Read-only filter; never mutates `workout_sets`.
- */
-export type VariantScope = {
-  attachment?: Attachment | null;
-  mount_position?: MountPosition | null;
-};
+import type { Exercise } from "../types";
+// BLD-1086 Phase 0a: VariantScope + helpers moved to variant-scope.ts.
+// Re-export for backward compatibility with all existing call-sites.
+export type { VariantScope } from "./variant-scope";
+export { buildVariantSql, variantDrizzleConditions } from "./variant-scope";
+import type { VariantScope } from "./variant-scope";
+import { buildVariantSql, variantDrizzleConditions } from "./variant-scope";
 
 export type ExerciseSession = {
   session_id: string;
@@ -97,60 +85,6 @@ export async function getExerciseHistory(
     avg_rpe: r.avg_rpe != null ? Number(r.avg_rpe) : null,
     max_modifier: r.max_modifier != null ? Number(r.max_modifier) : null,
   }));
-}
-
-/**
- * BLD-788: build the variant SQL fragment for raw queries.
- *
- * Returns `{ sql: " AND ws.attachment = ? AND ws.mount_position IS NULL", params: [...] }`.
- * Empty fragment (`""`, `[]`) when `scope` is undefined or has no dimensions set.
- *
- * Caller is responsible for placing the fragment in a position where the
- * `ws` alias is bound to `workout_sets`.
- */
-export function buildVariantSql(scope?: VariantScope): { sql: string; params: (string | null)[] } {
-  if (!scope) return { sql: "", params: [] };
-  const parts: string[] = [];
-  const params: (string | null)[] = [];
-
-  if (scope.attachment !== undefined) {
-    if (scope.attachment === null) {
-      parts.push("ws.attachment IS NULL");
-    } else {
-      parts.push("ws.attachment = ?");
-      params.push(scope.attachment);
-    }
-  }
-  if (scope.mount_position !== undefined) {
-    if (scope.mount_position === null) {
-      parts.push("ws.mount_position IS NULL");
-    } else {
-      parts.push("ws.mount_position = ?");
-      params.push(scope.mount_position);
-    }
-  }
-  if (parts.length === 0) return { sql: "", params: [] };
-  return { sql: " AND " + parts.join(" AND "), params };
-}
-
-/**
- * BLD-788: Drizzle-flavored variant predicate. Returns SQL fragments to AND
- * into a Drizzle `where()` chain. Returns `[]` when scope is empty.
- */
-function variantDrizzleConditions(scope?: VariantScope) {
-  const conds: ReturnType<typeof eq | typeof isNull>[] = [];
-  if (!scope) return conds;
-  if (scope.attachment !== undefined) {
-    conds.push(scope.attachment === null
-      ? isNull(workoutSets.attachment)
-      : eq(workoutSets.attachment, scope.attachment));
-  }
-  if (scope.mount_position !== undefined) {
-    conds.push(scope.mount_position === null
-      ? isNull(workoutSets.mount_position)
-      : eq(workoutSets.mount_position, scope.mount_position));
-  }
-  return conds;
 }
 
 /**

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -226,4 +226,16 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
     SET set_number = (SELECT rn FROM renumbered WHERE renumbered.id = workout_sets.id)
     WHERE id IN (SELECT id FROM renumbered WHERE rn != workout_sets.set_number)
   `);
+
+  // BLD-1086 Phase 0b: Composite index for per-variant PR aggregation.
+  // Covers (exercise_id, attachment, mount_position, grip_type, completed_at)
+  // so the GROUP BY query in bestPerVariant uses the index rather than scanning
+  // the full table. `stack_unit_at_log` is intentionally omitted — cardinality
+  // is ~1-2 per user; the index covers the high-cost variant fan-out first.
+  // CREATE INDEX IF NOT EXISTS is idempotent (safe on every boot).
+  await database.execAsync(`
+    CREATE INDEX IF NOT EXISTS idx_workout_sets_variant_pr
+      ON workout_sets (exercise_id, attachment, mount_position, grip_type, completed_at)
+  `);
 }
+

--- a/lib/db/pr-dashboard.ts
+++ b/lib/db/pr-dashboard.ts
@@ -8,9 +8,15 @@
  * where the max weight (or max reps for bodyweight exercises) exceeds the prior historical best.
  *
  * Duration/isometric PRs are out of scope for V1.
+ *
+ * BLD-1086: Cable exercises now expose per-variant breakdowns via `variants` on
+ * RecentPR/AllTimeBest. Non-cable exercises are unaffected. The variant-aware
+ * code path is gated behind `settings.show_variant_prs` (default true) — a
+ * manual rollback hatch only, NOT an auto-fallback on perf timeout.
  */
 
 import { query } from "./helpers";
+import { getAppSetting } from "./settings";
 import { epley } from "../rm";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -18,6 +24,23 @@ import { epley } from "../rm";
 export type PRStats = {
   totalPRs: number;
   prsThisMonth: number;
+};
+
+/**
+ * BLD-1086: per-variant best for a single cable exercise variant tuple.
+ * attachment/mountPosition/gripType/stackUnitAtLog are the four variant key
+ * dimensions (each can be null = user did not specify).
+ */
+export type VariantBest = {
+  attachment: string | null;
+  mountPosition: string | null;
+  gripType: string | null;
+  stackUnitAtLog: string | null;
+  weight: number;
+  reps: number;
+  e1rm: number;
+  achievedAt: number;
+  sessionCount: number;
 };
 
 export type RecentPR = {
@@ -29,6 +52,8 @@ export type RecentPR = {
   previous_best: number | null;
   date: number;
   is_weighted: boolean;
+  // BLD-1086: only set for cable exercises when show_variant_prs=true.
+  variants?: VariantBest[];
 };
 
 export type AllTimeBest = {
@@ -46,7 +71,10 @@ export type AllTimeBest = {
   // with at least one non-null modifier recorded).
   best_added_kg: number | null;
   best_assisted_kg: number | null;
+  // BLD-1086: only set for cable exercises when show_variant_prs=true.
+  variants?: VariantBest[];
 };
+
 
 /**
  * Weighted-bodyweight PR aggregate per exercise (BLD-541).
@@ -59,6 +87,101 @@ export type WeightedBodyweightPR = {
   best_added_kg: number | null;   // max positive modifier (best = most added)
   best_assisted_kg: number | null; // max negative modifier (best = least negative, closest to 0)
 };
+
+// ─── BLD-1086: Variant PR helpers ───────────────────────────────────────────
+
+/**
+ * Returns true when the per-variant display is enabled (kill-switch not flipped).
+ * Default: true. Manual rollback: set app setting show_variant_prs=0.
+ * NEVER auto-fallback to merged-best on perf timeout — callers must surface an
+ * explicit error state instead.
+ */
+export async function showVariantPrs(): Promise<boolean> {
+  const val = await getAppSetting("show_variant_prs");
+  return val !== "0";
+}
+
+/**
+ * BLD-1086: Per-variant best aggregation for a single cable exercise.
+ *
+ * Groups completed non-warmup sets by the full five-position variant key:
+ *   (exercise_id, attachment, mount_position, grip_type, stack_unit_at_log)
+ *
+ * NULL is a DISTINCT value at every position — four combinations of
+ * (rope, high), (rope, null), (null, high), (null, null) produce four rows.
+ * Caller must provide a cableExerciseId from an exercise WHERE equipment = 'cable'.
+ *
+ * Returns rows ordered by achievedAt DESC (most recent first).
+ */
+export async function bestPerVariant(exerciseId: string): Promise<VariantBest[]> {
+  const rows = await query<{
+    attachment: string | null;
+    mount_position: string | null;
+    grip_type: string | null;
+    stack_unit_at_log: string | null;
+    max_weight: number;
+    best_reps: number;
+    achieved_at: number;
+    session_count: number;
+  }>(
+    `SELECT
+       ws.attachment,
+       ws.mount_position,
+       ws.grip_type,
+       ws.stack_unit_at_log,
+       MAX(ws.weight)                                   AS max_weight,
+       ws.reps                                          AS best_reps,
+       MAX(ws.completed_at)                             AS achieved_at,
+       COUNT(DISTINCT ws.session_id)                    AS session_count
+     FROM workout_sets ws
+     INNER JOIN workout_sessions wss ON ws.session_id = wss.id
+     WHERE ws.exercise_id = ?
+       AND ws.completed = 1
+       AND ws.weight IS NOT NULL AND ws.weight > 0
+       AND ws.set_type != 'warmup'
+       AND wss.completed_at IS NOT NULL
+     GROUP BY ws.exercise_id,
+              ws.attachment,
+              ws.mount_position,
+              ws.grip_type,
+              ws.stack_unit_at_log
+     ORDER BY achieved_at DESC`,
+    [exerciseId]
+  );
+
+  return rows.map((r) => {
+    const e1rm =
+      r.max_weight > 0 && r.best_reps > 0
+        ? Math.round(epley(r.max_weight, r.best_reps) * 10) / 10
+        : 0;
+    return {
+      attachment: r.attachment ?? null,
+      mountPosition: r.mount_position ?? null,
+      gripType: r.grip_type ?? null,
+      stackUnitAtLog: r.stack_unit_at_log ?? null,
+      weight: r.max_weight,
+      reps: r.best_reps,
+      e1rm,
+      achievedAt: r.achieved_at,
+      sessionCount: r.session_count,
+    };
+  });
+}
+
+/**
+ * BLD-1086: IDs of cable exercises (equipment = 'cable') that appear in the
+ * given exercise ID set. Used to gate variant-aware paths without per-exercise N+1.
+ */
+async function getCableExerciseIds(exerciseIds: string[]): Promise<Set<string>> {
+  if (exerciseIds.length === 0) return new Set();
+  const placeholders = exerciseIds.map(() => "?").join(", ");
+  const rows = await query<{ id: string }>(
+    `SELECT id FROM exercises WHERE id IN (${placeholders}) AND equipment = 'cable'`,
+    exerciseIds
+  );
+  return new Set(rows.map((r) => r.id));
+}
+
 
 // ─── Queries ────────────────────────────────────────────────────────────────
 
@@ -151,11 +274,23 @@ export async function getPRStats(): Promise<PRStats> {
 /**
  * Recent PRs with improvement delta.
  * Returns weight PRs and rep PRs (bodyweight) ordered by date descending.
+ *
+ * BLD-1086: When show_variant_prs=true, cable exercises (equipment='cable')
+ * are handled by a separate variant-aware query where the prev_max subquery
+ * is scoped to the SAME variant tuple (NULL-safe IS equality). This correctly
+ * surfaces a rope PR even after a heavier straight-bar session in the same period.
+ * Cable exercises are excluded from the exercise-level query when variant mode
+ * is active, preventing double-counting.
  */
 export async function getRecentPRsWithDelta(
   limit: number = 20
 ): Promise<RecentPR[]> {
-  // Weight PRs
+  const variantEnabled = await showVariantPrs();
+
+  // Weight PRs — non-cable exercises (or all weighted when variant mode is off)
+  const nonCableFilter = variantEnabled
+    ? "AND (ex.equipment IS NULL OR ex.equipment NOT IN ('cable'))"
+    : "";
   const weightPRs = await query<{
     exercise_id: string;
     name: string;
@@ -187,10 +322,12 @@ export async function getRecentPRsWithDelta(
               ) as prev_max
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
+       LEFT JOIN exercises ex ON ws.exercise_id = ex.id
        WHERE ws.completed = 1
          AND ws.weight IS NOT NULL AND ws.weight > 0
          AND ws.set_type != 'warmup'
          AND wss.completed_at IS NOT NULL
+         ${nonCableFilter}
        GROUP BY ws.exercise_id, ws.session_id
        HAVING session_max > prev_max
      ) sub
@@ -200,7 +337,76 @@ export async function getRecentPRsWithDelta(
     [limit]
   );
 
-  // Rep PRs for bodyweight exercises
+  // BLD-1086: Cable variant-aware weight PRs — prev_max scoped to same variant tuple.
+  // Each group (exercise × session × variant_tuple) is its own PR event.
+  const cableVariantPRs: Array<{
+    exercise_id: string;
+    name: string;
+    category: string;
+    weight: number;
+    previous_best: number;
+    date: number;
+    attachment: string | null;
+    mount_position: string | null;
+    grip_type: string | null;
+    stack_unit_at_log: string | null;
+  }> = variantEnabled
+    ? await query(
+        `SELECT
+           sub.exercise_id,
+           COALESCE(e.name, 'Deleted Exercise') as name,
+           COALESCE(e.category, 'Other') as category,
+           sub.session_max as weight,
+           sub.prev_max as previous_best,
+           sub.date,
+           sub.attachment,
+           sub.mount_position,
+           sub.grip_type,
+           sub.stack_unit_at_log
+         FROM (
+           SELECT ws.exercise_id, ws.session_id,
+                  wss.started_at as date,
+                  ws.attachment,
+                  ws.mount_position,
+                  ws.grip_type,
+                  ws.stack_unit_at_log,
+                  MAX(ws.weight) as session_max,
+                  (SELECT COALESCE(MAX(ws2.weight), 0)
+                   FROM workout_sets ws2
+                   JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
+                   WHERE ws2.exercise_id = ws.exercise_id
+                     AND ws2.session_id != ws.session_id
+                     AND ws2.completed = 1
+                     AND ws2.weight IS NOT NULL AND ws2.weight > 0
+                     AND ws2.set_type != 'warmup'
+                     AND wss2.completed_at IS NOT NULL
+                     AND wss2.started_at < wss.started_at
+                     AND ws2.attachment IS ws.attachment
+                     AND ws2.mount_position IS ws.mount_position
+                     AND ws2.grip_type IS ws.grip_type
+                     AND ws2.stack_unit_at_log IS ws.stack_unit_at_log
+                  ) as prev_max
+           FROM workout_sets ws
+           JOIN workout_sessions wss ON ws.session_id = wss.id
+           JOIN exercises ex_cable ON ws.exercise_id = ex_cable.id
+             AND ex_cable.equipment = 'cable'
+           WHERE ws.completed = 1
+             AND ws.weight IS NOT NULL AND ws.weight > 0
+             AND ws.set_type != 'warmup'
+             AND wss.completed_at IS NOT NULL
+           GROUP BY ws.exercise_id, ws.session_id,
+                    ws.attachment, ws.mount_position,
+                    ws.grip_type, ws.stack_unit_at_log
+           HAVING session_max > prev_max
+         ) sub
+         LEFT JOIN exercises e ON sub.exercise_id = e.id
+         ORDER BY sub.date DESC
+         LIMIT ?`,
+        [limit]
+      )
+    : [];
+
+  // Rep PRs for bodyweight exercises (unchanged)
   const repPRs = await query<{
     exercise_id: string;
     name: string;
@@ -258,6 +464,28 @@ export async function getRecentPRsWithDelta(
       previous_best: p.previous_best,
       date: p.date,
       is_weighted: true,
+    })),
+    ...cableVariantPRs.map((p) => ({
+      exercise_id: p.exercise_id,
+      name: p.name,
+      category: p.category,
+      weight: p.weight,
+      reps: null as number | null,
+      previous_best: p.previous_best,
+      date: p.date,
+      is_weighted: true,
+      // Each cable variant PR carries exactly one variant tuple — the one that set the PR.
+      variants: [{
+        attachment: p.attachment,
+        mountPosition: p.mount_position,
+        gripType: p.grip_type,
+        stackUnitAtLog: p.stack_unit_at_log,
+        weight: p.weight,
+        reps: 0,
+        e1rm: 0,
+        achievedAt: p.date,
+        sessionCount: 1,
+      }] as VariantBest[],
     })),
     ...repPRs.map((p) => ({
       exercise_id: p.exercise_id,
@@ -439,6 +667,22 @@ export async function getAllTimeBests(): Promise<AllTimeBest[]> {
     if (catCmp !== 0) return catCmp;
     return a.name.localeCompare(b.name);
   });
+
+  // BLD-1086: attach per-variant breakdowns for cable exercises
+  const variantEnabled = await showVariantPrs();
+  if (variantEnabled && results.length > 0) {
+    const weightedIds = results.filter((r) => r.is_weighted).map((r) => r.exercise_id);
+    const cableIds = await getCableExerciseIds([...new Set(weightedIds)]);
+    if (cableIds.size > 0) {
+      await Promise.all(
+        results.map(async (best) => {
+          if (best.is_weighted && cableIds.has(best.exercise_id)) {
+            best.variants = await bestPerVariant(best.exercise_id);
+          }
+        })
+      );
+    }
+  }
 
   return results;
 }

--- a/lib/db/pr-dashboard.ts
+++ b/lib/db/pr-dashboard.ts
@@ -124,17 +124,51 @@ export async function bestPerVariant(exerciseId: string): Promise<VariantBest[]>
     achieved_at: number;
     session_count: number;
   }>(
+    // BLD-1086 fix: bare-column-from-MAX/MIN-row association ONLY works with
+    // EXACTLY ONE max()/min() in the SELECT. With two MAX() calls (weight +
+    // completed_at), SQLite selects bare columns (reps) arbitrarily.
+    // Use ROW_NUMBER() subquery to pin reps + completed_at to the max-weight row.
     `SELECT
        ws.attachment,
        ws.mount_position,
        ws.grip_type,
        ws.stack_unit_at_log,
        MAX(ws.weight)                                   AS max_weight,
-       ws.reps                                          AS best_reps,
-       MAX(ws.completed_at)                             AS achieved_at,
+       best.reps                                        AS best_reps,
+       best.completed_at                                AS achieved_at,
        COUNT(DISTINCT ws.session_id)                    AS session_count
      FROM workout_sets ws
      INNER JOIN workout_sessions wss ON ws.session_id = wss.id
+     LEFT JOIN (
+       SELECT
+         ws_b.exercise_id,
+         ws_b.attachment,
+         ws_b.mount_position,
+         ws_b.grip_type,
+         ws_b.stack_unit_at_log,
+         ws_b.reps,
+         ws_b.completed_at,
+         ROW_NUMBER() OVER (
+           PARTITION BY ws_b.exercise_id,
+                        ws_b.attachment,
+                        ws_b.mount_position,
+                        ws_b.grip_type,
+                        ws_b.stack_unit_at_log
+           ORDER BY ws_b.weight DESC, ws_b.completed_at DESC
+         ) AS rn
+       FROM workout_sets ws_b
+       INNER JOIN workout_sessions wss_b ON ws_b.session_id = wss_b.id
+       WHERE ws_b.exercise_id = ?
+         AND ws_b.completed = 1
+         AND ws_b.weight IS NOT NULL AND ws_b.weight > 0
+         AND ws_b.set_type != 'warmup'
+         AND wss_b.completed_at IS NOT NULL
+     ) best ON best.rn = 1
+           AND best.exercise_id = ws.exercise_id
+           AND best.attachment IS ws.attachment
+           AND best.mount_position IS ws.mount_position
+           AND best.grip_type IS ws.grip_type
+           AND best.stack_unit_at_log IS ws.stack_unit_at_log
      WHERE ws.exercise_id = ?
        AND ws.completed = 1
        AND ws.weight IS NOT NULL AND ws.weight > 0
@@ -145,8 +179,8 @@ export async function bestPerVariant(exerciseId: string): Promise<VariantBest[]>
               ws.mount_position,
               ws.grip_type,
               ws.stack_unit_at_log
-     ORDER BY achieved_at DESC`,
-    [exerciseId]
+     ORDER BY best.completed_at DESC`,
+    [exerciseId, exerciseId]
   );
 
   return rows.map((r) => {

--- a/lib/db/strength-overview.ts
+++ b/lib/db/strength-overview.ts
@@ -4,18 +4,70 @@ export type StrengthOverviewRow = {
   exercise_id: string;
   name: string;
   est_1rm: number;
+  // BLD-1086: variant provenance for caption-only display on Strength Levels card.
+  // Non-null only for cable exercises (equipment='cable'). Never changes the level.
+  best_variant_attachment: string | null;
+  best_variant_mount: string | null;
+  best_variant_grip_type: string | null;
 };
 
 /**
  * Get the best e1RM for all exercises that have at least one completed weighted set.
  * Used by the progress screen strength levels card.
+ *
+ * BLD-1086: For cable exercises the row also carries the variant tuple
+ * (attachment, mount_position, grip_type) of the single best set, so the
+ * Strength Levels card can show caption-only provenance ("best achieved with: Rope").
+ * The level itself stays exercise-best — no per-variant recalculation.
  */
 export async function getStrengthOverview(): Promise<StrengthOverviewRow[]> {
   return query<StrengthOverviewRow>(
     `SELECT
        ws.exercise_id,
        e.name,
-       MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS est_1rm
+       MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS est_1rm,
+       CASE WHEN e.equipment = 'cable'
+         THEN (
+           SELECT ws2.attachment
+           FROM workout_sets ws2
+           JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
+           WHERE ws2.exercise_id = ws.exercise_id
+             AND ws2.completed = 1 AND ws2.set_type != 'warmup'
+             AND ws2.weight > 0 AND ws2.reps > 0 AND ws2.reps <= 12
+             AND wss2.completed_at IS NOT NULL
+           ORDER BY ws2.weight * (1.0 + ws2.reps / 30.0) DESC
+           LIMIT 1
+         )
+         ELSE NULL
+       END AS best_variant_attachment,
+       CASE WHEN e.equipment = 'cable'
+         THEN (
+           SELECT ws2.mount_position
+           FROM workout_sets ws2
+           JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
+           WHERE ws2.exercise_id = ws.exercise_id
+             AND ws2.completed = 1 AND ws2.set_type != 'warmup'
+             AND ws2.weight > 0 AND ws2.reps > 0 AND ws2.reps <= 12
+             AND wss2.completed_at IS NOT NULL
+           ORDER BY ws2.weight * (1.0 + ws2.reps / 30.0) DESC
+           LIMIT 1
+         )
+         ELSE NULL
+       END AS best_variant_mount,
+       CASE WHEN e.equipment = 'cable'
+         THEN (
+           SELECT ws2.grip_type
+           FROM workout_sets ws2
+           JOIN workout_sessions wss2 ON ws2.session_id = wss2.id
+           WHERE ws2.exercise_id = ws.exercise_id
+             AND ws2.completed = 1 AND ws2.set_type != 'warmup'
+             AND ws2.weight > 0 AND ws2.reps > 0 AND ws2.reps <= 12
+             AND wss2.completed_at IS NOT NULL
+           ORDER BY ws2.weight * (1.0 + ws2.reps / 30.0) DESC
+           LIMIT 1
+         )
+         ELSE NULL
+       END AS best_variant_grip_type
      FROM workout_sets ws
      JOIN workout_sessions wss ON ws.session_id = wss.id
      JOIN exercises e ON ws.exercise_id = e.id

--- a/lib/db/variant-scope.ts
+++ b/lib/db/variant-scope.ts
@@ -1,0 +1,109 @@
+/**
+ * BLD-1086 Phase 0a: Variant scope helpers extracted from exercise-history.ts.
+ *
+ * `VariantScope` now includes all five variant-key dimensions used by the
+ * global PR Dashboard aggregation:
+ *   (exercise_id, attachment, mount_position, grip_type, stack_unit_at_log)
+ *
+ * Existing call-sites pass `gripType: undefined, stackUnitAtLog: undefined`
+ * (or nothing) so behavior is unchanged. New call-sites opt in by supplying values.
+ *
+ * NULL semantics per dimension:
+ *   - `field === undefined` → no constraint (wildcard)
+ *   - `field === null`      → match rows WHERE field IS NULL
+ *   - `field === <value>`   → match rows WHERE field = <value>
+ */
+
+import { eq, isNull } from "drizzle-orm";
+import { workoutSets } from "./schema";
+import type { Attachment, MountPosition, GripType } from "../types";
+
+export type VariantScope = {
+  attachment?: Attachment | null;
+  mount_position?: MountPosition | null;
+  gripType?: GripType | null;
+  stackUnitAtLog?: string | null;
+};
+
+/**
+ * Build raw SQL fragment for variant filtering (for use in raw `query()` calls).
+ *
+ * Returns `{ sql: " AND ws.attachment = ? …", params: [...] }`.
+ * Returns `{ sql: "", params: [] }` when scope is undefined or fully unconstrained.
+ *
+ * The caller is responsible for placing the fragment in a context where `ws`
+ * is bound to `workout_sets`.
+ */
+export function buildVariantSql(scope?: VariantScope): { sql: string; params: (string | null)[] } {
+  if (!scope) return { sql: "", params: [] };
+  const parts: string[] = [];
+  const params: (string | null)[] = [];
+
+  if (scope.attachment !== undefined) {
+    if (scope.attachment === null) {
+      parts.push("ws.attachment IS NULL");
+    } else {
+      parts.push("ws.attachment = ?");
+      params.push(scope.attachment);
+    }
+  }
+  if (scope.mount_position !== undefined) {
+    if (scope.mount_position === null) {
+      parts.push("ws.mount_position IS NULL");
+    } else {
+      parts.push("ws.mount_position = ?");
+      params.push(scope.mount_position);
+    }
+  }
+  if (scope.gripType !== undefined) {
+    if (scope.gripType === null) {
+      parts.push("ws.grip_type IS NULL");
+    } else {
+      parts.push("ws.grip_type = ?");
+      params.push(scope.gripType);
+    }
+  }
+  if (scope.stackUnitAtLog !== undefined) {
+    if (scope.stackUnitAtLog === null) {
+      parts.push("ws.stack_unit_at_log IS NULL");
+    } else {
+      parts.push("ws.stack_unit_at_log = ?");
+      params.push(scope.stackUnitAtLog);
+    }
+  }
+
+  if (parts.length === 0) return { sql: "", params: [] };
+  return { sql: " AND " + parts.join(" AND "), params };
+}
+
+/**
+ * Drizzle-flavored variant predicate. Returns SQL fragments to AND into a
+ * Drizzle `where()` chain. Returns `[]` when scope is empty.
+ */
+export function variantDrizzleConditions(scope?: VariantScope) {
+  const conds: ReturnType<typeof eq | typeof isNull>[] = [];
+  if (!scope) return conds;
+
+  if (scope.attachment !== undefined) {
+    conds.push(scope.attachment === null
+      ? isNull(workoutSets.attachment)
+      : eq(workoutSets.attachment, scope.attachment));
+  }
+  if (scope.mount_position !== undefined) {
+    conds.push(scope.mount_position === null
+      ? isNull(workoutSets.mount_position)
+      : eq(workoutSets.mount_position, scope.mount_position));
+  }
+  if (scope.gripType !== undefined) {
+    conds.push(scope.gripType === null
+      ? isNull(workoutSets.grip_type)
+      : eq(workoutSets.grip_type, scope.gripType));
+  }
+  if (scope.stackUnitAtLog !== undefined) {
+    conds.push(scope.stackUnitAtLog === null
+      ? isNull(workoutSets.stack_unit_at_log)
+      : eq(workoutSets.stack_unit_at_log, scope.stackUnitAtLog));
+  }
+
+  return conds;
+}


### PR DESCRIPTION
## Summary

Implements BLD-1086 (per PLAN-BLD-1085 APPROVED): adds per-variant PR breakdowns to the Global PR Dashboard for cable exercises. Non-cable exercises are completely unaffected.

## Changes

**Phase 0a — Refactor**
- `lib/db/variant-scope.ts` (NEW): extracted `VariantScope` type, `buildVariantSql()`, `variantDrizzleConditions()` from exercise-history
- `lib/db/exercise-history.ts`: re-exports from variant-scope for backward compat

**Phase 0b — Migration**
- `lib/db/migrations.ts`: adds composite index `idx_workout_sets_variant_pr` on `(exercise_id, attachment, mount_position, grip_type, completed_at)`

**Phase 1 — Feature**
- `lib/db/pr-dashboard.ts`: variant-scoped cable PR detection with NULL-safe `IS` comparisons, kill-switch via `show_variant_prs` setting
- `components/progress/records/VariantChip.tsx` (NEW): chip rendering attachment/mount/grip with em-dash for nulls, VoiceOver a11y label
- `components/progress/records/AllTimeBestsSection.tsx`: expands cable exercises to 1 card per variant
- `components/progress/records/RecentPRList.tsx`: shows VariantChip for cable PR entries
- `components/progress/StrengthLevelsCard.tsx`: `best achieved with: Rope · High` caption for cable strength levels
- `lib/db/strength-overview.ts`: returns best variant provenance columns for cable exercises

## Testing

- `tsc --noEmit`: zero errors
- `npm test`: 252 tests pass across 18 suites
- New test files: `VariantChip.test.tsx`, `variant-prs.test.ts` (four-bucket NULL matrix, kill-switch, byte-identity guard), `variant-prs-query-plan.test.ts` (EXPLAIN QUERY PLAN confirms index usage), `pr-dashboard.test.ts` (BLD-1086 variant suite added)

## Issue

Resolves BLD-1086 (parent: BLD-1085)