### PR TITLE
fix(privacy): include domain="file" in form-clips backup rules to satisfy Android lint (BLD-1101)

### DIFF
--- a/__tests__/plugins/with-form-clips-backup.test.js
+++ b/__tests__/plugins/with-form-clips-backup.test.js
@@ -79,6 +79,11 @@ describe("with-form-clips-backup plugin — Android XML files", () => {
       const cloudBackupSection = content.slice(cloudBackupStart, cloudBackupEnd);
       expect(cloudBackupSection).toContain('domain="sharedpref" path="SecureStore"');
       expect(cloudBackupSection).toContain('domain="file" path="form-clips/"');
+      // Android lint [FullBackupContent] requires every <exclude> to have a
+      // sibling <include> for the same domain. Without these, lintVitalRelease
+      // fails the release build (BLD-1101 regression guard).
+      expect(cloudBackupSection).toContain('<include domain="sharedpref" path="."/>');
+      expect(cloudBackupSection).toContain('<include domain="file" path="."/>');
     });
 
     it("device-transfer section contains BOTH SecureStore AND form-clips excludes", () => {
@@ -92,6 +97,9 @@ describe("with-form-clips-backup plugin — Android XML files", () => {
       const dtSection = content.slice(dtStart, dtEnd);
       expect(dtSection).toContain('domain="sharedpref" path="SecureStore"');
       expect(dtSection).toContain('domain="file" path="form-clips/"');
+      // Same lint sibling-include requirement (BLD-1101).
+      expect(dtSection).toContain('<include domain="sharedpref" path="."/>');
+      expect(dtSection).toContain('<include domain="file" path="."/>');
     });
 
     it("writes form_clips_backup_rules.xml (API < 31) with SecureStore AND form-clips excludes", () => {
@@ -104,6 +112,13 @@ describe("with-form-clips-backup plugin — Android XML files", () => {
       expect(content).toContain('domain="file" path="form-clips/"');
       expect(content).toContain("<full-backup-content>");
       expect(content).toContain('<?xml version="1.0" encoding="utf-8"?>');
+      // full-backup-content also needs sibling <include> for each domain
+      // referenced by <exclude> to satisfy lint [FullBackupContent] (BLD-1101).
+      const fbStart = content.indexOf("<full-backup-content>");
+      const fbEnd = content.indexOf("</full-backup-content>") + "</full-backup-content>".length;
+      const fbSection = content.slice(fbStart, fbEnd);
+      expect(fbSection).toContain('<include domain="sharedpref" path="."/>');
+      expect(fbSection).toContain('<include domain="file" path="."/>');
     });
 
     it("COMBINED_DATA_EXTRACTION_RULES_XML constant has valid structure with both exclusions", () => {

--- a/plugins/with-form-clips-backup.js
+++ b/plugins/with-form-clips-backup.js
@@ -62,11 +62,13 @@ const COMBINED_DATA_EXTRACTION_RULES_XML = `<?xml version="1.0" encoding="utf-8"
   <cloud-backup>
     <include domain="sharedpref" path="."/>
     <exclude domain="sharedpref" path="SecureStore"/>
+    <include domain="file" path="."/>
     <exclude domain="file" path="form-clips/"/>
   </cloud-backup>
   <device-transfer>
     <include domain="sharedpref" path="."/>
     <exclude domain="sharedpref" path="SecureStore"/>
+    <include domain="file" path="."/>
     <exclude domain="file" path="form-clips/"/>
   </device-transfer>
 </data-extraction-rules>
@@ -88,6 +90,7 @@ const COMBINED_FULL_BACKUP_CONTENT_XML = `<?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
   <include domain="sharedpref" path="."/>
   <exclude domain="sharedpref" path="SecureStore"/>
+  <include domain="file" path="."/>
   <exclude domain="file" path="form-clips/"/>
 </full-backup-content>
 `;


### PR DESCRIPTION
## Summary

Hotfix for v0.26.24 release: `:app:lintVitalRelease` failed with three `[FullBackupContent]` errors because the form-clips backup XML had `<exclude domain="file" path="form-clips/"/>` without a sibling `<include domain="file" .../>` in the same scope.

Lint requires every `<exclude>` to live under an explicit `<include>` of the same domain. Previously only `domain="sharedpref"` had an include, so all three file-domain excludes (cloud-backup, device-transfer, full-backup-content) were rejected.

## Fix

Added `<include domain="file" path="."/>` to every section in `plugins/with-form-clips-backup.js` that contains a file-domain `<exclude>`:
- `COMBINED_DATA_EXTRACTION_RULES_XML` → `<cloud-backup>` and `<device-transfer>`
- `COMBINED_FULL_BACKUP_CONTENT_XML` → `<full-backup-content>` (API < 31)

Semantically a no-op (default Auto Backup includes everything not excluded). Only purpose is to satisfy lint.

## Privacy guarantees preserved

- SecureStore `sharedpref` exclusion (auth tokens) — intact in all 3 scopes
- `form-clips/` `file` exclusion (form-check videos) — intact in all 3 scopes

## Tests

Extended `__tests__/plugins/with-form-clips-backup.test.js` with explicit assertions that BOTH `<include domain="sharedpref" path="."/>` AND `<include domain="file" path="."/>` are present in each of the three scopes (cloud-backup, device-transfer, full-backup-content). This prevents future regressions of this exact lint failure.

```
PASS __tests__/plugins/with-form-clips-backup.test.js (10/10 tests)
```

## Out of scope
- Re-bumping the version (release-bot already shipped v0.26.24 commit on main as `641a3b2a`)
- Other plugins
- iOS form-clips backup logic

## Post-merge

Manually trigger Scheduled Release to ship v0.26.24:
```bash
gh workflow run scheduled-release.yml --repo alankyshum/cablesnap
```

Closes BLD-1101.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>