### PR TITLE
feat(BLD-1168): Slice 1 — workout_set_segments schema + recomputeSetCaches + property tests

### DIFF
--- a/__tests__/fk-cascade-segments.test.ts
+++ b/__tests__/fk-cascade-segments.test.ts
@@ -1,84 +1,144 @@
 /**
- * BLD-1168 AC #274 — FK CASCADE segments test.
+ * BLD-1168 AC #274 — FK CASCADE segments integration test.
  *
- * GIVEN a parent advanced set with cached_volume_kg and cached_e1rm_kg populated
- * WHEN the FK CASCADE deletes the parent (e.g., session deletion)
- * THEN all workout_set_segments rows are deleted at the SQLite layer with no orphans.
+ * GIVEN a parent workout_set row with associated workout_set_segments
+ * WHEN the parent set is deleted (simulating session/set deletion)
+ * THEN all workout_set_segments rows are automatically deleted at the SQLite
+ *      layer with no orphans — enforced by the FK ON DELETE CASCADE constraint.
  *
- * Tests the schema DDL: ON DELETE CASCADE on workout_set_segments.set_id.
+ * Uses node:sqlite in-memory engine with PRAGMA foreign_keys = ON and the
+ * exact DDL from lib/db/tables.ts (createExtensionTables DDL for workout_set_segments).
+ * Pattern: same as __tests__/lib/db/foreign-keys-cascade.test.ts.
  */
 
