### PR TITLE
fix(audit-bundle): replace mapfile with portable read loop for bash 3.2

### DIFF
--- a/scripts/audit-bundle.sh
+++ b/scripts/audit-bundle.sh
@@ -113,7 +113,16 @@ fi
 echo "[audit-bundle] pruning audit-* releases older than 14 ..."
 # List audit-* releases sorted newest-first, drop the first 14, delete the rest.
 # --per-page 100 (TL#5) ensures we see old tags that would otherwise be paginated out.
-mapfile -t OLD < <(gh release list --limit 100 --json tagName,createdAt \
+#
+# Use a portable `while read` loop instead of `mapfile -t` because macOS ships
+# bash 3.2 (mapfile is bash 4+). The Jest harness for BLD-950 runs the script
+# under whatever `bash` is on PATH; on developer macOS that's 3.2 and `mapfile`
+# would exit 127. CI Linux has bash 5+ so either works, but portability wins.
+OLD=()
+while IFS= read -r tag; do
+  [[ -z "$tag" ]] && continue
+  OLD+=("$tag")
+done < <(gh release list --limit 100 --json tagName,createdAt \
   --jq '[.[] | select(.tagName | startswith("audit-"))] | sort_by(.createdAt) | reverse | .[14:] | .[].tagName')
 
 for tag in "${OLD[@]:-}"; do


### PR DESCRIPTION
## Summary
- `scripts/audit-bundle.sh` used `mapfile -t` (bash 4+ only); macOS bash 3.2 exited 127 → 5/7 tests in `scripts/__tests__/audit-bundle-idempotent.test.ts` failed locally on Macs.
- Replaced with portable `while IFS= read -r` loop. Same behavior on CI (Linux bash 5+); now also works on dev Macs.

## Verification
Before: 5 failed, 2 passed.
After: 7 passed, 0 failed.

```
$ npm test -- audit-bundle-idempotent
PASS scripts/__tests__/audit-bundle-idempotent.test.ts
  audit-bundle.sh — BLD-950 idempotent re-run
    ✓ real script passes bash -n syntax check
    ✓ AC3: clean first run → single published release with asset attached
    ✓ AC1a: re-run after partial draft → publishes successfully (no -v2 suffix needed)
    ✓ AC1a-regression: re-run against an already-published release does NOT re-flip it to draft
    ✓ AC1b: re-run hits immutable published release → falls back to unique tag suffix (no manual -v2)
    ✓ AC2: full success path attaches exactly one asset to the published release
    ✓ non-immutable upload failure (e.g., transient network) is NOT silently suffixed
Tests:       7 passed, 7 total
```