### PR TITLE
fix(e2e): UX Audit fixes — stack-marker tap→click & settings About viewport (BLD-1140)

### DIFF
--- a/e2e/scenarios/settings.spec.ts
+++ b/e2e/scenarios/settings.spec.ts
@@ -84,11 +84,20 @@ test.describe("@scenario settings", () => {
     await scrollEl.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
     await page.waitForTimeout(300);
 
+    // Ensure the About element is actually in the visible region. scrollHeight
+    // can be stale after new settings rows are added (e.g. rest-coach rows from
+    // BLD-1137) or when the floating tab bar shifts the visual clipping boundary.
+    // scrollIntoViewIfNeeded() is more robust: it scrolls the container just
+    // enough to bring the element into the visible rect, independent of the
+    // total content height. This preserves the BLD-1106 → BLD-1124 regression
+    // invariant: About/BMC must be visible above the floating tab bar.
+    const aboutEl = page.getByText(/about|buy me a coffee|thanks\.dev/i).first();
+    await aboutEl.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(200);
+
     // Assert a known bottom-of-settings element is visible before capturing,
     // so the spec detects the exact cutoff regression this ticket was filed for.
-    await expect(
-      page.getByText(/about|buy me a coffee|thanks\.dev/i).first(),
-    ).toBeInViewport({ timeout: 5_000 });
+    await expect(aboutEl).toBeInViewport({ timeout: 5_000 });
 
     const viewport = testInfo.project.name;
     await captureWithCvd({

--- a/e2e/scenarios/stack-marker.spec.ts
+++ b/e2e/scenarios/stack-marker.spec.ts
@@ -83,8 +83,9 @@ test.describe("@scenario stack-marker", () => {
       },
     });
 
-    // AC3 — tap the pill to commit the marker
-    await pill.tap();
+    // AC3 — click the pill to commit the marker (tap() requires hasTouch context;
+    // RN-Web maps onPress to mousedown/click so click() is equivalent)
+    await pill.click();
 
     // AC1 — marker-logged state: label is "<marker> · <weight> <unit>"
     await expect(pill).toHaveText("6 · 60 kg");


### PR DESCRIPTION
## Summary

Fixes two UX Audit failures on main (run [#25625318613](https://github.com/alankyshum/cablesnap/actions/runs/25625318613)):

## Changes

### Failure 1 — stack-marker.spec.ts (Option A: replace tap with click)

`pill.tap()` requires `hasTouch: true` in the Playwright project context. The default chromium project only sets `viewport` — no device/touch emulation. Replaced with `pill.click()` which is functionally equivalent for RN-Web (RN maps `onPress` to `mousedown`/`click` events). Zero blast radius — no changes to `playwright.config.ts` or other specs.

### Failure 2 — settings.spec.ts (scrollIntoViewIfNeeded fix)

After new settings rows were added (rest-coach rows from BLD-1137/BLD-1138 — `restPreEndCueSeconds`, `restLiveCountdown`, `restShowNextSet`), the total content height grew. The existing `scrollTo({top: el.scrollHeight})` approach relies on `scrollHeight` being accurate at call time, but the About card can still be partially hidden under the floating tab bar's visual boundary.

Fix: added `aboutEl.scrollIntoViewIfNeeded()` after the initial scroll. This is more robust — it scrolls just enough to bring the About element into the visible rect, independent of total content height or tab bar clipping. Preserves the BLD-1106 → BLD-1124 regression invariant.

## Testing

- Both spec changes are limited to e2e test  no app code modifiedfiles 
- UX Audit workflow will be triggered on this branch to verify green
- AC1/AC3 regression surface preserved: About/BMC must be visible above floating tab bar

## Issue

Resolves BLD-1140