### PR TITLE
feat(BLD-1174): Slice 5 — analytics surfaces → cached_volume_kg + cached_e1rm_kg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
+- **Advanced set schemes (analytics)**: rest-pause, cluster, and myo-rep sets now contribute correct volume and e1RM values to all analytics surfaces (weekly/monthly trends, exercise history bests, achievements). Previously, multi-segment sets were excluded or under-counted due to the reps ≤ 12 filter.
 - **Adaptive Macro Coach** (off by default): Enable in Settings → Nutrition → Adaptive Macro Coach to get a weekly advisory card that suggests a calorie target based on your trend weight and average intake over the past two weeks. The coach is advisory only — your target is never changed without your tap. Includes a hard safety floor (based on your sex and estimated metabolic rate), a ±300 kcal/week cap, Right Why check-in, and a one-tap one-month pause.
 - **Tempo Coach (haptic engine)**: Enable "Tempo Coach" in Settings → Preferences to get a haptic rep guide during your sets. When active, a vibration cues each phase of your tempo (eccentric → bottom pause → concentric → top pause) in real time. A compact overlay shows the current phase and lets you stop the coach at any time. The coach auto-stops when the set is logged and cancels if you background the app.
 

--- a/__tests__/analytics-parity-advanced-sets.test.ts
+++ b/__tests__/analytics-parity-advanced-sets.test.ts
@@ -1,0 +1,253 @@
+/**
+ * BLD-1174 AC #268 — Analytics parity for advanced set types.
+ *
+ * GIVEN a fixture session containing:
+ *   - rest_pause: 8+3+2 @ 100kg
+ *   - cluster:    3+3+2 @ 100/100/95kg (segment-level weight overrides)
+ *   - myo_reps:   15+5+5+4+3 @ 25kg
+ *
+ * THEN the cached column values computed by computeSetCacheValues() match
+ * hand-computed reference values within ±0.01, AND the analytics SQL
+ * expressions reading those cached columns produce the expected sums.
+ *
+ * Strategy: uses computeSetCacheValues (pure) for cache computation assertions,
+ * and node:sqlite for SQL aggregate assertions against a seeded in-memory DB.
+ */
+
+import { DatabaseSync } from "node:sqlite";
+import { computeSetCacheValues } from "../lib/db/sets";
+import { migrate } from "../lib/db/migrations";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type Row = Record<string, unknown>;
+type SqlParam = null | number | bigint | string | Uint8Array;
+
+function wrapDb(db: InstanceType<typeof DatabaseSync>) {
+  return {
+    execAsync: async (sql: string): Promise<void> => { db.exec(sql); },
+    getAllAsync: async <T = Row>(sql: string, params?: unknown[]): Promise<T[]> =>
+      db.prepare(sql).all(...((params ?? []) as SqlParam[])) as T[],
+    getFirstAsync: async <T = Row>(sql: string, params?: unknown[]): Promise<T | null> =>
+      (db.prepare(sql).get(...((params ?? []) as SqlParam[])) as T) ?? null,
+    runAsync: async (sql: string, params?: unknown[]): Promise<{ changes: number }> => {
+      const result = db.prepare(sql).run(...((params ?? []) as SqlParam[]));
+      return { changes: Number(result.changes) };
+    },
+  };
+}
+
+// ── Hand-computed reference values ───────────────────────────────────────────
+// rest_pause: 8+3+2 @ 100kg
+//   cached_volume_kg = (8+3+2) × 100 = 1300
+//   cached_e1rm_kg   = MAX(100×(1+8/30), 100×(1+3/30), 100×(1+2/30))
+//                    = MAX(126.667, 110, 106.667) = 126.667
+const REF_RP_VOLUME  = 1300;
+const REF_RP_E1RM    = 100 * (1 + 8 / 30); // ≈ 126.667
+
+// cluster: 3+3+2 @ 100/100/95kg segment-level overrides
+//   cached_volume_kg = 3×100 + 3×100 + 2×95 = 300 + 300 + 190 = 790
+//   cached_e1rm_kg   = MAX(100×(1+3/30), 100×(1+3/30), 95×(1+2/30))
+//                    = MAX(110, 110, 101.333) = 110
+const REF_CL_VOLUME  = 790;
+const REF_CL_E1RM    = 100 * (1 + 3 / 30); // = 110
+
+// myo_reps: 15+5+5+4+3 @ 25kg (all same weight)
+//   cached_volume_kg = (15+5+5+4+3) × 25 = 32 × 25 = 800
+//   cached_e1rm_kg   = MAX(25×(1+15/30), 25×(1+5/30), ...) = 25×(1+15/30) = 37.5
+const REF_MR_VOLUME  = 800;
+const REF_MR_E1RM    = 25 * (1 + 15 / 30); // = 37.5
+
+// ── Pure computeSetCacheValues assertions ─────────────────────────────────────
+
+describe("BLD-1174 AC#268 — computeSetCacheValues: rest_pause 8+3+2 @100kg", () => {
+  const result = computeSetCacheValues(
+    { weight: 100, reps: 13, isAdvancedSet: true },
+    [
+      { reps: 8, weight: null },
+      { reps: 3, weight: null },
+      { reps: 2, weight: null },
+    ]
+  );
+
+  it("cached_volume_kg = 1300", () => {
+    expect(result.cachedVolumeKg).toBeCloseTo(REF_RP_VOLUME, 2);
+  });
+
+  it("cached_e1rm_kg ≈ 126.67 (max-segment Epley)", () => {
+    expect(result.cachedE1rmKg).toBeCloseTo(REF_RP_E1RM, 2);
+  });
+
+  it("totalReps = 13", () => {
+    expect(result.totalReps).toBe(13);
+  });
+});
+
+describe("BLD-1174 AC#268 — computeSetCacheValues: cluster 3+3+2 @100/100/95kg", () => {
+  const result = computeSetCacheValues(
+    { weight: 100, reps: 8, isAdvancedSet: true },
+    [
+      { reps: 3, weight: 100 },
+      { reps: 3, weight: 100 },
+      { reps: 2, weight: 95 },
+    ]
+  );
+
+  it("cached_volume_kg = 790", () => {
+    expect(result.cachedVolumeKg).toBeCloseTo(REF_CL_VOLUME, 2);
+  });
+
+  it("cached_e1rm_kg = 110 (max of two equal 100kg×3 segments)", () => {
+    expect(result.cachedE1rmKg).toBeCloseTo(REF_CL_E1RM, 2);
+  });
+
+  it("totalReps = 8", () => {
+    expect(result.totalReps).toBe(8);
+  });
+});
+
+describe("BLD-1174 AC#268 — computeSetCacheValues: myo_reps 15+5+5+4+3 @25kg", () => {
+  const result = computeSetCacheValues(
+    { weight: 25, reps: 32, isAdvancedSet: true },
+    [
+      { reps: 15, weight: null },
+      { reps: 5,  weight: null },
+      { reps: 5,  weight: null },
+      { reps: 4,  weight: null },
+      { reps: 3,  weight: null },
+    ]
+  );
+
+  it("cached_volume_kg = 800", () => {
+    expect(result.cachedVolumeKg).toBeCloseTo(REF_MR_VOLUME, 2);
+  });
+
+  it("cached_e1rm_kg = 37.5 (activation segment wins)", () => {
+    expect(result.cachedE1rmKg).toBeCloseTo(REF_MR_E1RM, 2);
+  });
+
+  it("totalReps = 32", () => {
+    expect(result.totalReps).toBe(32);
+  });
+});
+
+// ── SQL aggregate assertions using in-memory SQLite ───────────────────────────
+
+describe("BLD-1174 AC#268 — SQL analytics parity: cached columns produce correct aggregates", () => {
+  let db: InstanceType<typeof DatabaseSync>;
+  let wdb: ReturnType<typeof wrapDb>;
+
+  const NOW = 1_700_000_000_000;
+  const SESSION_ID = "sess_fixture";
+
+  beforeAll(async () => {
+    db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA foreign_keys = ON;");
+    wdb = wrapDb(db);
+    await migrate(wdb as Parameters<typeof migrate>[0]);
+
+    // Insert a session
+    db.exec(`
+      INSERT INTO workout_sessions (id, started_at, completed_at, duration_seconds, kind)
+      VALUES ('${SESSION_ID}', ${NOW - 3600_000}, ${NOW}, 3600, 'workout')
+    `);
+
+    // Insert a sample exercise
+    db.prepare(
+      `INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty)
+       VALUES ('ex1', 'Press', 'chest', '[]', '[]', 'barbell', '', 'intermediate')`
+    ).run();
+
+    // Insert 3 sets with pre-computed cached values
+    const sets = [
+      { id: "set_rp",  set_type: "rest_pause", reps: 13, weight: 100, cv: REF_RP_VOLUME, ce: REF_RP_E1RM },
+      { id: "set_cl",  set_type: "cluster",    reps: 8,  weight: 100, cv: REF_CL_VOLUME, ce: REF_CL_E1RM },
+      { id: "set_mr",  set_type: "myo_reps",   reps: 32, weight: 25,  cv: REF_MR_VOLUME, ce: REF_MR_E1RM },
+    ];
+    for (let i = 0; i < sets.length; i++) {
+      const s = sets[i];
+      db.prepare(
+        `INSERT INTO workout_sets
+           (id, session_id, exercise_id, set_number, set_type, reps, weight,
+            cached_volume_kg, cached_e1rm_kg, completed, created_at)
+         VALUES (?,?,?,?,?,?,?,?,?,1,?)`
+      ).run(s.id, SESSION_ID, "ex1", i + 1, s.set_type, s.reps, s.weight, s.cv, s.ce, NOW);
+    }
+
+    // Also insert one warmup set (should be excluded from analytics)
+    db.prepare(
+      `INSERT INTO workout_sets
+         (id, session_id, exercise_id, set_number, set_type, reps, weight,
+          cached_volume_kg, cached_e1rm_kg, completed, created_at)
+       VALUES ('set_wu', ?, 'ex1', 0, 'warmup', 5, 60, 300, 62, 1, ?)`
+    ).run(SESSION_ID, NOW);
+  });
+
+  it("SUM(cached_volume_kg) excludes warmup and equals 1300+790+800=2890", async () => {
+    const row = await wdb.getFirstAsync<{ total: number }>(
+      `SELECT COALESCE(SUM(ws.cached_volume_kg), 0) AS total
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1
+          AND ws.set_type != 'warmup'
+          AND wss.completed_at IS NOT NULL`
+    );
+    expect(row!.total).toBeCloseTo(REF_RP_VOLUME + REF_CL_VOLUME + REF_MR_VOLUME, 2);
+  });
+
+  it("MAX(cached_e1rm_kg) is the rest_pause set ≈ 126.67", async () => {
+    const row = await wdb.getFirstAsync<{ max_e1rm: number }>(
+      `SELECT MAX(ws.cached_e1rm_kg) AS max_e1rm
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1
+          AND ws.set_type != 'warmup'
+          AND ws.cached_e1rm_kg > 0
+          AND wss.completed_at IS NOT NULL`
+    );
+    expect(row!.max_e1rm).toBeCloseTo(REF_RP_E1RM, 2);
+  });
+
+  it("volume per-session sum = 2890 (matches monthly/weekly-summary pattern)", async () => {
+    const rows = await wdb.getAllAsync<{ session_id: string; volume: number }>(
+      `SELECT ws.session_id, SUM(ws.cached_volume_kg) AS volume
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1
+          AND ws.set_type != 'warmup'
+          AND wss.completed_at IS NOT NULL
+        GROUP BY ws.session_id`
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].volume).toBeCloseTo(2890, 2);
+  });
+
+  it("achievements: max single-session volume = 2890", async () => {
+    const row = await wdb.getFirstAsync<{ volume: number }>(
+      `SELECT COALESCE(MAX(sv.volume), 0) AS volume FROM (
+         SELECT ws.session_id, SUM(ws.cached_volume_kg) AS volume
+           FROM workout_sets ws
+           JOIN workout_sessions wss ON ws.session_id = wss.id
+          WHERE ws.completed = 1
+            AND ws.set_type != 'warmup'
+            AND ws.cached_volume_kg > 0
+            AND wss.completed_at IS NOT NULL
+          GROUP BY ws.session_id
+       ) sv`
+    );
+    expect(row!.volume).toBeCloseTo(2890, 2);
+  });
+
+  it("legacy warmup set is excluded: total without it = 2890 not 3190", async () => {
+    const row = await wdb.getFirstAsync<{ total: number }>(
+      `SELECT COALESCE(SUM(ws.cached_volume_kg), 0) AS total
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1
+          AND ws.set_type != 'warmup'
+          AND wss.completed_at IS NOT NULL`
+    );
+    expect(row!.total).not.toBeCloseTo(3190, 2); // 2890 + 300 warmup
+    expect(row!.total).toBeCloseTo(2890, 2);
+  });
+});

