### PR TITLE
fix(gtg): BLD-1090 follow-ups — diagnosable index log, schema NOT NULL, CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS
+# Behaviour-sensitive UI components that require explicit CEO review before
+# adding new features or changing interaction flows.
+# See PLAN-BLD-1088.md §Risk Assessment row 5.
+
+components/home/QuickAddSheet.tsx @ceo

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -253,8 +253,10 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
         ON workout_sessions (day_session_exercise_id, day_session_date)
         WHERE kind = 'day_session'
     `);
-  } catch {
-    // Partial indexes not supported on all platforms — uniqueness enforced by UPSERT
+  } catch (err) {
+    // Partial indexes not supported on all platforms — uniqueness enforced by UPSERT.
+    // Log so a missing index is diagnosable in device/CI logs.
+    console.warn("[migrations] uniq_day_session_per_exercise_date partial index not created:", err);
   }
 }
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -90,7 +90,7 @@ export const workoutSessions = sqliteTable("workout_sessions", {
   // 'workout' (default) = normal session; 'day_session' = GTG backing row.
   // day_session rows have completed_at = started_at = device-local midnight
   // so every existing WHERE completed_at IS NOT NULL analytics filter passes.
-  kind: text("kind").default("workout"),
+  kind: text("kind").default("workout").notNull(),
   // day_session_exercise_id + day_session_date together form the partial unique
   // key enforced by uniq_day_session_per_exercise_date WHERE kind='day_session'.
   // Both are NULL for kind='workout' rows.


### PR DESCRIPTION
## Summary

Three small quality/governance follow-ups from techlead review of PR #521 (BLD-1089 — Grease-the-Groove Day Mode). None are correctness bugs; all are diagnosability, type accuracy, and governance improvements.

## Changes

1. **`lib/db/migrations.ts`**: Add `console.warn` on partial-index creation catch — so a missing `uniq_day_session_per_exercise_date` index is visible in device/CI logs. Correctness fallback path unchanged.

2. **`lib/db/schema.ts`**: `kind` column gains `.notNull()` to match the DDL (`TEXT NOT NULL DEFAULT 'workout'`). Eliminates spurious `string | null` Drizzle type at all call sites.

3. **`CODEOWNERS`**: New file gating `components/home/QuickAddSheet.tsx` behind `@ceo` review per PLAN-BLD-1088 §Risk Assessment row 5.

## Testing

- `npm run typecheck` — passes zero errors
- `npm test -- --testPathPattern="migration-grease|day-session|gtg"` — 18 tests pass

## References

- Parent: BLD-1089 / PR #521
- Plan: `/projects/cablesnap/.plans/PLAN-BLD-1088.md`
- Techlead review nits: BLD-1089 comment 2026-05-08T03:48Z

Resolves BLD-1090