### PR TITLE
feat(BLD-1173): Slice 6 — SetType cycle + IntraMiniSetRest mode + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
+- Foundation for advanced set schemes: rest-pause, cluster, and myo-reps set types added to the set-type cycle (no UI surfacing yet — wiring lands in later slices).
 - **Adaptive Macro Coach** (off by default): Enable in Settings → Nutrition → Adaptive Macro Coach to get a weekly advisory card that suggests a calorie target based on your trend weight and average intake over the past two weeks. The coach is advisory only — your target is never changed without your tap. Includes a hard safety floor (based on your sex and estimated metabolic rate), a ±300 kcal/week cap, Right Why check-in, and a one-tap one-month pause.
 - **Tempo Coach (haptic engine)**: Enable "Tempo Coach" in Settings → Preferences to get a haptic rep guide during your sets. When active, a vibration cues each phase of your tempo (eccentric → bottom pause → concentric → top pause) in real time. A compact overlay shows the current phase and lets you stop the coach at any time. The coach auto-stops when the set is logged and cancels if you background the app.
 

--- a/__tests__/lib/db/warmup-sets.test.ts
+++ b/__tests__/lib/db/warmup-sets.test.ts
@@ -200,13 +200,13 @@ tempo: null,
 // ---- SET_TYPE_CYCLE order ----
 
 describe('SET_TYPE_CYCLE', () => {
-  it('has correct cycle order: normal → warmup → dropset → failure', () => {
-    expect(SET_TYPE_CYCLE).toEqual(['normal', 'warmup', 'dropset', 'failure']);
+  it('has correct cycle order including advanced set types', () => {
+    expect(SET_TYPE_CYCLE).toEqual(['normal', 'warmup', 'dropset', 'failure', 'rest_pause', 'cluster', 'myo_reps']);
   });
 
-  it('cycles back to normal after failure', () => {
-    const failureIdx = SET_TYPE_CYCLE.indexOf('failure');
-    const next = SET_TYPE_CYCLE[(failureIdx + 1) % SET_TYPE_CYCLE.length];
+  it('cycles back to normal after myo_reps (last entry)', () => {
+    const lastIdx = SET_TYPE_CYCLE.length - 1;
+    const next = SET_TYPE_CYCLE[(lastIdx + 1) % SET_TYPE_CYCLE.length];
     expect(next).toBe('normal');
   });
 });

--- a/__tests__/rest-resolver-intra-vs-inter.test.ts
+++ b/__tests__/rest-resolver-intra-vs-inter.test.ts
@@ -1,0 +1,124 @@
+/**
+ * BLD-1173 — AC #272: rest-resolver intra-vs-inter mode switching
+ *
+ * GIVEN a parent advanced set is in progress with one or more completed segments
+ * WHEN the user completes another mini-set
+ * THEN lib/rest-resolver returns intra-mini-set mode (5/15/30s defaults per set_type)
+ *   AND a "Mini-set N of ?" badge is rendered
+ * WHEN the user marks the parent set complete
+ * THEN the resolver switches to inter-set mode
+ *   AND MIN_REST_SECONDS=10 floor is enforced (inter-set only)
+ */
+import {
+  resolveIntraMiniSetRest,
+  INTRA_MINI_SET_DEFAULTS,
+  isAdvancedSetType,
+} from "@/lib/rest-resolver";
+
+describe("intra-vs-inter mode switching — all advanced types", () => {
+  const advancedTypes = ["rest_pause", "cluster", "myo_reps"] as const;
+
+  for (const setType of advancedTypes) {
+    describe(`${setType}`, () => {
+      it("returns intra mode with correct default seconds when mid-parent", () => {
+        const result = resolveIntraMiniSetRest(setType, false, 1, 3);
+        expect(result.mode).toBe("intra");
+        if (result.mode === "intra") {
+          expect(result.seconds).toBe(INTRA_MINI_SET_DEFAULTS[setType]);
+          expect(result.setType).toBe(setType);
+        }
+      });
+
+      it("renders 'Mini-set N of M' badge when mid-parent with known total", () => {
+        const result = resolveIntraMiniSetRest(setType, false, 2, 4);
+        expect(result.mode).toBe("intra");
+        if (result.mode === "intra") {
+          expect(result.badge).toMatch(/^Mini-set \d+ of \d+$/);
+          expect(result.badge).toBe("Mini-set 2 of 4");
+        }
+      });
+
+      it("renders 'Mini-set N of ?' badge when total is unknown", () => {
+        const result = resolveIntraMiniSetRest(setType, false, 3, 0);
+        expect(result.mode).toBe("intra");
+        if (result.mode === "intra") {
+          expect(result.badge).toBe("Mini-set 3 of ?");
+        }
+      });
+
+      it("switches to inter mode when parent is marked complete", () => {
+        const result = resolveIntraMiniSetRest(setType, true, 3, 3);
+        expect(result.mode).toBe("inter");
+      });
+    });
+  }
+});
+
+describe("MIN_REST_SECONDS=10 floor — inter-set only", () => {
+  it("inter mode result is NOT a seconds value — callers use resolveRest for inter and enforce floor", () => {
+    const interResult = resolveIntraMiniSetRest("rest_pause", true, 2, 2);
+    // { mode: "inter" } — no seconds field; caller uses resolveRest() where 10s floor applies.
+    expect(interResult.mode).toBe("inter");
+    expect("seconds" in interResult).toBe(false);
+  });
+
+  it("myo_reps intra mode returns 5s — below MIN_REST_SECONDS=10 — floor is NOT enforced intra", () => {
+    const intraResult = resolveIntraMiniSetRest("myo_reps", false, 1, 0);
+    expect(intraResult.mode).toBe("intra");
+    if (intraResult.mode === "intra") {
+      // Must be 5s — Fagerli protocol; floor is advisory (non-blocking) in intra mode.
+      expect(intraResult.seconds).toBe(5);
+      expect(intraResult.seconds).toBeLessThan(10); // confirms floor not applied
+    }
+  });
+
+  it("rest_pause intra is 15s — above MIN_REST_SECONDS=10 regardless", () => {
+    const intraResult = resolveIntraMiniSetRest("rest_pause", false, 1, 0);
+    if (intraResult.mode === "intra") {
+      expect(intraResult.seconds).toBe(15);
+    }
+  });
+
+  it("cluster intra is 30s — well above MIN_REST_SECONDS=10", () => {
+    const intraResult = resolveIntraMiniSetRest("cluster", false, 2, 0);
+    if (intraResult.mode === "intra") {
+      expect(intraResult.seconds).toBe(30);
+    }
+  });
+});
+
+describe("badge format specification", () => {
+  it("badge shows completedMiniSets (1-based) as N", () => {
+    const r = resolveIntraMiniSetRest("rest_pause", false, 3, 5);
+    if (r.mode === "intra") expect(r.badge).toBe("Mini-set 3 of 5");
+  });
+
+  it("badge shows '?' when total is zero", () => {
+    const r = resolveIntraMiniSetRest("cluster", false, 1, 0);
+    if (r.mode === "intra") expect(r.badge).toBe("Mini-set 1 of ?");
+  });
+
+  it("badge text format is always 'Mini-set N of M'", () => {
+    for (const setType of ["rest_pause", "cluster", "myo_reps"] as const) {
+      const r = resolveIntraMiniSetRest(setType, false, 2, 3);
+      if (r.mode === "intra") {
+        expect(r.badge).toMatch(/^Mini-set \d+ of (\d+|\?)$/);
+      }
+    }
+  });
+});
+
+describe("isAdvancedSetType — integration with SetType cycle", () => {
+  it("all advanced types are identified correctly", () => {
+    expect(isAdvancedSetType("rest_pause")).toBe(true);
+    expect(isAdvancedSetType("cluster")).toBe(true);
+    expect(isAdvancedSetType("myo_reps")).toBe(true);
+  });
+
+  it("standard types are not advanced", () => {
+    expect(isAdvancedSetType("normal")).toBe(false);
+    expect(isAdvancedSetType("warmup")).toBe(false);
+    expect(isAdvancedSetType("dropset")).toBe(false);
+    expect(isAdvancedSetType("failure")).toBe(false);
+  });
+});

--- a/__tests__/rest-timer-mini-set.test.ts
+++ b/__tests__/rest-timer-mini-set.test.ts
@@ -1,0 +1,128 @@
+/**
+ * BLD-1173 — AC #259: IntraMiniSetRest mode (rest-pause set in progress)
+ *
+ * GIVEN a `rest_pause` set in progress
+ * WHEN the user completes a mini-set mid-parent
+ * THEN the rest timer resolves to ≤30 seconds (intra) and shows "Mini-set N of ?" badge
+ * WHEN the parent set is marked complete
+ * THEN normal inter-set rest resumes
+ */
+import {
+  resolveIntraMiniSetRest,
+  INTRA_MINI_SET_DEFAULTS,
+  isAdvancedSetType,
+  type AdvancedSetType,
+} from "@/lib/rest-resolver";
+
+describe("resolveIntraMiniSetRest — rest_pause mid-parent (AC #259)", () => {
+  it("returns intra mode with ≤30s when mini-set completes mid-parent", () => {
+    const result = resolveIntraMiniSetRest("rest_pause", false, 1, 3);
+    expect(result.mode).toBe("intra");
+    if (result.mode === "intra") {
+      expect(result.seconds).toBeLessThanOrEqual(30);
+      expect(result.seconds).toBe(INTRA_MINI_SET_DEFAULTS.rest_pause);
+    }
+  });
+
+  it("shows 'Mini-set N of ?' badge with known total", () => {
+    const result = resolveIntraMiniSetRest("rest_pause", false, 2, 3);
+    expect(result.mode).toBe("intra");
+    if (result.mode === "intra") {
+      expect(result.badge).toBe("Mini-set 2 of 3");
+    }
+  });
+
+  it("shows 'Mini-set N of ?' badge with unknown total (0)", () => {
+    const result = resolveIntraMiniSetRest("rest_pause", false, 1, 0);
+    expect(result.mode).toBe("intra");
+    if (result.mode === "intra") {
+      expect(result.badge).toBe("Mini-set 1 of ?");
+    }
+  });
+
+  it("switches to inter mode when parent set is marked complete", () => {
+    const result = resolveIntraMiniSetRest("rest_pause", true, 3, 3);
+    expect(result.mode).toBe("inter");
+  });
+
+  it("switches to inter mode when parentDone=true regardless of completedMiniSets", () => {
+    const result = resolveIntraMiniSetRest("rest_pause", true, 0, 0);
+    expect(result.mode).toBe("inter");
+  });
+});
+
+describe("resolveIntraMiniSetRest — cluster mid-parent", () => {
+  it("returns intra mode with 30s for cluster", () => {
+    const result = resolveIntraMiniSetRest("cluster", false, 2, 5);
+    expect(result.mode).toBe("intra");
+    if (result.mode === "intra") {
+      expect(result.seconds).toBe(30);
+      expect(result.setType).toBe("cluster");
+    }
+  });
+
+  it("switches to inter mode when cluster parent is done", () => {
+    const result = resolveIntraMiniSetRest("cluster", true, 5, 5);
+    expect(result.mode).toBe("inter");
+  });
+});
+
+describe("resolveIntraMiniSetRest — myo_reps mid-parent", () => {
+  it("returns intra mode with 5s for myo_reps (Fagerli protocol — non-blocking countdown)", () => {
+    const result = resolveIntraMiniSetRest("myo_reps", false, 1, 0);
+    expect(result.mode).toBe("intra");
+    if (result.mode === "intra") {
+      expect(result.seconds).toBe(5);
+      expect(result.setType).toBe("myo_reps");
+    }
+  });
+
+  it("myo_reps intra rest is NOT raised to MIN_REST_SECONDS floor (5s < 10s)", () => {
+    const result = resolveIntraMiniSetRest("myo_reps", false, 3, 0);
+    if (result.mode === "intra") {
+      // Floor is advisory only for intra — 5s must be preserved as-is.
+      expect(result.seconds).toBe(5);
+    }
+  });
+
+  it("switches to inter mode when myo_reps parent is done", () => {
+    const result = resolveIntraMiniSetRest("myo_reps", true, 4, 0);
+    expect(result.mode).toBe("inter");
+  });
+});
+
+describe("INTRA_MINI_SET_DEFAULTS constants", () => {
+  it("rest_pause defaults to 15s", () => {
+    expect(INTRA_MINI_SET_DEFAULTS.rest_pause).toBe(15);
+  });
+
+  it("cluster defaults to 30s", () => {
+    expect(INTRA_MINI_SET_DEFAULTS.cluster).toBe(30);
+  });
+
+  it("myo_reps defaults to 5s", () => {
+    expect(INTRA_MINI_SET_DEFAULTS.myo_reps).toBe(5);
+  });
+});
+
+describe("isAdvancedSetType", () => {
+  it("returns true for advanced set types", () => {
+    const advancedTypes: AdvancedSetType[] = ["rest_pause", "cluster", "myo_reps"];
+    for (const t of advancedTypes) {
+      expect(isAdvancedSetType(t)).toBe(true);
+    }
+  });
+
+  it("returns false for standard set types", () => {
+    const standardTypes = ["normal", "warmup", "dropset", "failure"];
+    for (const t of standardTypes) {
+      expect(isAdvancedSetType(t)).toBe(false);
+    }
+  });
+
+  it("returns false for unknown/garbage strings", () => {
+    expect(isAdvancedSetType("")).toBe(false);
+    expect(isAdvancedSetType("REST_PAUSE")).toBe(false);
+    expect(isAdvancedSetType("unknown")).toBe(false);
+  });
+});

--- a/lib/rest-resolver.ts
+++ b/lib/rest-resolver.ts
@@ -243,6 +243,75 @@ async function queryHistoryMedian(
   return { median, sampleCount: sorted.length };
 }
 
+// ─── BLD-1168: IntraMiniSetRest mode ─────────────────────────────────────────
+
+/** Advanced set types that use intra-mini-set rest. */
+export type AdvancedSetType = "rest_pause" | "cluster" | "myo_reps";
+
+/**
+ * Default intra-mini-set rest in seconds per set type.
+ *
+ * myo_reps = 5s  (per Borge Fagerli protocol — 5s non-blocking countdown)
+ * rest_pause = 15s  (typical mid-set pause duration)
+ * cluster   = 30s  (strength protocol: longer intra-cluster rest)
+ *
+ * The MIN_REST_SECONDS=10 floor is advisory in intra-mini-set mode only and
+ * is NEVER enforced here — myo_reps intentionally uses 5s. The floor only
+ * applies to inter-set rest (between parent sets).
+ */
+export const INTRA_MINI_SET_DEFAULTS: Record<AdvancedSetType, number> = {
+  myo_reps: 5,
+  rest_pause: 15,
+  cluster: 30,
+};
+
+export type IntraMiniSetRestResult = {
+  mode: "intra";
+  seconds: number;
+  /** Display badge shown during intra-mini-set rest. N is 1-based completed mini-set count. */
+  badge: string;
+  setType: AdvancedSetType;
+};
+
+export type IntraOrInterRestResult = IntraMiniSetRestResult | { mode: "inter" };
+
+/**
+ * Determine whether to use intra-mini-set or inter-set rest mode.
+ *
+ * Returns `{ mode: "intra", ... }` when a mini-set has just completed mid-parent
+ * (i.e. the parent set is NOT yet complete). Returns `{ mode: "inter" }` when the
+ * parent set is complete, signalling callers to use the regular `resolveRest` path
+ * and enforce the MIN_REST_SECONDS=10 floor.
+ *
+ * @param setType       The parent set's type (must be an AdvancedSetType).
+ * @param parentDone    True when the parent set has been marked complete.
+ * @param completedMiniSets  Count of mini-sets completed so far (≥1 to be mid-parent).
+ * @param totalMiniSets      Total planned mini-sets for the parent (may be unknown; 0 = "?").
+ */
+export function resolveIntraMiniSetRest(
+  setType: AdvancedSetType,
+  parentDone: boolean,
+  completedMiniSets: number,
+  totalMiniSets: number,
+): IntraOrInterRestResult {
+  if (parentDone) {
+    return { mode: "inter" };
+  }
+
+  const seconds = INTRA_MINI_SET_DEFAULTS[setType];
+  const totalLabel = totalMiniSets > 0 ? String(totalMiniSets) : "?";
+  const badge = `Mini-set ${completedMiniSets} of ${totalLabel}`;
+
+  return { mode: "intra", seconds, badge, setType };
+}
+
+/**
+ * Returns true if `setType` uses the intra-mini-set rest mode.
+ */
+export function isAdvancedSetType(setType: string): setType is AdvancedSetType {
+  return setType === "rest_pause" || setType === "cluster" || setType === "myo_reps";
+}
+
 // ─── Mutation: setUserRestSeconds ────────────────────────────────────────────
 
 /**

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -294,7 +294,8 @@ export type WorkoutSession = {
 
 export type SetType = "normal" | "warmup" | "dropset" | "failure" | "rest_pause" | "cluster" | "myo_reps";
 
-export const SET_TYPE_CYCLE: SetType[] = ["normal", "warmup", "dropset", "failure"];
+// BLD-1168: advanced set schemes appended so the cycle selector includes them.
+export const SET_TYPE_CYCLE: SetType[] = ["normal", "warmup", "dropset", "failure", "rest_pause", "cluster", "myo_reps"];
 
 /** BLD-1168: one ordered mini-set within a rest-pause / cluster / myo-reps parent set. */
 export type SetSegment = {


### PR DESCRIPTION
## Summary

Extends the set-type cycle to include the three advanced types and adds the `IntraMiniSetRest` mode to `lib/rest-resolver.ts` for intra-mini-set rest timing.

## Changes

- `lib/types.ts`: Append `rest_pause`, `cluster`, `myo_reps` to `SET_TYPE_CYCLE`
- `lib/rest-resolver.ts`: Add `resolveIntraMiniSetRest()` — returns intra (5/15/30s) or inter mode based on whether parent set is complete; `INTRA_MINI_SET_DEFAULTS` constant; `isAdvancedSetType()` guard; MIN_REST_SECONDS=10 floor advisory-only in intra mode, enforced on inter
- `__tests__/rest-timer-mini-set.test.ts`: AC #259 (21 tests)
- `__tests__/rest-resolver-intra-vs-inter.test.ts`: AC #272 (16 tests)

## Testing

All 37 tests pass.

## Dependencies

Stacked on PR #565 (Slice 3 — normalizeSetType)

## Issue

Resolves BLD-1173 (Slice 6 of BLD-1168 Advanced set schemes)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>