--- a/__tests__/analytics-parity-advanced-sets.test.ts
+++ b/__tests__/analytics-parity-advanced-sets.test.ts
@@ -148,8 +148,8 @@ describe("BLD-1174 AC#268 — SQL analytics parity: cached columns produce corre
 
     // Insert a session
     db.exec(`
-      INSERT INTO workout_sessions (id, started_at, completed_at, duration_seconds, kind)
-      VALUES ('${SESSION_ID}', ${NOW - 3600_000}, ${NOW}, 3600, 'workout')
+      INSERT INTO workout_sessions (id, name, started_at, completed_at, duration_seconds, kind)
+      VALUES ('${SESSION_ID}', 'Test Session', ${NOW - 3600_000}, ${NOW}, 3600, 'workout')
     `);
 
     // Insert a sample exercise
@@ -169,18 +169,18 @@ describe("BLD-1174 AC#268 — SQL analytics parity: cached columns produce corre
       db.prepare(
         `INSERT INTO workout_sets
            (id, session_id, exercise_id, set_number, set_type, reps, weight,
-            cached_volume_kg, cached_e1rm_kg, completed, created_at)
-         VALUES (?,?,?,?,?,?,?,?,?,1,?)`
-      ).run(s.id, SESSION_ID, "ex1", i + 1, s.set_type, s.reps, s.weight, s.cv, s.ce, NOW);
+            cached_volume_kg, cached_e1rm_kg, completed)
+         VALUES (?,?,?,?,?,?,?,?,?,1)`
+      ).run(s.id, SESSION_ID, "ex1", i + 1, s.set_type, s.reps, s.weight, s.cv, s.ce);
     }
 
     // Also insert one warmup set (should be excluded from analytics)
     db.prepare(
       `INSERT INTO workout_sets
          (id, session_id, exercise_id, set_number, set_type, reps, weight,
-          cached_volume_kg, cached_e1rm_kg, completed, created_at)
-       VALUES ('set_wu', ?, 'ex1', 0, 'warmup', 5, 60, 300, 62, 1, ?)`
-    ).run(SESSION_ID, NOW);
+          cached_volume_kg, cached_e1rm_kg, completed)
+       VALUES ('set_wu', ?, 'ex1', 0, 'warmup', 5, 60, 300, 62, 1)`
+    ).run(SESSION_ID);
   });
 
   it("SUM(cached_volume_kg) excludes warmup and equals 1300+790+800=2890", async () => {

--- a/__tests__/legacy-analytics-parity.test.ts
+++ b/__tests__/legacy-analytics-parity.test.ts
@@ -65,8 +65,8 @@ describe("BLD-1174 — legacy analytics parity: no regression on pre-BLD-1168 no
     await migrate(wdb as Parameters<typeof migrate>[0]);
 
     db.exec(`
-      INSERT INTO workout_sessions (id, started_at, completed_at, duration_seconds, kind)
-      VALUES ('${SESSION_ID}', ${NOW - 3600_000}, ${NOW}, 3600, 'workout')
+      INSERT INTO workout_sessions (id, name, started_at, completed_at, duration_seconds, kind)
+      VALUES ('${SESSION_ID}', 'Legacy Test Session', ${NOW - 3600_000}, ${NOW}, 3600, 'workout')
     `);
 
     db.prepare(
@@ -83,18 +83,18 @@ describe("BLD-1174 — legacy analytics parity: no regression on pre-BLD-1168 no
       db.prepare(
         `INSERT INTO workout_sets
            (id, session_id, exercise_id, set_number, set_type, reps, weight,
-            cached_volume_kg, cached_e1rm_kg, completed, created_at)
-         VALUES (?,?,?,?,?,?,?,?,?,1,?)`
-      ).run(s.id, SESSION_ID, "ex_legacy", i + 1, s.set_type, s.reps, s.weight, cv, ce, NOW);
+            cached_volume_kg, cached_e1rm_kg, completed)
+         VALUES (?,?,?,?,?,?,?,?,?,1)`
+      ).run(s.id, SESSION_ID, "ex_legacy", i + 1, s.set_type, s.reps, s.weight, cv, ce);
     }
 
     // Add a warmup set (must be excluded from all analytics)
     db.prepare(
       `INSERT INTO workout_sets
          (id, session_id, exercise_id, set_number, set_type, reps, weight,
-          cached_volume_kg, cached_e1rm_kg, completed, created_at)
-       VALUES ('l_wu', ?, 'ex_legacy', 0, 'warmup', 10, 40, 400, 41.33, 1, ?)`
-    ).run(SESSION_ID, NOW);
+          cached_volume_kg, cached_e1rm_kg, completed)
+       VALUES ('l_wu', ?, 'ex_legacy', 0, 'warmup', 10, 40, 400, 41.33, 1)`
+    ).run(SESSION_ID);
   });
 
   it("total volume (cached) matches legacy weight*reps sum", async () => {

--- a/__tests__/legacy-analytics-parity.test.ts
+++ b/__tests__/legacy-analytics-parity.test.ts
@@ -1,0 +1,173 @@
+/**
+ * BLD-1174 AC (from plan §261) — Legacy analytics parity.
+ *
+ * GIVEN a pre-BLD-1168 session (normal sets only, no segments, cached columns
+ *       backfilled via migration: cached_volume_kg = weight*reps,
+ *       cached_e1rm_kg = weight*(1+reps/30))
+ * WHEN analytics SQL queries reading cached columns are run
+ * THEN every numeric output matches what the pre-BLD-1168 formula would have
+ *      produced (weight*reps for volume, weight*(1+reps/30) for e1RM).
+ *      No analytic regression on legacy data.
+ *
+ * Strategy: seeds 5 representative legacy normal/dropset/failure sets,
+ * computes expected values using the legacy formula, then asserts the
+ * cached-column analytics SQL produces identical results.
+ */
+
+import { DatabaseSync } from "node:sqlite";
+import { migrate } from "../lib/db/migrations";
+
+// ── Thin async shim ────────────────────────────────────────────────────────────
+
+type Row = Record<string, unknown>;
+type SqlParam = null | number | bigint | string | Uint8Array;
+
+function wrapDb(db: InstanceType<typeof DatabaseSync>) {
+  return {
+    execAsync: async (sql: string): Promise<void> => { db.exec(sql); },
+    getAllAsync: async <T = Row>(sql: string, params?: unknown[]): Promise<T[]> =>
+      db.prepare(sql).all(...((params ?? []) as SqlParam[])) as T[],
+    getFirstAsync: async <T = Row>(sql: string, params?: unknown[]): Promise<T | null> =>
+      (db.prepare(sql).get(...((params ?? []) as SqlParam[])) as T) ?? null,
+    runAsync: async (sql: string, params?: unknown[]): Promise<{ changes: number }> => {
+      const result = db.prepare(sql).run(...((params ?? []) as SqlParam[]));
+      return { changes: Number(result.changes) };
+    },
+  };
+}
+
+// ── Legacy fixture sets (normal/dropset/failure — no segments) ────────────────
+
+const LEGACY_SETS = [
+  { id: "l1", set_type: "normal",  weight: 100, reps: 5 },
+  { id: "l2", set_type: "normal",  weight: 80,  reps: 8 },
+  { id: "l3", set_type: "dropset", weight: 70,  reps: 10 },
+  { id: "l4", set_type: "failure", weight: 60,  reps: 12 },
+  { id: "l5", set_type: "normal",  weight: 120, reps: 3 },
+];
+
+// Hand-computed expected totals using legacy formulas (now populated in cached columns by backfill)
+const EXPECTED_VOLUME = LEGACY_SETS.reduce((s, r) => s + r.weight * r.reps, 0);
+// e1RM per set; max across all non-warmup sets
+const EXPECTED_MAX_E1RM = Math.max(...LEGACY_SETS.map(r => r.weight * (1 + r.reps / 30)));
+
+describe("BLD-1174 — legacy analytics parity: no regression on pre-BLD-1168 normal sets", () => {
+  let db: InstanceType<typeof DatabaseSync>;
+  let wdb: ReturnType<typeof wrapDb>;
+
+  const NOW = 1_700_100_000_000;
+  const SESSION_ID = "sess_legacy";
+
+  beforeAll(async () => {
+    db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA foreign_keys = ON;");
+    wdb = wrapDb(db);
+    await migrate(wdb as Parameters<typeof migrate>[0]);
+
+    db.exec(`
+      INSERT INTO workout_sessions (id, started_at, completed_at, duration_seconds, kind)
+      VALUES ('${SESSION_ID}', ${NOW - 3600_000}, ${NOW}, 3600, 'workout')
+    `);
+
+    db.prepare(
+      `INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty)
+       VALUES ('ex_legacy', 'Squat', 'quads', '[]', '[]', 'barbell', '', 'intermediate')`
+    ).run();
+
+    // Seed legacy sets with cached columns set to the legacy formula values
+    // (simulates migration backfill: cached_volume_kg = weight*reps, cached_e1rm_kg = weight*(1+reps/30))
+    for (let i = 0; i < LEGACY_SETS.length; i++) {
+      const s = LEGACY_SETS[i];
+      const cv = s.weight * s.reps;
+      const ce = s.weight * (1 + s.reps / 30);
+      db.prepare(
+        `INSERT INTO workout_sets
+           (id, session_id, exercise_id, set_number, set_type, reps, weight,
+            cached_volume_kg, cached_e1rm_kg, completed, created_at)
+         VALUES (?,?,?,?,?,?,?,?,?,1,?)`
+      ).run(s.id, SESSION_ID, "ex_legacy", i + 1, s.set_type, s.reps, s.weight, cv, ce, NOW);
+    }
+
+    // Add a warmup set (must be excluded from all analytics)
+    db.prepare(
+      `INSERT INTO workout_sets
+         (id, session_id, exercise_id, set_number, set_type, reps, weight,
+          cached_volume_kg, cached_e1rm_kg, completed, created_at)
+       VALUES ('l_wu', ?, 'ex_legacy', 0, 'warmup', 10, 40, 400, 41.33, 1, ?)`
+    ).run(SESSION_ID, NOW);
+  });
+
+  it("total volume (cached) matches legacy weight*reps sum", async () => {
+    const row = await wdb.getFirstAsync<{ total: number }>(
+      `SELECT COALESCE(SUM(ws.cached_volume_kg), 0) AS total
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1 AND ws.set_type != 'warmup'
+          AND wss.completed_at IS NOT NULL`
+    );
+    expect(row!.total).toBeCloseTo(EXPECTED_VOLUME, 2);
+  });
+
+  it("max e1RM (cached) matches legacy formula", async () => {
+    const row = await wdb.getFirstAsync<{ max_e1rm: number }>(
+      `SELECT MAX(ws.cached_e1rm_kg) AS max_e1rm
+         FROM workout_sets ws
+         JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1 AND ws.set_type != 'warmup'
+          AND ws.cached_e1rm_kg > 0
+          AND wss.completed_at IS NOT NULL`
+    );
+    expect(row!.max_e1rm).toBeCloseTo(EXPECTED_MAX_E1RM, 2);
+  });
+
+  it("warmup set is excluded: volume without warmup ≠ volume with warmup", async () => {
+    const withWarmup = await wdb.getFirstAsync<{ total: number }>(
+      `SELECT COALESCE(SUM(ws.cached_volume_kg), 0) AS total
+         FROM workout_sets ws JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1 AND wss.completed_at IS NOT NULL`
+    );
+    expect(withWarmup!.total).toBeCloseTo(EXPECTED_VOLUME + 400, 2); // includes warmup
+    // Analytics queries exclude warmup — regression guard
+    const row = await wdb.getFirstAsync<{ total: number }>(
+      `SELECT COALESCE(SUM(ws.cached_volume_kg), 0) AS total
+         FROM workout_sets ws JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1 AND ws.set_type != 'warmup' AND wss.completed_at IS NOT NULL`
+    );
+    expect(row!.total).toBeCloseTo(EXPECTED_VOLUME, 2);
+  });
+
+  it("dropset and failure types are treated as working sets in volume sum", async () => {
+    const dropsetVol = LEGACY_SETS.filter(s => s.set_type === 'dropset' || s.set_type === 'failure')
+      .reduce((s, r) => s + r.weight * r.reps, 0);
+    const row = await wdb.getFirstAsync<{ total: number }>(
+      `SELECT COALESCE(SUM(ws.cached_volume_kg), 0) AS total
+         FROM workout_sets ws JOIN workout_sessions wss ON ws.session_id = wss.id
+        WHERE ws.completed = 1 AND ws.set_type IN ('dropset', 'failure') AND wss.completed_at IS NOT NULL`
+    );
+    expect(row!.total).toBeCloseTo(dropsetVol, 2);
+  });
+
+  it("per-set cached_volume_kg = weight*reps for every legacy set", async () => {
+    const rows = await wdb.getAllAsync<{ id: string; cached_volume_kg: number }>(
+      `SELECT id, cached_volume_kg FROM workout_sets WHERE session_id = ? AND set_type != 'warmup'`,
+      [SESSION_ID]
+    );
+    for (const row of rows) {
+      const fixture = LEGACY_SETS.find(s => s.id === row.id)!;
+      const expected = fixture.weight * fixture.reps;
+      expect(row.cached_volume_kg).toBeCloseTo(expected, 2);
+    }
+  });
+
+  it("per-set cached_e1rm_kg = weight*(1+reps/30) for every legacy set", async () => {
+    const rows = await wdb.getAllAsync<{ id: string; cached_e1rm_kg: number }>(
+      `SELECT id, cached_e1rm_kg FROM workout_sets WHERE session_id = ? AND set_type != 'warmup'`,
+      [SESSION_ID]
+    );
+    for (const row of rows) {
+      const fixture = LEGACY_SETS.find(s => s.id === row.id)!;
+      const expected = fixture.weight * (1 + fixture.reps / 30);
+      expect(row.cached_e1rm_kg).toBeCloseTo(expected, 2);
+    }
+  });
+});

--- a/__tests__/legacy-analytics-parity.test.ts
+++ b/__tests__/legacy-analytics-parity.test.ts
@@ -159,7 +159,7 @@ describe("BLD-1174 — legacy analytics parity: no regression on pre-BLD-1168 no
     }
   });
 
-  it("per-set cached_e1rm_kg = weight*(1+reps/30) for every legacy set", async () => {
+  it("per-set cached_e1rm_kg = weight*(1+reps/30) for every legacy set (reps ≤ 12)", async () => {
     const rows = await wdb.getAllAsync<{ id: string; cached_e1rm_kg: number }>(
       `SELECT id, cached_e1rm_kg FROM workout_sets WHERE session_id = ? AND set_type != 'warmup'`,
       [SESSION_ID]
@@ -169,5 +169,90 @@ describe("BLD-1174 — legacy analytics parity: no regression on pre-BLD-1168 no
       const expected = fixture.weight * (1 + fixture.reps / 30);
       expect(row.cached_e1rm_kg).toBeCloseTo(expected, 2);
     }
+  });
+});
+
+// ── AC #261: backfill caps cached_e1rm_kg at reps ≤ 12 for legacy normal sets ──
+//
+// Verifies that the migration backfill sets cached_e1rm_kg = 0 for sets with reps > 12
+// so that the `WHERE cached_e1rm_kg > 0` gate in analytics queries is equivalent to
+// the pre-BLD-1168 `AND ws.reps <= 12` filter.  Without this cap a user's "best e1RM"
+// could jump ~25 % after migration with no new training stimulus.
+
+describe("BLD-1174 AC #261 — backfill caps high-rep sets: cached_e1rm_kg = 0 for reps > 12", () => {
+  let db2: InstanceType<typeof DatabaseSync>;
+  let wdb2: ReturnType<typeof wrapDb>;
+
+  const NOW2 = 1_700_200_000_000;
+  const SID = "sess_hr";
+
+  beforeAll(async () => {
+    db2 = new DatabaseSync(":memory:");
+    db2.exec("PRAGMA foreign_keys = ON;");
+    wdb2 = wrapDb(db2);
+
+    // First migrate call creates the schema (empty DB — backfill has nothing to process)
+    await migrate(wdb2 as Parameters<typeof migrate>[0]);
+
+    db2.exec(`
+      INSERT INTO workout_sessions (id, name, started_at, completed_at, duration_seconds, kind)
+      VALUES ('${SID}', 'High Rep Session', ${NOW2 - 3600_000}, ${NOW2}, 3600, 'workout')
+    `);
+    db2.prepare(
+      `INSERT OR IGNORE INTO exercises (id, name, category, primary_muscles, secondary_muscles, equipment, instructions, difficulty)
+       VALUES ('ex_hr', 'Squat', 'quads', '[]', '[]', 'barbell', '', 'intermediate')`
+    ).run();
+
+    // Insert rows with cached columns = 0 (pre-backfill state)
+    // l_high: reps=20 — must be excluded from e1RM analytics (AC #261)
+    // l_low:  reps=10 — must be included in e1RM analytics
+    db2.prepare(
+      `INSERT INTO workout_sets
+         (id, session_id, exercise_id, set_number, set_type, reps, weight,
+          cached_volume_kg, cached_e1rm_kg, completed)
+       VALUES (?,?,?,?,?,?,?,0,0,1)`
+    ).run("l_high", SID, "ex_hr", 1, "normal", 20, 100);
+    db2.prepare(
+      `INSERT INTO workout_sets
+         (id, session_id, exercise_id, set_number, set_type, reps, weight,
+          cached_volume_kg, cached_e1rm_kg, completed)
+       VALUES (?,?,?,?,?,?,?,0,0,1)`
+    ).run("l_low", SID, "ex_hr", 2, "normal", 10, 80);
+
+    // Second migrate call — idempotent schema DDL, backfill runs on rows with cached = 0
+    await migrate(wdb2 as Parameters<typeof migrate>[0]);
+  });
+
+  it("high-rep set (reps=20) has cached_e1rm_kg = 0 after backfill", async () => {
+    const row = await wdb2.getFirstAsync<{ cached_e1rm_kg: number }>(
+      `SELECT cached_e1rm_kg FROM workout_sets WHERE id = 'l_high'`
+    );
+    expect(row!.cached_e1rm_kg).toBe(0);
+  });
+
+  it("high-rep set (reps=20) still gets cached_volume_kg = weight*reps after backfill", async () => {
+    const row = await wdb2.getFirstAsync<{ cached_volume_kg: number }>(
+      `SELECT cached_volume_kg FROM workout_sets WHERE id = 'l_high'`
+    );
+    expect(row!.cached_volume_kg).toBeCloseTo(100 * 20, 2);
+  });
+
+  it("low-rep set (reps=10) has cached_e1rm_kg = weight*(1+reps/30) after backfill", async () => {
+    const row = await wdb2.getFirstAsync<{ cached_e1rm_kg: number }>(
+      `SELECT cached_e1rm_kg FROM workout_sets WHERE id = 'l_low'`
+    );
+    expect(row!.cached_e1rm_kg).toBeCloseTo(80 * (1 + 10 / 30), 2);
+  });
+
+  it("MAX(cached_e1rm_kg) WHERE cached_e1rm_kg > 0 excludes l_high", async () => {
+    const row = await wdb2.getFirstAsync<{ max_e1rm: number }>(
+      `SELECT MAX(cached_e1rm_kg) AS max_e1rm
+         FROM workout_sets
+        WHERE session_id = ?
+          AND cached_e1rm_kg > 0`,
+      [SID]
+    );
+    // Should be l_low's value, not l_high's inflated value
+    expect(row!.max_e1rm).toBeCloseTo(80 * (1 + 10 / 30), 2);
   });
 });

--- a/__tests__/lib/db/streak-creep-production.test.ts
+++ b/__tests__/lib/db/streak-creep-production.test.ts
@@ -39,7 +39,9 @@ function createSchema(db: DatabaseSync) {
     CREATE TABLE workout_sets (
       id TEXT PRIMARY KEY, session_id TEXT, exercise_id TEXT,
       weight REAL, reps INTEGER, completed INTEGER DEFAULT 0,
-      set_type TEXT DEFAULT 'normal'
+      set_type TEXT DEFAULT 'normal',
+      cached_volume_kg REAL DEFAULT 0,
+      cached_e1rm_kg REAL DEFAULT 0
     );
     CREATE TABLE exercises (id TEXT PRIMARY KEY, name TEXT NOT NULL, primary_muscles TEXT);
     CREATE TABLE body_weight (id TEXT PRIMARY KEY, weight REAL NOT NULL, date TEXT NOT NULL);

--- a/__tests__/migration-cached-columns-backfill.test.ts
+++ b/__tests__/migration-cached-columns-backfill.test.ts
@@ -25,6 +25,17 @@ import { DatabaseSync } from "node:sqlite";
 import { migrate } from "../lib/db/migrations";
 import { computeSetCacheValues } from "../lib/db/sets";
 
+/**
+ * Mirror of the migration backfill SQL for e1RM.
+ * AC #261: legacy normal-set backfill caps at reps <= 12 so the
+ * `WHERE cached_e1rm_kg > 0` analytics gate is equivalent to the
+ * pre-BLD-1168 `AND ws.reps <= 12` filter.
+ */
+function backfillE1rm(weight: number | null, reps: number | null): number {
+  if (weight == null || reps == null || reps <= 0) return 0;
+  return reps <= 12 ? weight * (1 + reps / 30) : 0;
+}
+
 // ── Thin async shim (same as migration-upgrade-paths.test.ts) ────────────────
 
 type Row = Record<string, unknown>;
@@ -128,12 +139,10 @@ describe("BLD-1168 AC#275 — migration cached-columns backfill (integration)", 
       "SELECT cached_volume_kg, cached_e1rm_kg FROM workout_sets WHERE id = ?"
     ).get(id) as { cached_volume_kg: number; cached_e1rm_kg: number };
 
-    const { cachedVolumeKg, cachedE1rmKg } = computeSetCacheValues(
-      { weight, reps },
-      [],
-    );
+    const { cachedVolumeKg } = computeSetCacheValues({ weight, reps }, []);
     expect(row.cached_volume_kg).toBeCloseTo(cachedVolumeKg, 4);
-    expect(row.cached_e1rm_kg).toBeCloseTo(cachedE1rmKg, 4);
+    // AC #261: backfill caps e1RM at reps <= 12 to preserve legacy analytics parity
+    expect(row.cached_e1rm_kg).toBeCloseTo(backfillE1rm(weight, reps), 4);
   });
 
   it("backfill skips rows with NULL weight (leaves cached at 0)", () => {
@@ -160,12 +169,13 @@ describe("BLD-1168 AC#275 — migration cached-columns backfill (integration)", 
         "SELECT cached_volume_kg, cached_e1rm_kg FROM workout_sets WHERE id = ?"
       ).get(f.id) as { cached_volume_kg: number; cached_e1rm_kg: number };
 
-      const { cachedVolumeKg, cachedE1rmKg } = computeSetCacheValues(
+      const { cachedVolumeKg } = computeSetCacheValues(
         { weight: f.weight, reps: f.reps },
         [],
       );
       expect(row.cached_volume_kg).toBeCloseTo(cachedVolumeKg, 4);
-      expect(row.cached_e1rm_kg).toBeCloseTo(cachedE1rmKg, 4);
+      // AC #261: backfill caps e1RM at reps <= 12
+      expect(row.cached_e1rm_kg).toBeCloseTo(backfillE1rm(f.weight, f.reps), 4);
     }
   });
 });

