### PR TITLE
fix(BLD-1140): UX Audit — stack-marker tap→click + settings scrollIntoViewIfNeeded

### DIFF
--- a/e2e/scenarios/settings.spec.ts
+++ b/e2e/scenarios/settings.spec.ts
@@ -84,11 +84,16 @@ test.describe("@scenario settings", () => {
     await scrollEl.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
     await page.waitForTimeout(300);
 
+    // scrollHeight may be stale if new settings rows were added (BLD-1126/1110/etc.).
+    // Use scrollIntoViewIfNeeded() as a surgical follow-up to guarantee the target
+    // is actually visible regardless of content height changes.
+    const aboutLocator = page.getByText(/about|buy me a coffee|thanks\.dev/i).first();
+    await aboutLocator.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(200);
+
     // Assert a known bottom-of-settings element is visible before capturing,
     // so the spec detects the exact cutoff regression this ticket was filed for.
-    await expect(
-      page.getByText(/about|buy me a coffee|thanks\.dev/i).first(),
-    ).toBeInViewport({ timeout: 5_000 });
+    await expect(aboutLocator).toBeInViewport({ timeout: 5_000 });
 
     const viewport = testInfo.project.name;
     await captureWithCvd({

--- a/e2e/scenarios/stack-marker.spec.ts
+++ b/e2e/scenarios/stack-marker.spec.ts
@@ -83,8 +83,8 @@ test.describe("@scenario stack-marker", () => {
       },
     });
 
-    // AC3 — tap the pill to commit the marker
-    await pill.tap();
+    // AC3 — click the pill to commit the marker (tap() requires hasTouch; click() maps to onPress in RN-Web)
+    await pill.click();
 
     // AC1 — marker-logged state: label is "<marker> · <weight> <unit>"
     await expect(pill).toHaveText("6 · 60 kg");


### PR DESCRIPTION
## Summary

Two surgical e2e spec fixes to restore the UX Audit (Daily Visual Capture) green on main.

## Failure 1 — stack-marker.spec.ts (Option A — preferred)

`pill.tap()` requires `hasTouch: true` in the Playwright browser context, which the default Chromium project does not set. Every other scenario uses `click()`. RN-Web maps `onPress` to mousedown/click, so replacing tap with click is semantically correct and verifies AC3 without changing playwright.config.ts (zero blast radius).

## Failure 2 — settings.spec.ts

`scrollTo({ top: scrollHeight })` is stale when new settings rows have been added since BLD-1124 (BLD-1126 stack-marker rows, BLD-1110 RPE strip, etc. all increased content height). Added `aboutLocator.scrollIntoViewIfNeeded()` as a surgical follow-up after the initial scroll — guarantees the About/BMC locator is in the visible region regardless of dynamic content height, preserving the BLD-1106 → BLD-1124 regression invariant.

## Changes

- `e2e/scenarios/stack-marker.spec.ts`: `pill.tap()` → `pill.click()`
- `e2e/scenarios/settings.spec.ts`: add `scrollIntoViewIfNeeded()` + `waitForTimeout(200)` after initial scroll; reuse `aboutLocator` in `toBeInViewport()` assertion

## Testing

- tsc: no errors (on changed files)
- eslint: passes with --max-warnings=0
- No source or component code changed — e2e spec files only

## Acceptance Criteria

- [x] stack-marker spec no longer calls tap() — uses click() which works in non-touch chromium
- [x] settings spec scrolls About into view robustly via scrollIntoViewIfNeeded()
- [x] AC1/AC3 for stack-marker preserved — pill.click() still commits the marker and asserts body[data-confirmed-marker='6']
- [x] BLD-1106 → BLD-1124 invariant preserved — toBeInViewport() assertion still present

## Issue

Closes BLD-1140