-describe("BLD-1168 AC#274 — FK CASCADE on workout_set_segments", () => {
-  it("workout_set_segments DDL includes ON DELETE CASCADE on set_id", () => {
-    // This test validates the schema SQL string that is passed to execAsync.
-    // The migration creates the table with the FK constraint; we verify the DDL
-    // contains the cascade clause by inspecting lib/db/tables.ts at import time.
+import { DatabaseSync } from "node:sqlite";
+import { migrate } from "../lib/db/migrations";
 
-    // Read the tables.ts source to confirm the FK syntax is correct.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fs = require("fs");
-    const path = require("path");
-    const tablesSource: string = fs.readFileSync(
-      path.join(__dirname, "../lib/db/tables.ts"),
-      "utf-8",
-    );
+// ── Thin async shim — same pattern as migration-upgrade-paths.test.ts ────────
 
-    // Must contain the segment table name
-    expect(tablesSource).toMatch(/workout_set_segments/);
+type Row = Record<string, unknown>;
+type SqlParam = null | number | bigint | string | Uint8Array;
 
-    // Must reference the FK with CASCADE
-    expect(tablesSource).toMatch(/REFERENCES workout_sets\(id\) ON DELETE CASCADE/i);
+function wrapDb(db: InstanceType<typeof DatabaseSync>) {
+  return {
+    execAsync: async (sql: string): Promise<void> => { db.exec(sql); },
+    getAllAsync: async <T = Row>(sql: string, params?: unknown[]): Promise<T[]> =>
+      db.prepare(sql).all(...((params ?? []) as SqlParam[])) as T[],
+    getFirstAsync: async <T = Row>(sql: string, params?: unknown[]): Promise<T | null> =>
+      (db.prepare(sql).get(...((params ?? []) as SqlParam[])) as T) ?? null,
+    runAsync: async (sql: string, params?: unknown[]): Promise<{ changes: number }> => {
+      const result = db.prepare(sql).run(...((params ?? []) as SqlParam[]));
+      return { changes: Number(result.changes) };
+    },
+  };
+}
 
-    // Must have unique index on (set_id, segment_number)
-    expect(tablesSource).toMatch(/uq_set_segments_set_seg/);
-    expect(tablesSource).toMatch(/idx_set_segments_set/);
+function count(db: InstanceType<typeof DatabaseSync>, table: string, where = "1=1"): number {
+  return (db.prepare(`SELECT COUNT(*) AS c FROM ${table} WHERE ${where}`).get() as { c: number }).c;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("BLD-1168 AC#274 — FK CASCADE on workout_set_segments (integration)", () => {
+  it("deleting a parent workout_set cascades to orphan-free workout_set_segments", async () => {
+    const raw = new DatabaseSync(":memory:");
+    raw.exec("PRAGMA foreign_keys = ON;");
+    await migrate(wrapDb(raw) as Parameters<typeof migrate>[0]);
+
+    const now = Date.now();
+    raw.exec(`
+      INSERT INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty)
+      VALUES ('ex1', 'Cable Row', 'pull', '[]', '[]', 'cable', '', 'intermediate');
+
+      INSERT INTO workout_sessions (id, name, started_at)
+      VALUES ('sess1', 'Test', ${now});
+
+      INSERT INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed)
+      VALUES ('parent1', 'sess1', 'ex1', 1, 100, 13, 1);
+
+      INSERT INTO workout_set_segments (id, set_id, segment_number, reps, weight, created_at)
+      VALUES ('seg1', 'parent1', 1, 8, NULL, ${now}),
+             ('seg2', 'parent1', 2, 3, NULL, ${now}),
+             ('seg3', 'parent1', 3, 2, NULL, ${now});
+    `);
+
+    // Pre-condition: 3 segments exist.
+    expect(count(raw, "workout_set_segments", "set_id='parent1'")).toBe(3);
+
+    // Delete the parent set — CASCADE should remove all segments.
+    raw.prepare("DELETE FROM workout_sets WHERE id = ?").run("parent1");
+
+    // Post-condition: no orphan segments remain.
+    expect(count(raw, "workout_set_segments", "set_id='parent1'")).toBe(0);
+    expect(count(raw, "workout_sets")).toBe(0);
   });
 
-  it("workout_set_segments is in VALID_TABLES allowlist", () => {
-    // The DDL allowlist in tables.ts guards against SQL injection via table names.
-    // Verify workout_set_segments is present so addColumnIfMissing can be called on it.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fs = require("fs");
-    const path = require("path");
-    const tablesSource: string = fs.readFileSync(
-      path.join(__dirname, "../lib/db/tables.ts"),
-      "utf-8",
-    );
-    // VALID_TABLES is a Set; check that it contains the table name string
-    expect(tablesSource).toMatch(/"workout_set_segments"/);
+  it("cascade works for multiple parent sets — all segments orphan-free after bulk delete", async () => {
+    const raw = new DatabaseSync(":memory:");
+    raw.exec("PRAGMA foreign_keys = ON;");
+    await migrate(wrapDb(raw) as Parameters<typeof migrate>[0]);
+
+    const now = Date.now();
+    raw.exec(`
+      INSERT INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty)
+      VALUES ('ex1', 'Squat', 'legs', '[]', '[]', 'barbell', '', 'intermediate');
+
+      INSERT INTO workout_sessions (id, name, started_at)
+      VALUES ('sess1', 'Leg day', ${now});
+
+      INSERT INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed)
+      VALUES ('s1', 'sess1', 'ex1', 1, 120, 5, 1),
+             ('s2', 'sess1', 'ex1', 2, 120, 3, 1);
+
+      INSERT INTO workout_set_segments (id, set_id, segment_number, reps, weight, created_at)
+      VALUES ('sg1a', 's1', 1, 5, NULL, ${now}),
+             ('sg1b', 's1', 2, 3, NULL, ${now}),
+             ('sg2a', 's2', 1, 3, NULL, ${now});
+    `);
+
+    expect(count(raw, "workout_set_segments")).toBe(3);
+
+    // Delete both parent sets — CASCADE should remove all segments.
+    raw.exec("DELETE FROM workout_sets WHERE session_id = 'sess1'");
+
+    expect(count(raw, "workout_sets")).toBe(0);
+    expect(count(raw, "workout_set_segments")).toBe(0);
   });
 
-  it("schema.ts workoutSetSegments table has correct FK reference", () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fs = require("fs");
-    const path = require("path");
-    const schemaSource: string = fs.readFileSync(
-      path.join(__dirname, "../lib/db/schema.ts"),
-      "utf-8",
-    );
+  it("unique index uq_set_segments_set_seg prevents duplicate (set_id, segment_number)", async () => {
+    const raw = new DatabaseSync(":memory:");
+    raw.exec("PRAGMA foreign_keys = ON;");
+    await migrate(wrapDb(raw) as Parameters<typeof migrate>[0]);
 
-    expect(schemaSource).toMatch(/workoutSetSegments/);
-    expect(schemaSource).toMatch(/workout_set_segments/);
-    // The set_id FK is documented with ON DELETE CASCADE comment
-    expect(schemaSource).toMatch(/ON DELETE CASCADE/i);
-    // Unique index name
-    expect(schemaSource).toMatch(/uq_set_segments_set_seg/);
+    const now = Date.now();
+    raw.exec(`
+      INSERT INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty)
+      VALUES ('ex1', 'Press', 'push', '[]', '[]', 'barbell', '', 'intermediate');
+
+      INSERT INTO workout_sessions (id, name, started_at)
+      VALUES ('sess1', 'Push', ${now});
+
+      INSERT INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed)
+      VALUES ('p1', 'sess1', 'ex1', 1, 80, 5, 1);
+
+      INSERT INTO workout_set_segments (id, set_id, segment_number, reps, weight, created_at)
+      VALUES ('sg1', 'p1', 1, 5, NULL, ${now});
+    `);
+
+    // Inserting a second row with the same (set_id, segment_number) must fail.
+    expect(() => {
+      raw.prepare(
+        "INSERT INTO workout_set_segments (id, set_id, segment_number, reps, weight, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+      ).run("sg2", "p1", 1, 3, null, now);
+    }).toThrow();
   });
 
-  it("lib/db/sets.ts only issues writes via Drizzle (not raw SQL strings)", () => {
-    // Architecture invariant: sets.ts must NOT contain raw SQL UPDATE/DELETE strings
-    // that bypass Drizzle's typed layer.
+  it("workout_set_segments is in VALID_TABLES allowlist (tables.ts)", () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const fs = require("fs");
     const path = require("path");
-    const setsSource: string = fs.readFileSync(
-      path.join(__dirname, "../lib/db/sets.ts"),
-      "utf-8",
-    );
-
-    // Should not contain raw execAsync with UPDATE/DELETE strings
-    // (Drizzle's .update() and .delete() are the correct paths)
-    expect(setsSource).not.toMatch(/execAsync.*UPDATE\s+workout/i);
-    expect(setsSource).not.toMatch(/execAsync.*DELETE\s+FROM\s+workout/i);
+    const src: string = fs.readFileSync(path.join(__dirname, "../lib/db/tables.ts"), "utf-8");
+    expect(src).toMatch(/"workout_set_segments"/);
   });
 });
+

--- a/__tests__/fk-cascade-segments.test.ts
+++ b/__tests__/fk-cascade-segments.test.ts
@@ -1,0 +1,84 @@
+/**
+ * BLD-1168 AC #274 — FK CASCADE segments test.
+ *
+ * GIVEN a parent advanced set with cached_volume_kg and cached_e1rm_kg populated
+ * WHEN the FK CASCADE deletes the parent (e.g., session deletion)
+ * THEN all workout_set_segments rows are deleted at the SQLite layer with no orphans.
+ *
+ * Tests the schema DDL: ON DELETE CASCADE on workout_set_segments.set_id.
+ */
+
+describe("BLD-1168 AC#274 — FK CASCADE on workout_set_segments", () => {
+  it("workout_set_segments DDL includes ON DELETE CASCADE on set_id", () => {
+    // This test validates the schema SQL string that is passed to execAsync.
+    // The migration creates the table with the FK constraint; we verify the DDL
+    // contains the cascade clause by inspecting lib/db/tables.ts at import time.
+
+    // Read the tables.ts source to confirm the FK syntax is correct.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require("fs");
+    const path = require("path");
+    const tablesSource: string = fs.readFileSync(
+      path.join(__dirname, "../lib/db/tables.ts"),
+      "utf-8",
+    );
+
+    // Must contain the segment table name
+    expect(tablesSource).toMatch(/workout_set_segments/);
+
+    // Must reference the FK with CASCADE
+    expect(tablesSource).toMatch(/REFERENCES workout_sets\(id\) ON DELETE CASCADE/i);
+
+    // Must have unique index on (set_id, segment_number)
+    expect(tablesSource).toMatch(/uq_set_segments_set_seg/);
+    expect(tablesSource).toMatch(/idx_set_segments_set/);
+  });
+
+  it("workout_set_segments is in VALID_TABLES allowlist", () => {
+    // The DDL allowlist in tables.ts guards against SQL injection via table names.
+    // Verify workout_set_segments is present so addColumnIfMissing can be called on it.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require("fs");
+    const path = require("path");
+    const tablesSource: string = fs.readFileSync(
+      path.join(__dirname, "../lib/db/tables.ts"),
+      "utf-8",
+    );
+    // VALID_TABLES is a Set; check that it contains the table name string
+    expect(tablesSource).toMatch(/"workout_set_segments"/);
+  });
+
+  it("schema.ts workoutSetSegments table has correct FK reference", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require("fs");
+    const path = require("path");
+    const schemaSource: string = fs.readFileSync(
+      path.join(__dirname, "../lib/db/schema.ts"),
+      "utf-8",
+    );
+
+    expect(schemaSource).toMatch(/workoutSetSegments/);
+    expect(schemaSource).toMatch(/workout_set_segments/);
+    // The set_id FK is documented with ON DELETE CASCADE comment
+    expect(schemaSource).toMatch(/ON DELETE CASCADE/i);
+    // Unique index name
+    expect(schemaSource).toMatch(/uq_set_segments_set_seg/);
+  });
+
+  it("lib/db/sets.ts only issues writes via Drizzle (not raw SQL strings)", () => {
+    // Architecture invariant: sets.ts must NOT contain raw SQL UPDATE/DELETE strings
+    // that bypass Drizzle's typed layer.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require("fs");
+    const path = require("path");
+    const setsSource: string = fs.readFileSync(
+      path.join(__dirname, "../lib/db/sets.ts"),
+      "utf-8",
+    );
+
+    // Should not contain raw execAsync with UPDATE/DELETE strings
+    // (Drizzle's .update() and .delete() are the correct paths)
+    expect(setsSource).not.toMatch(/execAsync.*UPDATE\s+workout/i);
+    expect(setsSource).not.toMatch(/execAsync.*DELETE\s+FROM\s+workout/i);
+  });
+});

--- a/__tests__/lib/small-lib-batch.test.ts
+++ b/__tests__/lib/small-lib-batch.test.ts
@@ -119,9 +119,12 @@ describe("REST_MULTIPLIERS v1 snapshot", () => {
   it("set-type multipliers are frozen", () => {
     expect(REST_MULTIPLIERS.setType).toMatchInlineSnapshot(`
 {
+  "cluster": 0.5,
   "dropset": 0.1,
   "failure": 1.3,
+  "myo_reps": 0.1,
   "normal": 1,
+  "rest_pause": 0.15,
   "warmup": 0.3,
 }
 `);

--- a/__tests__/migration-cached-columns-backfill.test.ts
+++ b/__tests__/migration-cached-columns-backfill.test.ts
@@ -1,0 +1,124 @@
+/**
+ * BLD-1168 AC #275 — Migration backfill test.
+ *
+ * GIVEN a pre-migration database (no segments table, no cached columns on workout_sets)
+ * WHEN the new app version opens it
+ * THEN migration adds the table + columns AND a one-time backfill computes
+ *   cached_volume_kg = weight*reps
+ *   cached_e1rm_kg   = weight*(1+reps/30)
+ * for every existing row (legacy formula is correct because advanced sets don't exist yet).
+ */
+import { computeSetCacheValues } from "../lib/db/sets";
+
+describe("BLD-1168 AC#275 — migration cached-columns backfill", () => {
+  it("migrations.ts Phase 2 adds cached_volume_kg and cached_e1rm_kg via addColumnIfMissing", () => {
+    // Verify the migration source contains the two addColumnIfMissing calls.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require("fs");
+    const path = require("path");
+    const migSource: string = fs.readFileSync(
+      path.join(__dirname, "../lib/db/migrations.ts"),
+      "utf-8",
+    );
+
+    expect(migSource).toMatch(/addColumnIfMissing.*workout_sets.*cached_volume_kg/);
+    expect(migSource).toMatch(/addColumnIfMissing.*workout_sets.*cached_e1rm_kg/);
+    // Columns should be REAL NOT NULL DEFAULT 0
+    expect(migSource).toMatch(/REAL NOT NULL DEFAULT 0/);
+  });
+
+  it("migrations.ts Phase 3 contains backfill UPDATE with float literal 1.0", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require("fs");
+    const path = require("path");
+    const migSource: string = fs.readFileSync(
+      path.join(__dirname, "../lib/db/migrations.ts"),
+      "utf-8",
+    );
+
+    // Use the code-comment markers (not the JSDoc header)
+    const phase3Start = migSource.indexOf("// PHASE 3:");
+    const phase4Start = migSource.indexOf("// PHASE 4:");
+    expect(phase3Start).toBeGreaterThan(0);
+    expect(phase4Start).toBeGreaterThan(phase3Start);
+
+    const phase3Section = migSource.slice(phase3Start, phase4Start);
+    // Must contain the backfill UPDATE
+    expect(phase3Section).toMatch(/UPDATE workout_sets/);
+    expect(phase3Section).toMatch(/cached_volume_kg\s*=\s*weight\s*\*\s*reps/);
+    expect(phase3Section).toMatch(/cached_e1rm_kg/);
+    // Float literal — prevents integer division in SQLite
+    expect(phase3Section).toMatch(/1\.0/);
+  });
+
+  it("backfill formula is correct for representative legacy rows (pure math validation)", () => {
+    // These are the exact values the backfill UPDATE would produce for pre-existing rows.
+    const fixtures = [
+      // [weight, reps, expectedVolume, expectedE1rm]
+      [100, 5, 500, 100 * (1 + 5 / 30)],
+      [80, 8, 640, 80 * (1 + 8 / 30)],
+      [60, 12, 720, 60 * (1 + 12 / 30)],
+      [20, 20, 400, 20 * (1 + 20 / 30)],
+      [0, 10, 0, 0],  // bodyweight with 0kg base
+    ] as [number, number, number, number][];
+
+    for (const [weight, reps, expectedVolume, expectedE1rm] of fixtures) {
+      const { cachedVolumeKg, cachedE1rmKg } = computeSetCacheValues(
+        { weight, reps },
+        [], // no segments — legacy row
+      );
+      expect(cachedVolumeKg).toBeCloseTo(expectedVolume, 4);
+      expect(cachedE1rmKg).toBeCloseTo(expectedE1rm, 4);
+    }
+  });
+
+  it("backfill skips rows with NULL weight or NULL reps (guarded by WHERE clause)", () => {
+    // Verify migration SQL has the WHERE guard
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require("fs");
+    const path = require("path");
+    const migSource: string = fs.readFileSync(
+      path.join(__dirname, "../lib/db/migrations.ts"),
+      "utf-8",
+    );
+
+    const phase3Start = migSource.indexOf("// PHASE 3:");
+    const phase4Start = migSource.indexOf("// PHASE 4:");
+    const phase3Section = migSource.slice(phase3Start, phase4Start);
+
+    // Must have WHERE guard against NULL weight and NULL reps
+    expect(phase3Section).toMatch(/weight IS NOT NULL/);
+    expect(phase3Section).toMatch(/reps IS NOT NULL/);
+    // Must guard against rows already backfilled (idempotent re-run safety)
+    expect(phase3Section).toMatch(/cached_volume_kg\s*=\s*0/);
+  });
+
+  it("computeSetCacheValues for null weight and null reps returns zeros (no crash)", () => {
+    const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(
+      { weight: null, reps: null },
+      [],
+    );
+    expect(cachedVolumeKg).toBe(0);
+    expect(cachedE1rmKg).toBe(0);
+    expect(totalReps).toBe(0);
+  });
+
+  it("workout_set_segments table creation is in createExtensionTables (tables.ts)", () => {
+    // Verify the table DDL lives in createExtensionTables so it runs in Phase 1.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require("fs");
+    const path = require("path");
+    const tablesSource: string = fs.readFileSync(
+      path.join(__dirname, "../lib/db/tables.ts"),
+      "utf-8",
+    );
+
+    // createExtensionTables contains the segment table
+    const extTablesStart = tablesSource.indexOf("createExtensionTables");
+    expect(extTablesStart).toBeGreaterThan(0);
+    const extTablesSection = tablesSource.slice(extTablesStart);
+    expect(extTablesSection).toMatch(/CREATE TABLE IF NOT EXISTS workout_set_segments/);
+    expect(extTablesSection).toMatch(/segment_number INTEGER NOT NULL/);
+    expect(extTablesSection).toMatch(/created_at INTEGER NOT NULL/);
+  });
+});

--- a/__tests__/migration-cached-columns-backfill.test.ts
+++ b/__tests__/migration-cached-columns-backfill.test.ts
@@ -1,124 +1,171 @@
 /**
- * BLD-1168 AC #275 — Migration backfill test.
+ * BLD-1168 AC #275 — Migration backfill integration test.
  *
- * GIVEN a pre-migration database (no segments table, no cached columns on workout_sets)
- * WHEN the new app version opens it
- * THEN migration adds the table + columns AND a one-time backfill computes
- *   cached_volume_kg = weight*reps
- *   cached_e1rm_kg   = weight*(1+reps/30)
- * for every existing row (legacy formula is correct because advanced sets don't exist yet).
+ * GIVEN a pre-1168 database (workout_sets rows with weight/reps but cached columns
+ *       still at their DEFAULT 0 — which is the exact condition before the backfill)
+ * WHEN migrate() is called (or re-called — it's idempotent)
+ * THEN:
+ *   - the workout_set_segments table is created
+ *   - cached_volume_kg / cached_e1rm_kg columns are present on workout_sets
+ *   - the backfill computes cached_volume_kg = weight*reps and
+ *     cached_e1rm_kg = weight*(1.0+reps/30.0) for every non-null row
+ *   - rows with NULL weight or NULL reps are left at 0 (untouched by backfill)
+ *   - running migrate() twice produces the same results (idempotent)
+ *
+ * Strategy: fresh DB → migrate() once (schema ready, 0 rows) → insert
+ * test rows (cached values default to 0) → migrate() again (backfill fires
+ * on the 0-valued rows). This tests the actual backfill SQL path without
+ * requiring a hand-crafted pre-migration schema snapshot.
+ *
+ * Uses node:sqlite in-memory engine via the thin async shim pattern from
+ * __tests__/lib/db/migration-upgrade-paths.test.ts.
  */
+
+import { DatabaseSync } from "node:sqlite";
+import { migrate } from "../lib/db/migrations";
 import { computeSetCacheValues } from "../lib/db/sets";
 
-describe("BLD-1168 AC#275 — migration cached-columns backfill", () => {
-  it("migrations.ts Phase 2 adds cached_volume_kg and cached_e1rm_kg via addColumnIfMissing", () => {
-    // Verify the migration source contains the two addColumnIfMissing calls.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fs = require("fs");
-    const path = require("path");
-    const migSource: string = fs.readFileSync(
-      path.join(__dirname, "../lib/db/migrations.ts"),
-      "utf-8",
-    );
+// ── Thin async shim (same as migration-upgrade-paths.test.ts) ────────────────
 
-    expect(migSource).toMatch(/addColumnIfMissing.*workout_sets.*cached_volume_kg/);
-    expect(migSource).toMatch(/addColumnIfMissing.*workout_sets.*cached_e1rm_kg/);
-    // Columns should be REAL NOT NULL DEFAULT 0
-    expect(migSource).toMatch(/REAL NOT NULL DEFAULT 0/);
-  });
+type Row = Record<string, unknown>;
+type SqlParam = null | number | bigint | string | Uint8Array;
 
-  it("migrations.ts Phase 3 contains backfill UPDATE with float literal 1.0", () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fs = require("fs");
-    const path = require("path");
-    const migSource: string = fs.readFileSync(
-      path.join(__dirname, "../lib/db/migrations.ts"),
-      "utf-8",
-    );
+function wrapDb(db: InstanceType<typeof DatabaseSync>) {
+  return {
+    execAsync: async (sql: string): Promise<void> => { db.exec(sql); },
+    getAllAsync: async <T = Row>(sql: string, params?: unknown[]): Promise<T[]> =>
+      db.prepare(sql).all(...((params ?? []) as SqlParam[])) as T[],
+    getFirstAsync: async <T = Row>(sql: string, params?: unknown[]): Promise<T | null> =>
+      (db.prepare(sql).get(...((params ?? []) as SqlParam[])) as T) ?? null,
+    runAsync: async (sql: string, params?: unknown[]): Promise<{ changes: number }> => {
+      const result = db.prepare(sql).run(...((params ?? []) as SqlParam[]));
+      return { changes: Number(result.changes) };
+    },
+  };
+}
 
-    // Use the code-comment markers (not the JSDoc header)
-    const phase3Start = migSource.indexOf("// PHASE 3:");
-    const phase4Start = migSource.indexOf("// PHASE 4:");
-    expect(phase3Start).toBeGreaterThan(0);
-    expect(phase4Start).toBeGreaterThan(phase3Start);
+type WrappedDb = ReturnType<typeof wrapDb>;
 
-    const phase3Section = migSource.slice(phase3Start, phase4Start);
-    // Must contain the backfill UPDATE
-    expect(phase3Section).toMatch(/UPDATE workout_sets/);
-    expect(phase3Section).toMatch(/cached_volume_kg\s*=\s*weight\s*\*\s*reps/);
-    expect(phase3Section).toMatch(/cached_e1rm_kg/);
-    // Float literal — prevents integer division in SQLite
-    expect(phase3Section).toMatch(/1\.0/);
-  });
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
-  it("backfill formula is correct for representative legacy rows (pure math validation)", () => {
-    // These are the exact values the backfill UPDATE would produce for pre-existing rows.
-    const fixtures = [
-      // [weight, reps, expectedVolume, expectedE1rm]
-      [100, 5, 500, 100 * (1 + 5 / 30)],
-      [80, 8, 640, 80 * (1 + 8 / 30)],
-      [60, 12, 720, 60 * (1 + 12 / 30)],
-      [20, 20, 400, 20 * (1 + 20 / 30)],
-      [0, 10, 0, 0],  // bodyweight with 0kg base
-    ] as [number, number, number, number][];
+describe("BLD-1168 AC#275 — migration cached-columns backfill (integration)", () => {
+  const fixtures: Array<{
+    id: string;
+    weight: number | null;
+    reps: number | null;
+    label: string;
+  }> = [
+    { id: "set_100_5",  weight: 100, reps: 5,  label: "100kg×5" },
+    { id: "set_80_8",   weight: 80,  reps: 8,  label: "80kg×8" },
+    { id: "set_60_12",  weight: 60,  reps: 12, label: "60kg×12" },
+    { id: "set_20_20",  weight: 20,  reps: 20, label: "20kg×20" },
+    { id: "set_bw",     weight: 0,   reps: 10, label: "0kg×10 (bodyweight)" },
+    { id: "set_null_w", weight: null, reps: 5, label: "null weight (skip)" },
+    { id: "set_null_r", weight: 100, reps: null, label: "null reps (skip)" },
+  ];
 
-    for (const [weight, reps, expectedVolume, expectedE1rm] of fixtures) {
-      const { cachedVolumeKg, cachedE1rmKg } = computeSetCacheValues(
-        { weight, reps },
-        [], // no segments — legacy row
-      );
-      expect(cachedVolumeKg).toBeCloseTo(expectedVolume, 4);
-      expect(cachedE1rmKg).toBeCloseTo(expectedE1rm, 4);
+  let raw: InstanceType<typeof DatabaseSync>;
+  let db: WrappedDb;
+
+  beforeEach(async () => {
+    raw = new DatabaseSync(":memory:");
+    raw.exec("PRAGMA foreign_keys = ON;");
+    db = wrapDb(raw);
+
+    // First migrate: sets up the schema fully (no rows yet).
+    await migrate(db as Parameters<typeof migrate>[0]);
+
+    // Insert exercise + session — minimum required columns only.
+    const now = Date.now();
+    raw.exec(`
+      INSERT INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty)
+      VALUES ('ex1', 'Test Exercise', 'other', '[]', '[]', 'barbell', '', 'intermediate');
+      INSERT INTO workout_sessions (id, name, started_at)
+      VALUES ('sess1', 'Test', ${now});
+    `);
+
+    // Insert workout_sets with weight/reps but cached columns at their DEFAULT 0.
+    // This simulates the state of legacy rows when the app first boots after the
+    // BLD-1168 update: addColumnIfMissing added the columns with DEFAULT 0 and
+    // the backfill has not yet run (or for new rows, weight/reps are non-zero
+    // but cached values were never computed).
+    for (const f of fixtures) {
+      raw.prepare(
+        "INSERT INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed) VALUES (?, 'sess1', 'ex1', 1, ?, ?, 1)"
+      ).run(f.id, f.weight, f.reps);
     }
+
+    // Second migrate: columns already exist (idempotent); backfill runs on
+    // rows with cached_volume_kg = 0 AND cached_e1rm_kg = 0.
+    await migrate(db as Parameters<typeof migrate>[0]);
   });
 
-  it("backfill skips rows with NULL weight or NULL reps (guarded by WHERE clause)", () => {
-    // Verify migration SQL has the WHERE guard
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fs = require("fs");
-    const path = require("path");
-    const migSource: string = fs.readFileSync(
-      path.join(__dirname, "../lib/db/migrations.ts"),
-      "utf-8",
-    );
-
-    const phase3Start = migSource.indexOf("// PHASE 3:");
-    const phase4Start = migSource.indexOf("// PHASE 4:");
-    const phase3Section = migSource.slice(phase3Start, phase4Start);
-
-    // Must have WHERE guard against NULL weight and NULL reps
-    expect(phase3Section).toMatch(/weight IS NOT NULL/);
-    expect(phase3Section).toMatch(/reps IS NOT NULL/);
-    // Must guard against rows already backfilled (idempotent re-run safety)
-    expect(phase3Section).toMatch(/cached_volume_kg\s*=\s*0/);
+  it("migrate() ensures cached_volume_kg and cached_e1rm_kg columns exist on workout_sets", () => {
+    const cols = raw.prepare("PRAGMA table_info(workout_sets)").all() as Array<{ name: string }>;
+    const names = cols.map((c) => c.name);
+    expect(names).toContain("cached_volume_kg");
+    expect(names).toContain("cached_e1rm_kg");
   });
 
-  it("computeSetCacheValues for null weight and null reps returns zeros (no crash)", () => {
-    const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(
-      { weight: null, reps: null },
+  it("migrate() creates the workout_set_segments table with FK and unique index", () => {
+    const tables = raw.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='workout_set_segments'"
+    ).all();
+    expect(tables).toHaveLength(1);
+
+    const indexes = raw.prepare(
+      "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='workout_set_segments'"
+    ).all() as Array<{ name: string }>;
+    const indexNames = indexes.map((i) => i.name);
+    expect(indexNames).toContain("uq_set_segments_set_seg");
+    expect(indexNames).toContain("idx_set_segments_set");
+  });
+
+  it.each(
+    fixtures.filter((f) => f.weight !== null && f.reps !== null && f.weight > 0 && (f.reps ?? 0) > 0)
+  )("backfill correct for $label", ({ id, weight, reps }) => {
+    const row = raw.prepare(
+      "SELECT cached_volume_kg, cached_e1rm_kg FROM workout_sets WHERE id = ?"
+    ).get(id) as { cached_volume_kg: number; cached_e1rm_kg: number };
+
+    const { cachedVolumeKg, cachedE1rmKg } = computeSetCacheValues(
+      { weight, reps },
       [],
     );
-    expect(cachedVolumeKg).toBe(0);
-    expect(cachedE1rmKg).toBe(0);
-    expect(totalReps).toBe(0);
+    expect(row.cached_volume_kg).toBeCloseTo(cachedVolumeKg, 4);
+    expect(row.cached_e1rm_kg).toBeCloseTo(cachedE1rmKg, 4);
   });
 
-  it("workout_set_segments table creation is in createExtensionTables (tables.ts)", () => {
-    // Verify the table DDL lives in createExtensionTables so it runs in Phase 1.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const fs = require("fs");
-    const path = require("path");
-    const tablesSource: string = fs.readFileSync(
-      path.join(__dirname, "../lib/db/tables.ts"),
-      "utf-8",
-    );
+  it("backfill skips rows with NULL weight (leaves cached at 0)", () => {
+    const row = raw.prepare(
+      "SELECT cached_volume_kg, cached_e1rm_kg FROM workout_sets WHERE id = 'set_null_w'"
+    ).get() as { cached_volume_kg: number; cached_e1rm_kg: number };
+    expect(row.cached_volume_kg).toBe(0);
+    expect(row.cached_e1rm_kg).toBe(0);
+  });
 
-    // createExtensionTables contains the segment table
-    const extTablesStart = tablesSource.indexOf("createExtensionTables");
-    expect(extTablesStart).toBeGreaterThan(0);
-    const extTablesSection = tablesSource.slice(extTablesStart);
-    expect(extTablesSection).toMatch(/CREATE TABLE IF NOT EXISTS workout_set_segments/);
-    expect(extTablesSection).toMatch(/segment_number INTEGER NOT NULL/);
-    expect(extTablesSection).toMatch(/created_at INTEGER NOT NULL/);
+  it("backfill skips rows with NULL reps (leaves cached at 0)", () => {
+    const row = raw.prepare(
+      "SELECT cached_volume_kg, cached_e1rm_kg FROM workout_sets WHERE id = 'set_null_r'"
+    ).get() as { cached_volume_kg: number; cached_e1rm_kg: number };
+    expect(row.cached_volume_kg).toBe(0);
+    expect(row.cached_e1rm_kg).toBe(0);
+  });
+
+  it("idempotent — running migrate() a third time does not corrupt cached values", async () => {
+    await migrate(db as Parameters<typeof migrate>[0]);
+
+    for (const f of fixtures.filter((fi) => fi.weight !== null && fi.reps !== null && fi.weight > 0 && (fi.reps ?? 0) > 0)) {
+      const row = raw.prepare(
+        "SELECT cached_volume_kg, cached_e1rm_kg FROM workout_sets WHERE id = ?"
+      ).get(f.id) as { cached_volume_kg: number; cached_e1rm_kg: number };
+
+      const { cachedVolumeKg, cachedE1rmKg } = computeSetCacheValues(
+        { weight: f.weight, reps: f.reps },
+        [],
+      );
+      expect(row.cached_volume_kg).toBeCloseTo(cachedVolumeKg, 4);
+      expect(row.cached_e1rm_kg).toBeCloseTo(cachedE1rmKg, 4);
+    }
   });
 });

--- a/__tests__/parent-segment-invariant.property.test.ts
+++ b/__tests__/parent-segment-invariant.property.test.ts
@@ -1,0 +1,191 @@
+/**
+ * BLD-1168 AC #266 — Property test: parent.reps == Σ segments.reps AND
+ * parent.cached_volume_kg == Σ (seg.reps × (seg.weight ?? parent.weight))
+ * after any sequence of insert/update/delete mutations.
+ *
+ * Uses the pure computeSetCacheValues() helper so no DB mocking is required.
+ * 1000 random sequences are executed.
+ */
+import { computeSetCacheValues } from "../lib/db/sets";
+
+// ─── Random helpers ──────────────────────────────────────────────────────────
+
+function randInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function randFloat(min: number, max: number): number {
+  return Math.random() * (max - min) + min;
+}
+
+function maybe<T>(value: T, prob = 0.2): T | null {
+  return Math.random() < prob ? null : value;
+}
+
+type Seg = { reps: number; weight: number | null };
+
+/** Apply one random mutation to a segment list and return the new list. */
+function applyMutation(
+  segments: Seg[],
+): Seg[] {
+  const ops = ["insert", "update", "delete"] as const;
+  const op = ops[randInt(0, 2)];
+
+  if (op === "insert" || segments.length === 0) {
+    return [
+      ...segments,
+      { reps: randInt(1, 20), weight: maybe(randFloat(10, 200), 0.3) },
+    ];
+  }
+  if (op === "delete") {
+    const idx = randInt(0, segments.length - 1);
+    return segments.filter((_, i) => i !== idx);
+  }
+  // update
+  const idx = randInt(0, segments.length - 1);
+  const updated = [...segments];
+  updated[idx] = {
+    reps: randInt(1, 20),
+    weight: maybe(randFloat(10, 200), 0.3),
+  };
+  return updated;
+}
+
+// ─── Property assertion ──────────────────────────────────────────────────────
+
+function assertInvariant(
+  parent: { weight: number | null; reps: number | null },
+  segments: Seg[],
+): void {
+  const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(parent, segments);
+
+  // Invariant 1: totalReps == Σ segments.reps
+  const expectedTotalReps =
+    segments.length === 0 ? (parent.reps ?? 0) : segments.reduce((sum, s) => sum + s.reps, 0);
+  expect(totalReps).toBe(expectedTotalReps);
+
+  // Invariant 2: cachedVolumeKg == Σ (seg.reps × effective_weight)
+  const expectedVolume =
+    segments.length === 0
+      ? (parent.weight ?? 0) * (parent.reps ?? 0)
+      : segments.reduce((sum, s) => sum + s.reps * (s.weight ?? parent.weight ?? 0), 0);
+  expect(cachedVolumeKg).toBeCloseTo(expectedVolume, 6);
+
+  // Invariant 3: cachedE1rmKg >= 0 and uses correct formula
+  if (segments.length === 0) {
+    const r = parent.reps ?? 0;
+    const w = parent.weight ?? 0;
+    const expected = r > 0 ? w * (1 + r / 30) : 0;
+    expect(cachedE1rmKg).toBeCloseTo(expected, 6);
+  } else {
+    // e1RM = MAX over segments
+    let maxE1rm = 0;
+    for (const seg of segments) {
+      const sw = seg.weight ?? parent.weight ?? 0;
+      const e = seg.reps > 0 ? sw * (1 + seg.reps / 30) : 0;
+      if (e > maxE1rm) maxE1rm = e;
+    }
+    expect(cachedE1rmKg).toBeCloseTo(maxE1rm, 6);
+  }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("BLD-1168 AC#266 — parent-segment cache invariants", () => {
+  it("no-segment (legacy) row: volume = weight*reps, e1RM = Epley formula", () => {
+    const parent = { weight: 100, reps: 8 };
+    const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(parent, []);
+    expect(cachedVolumeKg).toBeCloseTo(800, 6);
+    expect(cachedE1rmKg).toBeCloseTo(100 * (1 + 8 / 30), 6);
+    expect(totalReps).toBe(8);
+  });
+
+  it("rest-pause 8+3+2 @ 100kg: volume=1300, e1RM from heaviest segment", () => {
+    const parent = { weight: 100, reps: null };
+    const segments: Seg[] = [
+      { reps: 8, weight: null },
+      { reps: 3, weight: null },
+      { reps: 2, weight: null },
+    ];
+    const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(parent, segments);
+    expect(cachedVolumeKg).toBeCloseTo(1300, 6);  // (8+3+2) * 100
+    expect(totalReps).toBe(13);
+    // e1RM from segment 1 (8 reps): 100 * (1 + 8/30) = 126.667
+    expect(cachedE1rmKg).toBeCloseTo(100 * (1 + 8 / 30), 4);
+  });
+
+  it("cluster 3+3+2 @ 100/100/95kg: volume=800, e1RM from 100kg×3 segment", () => {
+    const parent = { weight: 100, reps: null };
+    const segments: Seg[] = [
+      { reps: 3, weight: 100 },
+      { reps: 3, weight: 100 },
+      { reps: 2, weight: 95 },
+    ];
+    const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(parent, segments);
+    expect(cachedVolumeKg).toBeCloseTo(3 * 100 + 3 * 100 + 2 * 95, 6);  // 790
+    expect(totalReps).toBe(8);
+    // MAX e1RM: 100*(1+3/30)=110 vs 100*(1+3/30)=110 vs 95*(1+2/30)≈101.3 → 110
+    const expected = Math.max(
+      100 * (1 + 3 / 30),
+      100 * (1 + 3 / 30),
+      95 * (1 + 2 / 30),
+    );
+    expect(cachedE1rmKg).toBeCloseTo(expected, 4);
+  });
+
+  it("myo-reps 15+5+5+4+3 @ 25kg: volume=800, e1RM from activation (15 reps)", () => {
+    const parent = { weight: 25, reps: null };
+    const segments: Seg[] = [
+      { reps: 15, weight: null },
+      { reps: 5, weight: null },
+      { reps: 5, weight: null },
+      { reps: 4, weight: null },
+      { reps: 3, weight: null },
+    ];
+    const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(parent, segments);
+    expect(cachedVolumeKg).toBeCloseTo((15 + 5 + 5 + 4 + 3) * 25, 6);  // 800
+    expect(totalReps).toBe(32);
+    // MAX e1RM from activation: 25 * (1 + 15/30) = 37.5
+    expect(cachedE1rmKg).toBeCloseTo(25 * (1 + 15 / 30), 4);
+  });
+
+  it("segment with NULL weight inherits parent weight", () => {
+    const parent = { weight: 80, reps: null };
+    const segments: Seg[] = [
+      { reps: 5, weight: null },   // inherits 80kg
+      { reps: 5, weight: 60 },     // explicit override
+    ];
+    const { cachedVolumeKg } = computeSetCacheValues(parent, segments);
+    expect(cachedVolumeKg).toBeCloseTo(5 * 80 + 5 * 60, 6);  // 700
+  });
+
+  it("parent with null weight and null reps yields zeros", () => {
+    const parent = { weight: null, reps: null };
+    const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(parent, []);
+    expect(cachedVolumeKg).toBe(0);
+    expect(cachedE1rmKg).toBe(0);
+    expect(totalReps).toBe(0);
+  });
+
+  it("property: invariants hold across 1000 random mutation sequences", () => {
+    for (let trial = 0; trial < 1000; trial++) {
+      const parentWeight = Math.random() < 0.1 ? null : randFloat(10, 300);
+      const parentReps = Math.random() < 0.1 ? null : randInt(1, 20);
+      const parent = { weight: parentWeight, reps: parentReps };
+
+      // Start with 0-4 initial segments
+      let segments: Seg[] = [];
+      const initialCount = randInt(0, 4);
+      for (let i = 0; i < initialCount; i++) {
+        segments = applyMutation(segments);
+      }
+
+      // Apply 3-8 additional mutations
+      const mutationCount = randInt(3, 8);
+      for (let m = 0; m < mutationCount; m++) {
+        segments = applyMutation(segments);
+        assertInvariant(parent, segments);
+      }
+    }
+  });
+});

--- a/__tests__/parent-segment-invariant.property.test.ts
+++ b/__tests__/parent-segment-invariant.property.test.ts
@@ -3,13 +3,17 @@
  * parent.cached_volume_kg == Σ (seg.reps × (seg.weight ?? parent.weight))
  * after any sequence of insert/update/delete mutations.
  *
+ * Also covers the advanced-set-zero-segment invariant (AC #266 plan:76,117,266):
+ * when an advanced set type (rest_pause/cluster/myo_reps) has all segments deleted,
+ * reps=0, cached_volume_kg=0, cached_e1rm_kg=0 (not the legacy parent fallback).
+ *
  * Uses the pure computeSetCacheValues() helper so no DB mocking is required.
  * 1000 random sequences are executed.
  *
  * Reproducible failures: set SEED=<number> env var to replay a failed trial.
  * The seed is logged before each run so failures can be replayed deterministically.
  */
-import { computeSetCacheValues } from "../lib/db/sets";
+import { computeSetCacheValues, ADVANCED_SET_TYPES } from "../lib/db/sets";
 
 // ─── Seeded PRNG (mulberry32) ─────────────────────────────────────────────────
 
@@ -69,40 +73,43 @@ function applyMutation(
 
 // ─── Property assertion ──────────────────────────────────────────────────────
 
+function expectedReps(parent: { reps: number | null; isAdvancedSet?: boolean }, segments: Seg[]): number {
+  if (segments.length === 0) return parent.isAdvancedSet ? 0 : (parent.reps ?? 0);
+  return segments.reduce((sum, s) => sum + s.reps, 0);
+}
+
+function expectedVolume(parent: { weight: number | null; reps: number | null; isAdvancedSet?: boolean }, segments: Seg[]): number {
+  if (segments.length === 0) {
+    if (parent.isAdvancedSet) return 0;
+    return (parent.weight ?? 0) * (parent.reps ?? 0);
+  }
+  return segments.reduce((sum, s) => sum + s.reps * (s.weight ?? parent.weight ?? 0), 0);
+}
+
+function expectedE1rm(parent: { weight: number | null; reps: number | null; isAdvancedSet?: boolean }, segments: Seg[]): number {
+  if (segments.length === 0) {
+    if (parent.isAdvancedSet) return 0;
+    const r = parent.reps ?? 0;
+    const w = parent.weight ?? 0;
+    return r > 0 ? w * (1 + r / 30) : 0;
+  }
+  let maxE1rm = 0;
+  for (const seg of segments) {
+    const sw = seg.weight ?? parent.weight ?? 0;
+    const e = seg.reps > 0 ? sw * (1 + seg.reps / 30) : 0;
+    if (e > maxE1rm) maxE1rm = e;
+  }
+  return maxE1rm;
+}
+
 function assertInvariant(
-  parent: { weight: number | null; reps: number | null },
+  parent: { weight: number | null; reps: number | null; isAdvancedSet?: boolean },
   segments: Seg[],
 ): void {
   const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(parent, segments);
-
-  // Invariant 1: totalReps == Σ segments.reps
-  const expectedTotalReps =
-    segments.length === 0 ? (parent.reps ?? 0) : segments.reduce((sum, s) => sum + s.reps, 0);
-  expect(totalReps).toBe(expectedTotalReps);
-
-  // Invariant 2: cachedVolumeKg == Σ (seg.reps × effective_weight)
-  const expectedVolume =
-    segments.length === 0
-      ? (parent.weight ?? 0) * (parent.reps ?? 0)
-      : segments.reduce((sum, s) => sum + s.reps * (s.weight ?? parent.weight ?? 0), 0);
-  expect(cachedVolumeKg).toBeCloseTo(expectedVolume, 6);
-
-  // Invariant 3: cachedE1rmKg >= 0 and uses correct formula
-  if (segments.length === 0) {
-    const r = parent.reps ?? 0;
-    const w = parent.weight ?? 0;
-    const expected = r > 0 ? w * (1 + r / 30) : 0;
-    expect(cachedE1rmKg).toBeCloseTo(expected, 6);
-  } else {
-    // e1RM = MAX over segments
-    let maxE1rm = 0;
-    for (const seg of segments) {
-      const sw = seg.weight ?? parent.weight ?? 0;
-      const e = seg.reps > 0 ? sw * (1 + seg.reps / 30) : 0;
-      if (e > maxE1rm) maxE1rm = e;
-    }
-    expect(cachedE1rmKg).toBeCloseTo(maxE1rm, 6);
-  }
+  expect(totalReps).toBe(expectedReps(parent, segments));
+  expect(cachedVolumeKg).toBeCloseTo(expectedVolume(parent, segments), 6);
+  expect(cachedE1rmKg).toBeCloseTo(expectedE1rm(parent, segments), 6);
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
@@ -175,6 +182,60 @@ describe("BLD-1168 AC#266 — parent-segment cache invariants", () => {
     expect(cachedVolumeKg).toBeCloseTo(5 * 80 + 5 * 60, 6);  // 700
   });
 
+  it("advanced set (rest_pause) with zero segments yields zeros", () => {
+    const parent = { weight: 100, reps: 13, isAdvancedSet: true };
+    const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(parent, []);
+    expect(totalReps).toBe(0);
+    expect(cachedVolumeKg).toBe(0);
+    expect(cachedE1rmKg).toBe(0);
+  });
+
+  it("advanced set: 8+3+2 segments → delete all → zeros (deterministic delete-down sequence)", () => {
+    const parent = { weight: 100, reps: null, isAdvancedSet: true };
+    let segments: Seg[] = [
+      { reps: 8, weight: null },
+      { reps: 3, weight: null },
+      { reps: 2, weight: null },
+    ];
+
+    // Verify non-zero state with all segments present
+    const withSegments = computeSetCacheValues(parent, segments);
+    expect(withSegments.totalReps).toBe(13);
+    expect(withSegments.cachedVolumeKg).toBeCloseTo(1300, 4);
+
+    // Delete segments one by one — final delete must yield zeros
+    segments = segments.slice(1);
+    assertInvariant(parent, segments); // 2 segments: 3+2
+
+    segments = segments.slice(1);
+    assertInvariant(parent, segments); // 1 segment: 2
+
+    segments = [];
+    assertInvariant(parent, segments); // 0 segments → zeros
+  });
+
+  it.each(["rest_pause", "cluster", "myo_reps"] as const)(
+    "ADVANCED_SET_TYPES includes %s",
+    (type) => {
+      expect(ADVANCED_SET_TYPES.has(type)).toBe(true);
+    }
+  );
+
+  it.each(["normal", "warmup", "dropset", "failure"] as const)(
+    "ADVANCED_SET_TYPES excludes legacy type %s",
+    (type) => {
+      expect(ADVANCED_SET_TYPES.has(type)).toBe(false);
+    }
+  );
+
+  it("legacy set (normal) with zero segments uses parent reps (not zeroed)", () => {
+    const parent = { weight: 100, reps: 8, isAdvancedSet: false };
+    const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(parent, []);
+    expect(totalReps).toBe(8);
+    expect(cachedVolumeKg).toBeCloseTo(800, 4);
+    expect(cachedE1rmKg).toBeCloseTo(100 * (1 + 8 / 30), 4);
+  });
+
   it("parent with null weight and null reps yields zeros", () => {
     const parent = { weight: null, reps: null };
     const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(parent, []);
@@ -183,13 +244,16 @@ describe("BLD-1168 AC#266 — parent-segment cache invariants", () => {
     expect(totalReps).toBe(0);
   });
 
-  it("property: invariants hold across 1000 random mutation sequences", () => {
+  it("property: invariants hold across 1000 random mutation sequences (legacy and advanced sets)", () => {
     // Log seed so a failed trial can be replayed: SEED=<value> npx jest parent-segment
     console.log(`[property test] SEED=${SEED}`);
+    const allSetTypes = ["normal", "warmup", "dropset", "failure", "rest_pause", "cluster", "myo_reps"] as const;
     for (let trial = 0; trial < 1000; trial++) {
       const parentWeight = rand() < 0.1 ? null : randFloat(10, 300);
       const parentReps = rand() < 0.1 ? null : randInt(1, 20);
-      const parent = { weight: parentWeight, reps: parentReps };
+      const setType = allSetTypes[randInt(0, allSetTypes.length - 1)];
+      const isAdvancedSet = ADVANCED_SET_TYPES.has(setType);
+      const parent = { weight: parentWeight, reps: parentReps, isAdvancedSet };
 
       // Start with 0-4 initial segments
       let segments: Seg[] = [];

--- a/__tests__/parent-segment-invariant.property.test.ts
+++ b/__tests__/parent-segment-invariant.property.test.ts
@@ -5,21 +5,37 @@
  *
  * Uses the pure computeSetCacheValues() helper so no DB mocking is required.
  * 1000 random sequences are executed.
+ *
+ * Reproducible failures: set SEED=<number> env var to replay a failed trial.
+ * The seed is logged before each run so failures can be replayed deterministically.
  */
 import { computeSetCacheValues } from "../lib/db/sets";
 
-// ─── Random helpers ──────────────────────────────────────────────────────────
+// ─── Seeded PRNG (mulberry32) ─────────────────────────────────────────────────
+
+function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return (): number => {
+    s += 0x6D2B79F5;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) >>> 0;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const SEED = process.env.SEED ? parseInt(process.env.SEED, 10) : Date.now();
+const rand = mulberry32(SEED);
 
 function randInt(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+  return Math.floor(rand() * (max - min + 1)) + min;
 }
 
 function randFloat(min: number, max: number): number {
-  return Math.random() * (max - min) + min;
+  return rand() * (max - min) + min;
 }
 
 function maybe<T>(value: T, prob = 0.2): T | null {
-  return Math.random() < prob ? null : value;
+  return rand() < prob ? null : value;
 }
 
 type Seg = { reps: number; weight: number | null };
@@ -168,9 +184,11 @@ describe("BLD-1168 AC#266 — parent-segment cache invariants", () => {
   });
 
   it("property: invariants hold across 1000 random mutation sequences", () => {
+    // Log seed so a failed trial can be replayed: SEED=<value> npx jest parent-segment
+    console.log(`[property test] SEED=${SEED}`);
     for (let trial = 0; trial < 1000; trial++) {
-      const parentWeight = Math.random() < 0.1 ? null : randFloat(10, 300);
-      const parentReps = Math.random() < 0.1 ? null : randInt(1, 20);
+      const parentWeight = rand() < 0.1 ? null : randFloat(10, 300);
+      const parentReps = rand() < 0.1 ? null : randInt(1, 20);
       const parent = { weight: parentWeight, reps: parentReps };
 
       // Start with 0-4 initial segments

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -167,6 +167,12 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   await addColumnIfMissing(database, "workout_sets", "stack_name_at_log", "TEXT DEFAULT NULL");
   // BLD-1114: per-set pulley pin (Setup Snapshot).
   await addColumnIfMissing(database, "workout_sets", "pulley_pin", "INTEGER DEFAULT NULL");
+  // BLD-1168: cached aggregate columns for advanced set scheme analytics.
+  // DEFAULT 0 so reads on pre-backfill rows see 0 not NULL. The one-time
+  // backfill in Phase 3 populates correct values for all existing rows.
+  // addColumnIfMissing is idempotent — safe to call on every boot.
+  await addColumnIfMissing(database, "workout_sets", "cached_volume_kg", "REAL NOT NULL DEFAULT 0");
+  await addColumnIfMissing(database, "workout_sets", "cached_e1rm_kg", "REAL NOT NULL DEFAULT 0");
 
   // workout_sets.set_type migration (replaces deprecated is_warmup column).
   // Kept as a single block: the UPDATEs only reference set_type (just added)
@@ -236,6 +242,28 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
     SET set_number = (SELECT rn FROM renumbered WHERE renumbered.id = workout_sets.id)
     WHERE id IN (SELECT id FROM renumbered WHERE rn != workout_sets.set_number)
   `);
+
+  // BLD-1168: one-time backfill of cached_volume_kg and cached_e1rm_kg for legacy rows.
+  // Pre-migration rows have no segments so parent.weight × parent.reps is the correct formula.
+  // Uses 30.0 (float literal) to prevent SQLite integer division truncation.
+  // Idempotent: rows that already have correct cached values are re-written to the same value.
+  // Guard: only runs if the column was just added OR values are still at the default 0.
+  // Non-advanced sets that genuinely have reps=0 or weight=NULL are unaffected (WHERE guard).
+  try {
+    await database.execAsync(`
+      UPDATE workout_sets
+      SET cached_volume_kg = weight * reps,
+          cached_e1rm_kg   = weight * (1.0 + reps / 30.0)
+      WHERE weight IS NOT NULL
+        AND reps IS NOT NULL
+        AND reps > 0
+        AND cached_volume_kg = 0
+        AND cached_e1rm_kg = 0
+    `);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`Migration: cached_volume_kg/cached_e1rm_kg backfill failed: ${msg}`, { cause: err });
+  }
 
   // BLD-1086 Phase 0b: Composite index for per-variant PR aggregation.
   // Covers (exercise_id, attachment, mount_position, grip_type, completed_at)

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -148,11 +148,37 @@ export const workoutSets = sqliteTable("workout_sets", {
   stack_name_at_log: text("stack_name_at_log"),
   // BLD-1114: per-set cable pulley pin. NULL = unset.
   pulley_pin: integer("pulley_pin"),
+  // BLD-1168: cached aggregate columns — single source of truth for all analytics surfaces.
+  // Populated exclusively by recomputeSetCaches(setId) in lib/db/sets.ts.
+  // DEFAULT 0 so pre-migration rows have a defined value (backfill in migrate() sets correct values).
+  cached_volume_kg: real("cached_volume_kg").default(0),
+  cached_e1rm_kg: real("cached_e1rm_kg").default(0),
 }, (table) => [
   index("idx_workout_sets_exercise").on(table.exercise_id),
   index("idx_workout_sets_session").on(table.session_id),
   index("idx_workout_sets_session_exercise").on(table.session_id, table.exercise_id),
 ]);
+
+// ─── Advanced Set Segments (BLD-1168) ─────────────────────────────────────
+// One row per mini-set within a rest-pause / cluster / myo-reps parent set.
+// FK ON DELETE CASCADE ensures orphan-free cleanup when the parent set is deleted.
+// PRAGMA foreign_keys=ON is enforced per BLD-1094.
+
+export const workoutSetSegments = sqliteTable("workout_set_segments", {
+  id: text("id").primaryKey(),
+  set_id: text("set_id").notNull(),               // FK → workout_sets.id ON DELETE CASCADE
+  segment_number: integer("segment_number").notNull(),   // 1-based, ordered within parent
+  reps: integer("reps").notNull(),
+  weight: real("weight"),                          // NULL = inherit from parent workout_sets.weight
+  rest_after_seconds: integer("rest_after_seconds"), // actual intra-mini-set rest taken
+  completed_at: integer("completed_at"),
+  created_at: integer("created_at").notNull(),
+}, (t) => [
+  uniqueIndex("uq_set_segments_set_seg").on(t.set_id, t.segment_number),
+  index("idx_set_segments_set").on(t.set_id),
+]);
+
+export type WorkoutSetSegmentRow = typeof workoutSetSegments.$inferSelect;
 
 // ─── Form Check Videos (BLD-1092) ─────────────────────────────────────────
 // One video clip per completed working set (uniqueness enforced by uq_set_media_set_id).

--- a/lib/db/sets.ts
+++ b/lib/db/sets.ts
@@ -7,7 +7,8 @@
  * every mutation and the cached_volume_kg / cached_e1rm_kg columns remain in sync.
  *
  * The architecture grep-test (__tests__/architecture-set-write-path.test.ts)
- * fails CI if any file outside this module contains:
+ * enforcing this invariant is added in Slice 2 (BLD-1170). It will fail CI
+ * if any file outside this module contains:
  *   - UPDATE workout_sets / db.update(workoutSets)
  *   - INSERT INTO workout_set_segments / UPDATE workout_set_segments / DELETE FROM workout_set_segments
  *   - weight * reps  (raw ad-hoc volume computation)
@@ -105,6 +106,11 @@ export async function recomputeSetCaches(setId: string): Promise<void> {
     .from(workoutSetSegments)
     .where(eq(workoutSetSegments.set_id, setId))
     .all();
+
+  if (segments.length === 0) {
+    // Legacy/non-segmented set — caches stay as backfilled, reps untouched.
+    return;
+  }
 
   const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(
     { weight: parent.weight ?? null, reps: parent.reps ?? null },

--- a/lib/db/sets.ts
+++ b/lib/db/sets.ts
@@ -18,27 +18,43 @@ import { eq, and } from "drizzle-orm";
 import { getDrizzle } from "./helpers";
 import { workoutSets, workoutSetSegments } from "./schema";
 import { uuid } from "../uuid";
-import type { SetSegment } from "../types";
+import type { SetSegment, SetType } from "../types";
 
 export type { SetSegment };
+
+/** Set types that support mini-set segments. When all segments are deleted, these sets
+ *  must store reps=0 / cached_volume_kg=0 / cached_e1rm_kg=0 (not legacy parent fallback). */
+export const ADVANCED_SET_TYPES: ReadonlySet<SetType> = new Set(["rest_pause", "cluster", "myo_reps"]);
 
 // ─── Pure computation (exported for tests) ─────────────────────────────────
 
 export type SegmentInput = { reps: number; weight: number | null };
-export type ParentInput = { weight: number | null; reps: number | null };
+export type ParentInput = {
+  weight: number | null;
+  reps: number | null;
+  /** When true and segments is empty, returns zeros instead of legacy parent fallback. */
+  isAdvancedSet?: boolean;
+};
 
 /**
  * Pure function: computes cached_volume_kg, cached_e1rm_kg, and total_reps
  * from a parent set and its segments. No DB access.
  *
- * This is the canonical formula — all write paths call computeSetCacheValues,
- * then persist the result via recomputeSetCaches().
+ * For advanced set types (rest_pause, cluster, myo_reps) with zero segments,
+ * returns zeros — the parent row reflects "0 reps, tap to add mini-set".
+ *
+ * For legacy set types with zero segments, falls back to parent.weight × parent.reps
+ * (backwards-compatible with pre-BLD-1168 rows that have no segments).
  */
 export function computeSetCacheValues(
   parent: ParentInput,
   segments: SegmentInput[],
 ): { cachedVolumeKg: number; cachedE1rmKg: number; totalReps: number } {
   if (segments.length === 0) {
+    if (parent.isAdvancedSet) {
+      // Advanced set with no mini-sets: parent is effectively "0 reps"
+      return { cachedVolumeKg: 0, cachedE1rmKg: 0, totalReps: 0 };
+    }
     const w = parent.weight ?? 0;
     const r = parent.reps ?? 0;
     return {
@@ -84,18 +100,21 @@ export function computeSetCacheValues(
 export async function recomputeSetCaches(setId: string): Promise<void> {
   const db = await getDrizzle();
 
-  // Load parent set
+  // Load parent set (including set_type to distinguish advanced vs legacy)
   const parent = await db
     .select({
       id: workoutSets.id,
       weight: workoutSets.weight,
       reps: workoutSets.reps,
+      set_type: workoutSets.set_type,
     })
     .from(workoutSets)
     .where(eq(workoutSets.id, setId))
     .get();
 
   if (!parent) return; // set was deleted; nothing to recompute
+
+  const isAdvancedSet = ADVANCED_SET_TYPES.has((parent.set_type ?? "normal") as SetType);
 
   // Load all segments ordered by segment_number
   const segments = await db
@@ -107,13 +126,13 @@ export async function recomputeSetCaches(setId: string): Promise<void> {
     .where(eq(workoutSetSegments.set_id, setId))
     .all();
 
-  if (segments.length === 0) {
+  if (segments.length === 0 && !isAdvancedSet) {
     // Legacy/non-segmented set — caches stay as backfilled, reps untouched.
     return;
   }
 
   const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(
-    { weight: parent.weight ?? null, reps: parent.reps ?? null },
+    { weight: parent.weight ?? null, reps: parent.reps ?? null, isAdvancedSet },
     segments.map((s) => ({ reps: s.reps, weight: s.weight ?? null })),
   );
 

--- a/lib/db/sets.ts
+++ b/lib/db/sets.ts
@@ -1,0 +1,241 @@
+/**
+ * BLD-1168: Single write-path for workout_sets mutations.
+ *
+ * ARCHITECTURE INVARIANT: Only this file may UPDATE workout_sets or issue
+ * INSERT/UPDATE/DELETE on workout_set_segments. All callers must route through
+ * the functions here so that recomputeSetCaches() is guaranteed to run after
+ * every mutation and the cached_volume_kg / cached_e1rm_kg columns remain in sync.
+ *
+ * The architecture grep-test (__tests__/architecture-set-write-path.test.ts)
+ * fails CI if any file outside this module contains:
+ *   - UPDATE workout_sets / db.update(workoutSets)
+ *   - INSERT INTO workout_set_segments / UPDATE workout_set_segments / DELETE FROM workout_set_segments
+ *   - weight * reps  (raw ad-hoc volume computation)
+ *   - weight * (1 + reps / 30)  (raw ad-hoc e1RM computation)
+ */
+import { eq, and } from "drizzle-orm";
+import { getDrizzle } from "./helpers";
+import { workoutSets, workoutSetSegments } from "./schema";
+import { uuid } from "../uuid";
+import type { SetSegment } from "../types";
+
+export type { SetSegment };
+
+// ─── Pure computation (exported for tests) ─────────────────────────────────
+
+export type SegmentInput = { reps: number; weight: number | null };
+export type ParentInput = { weight: number | null; reps: number | null };
+
+/**
+ * Pure function: computes cached_volume_kg, cached_e1rm_kg, and total_reps
+ * from a parent set and its segments. No DB access.
+ *
+ * This is the canonical formula — all write paths call computeSetCacheValues,
+ * then persist the result via recomputeSetCaches().
+ */
+export function computeSetCacheValues(
+  parent: ParentInput,
+  segments: SegmentInput[],
+): { cachedVolumeKg: number; cachedE1rmKg: number; totalReps: number } {
+  if (segments.length === 0) {
+    const w = parent.weight ?? 0;
+    const r = parent.reps ?? 0;
+    return {
+      cachedVolumeKg: w * r,
+      cachedE1rmKg: r > 0 ? w * (1 + r / 30) : 0,
+      totalReps: r,
+    };
+  }
+
+  let cachedVolumeKg = 0;
+  let cachedE1rmKg = 0;
+  let totalReps = 0;
+
+  for (const seg of segments) {
+    const segWeight = seg.weight ?? parent.weight ?? 0;
+    cachedVolumeKg += segWeight * seg.reps;
+    totalReps += seg.reps;
+    const e1rm = seg.reps > 0 ? segWeight * (1 + seg.reps / 30) : 0;
+    if (e1rm > cachedE1rmKg) cachedE1rmKg = e1rm;
+  }
+
+  return { cachedVolumeKg, cachedE1rmKg, totalReps };
+}
+
+// ─── Cache recomputation ────────────────────────────────────────────────────
+
+/**
+ * Recomputes cached_volume_kg and cached_e1rm_kg for a parent workout_sets row
+ * and updates the parent's reps to Σ segments.reps (for advanced set types).
+ *
+ * Formula:
+ *   cached_volume_kg = Σ (seg.reps × (seg.weight ?? parent.weight))
+ *   cached_e1rm_kg   = MAX over segments of (seg_weight × (1 + seg_reps / 30))
+ *                      where seg_weight = seg.weight ?? parent.weight
+ *
+ * For rows with no segments (normal/warmup/dropset/failure), falls back to
+ * parent.weight × parent.reps (same as legacy formula).
+ *
+ * This function is the ONLY path that writes cached_volume_kg and cached_e1rm_kg.
+ * It must be called after every INSERT/UPDATE/DELETE on workout_set_segments,
+ * and after any change to workout_sets.weight or workout_sets.reps.
+ */
+export async function recomputeSetCaches(setId: string): Promise<void> {
+  const db = await getDrizzle();
+
+  // Load parent set
+  const parent = await db
+    .select({
+      id: workoutSets.id,
+      weight: workoutSets.weight,
+      reps: workoutSets.reps,
+    })
+    .from(workoutSets)
+    .where(eq(workoutSets.id, setId))
+    .get();
+
+  if (!parent) return; // set was deleted; nothing to recompute
+
+  // Load all segments ordered by segment_number
+  const segments = await db
+    .select({
+      reps: workoutSetSegments.reps,
+      weight: workoutSetSegments.weight,
+    })
+    .from(workoutSetSegments)
+    .where(eq(workoutSetSegments.set_id, setId))
+    .all();
+
+  const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(
+    { weight: parent.weight ?? null, reps: parent.reps ?? null },
+    segments.map((s) => ({ reps: s.reps, weight: s.weight ?? null })),
+  );
+
+  // Write back — update both cached columns and parent.reps (for advanced types with segments).
+  // For non-advanced sets parent.reps is unchanged (totalReps === parent.reps ?? 0).
+  await db
+    .update(workoutSets)
+    .set({
+      cached_volume_kg: cachedVolumeKg,
+      cached_e1rm_kg: cachedE1rmKg,
+      reps: totalReps,
+    })
+    .where(eq(workoutSets.id, setId));
+}
+
+// ─── Segment mutations ───────────────────────────────────────────────────────
+
+export type InsertSegmentParams = {
+  setId: string;
+  segmentNumber: number;
+  reps: number;
+  weight?: number | null;
+  restAfterSeconds?: number | null;
+  completedAt?: number | null;
+};
+
+/** Insert a new mini-set segment and recompute parent caches. */
+export async function insertSegment(params: InsertSegmentParams): Promise<SetSegment> {
+  const db = await getDrizzle();
+  const now = Date.now();
+  const id = uuid();
+
+  await db.insert(workoutSetSegments).values({
+    id,
+    set_id: params.setId,
+    segment_number: params.segmentNumber,
+    reps: params.reps,
+    weight: params.weight ?? null,
+    rest_after_seconds: params.restAfterSeconds ?? null,
+    completed_at: params.completedAt ?? null,
+    created_at: now,
+  });
+
+  await recomputeSetCaches(params.setId);
+
+  return {
+    id,
+    set_id: params.setId,
+    segment_number: params.segmentNumber,
+    reps: params.reps,
+    weight: params.weight ?? null,
+    rest_after_seconds: params.restAfterSeconds ?? null,
+    completed_at: params.completedAt ?? null,
+    created_at: now,
+  };
+}
+
+export type UpdateSegmentParams = {
+  segmentId: string;
+  setId: string;
+  reps?: number;
+  weight?: number | null;
+  restAfterSeconds?: number | null;
+  completedAt?: number | null;
+};
+
+/** Update an existing mini-set segment and recompute parent caches. */
+export async function updateSegment(params: UpdateSegmentParams): Promise<void> {
+  const db = await getDrizzle();
+
+  const updates: Partial<{
+    reps: number;
+    weight: number | null;
+    rest_after_seconds: number | null;
+    completed_at: number | null;
+  }> = {};
+
+  if (params.reps !== undefined) updates.reps = params.reps;
+  if ("weight" in params) updates.weight = params.weight ?? null;
+  if ("restAfterSeconds" in params) updates.rest_after_seconds = params.restAfterSeconds ?? null;
+  if ("completedAt" in params) updates.completed_at = params.completedAt ?? null;
+
+  if (Object.keys(updates).length > 0) {
+    await db
+      .update(workoutSetSegments)
+      .set(updates)
+      .where(and(eq(workoutSetSegments.id, params.segmentId), eq(workoutSetSegments.set_id, params.setId)));
+  }
+
+  await recomputeSetCaches(params.setId);
+}
+
+/** Delete a mini-set segment and recompute parent caches. */
+export async function deleteSegment(segmentId: string, setId: string): Promise<void> {
+  const db = await getDrizzle();
+
+  await db
+    .delete(workoutSetSegments)
+    .where(and(eq(workoutSetSegments.id, segmentId), eq(workoutSetSegments.set_id, setId)));
+
+  await recomputeSetCaches(setId);
+}
+
+/** Delete all segments for a set (e.g., when changing set_type back to normal). */
+export async function deleteAllSegmentsForSet(setId: string): Promise<void> {
+  const db = await getDrizzle();
+  await db.delete(workoutSetSegments).where(eq(workoutSetSegments.set_id, setId));
+  await recomputeSetCaches(setId);
+}
+
+/** Load all segments for a set ordered by segment_number. */
+export async function getSegmentsForSet(setId: string): Promise<SetSegment[]> {
+  const db = await getDrizzle();
+  const rows = await db
+    .select()
+    .from(workoutSetSegments)
+    .where(eq(workoutSetSegments.set_id, setId))
+    .orderBy(workoutSetSegments.segment_number)
+    .all();
+
+  return rows.map((r) => ({
+    id: r.id,
+    set_id: r.set_id,
+    segment_number: r.segment_number,
+    reps: r.reps,
+    weight: r.weight ?? null,
+    rest_after_seconds: r.rest_after_seconds ?? null,
+    completed_at: r.completed_at ?? null,
+    created_at: r.created_at,
+  }));
+}

--- a/lib/db/tables.ts
+++ b/lib/db/tables.ts
@@ -4,7 +4,7 @@ import * as SQLite from "expo-sqlite";
 // Defense-in-depth: validate before interpolation to prevent accidental SQL injection.
 const VALID_TABLES = new Set([
   "exercises", "workout_templates", "template_exercises",
-  "workout_sessions", "workout_sets", "food_entries", "daily_log",
+  "workout_sessions", "workout_sets", "workout_set_segments", "food_entries", "daily_log",
   "macro_targets", "error_log", "body_weight", "body_measurements",
   "body_settings", "programs", "program_days", "program_log",
   "interaction_log", "progress_photos", "achievements_earned",
@@ -400,6 +400,22 @@ export async function createExtensionTables(database: SQLite.SQLiteDatabase): Pr
     -- version without gym_id) raises "no such column: gym_id" and aborts the
     -- entire migration. The index is created in migrations.ts Phase 3 (after
     -- addColumnIfMissing in Phase 2 guarantees the column exists).
+
+    -- BLD-1168: advanced set segments table.
+    -- Each row is one mini-set within a rest-pause / cluster / myo-reps parent set.
+    -- FK ON DELETE CASCADE ensures orphan-free cleanup; enforced by PRAGMA foreign_keys=ON (BLD-1094).
+    CREATE TABLE IF NOT EXISTS workout_set_segments (
+      id TEXT PRIMARY KEY,
+      set_id TEXT NOT NULL REFERENCES workout_sets(id) ON DELETE CASCADE,
+      segment_number INTEGER NOT NULL,
+      reps INTEGER NOT NULL,
+      weight REAL,
+      rest_after_seconds INTEGER,
+      completed_at INTEGER,
+      created_at INTEGER NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_set_segments_set_seg ON workout_set_segments(set_id, segment_number);
+    CREATE INDEX IF NOT EXISTS idx_set_segments_set ON workout_set_segments(set_id);
   `);
 }
 

--- a/lib/rest.ts
+++ b/lib/rest.ts
@@ -42,6 +42,11 @@ export const REST_MULTIPLIERS = {
     warmup: 0.3,
     dropset: 0.1,
     failure: 1.3,
+    // BLD-1168: advanced set scheme inter-set multipliers.
+    // Intra-mini-set rest is handled separately by lib/rest-resolver.ts IntraMiniSetRest mode.
+    rest_pause: 0.15,
+    cluster: 0.5,
+    myo_reps: 0.10,
   } satisfies Record<SetType, number>,
   // RPE buckets: keyed by ceiling comparisons (see resolveRpeFactor).
   rpe: {

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
-const templateSetTypeSchema = z.enum(["normal", "warmup", "dropset", "failure"]);
+// BLD-1168: extended with rest_pause, cluster, myo_reps.
+const templateSetTypeSchema = z.enum(["normal", "warmup", "dropset", "failure", "rest_pause", "cluster", "myo_reps"]);
 const templateSourceSchema = z.enum(["coach"]);
 
 const exerciseImportSchema = z.object({

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -292,15 +292,33 @@ export type WorkoutSession = {
   day_session_date?: string | null;
 };
 
-export type SetType = "normal" | "warmup" | "dropset" | "failure";
+export type SetType = "normal" | "warmup" | "dropset" | "failure" | "rest_pause" | "cluster" | "myo_reps";
 
 export const SET_TYPE_CYCLE: SetType[] = ["normal", "warmup", "dropset", "failure"];
+
+/** BLD-1168: one ordered mini-set within a rest-pause / cluster / myo-reps parent set. */
+export type SetSegment = {
+  id: string;
+  set_id: string;
+  segment_number: number;
+  reps: number;
+  /** NULL = inherit weight from parent workout_sets row. */
+  weight?: number | null;
+  /** Actual intra-mini-set rest taken, in seconds. */
+  rest_after_seconds?: number | null;
+  completed_at?: number | null;
+  created_at: number;
+};
 
 export const SET_TYPE_LABELS: Record<SetType, { label: string; short: string }> = {
   normal: { label: "Normal", short: "" },
   warmup: { label: "Warm-up", short: "W" },
   dropset: { label: "Dropset", short: "D" },
   failure: { label: "Failure", short: "F" },
+  // BLD-1168: advanced set schemes — display-only; UI added in Slice 6.
+  rest_pause: { label: "Rest-pause", short: "RP" },
+  cluster: { label: "Cluster", short: "CL" },
+  myo_reps: { label: "Myo-reps", short: "MR" },
 };
 
 export type WorkoutSet = {
@@ -335,6 +353,9 @@ export type WorkoutSet = {
   stack_unit_at_log?: string | null;
   stack_name_at_log?: string | null;
   pulley_pin?: number | null;
+  // BLD-1168: cached aggregate columns populated by recomputeSetCaches(). DEFAULT 0.
+  cached_volume_kg?: number;
+  cached_e1rm_kg?: number;
 };
 
 export type LinkedGroup = {


### PR DESCRIPTION
## Summary

Slice 1 of the BLD-1168 Advanced Set Schemes feature. No UI changes — this slice establishes the data layer that all subsequent slices build upon.

## Changes

**Schema & Migrations**
- New `workout_set_segments` table (mini-sets for rest-pause/cluster/myo-reps parents); FK `ON DELETE CASCADE` on `set_id`
- Two new cached columns on `workout_sets`: `cached_volume_kg` + `cached_e1rm_kg` (ADD COLUMN, additive, DEFAULT 0)
- One-time backfill in Phase 3: `weight*reps` + `weight*(1.0+reps/30.0)` for all legacy rows

**Type System (lib/types.ts)**
- `SetType` extended: `rest_pause | cluster | myo_reps`
- `SetSegment` type added
- `SET_TYPE_LABELS` extended (RP/CL/MR short labels)
- `WorkoutSet` extended with optional `cached_volume_kg` / `cached_e1rm_kg`

**Service Layer (lib/db/sets.ts — new file)**
- `computeSetCacheValues` (pure — no DB, testable)
- `recomputeSetCaches(setId)` (single DB write funnel)
- `insertSegment / updateSegment / deleteSegment / deleteAllSegmentsForSet / getSegmentsForSet`

**Other**
- REST_MULTIPLIERS extended: `rest_pause=0.15`, `cluster=0.5`, `myo_reps=0.10` (inter-set; intra handled in Slice 6)
- Zod schema (`lib/schemas.ts`) extended for template round-trip

## Testing

- `__tests__/parent-segment-invariant.property.test.ts` — 1000 random mutation sequences assert `parent.reps == Σ segments.reps`, volume, and e1RM invariants (AC #266)
- `__tests__/fk-cascade-segments.test.ts` — architecture + schema DDL assertions (AC #274)
- `__tests__/migration-cached-columns-backfill.test.ts` — migration phase ordering + backfill formula (AC #275)
- All 4084 pre-existing tests pass; REST_MULTIPLIERS snapshot updated

## Issue

Resolves part of BLD-1171 (Slice 1 sub-issue), parent: BLD-1168