--- a/hooks/useSessionDetail.ts
+++ b/hooks/useSessionDetail.ts
@@ -109,8 +109,9 @@ export function useSessionDetail(id: string | undefined) {
     let total = 0;
     for (const g of groups) {
       for (const s of g.sets) {
-        if (s.completed && s.set_type !== "warmup" && s.weight && s.reps) {
-          total += s.weight * s.reps;
+        // BLD-1174: use cached_volume_kg (segment-aware); fall back to weight*reps for legacy rows
+        if (s.completed && s.set_type !== "warmup") {
+          total += s.cached_volume_kg ?? (s.weight && s.reps ? s.weight * s.reps : 0);
         }
       }
     }

--- a/hooks/useSessionShareData.ts
+++ b/hooks/useSessionShareData.ts
@@ -33,7 +33,10 @@ export function useSessionShareData(
   const duration = session?.duration_seconds ? formatTime(session.duration_seconds) : "0:00";
   const volumeRaw = groups.reduce((sum, g) => {
     for (const s of g.sets) {
-      if (s.completed) sum += (s.weight ?? 0) * (s.reps ?? 0);
+      // BLD-1174: use cached_volume_kg (segment-aware); fall back to weight*reps for legacy rows
+      if (s.completed && s.set_type !== 'warmup') {
+        sum += s.cached_volume_kg ?? (s.weight ?? 0) * (s.reps ?? 0);
+      }
     }
     return sum;
   }, 0);

--- a/hooks/useSummaryData.ts
+++ b/hooks/useSummaryData.ts
@@ -127,7 +127,10 @@ export function useSummaryData(id: string | undefined) {
   const volume = useMemo(() => {
     let total = 0;
     for (const s of completed) {
-      if (s.weight && s.reps && s.set_type !== 'warmup') total += s.weight * s.reps;
+      // BLD-1174: use cached_volume_kg (segment-aware); fall back to weight*reps for legacy rows
+      if (s.set_type !== 'warmup') {
+        total += s.cached_volume_kg ?? (s.weight && s.reps ? s.weight * s.reps : 0);
+      }
     }
     return total;
   }, [completed]);

--- a/lib/db/achievements.ts
+++ b/lib/db/achievements.ts
@@ -57,25 +57,23 @@ export async function buildAchievementContext(): Promise<AchievementContext> {
     ),
     queryOne<{ volume: number }>(
       `SELECT COALESCE(MAX(sv.volume), 0) AS volume FROM (
-        SELECT ws.session_id, SUM(ws.weight * ws.reps) AS volume
+        SELECT ws.session_id, SUM(ws.cached_volume_kg) AS volume -- BLD-1174
         FROM workout_sets ws
         JOIN workout_sessions wss ON ws.session_id = wss.id
         WHERE ws.completed = 1
           AND ws.set_type != 'warmup'
-          AND ws.weight IS NOT NULL
-          AND ws.reps IS NOT NULL
+          AND ws.cached_volume_kg > 0 -- BLD-1174
           AND wss.completed_at IS NOT NULL
         GROUP BY ws.session_id
       ) sv`
     ),
     queryOne<{ volume: number }>(
-      `SELECT COALESCE(SUM(ws.weight * ws.reps), 0) AS volume
+      `SELECT COALESCE(SUM(ws.cached_volume_kg), 0) AS volume -- BLD-1174
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.weight IS NOT NULL
-         AND ws.reps IS NOT NULL
+         AND ws.cached_volume_kg > 0 -- BLD-1174
          AND wss.completed_at IS NOT NULL`
     ),
     query<{ date: string }>(

--- a/lib/db/e1rm-trends.ts
+++ b/lib/db/e1rm-trends.ts
@@ -33,15 +33,13 @@ export async function getWeeklyE1RMTrends(now: number = Date.now()): Promise<Wee
        ws.exercise_id,
        COALESCE(e.name, 'Deleted Exercise') AS name,
        CAST((wss.started_at / ?) * ? AS INTEGER) AS week_start,
-       MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS max_e1rm
+       MAX(ws.cached_e1rm_kg) AS max_e1rm -- BLD-1174: segment-aware cached value
      FROM workout_sets ws
      JOIN workout_sessions wss ON ws.session_id = wss.id
      LEFT JOIN exercises e ON ws.exercise_id = e.id
      WHERE ws.completed = 1
        AND ws.set_type != 'warmup'
-       AND ws.weight > 0
-       AND ws.reps > 0
-       AND ws.reps <= 12
+       AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
        AND wss.completed_at IS NOT NULL
        AND wss.started_at >= ?
      GROUP BY ws.exercise_id, week_start
@@ -180,15 +178,13 @@ export async function getE1RMTrends(gymId?: string | null): Promise<E1RMTrendRow
          prev.e1rm AS previous_e1rm
        FROM (
          SELECT ws.exercise_id,
-                MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm,
+                MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value,
                 COUNT(DISTINCT wss.id) AS session_count
          FROM workout_sets ws
          JOIN workout_sessions wss ON ws.session_id = wss.id
          WHERE ws.completed = 1
            AND ws.set_type != 'warmup'
-           AND ws.weight > 0
-           AND ws.reps > 0
-           AND ws.reps <= 12
+           AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
            AND wss.completed_at IS NOT NULL
            AND wss.gym_id = ?
            AND wss.started_at >= ?
@@ -197,14 +193,12 @@ export async function getE1RMTrends(gymId?: string | null): Promise<E1RMTrendRow
        ) cur
        JOIN (
          SELECT ws.exercise_id,
-                MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm
+                MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value
          FROM workout_sets ws
          JOIN workout_sessions wss ON ws.session_id = wss.id
          WHERE ws.completed = 1
            AND ws.set_type != 'warmup'
-           AND ws.weight > 0
-           AND ws.reps > 0
-           AND ws.reps <= 12
+           AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
            AND wss.completed_at IS NOT NULL
            AND wss.gym_id = ?
            AND wss.started_at >= ? AND wss.started_at < ?
@@ -226,15 +220,13 @@ export async function getE1RMTrends(gymId?: string | null): Promise<E1RMTrendRow
        prev.e1rm AS previous_e1rm
      FROM (
        SELECT ws.exercise_id,
-              MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm,
+              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value,
               COUNT(DISTINCT wss.id) AS session_count
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.weight > 0
-         AND ws.reps > 0
-         AND ws.reps <= 12
+         AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
          AND wss.completed_at IS NOT NULL
          AND wss.started_at >= ?
        GROUP BY ws.exercise_id
@@ -242,14 +234,12 @@ export async function getE1RMTrends(gymId?: string | null): Promise<E1RMTrendRow
      ) cur
      JOIN (
        SELECT ws.exercise_id,
-              MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm
+              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.weight > 0
-         AND ws.reps > 0
-         AND ws.reps <= 12
+         AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
          AND wss.completed_at IS NOT NULL
          AND wss.started_at >= ? AND wss.started_at < ?
        GROUP BY ws.exercise_id
@@ -281,15 +271,13 @@ export async function getE1RMTrendsByGym(gymId: string): Promise<E1RMTrendRow[]>
        prev.e1rm AS previous_e1rm
      FROM (
        SELECT ws.exercise_id,
-              MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm,
+              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value,
               COUNT(DISTINCT wss.id) AS session_count
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.weight > 0
-         AND ws.reps > 0
-         AND ws.reps <= 12
+         AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
          AND wss.completed_at IS NOT NULL
          AND wss.gym_id = ?
          AND wss.started_at >= ?
@@ -298,14 +286,12 @@ export async function getE1RMTrendsByGym(gymId: string): Promise<E1RMTrendRow[]>
      ) cur
      JOIN (
        SELECT ws.exercise_id,
-              MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm
+              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.weight > 0
-         AND ws.reps > 0
-         AND ws.reps <= 12
+         AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
          AND wss.completed_at IS NOT NULL
          AND wss.gym_id = ?
          AND wss.started_at >= ? AND wss.started_at < ?

--- a/lib/db/e1rm-trends.ts
+++ b/lib/db/e1rm-trends.ts
@@ -33,13 +33,13 @@ export async function getWeeklyE1RMTrends(now: number = Date.now()): Promise<Wee
        ws.exercise_id,
        COALESCE(e.name, 'Deleted Exercise') AS name,
        CAST((wss.started_at / ?) * ? AS INTEGER) AS week_start,
-       MAX(ws.cached_e1rm_kg) AS max_e1rm -- BLD-1174: segment-aware cached value
+       MAX(ws.cached_e1rm_kg) AS max_e1rm /* BLD-1174: segment-aware cached value */
      FROM workout_sets ws
      JOIN workout_sessions wss ON ws.session_id = wss.id
      LEFT JOIN exercises e ON ws.exercise_id = e.id
      WHERE ws.completed = 1
        AND ws.set_type != 'warmup'
-       AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
+       AND ws.cached_e1rm_kg > 0 /* BLD-1174: cached handles segment-level reps */
        AND wss.completed_at IS NOT NULL
        AND wss.started_at >= ?
      GROUP BY ws.exercise_id, week_start
@@ -178,13 +178,13 @@ export async function getE1RMTrends(gymId?: string | null): Promise<E1RMTrendRow
          prev.e1rm AS previous_e1rm
        FROM (
          SELECT ws.exercise_id,
-                MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value,
+                MAX(ws.cached_e1rm_kg) AS e1rm, /* BLD-1174: segment-aware cached value */
                 COUNT(DISTINCT wss.id) AS session_count
          FROM workout_sets ws
          JOIN workout_sessions wss ON ws.session_id = wss.id
          WHERE ws.completed = 1
            AND ws.set_type != 'warmup'
-           AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
+           AND ws.cached_e1rm_kg > 0 /* BLD-1174: cached handles segment-level reps */
            AND wss.completed_at IS NOT NULL
            AND wss.gym_id = ?
            AND wss.started_at >= ?
@@ -193,12 +193,12 @@ export async function getE1RMTrends(gymId?: string | null): Promise<E1RMTrendRow
        ) cur
        JOIN (
          SELECT ws.exercise_id,
-                MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value
+                MAX(ws.cached_e1rm_kg) AS e1rm /* BLD-1174: segment-aware cached value */
          FROM workout_sets ws
          JOIN workout_sessions wss ON ws.session_id = wss.id
          WHERE ws.completed = 1
            AND ws.set_type != 'warmup'
-           AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
+           AND ws.cached_e1rm_kg > 0 /* BLD-1174: cached handles segment-level reps */
            AND wss.completed_at IS NOT NULL
            AND wss.gym_id = ?
            AND wss.started_at >= ? AND wss.started_at < ?
@@ -220,13 +220,13 @@ export async function getE1RMTrends(gymId?: string | null): Promise<E1RMTrendRow
        prev.e1rm AS previous_e1rm
      FROM (
        SELECT ws.exercise_id,
-              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value,
+              MAX(ws.cached_e1rm_kg) AS e1rm, /* BLD-1174: segment-aware cached value */
               COUNT(DISTINCT wss.id) AS session_count
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
+         AND ws.cached_e1rm_kg > 0 /* BLD-1174: cached handles segment-level reps */
          AND wss.completed_at IS NOT NULL
          AND wss.started_at >= ?
        GROUP BY ws.exercise_id
@@ -234,12 +234,12 @@ export async function getE1RMTrends(gymId?: string | null): Promise<E1RMTrendRow
      ) cur
      JOIN (
        SELECT ws.exercise_id,
-              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value
+              MAX(ws.cached_e1rm_kg) AS e1rm /* BLD-1174: segment-aware cached value */
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
+         AND ws.cached_e1rm_kg > 0 /* BLD-1174: cached handles segment-level reps */
          AND wss.completed_at IS NOT NULL
          AND wss.started_at >= ? AND wss.started_at < ?
        GROUP BY ws.exercise_id
@@ -271,13 +271,13 @@ export async function getE1RMTrendsByGym(gymId: string): Promise<E1RMTrendRow[]>
        prev.e1rm AS previous_e1rm
      FROM (
        SELECT ws.exercise_id,
-              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value,
+              MAX(ws.cached_e1rm_kg) AS e1rm, /* BLD-1174: segment-aware cached value */
               COUNT(DISTINCT wss.id) AS session_count
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
+         AND ws.cached_e1rm_kg > 0 /* BLD-1174: cached handles segment-level reps */
          AND wss.completed_at IS NOT NULL
          AND wss.gym_id = ?
          AND wss.started_at >= ?
@@ -286,12 +286,12 @@ export async function getE1RMTrendsByGym(gymId: string): Promise<E1RMTrendRow[]>
      ) cur
      JOIN (
        SELECT ws.exercise_id,
-              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174: segment-aware cached value
+              MAX(ws.cached_e1rm_kg) AS e1rm /* BLD-1174: segment-aware cached value */
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.cached_e1rm_kg > 0 -- BLD-1174: cached handles segment-level reps
+         AND ws.cached_e1rm_kg > 0 /* BLD-1174: cached handles segment-level reps */
          AND wss.completed_at IS NOT NULL
          AND wss.gym_id = ?
          AND wss.started_at >= ? AND wss.started_at < ?

--- a/lib/db/exercise-history.ts
+++ b/lib/db/exercise-history.ts
@@ -189,10 +189,10 @@ export async function getExerciseRecords(
     ),
 
     queryOne<{ val: number | null }>(
-      `SELECT MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS val
+      `SELECT MAX(ws.cached_e1rm_kg) AS val
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
-       WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.set_type != 'warmup' AND ws.weight > 0 AND ws.reps > 0 AND ws.reps <= 12 AND wss.completed_at IS NOT NULL${variantSql.sql}`,
+       WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.set_type != 'warmup' AND ws.cached_e1rm_kg > 0 AND wss.completed_at IS NOT NULL${variantSql.sql}`,
       [exerciseId, ...variantSql.params]
     ),
 
@@ -244,15 +244,12 @@ export async function getExercise1RMChartData(
   return query<{ date: number; value: number }>(
     `SELECT * FROM (
        SELECT wss.started_at AS date,
-              MAX(ws.weight * (1 + ws.reps / 30.0)) AS value
+              MAX(ws.cached_e1rm_kg) AS value
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.exercise_id = ?
          AND ws.completed = 1
-         AND ws.weight IS NOT NULL
-         AND ws.weight > 0
-         AND ws.reps IS NOT NULL
-         AND ws.reps > 0
+         AND ws.cached_e1rm_kg > 0
          AND ws.set_type != 'warmup'
          AND wss.completed_at IS NOT NULL${v.sql}
        GROUP BY wss.id

--- a/lib/db/exercise-history.ts
+++ b/lib/db/exercise-history.ts
@@ -56,7 +56,7 @@ export async function getExerciseHistory(
       max_reps: max(workoutSets.reps),
       total_reps: sum(workoutSets.reps),
       set_count: count(workoutSets.id),
-      volume: sql<number>`SUM(${workoutSets.weight} * ${workoutSets.reps})`,
+      volume: sql<number>`SUM(${workoutSets.cached_volume_kg})`, /* BLD-1174 */
       avg_rpe: sql<number | null>`AVG(CASE WHEN ${workoutSets.rpe} IS NOT NULL THEN ${workoutSets.rpe} END)`,
       max_modifier: sql<number | null>`MAX(${workoutSets.bodyweight_modifier_kg})`,
     })
@@ -179,7 +179,7 @@ export async function getExerciseRecords(
   const [vol, rm, weighted, bwBests] = await Promise.all([
     queryOne<{ val: number | null }>(
       `SELECT MAX(sv) AS val FROM (
-         SELECT SUM(ws.weight * ws.reps) AS sv
+         SELECT SUM(ws.cached_volume_kg) AS sv /* BLD-1174 */
          FROM workout_sets ws
          JOIN workout_sessions wss ON ws.session_id = wss.id
          WHERE ws.exercise_id = ? AND ws.completed = 1 AND ws.set_type != 'warmup' AND wss.completed_at IS NOT NULL${variantSql.sql}

--- a/lib/db/migrations.ts
+++ b/lib/db/migrations.ts
@@ -249,11 +249,19 @@ export async function migrate(database: SQLite.SQLiteDatabase): Promise<void> {
   // Idempotent: rows that already have correct cached values are re-written to the same value.
   // Guard: only runs if the column was just added OR values are still at the default 0.
   // Non-advanced sets that genuinely have reps=0 or weight=NULL are unaffected (WHERE guard).
+  // AC #261: cap e1RM at reps <= 12 to preserve pre-BLD-1168 analytics for legacy normal sets.
+  // Sets with reps > 12 get cached_e1rm_kg = 0 so the `> 0` filter in analytics excludes them,
+  // matching the old `AND ws.reps <= 12` WHERE clause.  Advanced-set rows are never touched here
+  // because recomputeSetCaches writes their cached values via segment arithmetic before they reach
+  // this backfill guard (cached_e1rm_kg is non-zero by the time migrate() runs in production).
   try {
     await database.execAsync(`
       UPDATE workout_sets
       SET cached_volume_kg = weight * reps,
-          cached_e1rm_kg   = weight * (1.0 + reps / 30.0)
+          cached_e1rm_kg   = CASE WHEN reps <= 12
+                                  THEN weight * (1.0 + reps / 30.0)
+                                  ELSE 0
+                             END
       WHERE weight IS NOT NULL
         AND reps IS NOT NULL
         AND reps > 0

--- a/lib/db/monthly-report.ts
+++ b/lib/db/monthly-report.ts
@@ -318,13 +318,13 @@ async function getMonthlyMostImproved(
        prev.e1rm AS previous_e1rm
      FROM (
        SELECT ws.exercise_id,
-              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174,
+              MAX(ws.cached_e1rm_kg) AS e1rm, /* BLD-1174 */
               COUNT(DISTINCT wss.id) AS session_count
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.cached_e1rm_kg > 0 -- BLD-1174
+         AND ws.cached_e1rm_kg > 0 /* BLD-1174 */
          AND wss.completed_at IS NOT NULL
          AND wss.started_at >= ? AND wss.started_at < ?
        GROUP BY ws.exercise_id
@@ -332,12 +332,12 @@ async function getMonthlyMostImproved(
      ) cur
      JOIN (
        SELECT ws.exercise_id,
-              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174
+              MAX(ws.cached_e1rm_kg) AS e1rm /* BLD-1174 */
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.cached_e1rm_kg > 0 -- BLD-1174
+         AND ws.cached_e1rm_kg > 0 /* BLD-1174 */
          AND wss.completed_at IS NOT NULL
          AND wss.started_at >= ? AND wss.started_at < ?
        GROUP BY ws.exercise_id

--- a/lib/db/monthly-report.ts
+++ b/lib/db/monthly-report.ts
@@ -118,7 +118,7 @@ async function getMonthlyWorkouts(
       .get(),
     db
       .select({
-        volume: sql<number>`COALESCE(SUM(${workoutSets.weight} * ${workoutSets.reps}), 0)`.as("volume"),
+        volume: sql<number>`COALESCE(SUM(${workoutSets.cached_volume_kg}), 0)`.as("volume") /* BLD-1174 */,
       })
       .from(workoutSets)
       .innerJoin(workoutSessions, eq(workoutSets.session_id, workoutSessions.id))
@@ -149,7 +149,7 @@ async function getMonthlyWorkouts(
       .get(),
     db
       .select({
-        volume: sql<number>`COALESCE(SUM(${workoutSets.weight} * ${workoutSets.reps}), 0)`.as("volume"),
+        volume: sql<number>`COALESCE(SUM(${workoutSets.cached_volume_kg}), 0)`.as("volume") /* BLD-1174 */,
       })
       .from(workoutSets)
       .innerJoin(workoutSessions, eq(workoutSets.session_id, workoutSessions.id))
@@ -318,15 +318,13 @@ async function getMonthlyMostImproved(
        prev.e1rm AS previous_e1rm
      FROM (
        SELECT ws.exercise_id,
-              MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm,
+              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174,
               COUNT(DISTINCT wss.id) AS session_count
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.weight > 0
-         AND ws.reps > 0
-         AND ws.reps <= 12
+         AND ws.cached_e1rm_kg > 0 -- BLD-1174
          AND wss.completed_at IS NOT NULL
          AND wss.started_at >= ? AND wss.started_at < ?
        GROUP BY ws.exercise_id
@@ -334,14 +332,12 @@ async function getMonthlyMostImproved(
      ) cur
      JOIN (
        SELECT ws.exercise_id,
-              MAX(ws.weight * (1.0 + ws.reps / 30.0)) AS e1rm
+              MAX(ws.cached_e1rm_kg) AS e1rm -- BLD-1174
        FROM workout_sets ws
        JOIN workout_sessions wss ON ws.session_id = wss.id
        WHERE ws.completed = 1
          AND ws.set_type != 'warmup'
-         AND ws.weight > 0
-         AND ws.reps > 0
-         AND ws.reps <= 12
+         AND ws.cached_e1rm_kg > 0 -- BLD-1174
          AND wss.completed_at IS NOT NULL
          AND wss.started_at >= ? AND wss.started_at < ?
        GROUP BY ws.exercise_id

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -151,8 +151,8 @@ export const workoutSets = sqliteTable("workout_sets", {
   // BLD-1168: cached aggregate columns — single source of truth for all analytics surfaces.
   // Populated exclusively by recomputeSetCaches(setId) in lib/db/sets.ts.
   // DEFAULT 0 so pre-migration rows have a defined value (backfill in migrate() sets correct values).
-  cached_volume_kg: real("cached_volume_kg").default(0),
-  cached_e1rm_kg: real("cached_e1rm_kg").default(0),
+  cached_volume_kg: real("cached_volume_kg").default(0).notNull(),
+  cached_e1rm_kg: real("cached_e1rm_kg").default(0).notNull(),
 }, (table) => [
   index("idx_workout_sets_exercise").on(table.exercise_id),
   index("idx_workout_sets_session").on(table.session_id),

--- a/lib/db/weekly-summary.ts
+++ b/lib/db/weekly-summary.ts
@@ -118,7 +118,7 @@ export async function getWeeklyWorkouts(
         .get(),
       db
         .select({
-          volume: sql<number>`COALESCE(SUM(${workoutSets.weight} * ${workoutSets.reps}), 0)`.as("volume"),
+          volume: sql<number>`COALESCE(SUM(${workoutSets.cached_volume_kg}), 0)`.as("volume") /* BLD-1174 */,
         })
         .from(workoutSets)
         .innerJoin(workoutSessions, eq(workoutSets.session_id, workoutSessions.id))
@@ -149,7 +149,7 @@ export async function getWeeklyWorkouts(
         .get(),
       db
         .select({
-          volume: sql<number>`COALESCE(SUM(${workoutSets.weight} * ${workoutSets.reps}), 0)`.as("volume"),
+          volume: sql<number>`COALESCE(SUM(${workoutSets.cached_volume_kg}), 0)`.as("volume") /* BLD-1174 */,
         })
         .from(workoutSets)
         .innerJoin(workoutSessions, eq(workoutSets.session_id, workoutSessions.id))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cablesnap",
-  "version": "0.26.29",
+  "version": "0.26.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cablesnap",
-      "version": "0.26.29",
+      "version": "0.26.32",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {


### PR DESCRIPTION
## Summary

Updates all 8 analytics surfaces to read `cached_volume_kg` and `cached_e1rm_kg` instead of computing `weight * reps` / `weight * (1 + reps/30)` ad hoc. This makes advanced set types (rest_pause, cluster, myo_reps) correctly contribute to volume and e1RM analytics.

## Changes

**Analytics surfaces updated (AC #268):**
- `lib/db/e1rm-trends.ts` — 7 sites: replace ad-hoc e1RM formula with `cached_e1rm_kg`; filter on `cached_e1rm_kg > 0` (handles advanced sets where sum reps > 12)
- `lib/db/monthly-report.ts` — 4 sites: volume (lines 121/152) + e1RM (lines 321/337)
- `lib/db/weekly-summary.ts` — 2 sites (lines 121/152)
- `lib/db/achievements.ts` — 2 sites: Drizzle + raw SQL volume
- `lib/db/exercise-history.ts` — 2 sites: Drizzle + raw SQL volume
- `hooks/useSessionDetail.ts` — TS in-memory volume calc
- `hooks/useSummaryData.ts` — TS in-memory volume calc
- `hooks/useSessionShareData.ts` — TS in-memory volume calc (also excludes warmup)

**Tests:**
- `__tests__/analytics-parity-advanced-sets.test.ts`: AC #268 — fixture: rest_pause 8+3+2@100kg (vol=1300, e1rm≈126.67), cluster 3+3+2@100/100/95 (vol=790, e1rm=110), myo_reps 15+5+5+4+3@25 (vol=800, e1rm=37.5). Pure computeSetCacheValues assertions + SQL aggregate assertions.
- `__tests__/legacy-analytics-parity.test.ts`: AC (#261) — legacy normal/dropset/failure sets verify no regression: SUM(cached_volume_kg) = SUM(weightreps), MAX(cached_e1rm_kg) = MAX(weight×(1+reps/30)).

## Testing

- TSC: zero errors in source + test files ✅

## Issue

Resolves BLD-1174

**Stack:** Depends on PR for BLD-1168 Slice 1 (bld-1168-slice1-schema-recompute → main)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>