### PR TITLE
test(BLD-1156): anchor Playwright thumbnail locators in form-clip-compare spec

### DIFF
--- a/components/session/FormLibraryTab.tsx
+++ b/components/session/FormLibraryTab.tsx
@@ -542,7 +542,11 @@ function ClipThumbnail({ clip, selectMode, selected, onPress, onLongPress, onRep
         onPress={onPress}
         onLongPress={onLongPress}
         accessibilityRole="button"
-        accessibilityLabel={`Clip from ${dateStr}${selectMode ? (selected ? ", selected" : ", not selected") : ""}`}
+        accessibilityLabel={
+          selectMode
+            ? (selected ? `Deselect clip from ${dateStr}` : `Select clip from ${dateStr}`)
+            : `Clip from ${dateStr}`
+        }
         accessibilityState={selectMode ? { selected } : undefined}
       >
         {/* Placeholder — real thumbnail generation deferred to post-save */}

--- a/components/session/FormLibraryTab.tsx
+++ b/components/session/FormLibraryTab.tsx
@@ -542,11 +542,7 @@ function ClipThumbnail({ clip, selectMode, selected, onPress, onLongPress, onRep
         onPress={onPress}
         onLongPress={onLongPress}
         accessibilityRole="button"
-        accessibilityLabel={
-          selectMode
-            ? (selected ? `Deselect clip from ${dateStr}` : `Select clip from ${dateStr}`)
-            : `Clip from ${dateStr}`
-        }
+        accessibilityLabel={`Clip from ${dateStr}${selectMode ? (selected ? ", selected" : ", not selected") : ""}`}
         accessibilityState={selectMode ? { selected } : undefined}
       >
         {/* Placeholder — real thumbnail generation deferred to post-save */}

--- a/e2e/scenarios/form-clip-compare.spec.ts
+++ b/e2e/scenarios/form-clip-compare.spec.ts
@@ -81,13 +81,15 @@ test.describe("@scenario form-clip-compare", () => {
     // Enter select mode.
     await page.getByRole("button", { name: "Select clips" }).click();
 
-    // Select both clips — clips render as pressable thumbnails.
-    const thumbnails = page.getByRole("button", { name: /Select clip/i });
+    // Select both clips — clips render as pressable thumbnails with labels like
+    // "Clip from {date}, not selected" (production accessibilityLabel).
+    const thumbnails = page.getByRole("button", { name: /Clip from/i });
     await thumbnails.first().click();
     await thumbnails.last().click();
 
     // Compare button should become active.
-    const compareBtn = page.getByRole("button", { name: "Compare" });
+    // accessibilityLabel="Compare selected clips" — use partial match.
+    const compareBtn = page.getByRole("button", { name: /Compare/i });
     await expect(compareBtn).toBeVisible({ timeout: 5000 });
     // Must not be aria-disabled when 2 are selected.
     await expect(compareBtn).not.toHaveAttribute("aria-disabled", "true");
@@ -116,12 +118,12 @@ test.describe("@scenario form-clip-compare", () => {
     // Enter select mode.
     await page.getByRole("button", { name: "Select clips" }).click();
 
-    // Select only one clip.
-    const thumbnails = page.getByRole("button", { name: /Select clip/i });
+    // Select only one clip — label matches "Clip from {date}, not selected".
+    const thumbnails = page.getByRole("button", { name: /Clip from/i });
     await thumbnails.first().click();
 
     // With only one selected, Compare should not be present or should be disabled.
-    const compareBtn = page.getByRole("button", { name: "Compare" });
+    const compareBtn = page.getByRole("button", { name: /Compare/i });
     const visible = await compareBtn.isVisible().catch(() => false);
     if (visible) {
       // If it's visible, it must be disabled.

--- a/e2e/scenarios/form-clip-compare.spec.ts
+++ b/e2e/scenarios/form-clip-compare.spec.ts
@@ -81,9 +81,10 @@ test.describe("@scenario form-clip-compare", () => {
     // Enter select mode.
     await page.getByRole("button", { name: "Select clips" }).click();
 
-    // Select both clips — clips render as pressable thumbnails with labels like
-    // "Clip from {date}, not selected" (production accessibilityLabel).
-    const thumbnails = page.getByRole("button", { name: /Clip from/i });
+    // ClipThumbnail in components/session/FormLibraryTab.tsx renders:
+    //   accessibilityLabel=`Clip from ${dateStr}, not selected` (in select mode)
+    // Anchor with ^ so this doesn't also match overflow labels like "More options for clip from …".
+    const thumbnails = page.getByRole("button", { name: /^Clip from / });
     await thumbnails.first().click();
     await thumbnails.last().click();
 
@@ -118,8 +119,10 @@ test.describe("@scenario form-clip-compare", () => {
     // Enter select mode.
     await page.getByRole("button", { name: "Select clips" }).click();
 
-    // Select only one clip — label matches "Clip from {date}, not selected".
-    const thumbnails = page.getByRole("button", { name: /Clip from/i });
+    // ClipThumbnail in components/session/FormLibraryTab.tsx renders:
+    //   accessibilityLabel=`Clip from ${dateStr}, not selected` (in select mode)
+    // Anchor with ^ so this doesn't also match overflow labels like "More options for clip from …".
+    const thumbnails = page.getByRole("button", { name: /^Clip from / });
     await thumbnails.first().click();
 
     // With only one selected, Compare should not be present or should be disabled.


### PR DESCRIPTION
Fixes 2 failing Playwright e2e tests in `form-clip-compare.spec.ts` after BLD-1151 merge.

**No production code changes.** Only `e2e/scenarios/form-clip-compare.spec.ts` is modified.

## Root Cause

Spec used `/Select clip/i` to find thumbnails, but `ClipThumbnail` in `FormLibraryTab.tsx` renders `accessibilityLabel` as `"Clip from {date}, not selected"` in select mode.

## Changes

- Thumbnail locator: `/Select clip/i` → `/^Clip from /` (anchored — matches `ClipThumbnail` in `FormLibraryTab.tsx`; `^` prevents false matches on overflow buttons like "More options for clip from …")
- Compare button: `"Compare"` → `/Compare/i` (matches `accessibilityLabel="Compare selected clips"`)
- Added comments above each locator citing `components/session/FormLibraryTab.tsx / ClipThumbnail`

## Resolves

BLD-1156