### PR TITLE
ci: rename 'Android Lint (backup XML)' → 'Backup XML validation' (BLD-1118)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         # usage predictable on the GitHub-hosted runner.
         run: npm test -- --ci --runInBand
 
-  backup-xml-validation:
+  android-lint:
     name: Backup XML validation
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
         # usage predictable on the GitHub-hosted runner.
         run: npm test -- --ci --runInBand
 
-  android-lint:
-    name: Android Lint (backup XML)
+  backup-xml-validation:
+    name: Backup XML validation
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # BLD-1114: Verify backup XML rules (set-media/ include/exclude) are valid


### PR DESCRIPTION
## Summary

Renames the CI job that validates backup XML files from the misleading `Android Lint (backup XML)` to `Backup XML validation`, reflecting its actual semantics since BLD-1115 (bdf83f4c).

## Changes

- `.github/workflows/ci.yml`: rename job key `android-lint` → `backup-xml-validation` and `name:` field accordingly
- Branch protection required-check updated in lockstep: `Android Lint (backup XML)` → `Backup XML validation`

## Testing

CI-only change — no logic modified. The job still runs `xmllint --noout` on the two prebuild-generated backup XML files.

## Issue

Resolves BLD-1118