### PR TITLE
ci: assert AndroidManifest references both backup XMLs (BLD-1119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,11 +156,11 @@ jobs:
             echo "::error::AndroidManifest.xml not found at $MANIFEST"
             exit 1
           fi
-          if ! grep -qF 'android:dataExtractionRules="@xml/data_extraction_rules"' "$MANIFEST"; then
+          if ! grep -qF 'android:dataExtractionRules="@xml/form_clips_data_extraction_rules"' "$MANIFEST"; then
             echo "::error::AndroidManifest is missing dataExtractionRules reference — check plugins/with-form-clips-backup.js"
             exit 1
           fi
-          if ! grep -qF 'android:fullBackupContent="@xml/full_backup_content"' "$MANIFEST"; then
+          if ! grep -qF 'android:fullBackupContent="@xml/form_clips_backup_rules"' "$MANIFEST"; then
             echo "::error::AndroidManifest is missing fullBackupContent reference — check plugins/with-form-clips-backup.js"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,23 @@ jobs:
             echo "✓ $f — well-formed XML with set-media/ exclusion"
           done
           echo "Backup XML gate passed."
+
+      - name: Assert AndroidManifest references backup XMLs
+        # BLD-1119: If the Expo plugin chain regresses and the manifest stops
+        # referencing the backup XMLs, the set-media/ exclude rules silently
+        # stop being applied. Fail fast with a precise diagnosis.
+        run: |
+          MANIFEST=android/app/src/main/AndroidManifest.xml
+          if [ ! -f "$MANIFEST" ]; then
+            echo "::error::AndroidManifest.xml not found at $MANIFEST"
+            exit 1
+          fi
+          if ! grep -qF 'android:dataExtractionRules="@xml/data_extraction_rules"' "$MANIFEST"; then
+            echo "::error::AndroidManifest is missing dataExtractionRules reference — check plugins/with-form-clips-backup.js"
+            exit 1
+          fi
+          if ! grep -qF 'android:fullBackupContent="@xml/full_backup_content"' "$MANIFEST"; then
+            echo "::error::AndroidManifest is missing fullBackupContent reference — check plugins/with-form-clips-backup.js"
+            exit 1
+          fi
+          echo "✓ AndroidManifest references both backup XMLs."


### PR DESCRIPTION
## Summary

Extends the `Backup XML validation` CI job to grep the prebuild-generated `AndroidManifest.xml` for the two attributes that wire the backup XML files into the Android backup system.

## Changes

- New step **Assert AndroidManifest references backup XMLs** added after the existing xmllint validation step
- Checks `android:dataExtractionRules="@xml/data_extraction_rules"` is present
- Checks `android:fullBackupContent="@xml/full_backup_content"` is present
- Fails with a precise message pointing at `plugins/with-form-clips-backup.js` if either attribute is missing

## Why

Without this check, a regression in the Expo plugin chain could silently stop the manifest from referencing the backup XMLs, causing the `set-media/` exclude rules to be ignored and user setup photos / form clips to get backed up to Google Drive — exactly the failure mode BLD-1101 fixed.

## Testing

CI-only change. The new step runs inside the existing `backup-xml-validation` job which already runs `npx expo prebuild --clean` — the manifest is present by the time the assertion runs.

## Issue

Closes BLD-1119