### PR TITLE
feat(BLD-1172): Slice 4 — named reps accessors + exercises.ts progression fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
+- Foundation for advanced set schemes: rest-pause, cluster, and myo-reps set types added to the set-type cycle (no UI surfacing yet — wiring lands in later slices).
 - **Adaptive Macro Coach** (off by default): Enable in Settings → Nutrition → Adaptive Macro Coach to get a weekly advisory card that suggests a calorie target based on your trend weight and average intake over the past two weeks. The coach is advisory only — your target is never changed without your tap. Includes a hard safety floor (based on your sex and estimated metabolic rate), a ±300 kcal/week cap, Right Why check-in, and a one-tap one-month pause.
 - **Tempo Coach (haptic engine)**: Enable "Tempo Coach" in Settings → Preferences to get a haptic rep guide during your sets. When active, a vibration cues each phase of your tempo (eccentric → bottom pause → concentric → top pause) in real time. A compact overlay shows the current phase and lets you stop the coach at any time. The coach auto-stops when the set is logged and cancels if you background the app.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ marker) at release time.
 ## Unreleased
 
 - Foundation for advanced set schemes: rest-pause, cluster, and myo-reps set types added to the set-type cycle (no UI surfacing yet — wiring lands in later slices).
+- Progression suggestions now correctly evaluate advanced set types (rest-pause, cluster, myo-reps) using the working-set reps of the activation segment, rather than the inflated total-reps sum.
 - **Adaptive Macro Coach** (off by default): Enable in Settings → Nutrition → Adaptive Macro Coach to get a weekly advisory card that suggests a calorie target based on your trend weight and average intake over the past two weeks. The coach is advisory only — your target is never changed without your tap. Includes a hard safety floor (based on your sex and estimated metabolic rate), a ±300 kcal/week cap, Right Why check-in, and a one-tap one-month pause.
 - **Tempo Coach (haptic engine)**: Enable "Tempo Coach" in Settings → Preferences to get a haptic rep guide during your sets. When active, a vibration cues each phase of your tempo (eccentric → bottom pause → concentric → top pause) in real time. A compact overlay shows the current phase and lets you stop the coach at any time. The coach auto-stops when the set is logged and cancels if you background the app.
 

--- a/__tests__/acceptance/setup-snapshot.test.ts
+++ b/__tests__/acceptance/setup-snapshot.test.ts
@@ -33,6 +33,7 @@ describe("Setup Snapshot — CSV export includes pulley_pin (BLD-1114 AC-CSV)", 
     pulley_pin: null,
     stack_marker: null,
     stack_name_at_log: null,
+    set_type: null,
   };
 
   it("header includes pulley_pin column", () => {

--- a/__tests__/lib/db/progression-chain.test.ts
+++ b/__tests__/lib/db/progression-chain.test.ts
@@ -164,7 +164,43 @@ describe("getProgressionSuggestion", () => {
   it("returns shouldSuggest=false when latest session has sets under 12 reps", async () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 1 }]);
+    // BLD-1172: workSets row with 11 reps — explicitly under the 12-rep threshold
+    mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-1", set_type: "normal", reps: 11 }]);
+    // BLD-1172: batch segments query (normal sets have no segments → empty array)
+    mockDb.getAllAsync.mockResolvedValueOnce([]);
+    const result = await getProgressionSuggestion("e2", chain);
+    expect(result.shouldSuggest).toBe(false);
+  });
+
+  it("returns shouldSuggest=true for myo_reps when activation-segment reps >= 12", async () => {
+    // AC #271 variant: myo_reps set with total reps=32 (sum), but activation segment = 15.
+    // getWorkingRepsForOverloadDecision returns 15 (first segment) not 32 (total).
+    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-2", set_type: "myo_reps", reps: 32 }]);
+    // Batch segments: activation segment (15 reps) + 2 mini-clusters (9, 8)
+    mockDb.getAllAsync.mockResolvedValueOnce([
+      { id: "seg-1", set_id: "ws-2", segment_number: 1, reps: 15, created_at: 1 },
+      { id: "seg-2", set_id: "ws-2", segment_number: 2, reps: 9, created_at: 1 },
+      { id: "seg-3", set_id: "ws-2", segment_number: 3, reps: 8, created_at: 1 },
+    ]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]); // nextLogged = 0
+    const result = await getProgressionSuggestion("e2", chain);
+    expect(result.shouldSuggest).toBe(true);
+    expect(result.nextExercise).toEqual({ id: "e3", name: "Diamond Push-Up" });
+  });
+
+  it("returns shouldSuggest=false for rest_pause when first-segment reps < 12", async () => {
+    // AC #270 variant: rest_pause set with total reps=13 but first segment only 8.
+    // getWorkingRepsForOverloadDecision returns 8 (first segment) not 13 (total).
+    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-3", set_type: "rest_pause", reps: 13 }]);
+    // Batch segments: first segment 8 reps (working effort) + rest-pause continuation 5 reps
+    mockDb.getAllAsync.mockResolvedValueOnce([
+      { id: "seg-4", set_id: "ws-3", segment_number: 1, reps: 8, created_at: 1 },
+      { id: "seg-5", set_id: "ws-3", segment_number: 2, reps: 5, created_at: 1 },
+    ]);
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(false);
   });

--- a/__tests__/lib/db/progression-chain.test.ts
+++ b/__tests__/lib/db/progression-chain.test.ts
@@ -172,9 +172,10 @@ describe("getProgressionSuggestion", () => {
   it("returns shouldSuggest=true when all criteria met", async () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 3 }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
+    // BLD-1172: workSets query now returns actual rows {id, set_type, reps}
+    mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-1", set_type: "normal", reps: 15 }]);
+    // getSegmentsForSet uses Drizzle .all() → always [] in tests (mocked via drizzle-orm mock)
+    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]); // nextLogged = 0
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(true);
     expect(result.nextExercise).toEqual({ id: "e3", name: "Diamond Push-Up" });
@@ -184,9 +185,9 @@ describe("getProgressionSuggestion", () => {
   it("returns shouldSuggest=false when next exercise already logged recently", async () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 3 }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 2 }]);
+    // BLD-1172: workSets with reps >= 12 so we reach the nextLogged check
+    mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-1", set_type: "normal", reps: 15 }]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 2 }]); // nextLogged = 2 → recently logged
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(false);
   });
@@ -194,8 +195,8 @@ describe("getProgressionSuggestion", () => {
   it("returns shouldSuggest=false when no normal completed sets exist", async () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
+    // BLD-1172: empty workSets array → hits workSets.length === 0 early-exit
+    mockDb.getAllAsync.mockResolvedValueOnce([]);
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(false);
   });

--- a/__tests__/lib/db/progression-chain.test.ts
+++ b/__tests__/lib/db/progression-chain.test.ts
@@ -174,7 +174,8 @@ describe("getProgressionSuggestion", () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
     // BLD-1172: workSets query now returns actual rows {id, set_type, reps}
     mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-1", set_type: "normal", reps: 15 }]);
-    // getSegmentsForSet uses Drizzle .all() → always [] in tests (mocked via drizzle-orm mock)
+    // BLD-1172: batch segments query (normal sets have no segments → empty array)
+    mockDb.getAllAsync.mockResolvedValueOnce([]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]); // nextLogged = 0
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(true);
@@ -187,6 +188,8 @@ describe("getProgressionSuggestion", () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
     // BLD-1172: workSets with reps >= 12 so we reach the nextLogged check
     mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-1", set_type: "normal", reps: 15 }]);
+    // BLD-1172: batch segments query (normal sets have no segments → empty array)
+    mockDb.getAllAsync.mockResolvedValueOnce([]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 2 }]); // nextLogged = 2 → recently logged
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(false);

--- a/__tests__/lib/db/warmup-sets.test.ts
+++ b/__tests__/lib/db/warmup-sets.test.ts
@@ -200,13 +200,13 @@ tempo: null,
 // ---- SET_TYPE_CYCLE order ----
 
 describe('SET_TYPE_CYCLE', () => {
-  it('has correct cycle order: normal → warmup → dropset → failure', () => {
-    expect(SET_TYPE_CYCLE).toEqual(['normal', 'warmup', 'dropset', 'failure']);
+  it('has correct cycle order including advanced set types', () => {
+    expect(SET_TYPE_CYCLE).toEqual(['normal', 'warmup', 'dropset', 'failure', 'rest_pause', 'cluster', 'myo_reps']);
   });
 
-  it('cycles back to normal after failure', () => {
-    const failureIdx = SET_TYPE_CYCLE.indexOf('failure');
-    const next = SET_TYPE_CYCLE[(failureIdx + 1) % SET_TYPE_CYCLE.length];
+  it('cycles back to normal after myo_reps (last entry)', () => {
+    const lastIdx = SET_TYPE_CYCLE.length - 1;
+    const next = SET_TYPE_CYCLE[(lastIdx + 1) % SET_TYPE_CYCLE.length];
     expect(next).toBe('normal');
   });
 });

--- a/__tests__/lib/small-lib-batch.test.ts
+++ b/__tests__/lib/small-lib-batch.test.ts
@@ -261,6 +261,7 @@ describe("workoutCSV — bodyweight_modifier_kg column (BLD-541)", () => {
     pulley_pin: null,
     stack_marker: null,
     stack_name_at_log: null,
+    set_type: null,
   };
 
   it.each([
@@ -273,11 +274,11 @@ describe("workoutCSV — bodyweight_modifier_kg column (BLD-541)", () => {
     const out = workoutCSV([row]);
     const [header, data] = out.split("\n");
     expect(header).toBe(
-      "date,exercise,set_number,weight,reps,duration_seconds,notes,set_rpe,set_notes,link_id,bodyweight_modifier_kg,pulley_pin,kind,day_session_exercise_id,day_session_date,stack_marker,stack_name_at_log"
+      "date,exercise,set_number,weight,reps,duration_seconds,notes,set_rpe,set_notes,link_id,bodyweight_modifier_kg,pulley_pin,kind,day_session_exercise_id,day_session_date,stack_marker,stack_name_at_log,set_type"
     );
     const cells = data.split(",");
-    // bodyweight_modifier_kg is 4 columns before the end (pulley_pin, kind, dseid, dsdate follow)
-    expect(cells[cells.length - 7]).toBe(expected);
+    // bodyweight_modifier_kg is index 10 (0-based); set_type appended at end adds 1 more column
+    expect(cells[cells.length - 8]).toBe(expected);
   });
 });
 
@@ -303,6 +304,7 @@ describe("workoutCSV — stack_marker CSV round-trip (BLD-1126 AC13)", () => {
     pulley_pin: null,
     stack_marker: 10,
     stack_name_at_log: "Main Stack",
+    set_type: null,
   };
 
   it("header includes stack_marker and stack_name_at_log", () => {

--- a/__tests__/normalize-set-type.test.ts
+++ b/__tests__/normalize-set-type.test.ts
@@ -1,0 +1,114 @@
+/**
+ * BLD-1169 — Slice 3: normalizeSetType unit tests (AC #269)
+ *
+ * Verifies that:
+ * 1. All 7 valid SetType strings pass through unchanged.
+ * 2. Garbage inputs (unknown string, null, undefined, "", non-string)
+ *    are coerced to "normal" without throwing.
+ * 3. The raw DB row object is NOT mutated by the helper.
+ */
+import { normalizeSetType } from "@/lib/db/sets";
+
+const VALID_TYPES = [
+  "normal",
+  "warmup",
+  "dropset",
+  "failure",
+  "rest_pause",
+  "cluster",
+  "myo_reps",
+] as const;
+
+describe("normalizeSetType — valid values", () => {
+  for (const st of VALID_TYPES) {
+    it(`passes "${st}" through unchanged`, () => {
+      expect(normalizeSetType(st)).toBe(st);
+    });
+  }
+});
+
+describe("normalizeSetType — coercion to 'normal'", () => {
+  const garbageInputs: unknown[] = [
+    "drop_set_v2",     // typo / legacy string
+    "REST_PAUSE",      // wrong case
+    "WARMUP",          // wrong case
+    "",                // empty string
+    null,
+    undefined,
+    0,
+    false,
+    {},
+    [],
+    "unknown",
+    "myo reps",        // space instead of underscore
+  ];
+
+  for (const input of garbageInputs) {
+    it(`coerces ${JSON.stringify(input)} to "normal" without throwing`, () => {
+      expect(() => normalizeSetType(input)).not.toThrow();
+      expect(normalizeSetType(input)).toBe("normal");
+    });
+  }
+});
+
+describe("normalizeSetType — raw DB row not mutated", () => {
+  it("does not modify the source row object", () => {
+    const row = { id: "abc", set_type: "drop_set_v2", reps: 10 };
+    const rowCopy = { ...row };
+    normalizeSetType(row.set_type);
+    expect(row).toEqual(rowCopy);
+    expect(row.set_type).toBe("drop_set_v2");
+  });
+
+  it("does not modify row when value is valid", () => {
+    const row = { id: "abc", set_type: "dropset", reps: 5 };
+    const before = row.set_type;
+    normalizeSetType(row.set_type);
+    expect(row.set_type).toBe(before);
+  });
+});
+
+describe("normalizeSetType — boundary integration snapshots", () => {
+  it("session-sets.ts hydration: getSessionSets style cast", () => {
+    // Simulates: set_type: normalizeSetType(r.set_type)
+    const dbRow = { set_type: "rest_pause" as unknown };
+    expect(normalizeSetType(dbRow.set_type)).toBe("rest_pause");
+  });
+
+  it("session-sets.ts hydration: unknown value from older DB", () => {
+    const dbRow = { set_type: "superset" as unknown };
+    expect(normalizeSetType(dbRow.set_type)).toBe("normal");
+  });
+
+  it("sessions.ts template parser: null set_type", () => {
+    // Simulates: group.map((s) => normalizeSetType(s.set_type))
+    expect(normalizeSetType(null)).toBe("normal");
+  });
+
+  it("import-export.ts restore path: old backup with unknown type", () => {
+    // Simulates: normalizeSetType(row.set_type ?? (row.is_warmup ? "warmup" : "normal"))
+    const row = { set_type: null as unknown, is_warmup: 0 };
+    const rawType = row.set_type ?? (row.is_warmup ? "warmup" : "normal");
+    expect(normalizeSetType(rawType)).toBe("normal");
+  });
+
+  it("import-export.ts restore path: is_warmup legacy backup", () => {
+    const row = { set_type: null as unknown, is_warmup: 1 };
+    const rawType = row.set_type ?? (row.is_warmup ? "warmup" : "normal");
+    expect(normalizeSetType(rawType)).toBe("warmup");
+  });
+
+  it("csv-import.ts: set_type from parsed CSV row", () => {
+    // Simulates: normalizeSetType(set.set_type ?? "normal")
+    expect(normalizeSetType(undefined)).toBe("normal");
+    expect(normalizeSetType("myo_reps")).toBe("myo_reps");
+    expect(normalizeSetType("unknown_future_type")).toBe("normal");
+  });
+
+  it("ExerciseGroupRow.tsx: SET_TYPE_LABELS lookup safety", () => {
+    // normalizeSetType guarantees SET_TYPE_LABELS[st] never throws (key is always valid)
+    const unknownDbValue = "drop_set_v2";
+    const st = normalizeSetType(unknownDbValue);
+    expect(st).toBe("normal");
+  });
+});

--- a/__tests__/rest-resolver-intra-vs-inter.test.ts
+++ b/__tests__/rest-resolver-intra-vs-inter.test.ts
@@ -1,0 +1,124 @@
+/**
+ * BLD-1173 — AC #272: rest-resolver intra-vs-inter mode switching
+ *
+ * GIVEN a parent advanced set is in progress with one or more completed segments
+ * WHEN the user completes another mini-set
+ * THEN lib/rest-resolver returns intra-mini-set mode (5/15/30s defaults per set_type)
+ *   AND a "Mini-set N of ?" badge is rendered
+ * WHEN the user marks the parent set complete
+ * THEN the resolver switches to inter-set mode
+ *   AND MIN_REST_SECONDS=10 floor is enforced (inter-set only)
+ */
+import {
+  resolveIntraMiniSetRest,
+  INTRA_MINI_SET_DEFAULTS,
+  isAdvancedSetType,
+} from "@/lib/rest-resolver";
+
+describe("intra-vs-inter mode switching — all advanced types", () => {
+  const advancedTypes = ["rest_pause", "cluster", "myo_reps"] as const;
+
+  for (const setType of advancedTypes) {
+    describe(`${setType}`, () => {
+      it("returns intra mode with correct default seconds when mid-parent", () => {
+        const result = resolveIntraMiniSetRest(setType, false, 1, 3);
+        expect(result.mode).toBe("intra");
+        if (result.mode === "intra") {
+          expect(result.seconds).toBe(INTRA_MINI_SET_DEFAULTS[setType]);
+          expect(result.setType).toBe(setType);
+        }
+      });
+
+      it("renders 'Mini-set N of M' badge when mid-parent with known total", () => {
+        const result = resolveIntraMiniSetRest(setType, false, 2, 4);
+        expect(result.mode).toBe("intra");
+        if (result.mode === "intra") {
+          expect(result.badge).toMatch(/^Mini-set \d+ of \d+$/);
+          expect(result.badge).toBe("Mini-set 2 of 4");
+        }
+      });
+
+      it("renders 'Mini-set N of ?' badge when total is unknown", () => {
+        const result = resolveIntraMiniSetRest(setType, false, 3, 0);
+        expect(result.mode).toBe("intra");
+        if (result.mode === "intra") {
+          expect(result.badge).toBe("Mini-set 3 of ?");
+        }
+      });
+
+      it("switches to inter mode when parent is marked complete", () => {
+        const result = resolveIntraMiniSetRest(setType, true, 3, 3);
+        expect(result.mode).toBe("inter");
+      });
+    });
+  }
+});
+
+describe("MIN_REST_SECONDS=10 floor — inter-set only", () => {
+  it("inter mode result is NOT a seconds value — callers use resolveRest for inter and enforce floor", () => {
+    const interResult = resolveIntraMiniSetRest("rest_pause", true, 2, 2);
+    // { mode: "inter" } — no seconds field; caller uses resolveRest() where 10s floor applies.
+    expect(interResult.mode).toBe("inter");
+    expect("seconds" in interResult).toBe(false);
+  });
+
+  it("myo_reps intra mode returns 5s — below MIN_REST_SECONDS=10 — floor is NOT enforced intra", () => {
+    const intraResult = resolveIntraMiniSetRest("myo_reps", false, 1, 0);
+    expect(intraResult.mode).toBe("intra");
+    if (intraResult.mode === "intra") {
+      // Must be 5s — Fagerli protocol; floor is advisory (non-blocking) in intra mode.
+      expect(intraResult.seconds).toBe(5);
+      expect(intraResult.seconds).toBeLessThan(10); // confirms floor not applied
+    }
+  });
+
+  it("rest_pause intra is 15s — above MIN_REST_SECONDS=10 regardless", () => {
+    const intraResult = resolveIntraMiniSetRest("rest_pause", false, 1, 0);
+    if (intraResult.mode === "intra") {
+      expect(intraResult.seconds).toBe(15);
+    }
+  });
+
+  it("cluster intra is 30s — well above MIN_REST_SECONDS=10", () => {
+    const intraResult = resolveIntraMiniSetRest("cluster", false, 2, 0);
+    if (intraResult.mode === "intra") {
+      expect(intraResult.seconds).toBe(30);
+    }
+  });
+});
+
+describe("badge format specification", () => {
+  it("badge shows completedMiniSets (1-based) as N", () => {
+    const r = resolveIntraMiniSetRest("rest_pause", false, 3, 5);
+    if (r.mode === "intra") expect(r.badge).toBe("Mini-set 3 of 5");
+  });
+
+  it("badge shows '?' when total is zero", () => {
+    const r = resolveIntraMiniSetRest("cluster", false, 1, 0);
+    if (r.mode === "intra") expect(r.badge).toBe("Mini-set 1 of ?");
+  });
+
+  it("badge text format is always 'Mini-set N of M'", () => {
+    for (const setType of ["rest_pause", "cluster", "myo_reps"] as const) {
+      const r = resolveIntraMiniSetRest(setType, false, 2, 3);
+      if (r.mode === "intra") {
+        expect(r.badge).toMatch(/^Mini-set \d+ of (\d+|\?)$/);
+      }
+    }
+  });
+});
+
+describe("isAdvancedSetType — integration with SetType cycle", () => {
+  it("all advanced types are identified correctly", () => {
+    expect(isAdvancedSetType("rest_pause")).toBe(true);
+    expect(isAdvancedSetType("cluster")).toBe(true);
+    expect(isAdvancedSetType("myo_reps")).toBe(true);
+  });
+
+  it("standard types are not advanced", () => {
+    expect(isAdvancedSetType("normal")).toBe(false);
+    expect(isAdvancedSetType("warmup")).toBe(false);
+    expect(isAdvancedSetType("dropset")).toBe(false);
+    expect(isAdvancedSetType("failure")).toBe(false);
+  });
+});

--- a/__tests__/rest-timer-mini-set.test.ts
+++ b/__tests__/rest-timer-mini-set.test.ts
@@ -1,0 +1,128 @@
+/**
+ * BLD-1173 — AC #259: IntraMiniSetRest mode (rest-pause set in progress)
+ *
+ * GIVEN a `rest_pause` set in progress
+ * WHEN the user completes a mini-set mid-parent
+ * THEN the rest timer resolves to ≤30 seconds (intra) and shows "Mini-set N of ?" badge
+ * WHEN the parent set is marked complete
+ * THEN normal inter-set rest resumes
+ */
+import {
+  resolveIntraMiniSetRest,
+  INTRA_MINI_SET_DEFAULTS,
+  isAdvancedSetType,
+  type AdvancedSetType,
+} from "@/lib/rest-resolver";
+
+describe("resolveIntraMiniSetRest — rest_pause mid-parent (AC #259)", () => {
+  it("returns intra mode with ≤30s when mini-set completes mid-parent", () => {
+    const result = resolveIntraMiniSetRest("rest_pause", false, 1, 3);
+    expect(result.mode).toBe("intra");
+    if (result.mode === "intra") {
+      expect(result.seconds).toBeLessThanOrEqual(30);
+      expect(result.seconds).toBe(INTRA_MINI_SET_DEFAULTS.rest_pause);
+    }
+  });
+
+  it("shows 'Mini-set N of ?' badge with known total", () => {
+    const result = resolveIntraMiniSetRest("rest_pause", false, 2, 3);
+    expect(result.mode).toBe("intra");
+    if (result.mode === "intra") {
+      expect(result.badge).toBe("Mini-set 2 of 3");
+    }
+  });
+
+  it("shows 'Mini-set N of ?' badge with unknown total (0)", () => {
+    const result = resolveIntraMiniSetRest("rest_pause", false, 1, 0);
+    expect(result.mode).toBe("intra");
+    if (result.mode === "intra") {
+      expect(result.badge).toBe("Mini-set 1 of ?");
+    }
+  });
+
+  it("switches to inter mode when parent set is marked complete", () => {
+    const result = resolveIntraMiniSetRest("rest_pause", true, 3, 3);
+    expect(result.mode).toBe("inter");
+  });
+
+  it("switches to inter mode when parentDone=true regardless of completedMiniSets", () => {
+    const result = resolveIntraMiniSetRest("rest_pause", true, 0, 0);
+    expect(result.mode).toBe("inter");
+  });
+});
+
+describe("resolveIntraMiniSetRest — cluster mid-parent", () => {
+  it("returns intra mode with 30s for cluster", () => {
+    const result = resolveIntraMiniSetRest("cluster", false, 2, 5);
+    expect(result.mode).toBe("intra");
+    if (result.mode === "intra") {
+      expect(result.seconds).toBe(30);
+      expect(result.setType).toBe("cluster");
+    }
+  });
+
+  it("switches to inter mode when cluster parent is done", () => {
+    const result = resolveIntraMiniSetRest("cluster", true, 5, 5);
+    expect(result.mode).toBe("inter");
+  });
+});
+
+describe("resolveIntraMiniSetRest — myo_reps mid-parent", () => {
+  it("returns intra mode with 5s for myo_reps (Fagerli protocol — non-blocking countdown)", () => {
+    const result = resolveIntraMiniSetRest("myo_reps", false, 1, 0);
+    expect(result.mode).toBe("intra");
+    if (result.mode === "intra") {
+      expect(result.seconds).toBe(5);
+      expect(result.setType).toBe("myo_reps");
+    }
+  });
+
+  it("myo_reps intra rest is NOT raised to MIN_REST_SECONDS floor (5s < 10s)", () => {
+    const result = resolveIntraMiniSetRest("myo_reps", false, 3, 0);
+    if (result.mode === "intra") {
+      // Floor is advisory only for intra — 5s must be preserved as-is.
+      expect(result.seconds).toBe(5);
+    }
+  });
+
+  it("switches to inter mode when myo_reps parent is done", () => {
+    const result = resolveIntraMiniSetRest("myo_reps", true, 4, 0);
+    expect(result.mode).toBe("inter");
+  });
+});
+
+describe("INTRA_MINI_SET_DEFAULTS constants", () => {
+  it("rest_pause defaults to 15s", () => {
+    expect(INTRA_MINI_SET_DEFAULTS.rest_pause).toBe(15);
+  });
+
+  it("cluster defaults to 30s", () => {
+    expect(INTRA_MINI_SET_DEFAULTS.cluster).toBe(30);
+  });
+
+  it("myo_reps defaults to 5s", () => {
+    expect(INTRA_MINI_SET_DEFAULTS.myo_reps).toBe(5);
+  });
+});
+
+describe("isAdvancedSetType", () => {
+  it("returns true for advanced set types", () => {
+    const advancedTypes: AdvancedSetType[] = ["rest_pause", "cluster", "myo_reps"];
+    for (const t of advancedTypes) {
+      expect(isAdvancedSetType(t)).toBe(true);
+    }
+  });
+
+  it("returns false for standard set types", () => {
+    const standardTypes = ["normal", "warmup", "dropset", "failure"];
+    for (const t of standardTypes) {
+      expect(isAdvancedSetType(t)).toBe(false);
+    }
+  });
+
+  it("returns false for unknown/garbage strings", () => {
+    expect(isAdvancedSetType("")).toBe(false);
+    expect(isAdvancedSetType("REST_PAUSE")).toBe(false);
+    expect(isAdvancedSetType("unknown")).toBe(false);
+  });
+});

--- a/__tests__/set-accessors.test.ts
+++ b/__tests__/set-accessors.test.ts
@@ -1,0 +1,223 @@
+/**
+ * BLD-1172: Unit tests for lib/sets-accessors.ts named reps accessors.
+ *
+ * AC #270: GIVEN a rest_pause set with parent.reps=13 (segments 8,3,2 @ 100kg)
+ *          WHEN getWorkingRepsForOverloadDecision is called
+ *          THEN it returns 8 (the first segment reps), NOT 13.
+ *
+ * AC #271: GIVEN a myo_reps set with activation 15 reps + clusters 5,5,4,3
+ *          WHEN getEffortRepsForPlateau is called
+ *          THEN it returns 15 (activation segment), NOT 32 (sum) or 5 (heaviest cluster).
+ */
+
+import {
+  getWorkingRepsForOverloadDecision,
+  getEffortRepsForPlateau,
+  getHeaviestSegmentReps,
+  getTotalRepsForVolume,
+} from "../lib/sets-accessors";
+import type { WorkoutSet, SetSegment } from "../lib/types";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeSet(overrides: Partial<WorkoutSet>): WorkoutSet {
+  return {
+    id: "s1",
+    session_id: "sess1",
+    exercise_id: "ex1",
+    set_number: 1,
+    weight: 100,
+    reps: null,
+    completed: true,
+    completed_at: null,
+    rpe: null,
+    notes: "",
+    link_id: null,
+    round: null,
+    tempo: null,
+    swapped_from_exercise_id: null,
+    set_type: "normal",
+    duration_seconds: null,
+    exercise_position: 0,
+    ...overrides,
+  };
+}
+
+function makeSegment(segmentNumber: number, reps: number, weight?: number): SetSegment {
+  return {
+    id: `seg${segmentNumber}`,
+    set_id: "s1",
+    segment_number: segmentNumber,
+    reps,
+    weight: weight ?? null,
+    rest_after_seconds: null,
+    completed_at: null,
+    created_at: Date.now(),
+  };
+}
+
+// ─── getWorkingRepsForOverloadDecision ──────────────────────────────────────
+
+describe("getWorkingRepsForOverloadDecision", () => {
+  it("AC #270 — rest_pause 8+3+2 @ 100kg returns 8 (first segment), not 13 (sum)", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 13, weight: 100 });
+    const segments = [
+      makeSegment(1, 8),
+      makeSegment(2, 3),
+      makeSegment(3, 2),
+    ];
+    expect(getWorkingRepsForOverloadDecision(set, segments)).toBe(8);
+  });
+
+  it("cluster — first segment (4) returned as working reps", () => {
+    const set = makeSet({ set_type: "cluster", reps: 12, weight: 80 });
+    const segments = [
+      makeSegment(1, 4),
+      makeSegment(2, 4),
+      makeSegment(3, 4),
+    ];
+    expect(getWorkingRepsForOverloadDecision(set, segments)).toBe(4);
+  });
+
+  it("myo_reps — activation segment (15) returned", () => {
+    const set = makeSet({ set_type: "myo_reps", reps: 32, weight: 25 });
+    const segments = [
+      makeSegment(1, 15), // activation
+      makeSegment(2, 5),
+      makeSegment(3, 5),
+      makeSegment(4, 4),
+      makeSegment(5, 3),
+    ];
+    expect(getWorkingRepsForOverloadDecision(set, segments)).toBe(15);
+  });
+
+  it("normal set — returns set.reps directly", () => {
+    const set = makeSet({ set_type: "normal", reps: 10 });
+    expect(getWorkingRepsForOverloadDecision(set, [])).toBe(10);
+  });
+
+  it("warmup set — returns set.reps directly", () => {
+    const set = makeSet({ set_type: "warmup", reps: 15 });
+    expect(getWorkingRepsForOverloadDecision(set, [])).toBe(15);
+  });
+
+  it("advanced set with zero segments — falls back to set.reps", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 0 });
+    expect(getWorkingRepsForOverloadDecision(set, [])).toBe(0);
+  });
+
+  it("segments out of order — still picks the segment with lowest segment_number", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 11, weight: 100 });
+    const segments = [
+      makeSegment(3, 2),
+      makeSegment(1, 8),
+      makeSegment(2, 1),
+    ];
+    expect(getWorkingRepsForOverloadDecision(set, segments)).toBe(8);
+  });
+});
+
+// ─── getEffortRepsForPlateau ─────────────────────────────────────────────────
+
+describe("getEffortRepsForPlateau", () => {
+  it("AC #271 — myo_reps activation=15 returns 15, not 32 (sum) or 5 (cluster reps)", () => {
+    const set = makeSet({ set_type: "myo_reps", reps: 32, weight: 25 });
+    const segments = [
+      makeSegment(1, 15), // activation
+      makeSegment(2, 5),
+      makeSegment(3, 5),
+      makeSegment(4, 4),
+      makeSegment(5, 3),
+    ];
+    expect(getEffortRepsForPlateau(set, segments)).toBe(15);
+  });
+
+  it("rest_pause — returns first segment reps for plateau check", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 13, weight: 100 });
+    const segments = [
+      makeSegment(1, 8),
+      makeSegment(2, 3),
+      makeSegment(3, 2),
+    ];
+    expect(getEffortRepsForPlateau(set, segments)).toBe(8);
+  });
+
+  it("cluster — returns first segment reps", () => {
+    const set = makeSet({ set_type: "cluster", reps: 15, weight: 90 });
+    const segments = [makeSegment(1, 5), makeSegment(2, 5), makeSegment(3, 5)];
+    expect(getEffortRepsForPlateau(set, segments)).toBe(5);
+  });
+
+  it("normal set — returns set.reps directly", () => {
+    const set = makeSet({ set_type: "normal", reps: 8 });
+    expect(getEffortRepsForPlateau(set, [])).toBe(8);
+  });
+
+  it("failure set — returns set.reps directly", () => {
+    const set = makeSet({ set_type: "failure", reps: 12 });
+    expect(getEffortRepsForPlateau(set, [])).toBe(12);
+  });
+});
+
+// ─── getHeaviestSegmentReps ──────────────────────────────────────────────────
+
+describe("getHeaviestSegmentReps", () => {
+  it("rest_pause — returns the max segment reps", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 13, weight: 100 });
+    const segments = [makeSegment(1, 8), makeSegment(2, 3), makeSegment(3, 2)];
+    expect(getHeaviestSegmentReps(set, segments)).toBe(8);
+  });
+
+  it("myo_reps with activation=15, clusters=5 — returns 15", () => {
+    const set = makeSet({ set_type: "myo_reps", reps: 32, weight: 25 });
+    const segments = [
+      makeSegment(1, 15),
+      makeSegment(2, 5),
+      makeSegment(3, 5),
+    ];
+    expect(getHeaviestSegmentReps(set, segments)).toBe(15);
+  });
+
+  it("cluster equal reps — returns that rep count", () => {
+    const set = makeSet({ set_type: "cluster", reps: 15, weight: 90 });
+    const segments = [makeSegment(1, 5), makeSegment(2, 5), makeSegment(3, 5)];
+    expect(getHeaviestSegmentReps(set, segments)).toBe(5);
+  });
+
+  it("normal set — returns set.reps", () => {
+    const set = makeSet({ set_type: "normal", reps: 10 });
+    expect(getHeaviestSegmentReps(set, [])).toBe(10);
+  });
+});
+
+// ─── getTotalRepsForVolume ───────────────────────────────────────────────────
+
+describe("getTotalRepsForVolume", () => {
+  it("rest_pause 8+3+2 — returns 13 (sum)", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 13, weight: 100 });
+    const segments = [makeSegment(1, 8), makeSegment(2, 3), makeSegment(3, 2)];
+    expect(getTotalRepsForVolume(set, segments)).toBe(13);
+  });
+
+  it("myo_reps 15+5+5+4+3 — returns 32 (sum)", () => {
+    const set = makeSet({ set_type: "myo_reps", reps: 32, weight: 25 });
+    const segments = [
+      makeSegment(1, 15),
+      makeSegment(2, 5),
+      makeSegment(3, 5),
+      makeSegment(4, 4),
+      makeSegment(5, 3),
+    ];
+    expect(getTotalRepsForVolume(set, segments)).toBe(32);
+  });
+
+  it("normal set — returns set.reps", () => {
+    const set = makeSet({ set_type: "normal", reps: 10 });
+    expect(getTotalRepsForVolume(set, [])).toBe(10);
+  });
+
+  it("advanced set with no segments — returns 0 (set.reps=0)", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 0 });
+    expect(getTotalRepsForVolume(set, [])).toBe(0);
+  });
+});

--- a/components/session/detail/ExerciseGroupRow.tsx
+++ b/components/session/detail/ExerciseGroupRow.tsx
@@ -6,6 +6,7 @@ import { rpeColor, rpeText } from "@/lib/rpe";
 import type { ExerciseGroup } from "@/hooks/useSessionDetail";
 import type { ThemeColors } from "@/hooks/useThemeColors";
 import { fontSizes } from "@/constants/design-tokens";
+import { normalizeSetType } from "@/lib/db/sets";
 
 type Props = {
   group: ExerciseGroup;
@@ -55,14 +56,14 @@ export function ExerciseGroupRow({ group, groups, linkIds, palette, colors }: Pr
           .map((set) => (
             <View key={set.id}>
               <View style={[styles.setRow, (() => {
-                const st = set.set_type ?? "normal";
+                const st = normalizeSetType(set.set_type);
                 if (st === "warmup") return { borderLeftWidth: 3, borderLeftColor: colors.surfaceVariant, paddingLeft: 5 };
                 if (st === "dropset") return { borderLeftWidth: 3, borderLeftColor: colors.tertiaryContainer, paddingLeft: 5 };
                 if (st === "failure") return { borderLeftWidth: 3, borderLeftColor: colors.errorContainer, paddingLeft: 5 };
                 return {};
               })()]}>
                 {(() => {
-                  const st = set.set_type ?? "normal";
+                  const st = normalizeSetType(set.set_type);
                   const label = SET_TYPE_LABELS[st];
                   if (label.short) {
                     const chipColors = st === "warmup"

--- a/lib/csv-format.ts
+++ b/lib/csv-format.ts
@@ -9,7 +9,7 @@ import type {
 
 export function workoutCSV(rows: WorkoutCSVRow[]): string {
   const header =
-    "date,exercise,set_number,weight,reps,duration_seconds,notes,set_rpe,set_notes,link_id,bodyweight_modifier_kg,pulley_pin,kind,day_session_exercise_id,day_session_date,stack_marker,stack_name_at_log";
+    "date,exercise,set_number,weight,reps,duration_seconds,notes,set_rpe,set_notes,link_id,bodyweight_modifier_kg,pulley_pin,kind,day_session_exercise_id,day_session_date,stack_marker,stack_name_at_log,set_type";
   const lines: string[] = [];
   for (const r of rows) {
     lines.push(
@@ -31,6 +31,8 @@ export function workoutCSV(rows: WorkoutCSVRow[]): string {
         csvEscape(r.day_session_date),
         csvEscape(r.stack_marker),
         csvEscape(r.stack_name_at_log),
+        // BLD-1168: set_type is the last column for backward-compatibility (older importers ignore unknown trailing columns).
+        csvEscape(r.set_type ?? "normal"),
       ].join(",")
     );
   }

--- a/lib/csv-import-formats.ts
+++ b/lib/csv-import-formats.ts
@@ -25,6 +25,8 @@ export type ParsedCsvRow = {
   kind?: string | null;
   daySessionExerciseId?: string | null;
   daySessionDate?: string | null;
+  /** BLD-1169: raw set_type string from CableSnap CSV; normalised at DB insertion. */
+  set_type?: string | null;
 };
 
 export type FormatDefinition = {
@@ -203,6 +205,8 @@ const cablesnap: FormatDefinition = {
       kind,
       daySessionExerciseId,
       daySessionDate,
+      // BLD-1169: pass raw set_type through; normalizeSetType is applied at DB insertion.
+      set_type: row["set_type"]?.trim() || null,
     };
   },
   detectWeightUnit() {

--- a/lib/csv-import.ts
+++ b/lib/csv-import.ts
@@ -17,6 +17,8 @@ export type ImportedSet = {
   rpe: number | null;
   durationSeconds: number | null;
   notes: string;
+  /** Set type from source CSV (CableSnap format). Coerced to valid SetType at DB insertion. */
+  set_type?: string | null;
 };
 
 export type ImportedSession = {
@@ -140,6 +142,7 @@ function buildSession({
     rpe: row.rpe,
     durationSeconds: row.durationSeconds,
     notes: row.notes,
+    set_type: row.set_type ?? null,
   }));
   const firstRow = sessionRows[0];
   return {

--- a/lib/db/csv-import.ts
+++ b/lib/db/csv-import.ts
@@ -9,6 +9,7 @@ import type { ImportedSession } from "../csv-import";
 import type { MatchResult } from "../exercise-matcher";
 import type { NlpResult } from "../exercise-nlp";
 import type { Category, Equipment, Difficulty, MuscleGroup } from "../types";
+import { normalizeSetType } from "./sets";
 
 // ---- Types ----
 
@@ -137,7 +138,7 @@ export async function importCsvSessions(
         const setId = uuid();
         await database.runAsync(
           `INSERT INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, set_type)
-           VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, 'normal')`,
+           VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)`,
           [
             setId,
             sessionId,
@@ -148,6 +149,7 @@ export async function importCsvSessions(
             completedAt,
             set.rpe,
             set.notes,
+            normalizeSetType(set.set_type ?? "normal"),
           ]
         );
         setsInserted++;

--- a/lib/db/csv.ts
+++ b/lib/db/csv.ts
@@ -25,6 +25,8 @@ export type WorkoutCSVRow = {
   // BLD-1126 AC13: stack marker and snapshot stack name for cable sets.
   stack_marker: number | null;
   stack_name_at_log: string | null;
+  // BLD-1168: advanced set type (rest_pause, cluster, myo_reps, or legacy normal/warmup/dropset/failure).
+  set_type: string | null;
 };
 
 export type NutritionCSVRow = {
@@ -82,6 +84,7 @@ export async function getWorkoutCSVData(since: number): Promise<WorkoutCSVRow[]>
       day_session_date: workoutSessions.day_session_date,
       stack_marker: workoutSets.stack_marker,
       stack_name_at_log: workoutSets.stack_name_at_log,
+      set_type: workoutSets.set_type,
     })
     .from(workoutSessions)
     .innerJoin(workoutSets, sql`${workoutSets.session_id} = ${workoutSessions.id}`)

--- a/lib/db/exercises.ts
+++ b/lib/db/exercises.ts
@@ -5,6 +5,8 @@ import { uuid } from "../uuid";
 import { getDrizzle, query, withTransaction } from "./helpers";
 import { exercises, templateExercises } from "./schema";
 import type { ExerciseRow } from "./schema";
+import { getWorkingRepsForOverloadDecision } from "../sets-accessors";
+import { getSegmentsForSet } from "./sets";
 
 function mapRow(row: ExerciseRow): Exercise {
   return {
@@ -306,32 +308,37 @@ export async function getProgressionSuggestion(
     return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
   }
 
-  const failingSet = await query<{ count: number }>(
-    `SELECT COUNT(*) as count
+  // Load all completed work sets (normal + advanced) from the latest session.
+  // BLD-1172: use getWorkingRepsForOverloadDecision() instead of set.reps directly,
+  // because for advanced set types (rest_pause, cluster, myo_reps) set.reps is the
+  // SUM of all mini-set reps, which would incorrectly inflate the progression check.
+  // The accessor returns the first-segment reps (the heaviest working effort) for
+  // advanced types, and set.reps unchanged for normal/warmup/dropset/failure.
+  const workSets = await query<{ id: string; set_type: string; reps: number | null }>(
+    `SELECT id, set_type, reps
      FROM workout_sets
      WHERE session_id = ?
        AND exercise_id = ?
-       AND set_type = 'normal'
-       AND completed = 1
-       AND (reps IS NULL OR reps < 12)`,
-    [latestSession[0].session_id, exerciseId]
-  );
-  if ((failingSet[0]?.count ?? 1) > 0) {
-    return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
-  }
-
-  // Also check there was at least one normal completed set (don't suggest on empty sessions)
-  const normalSetCount = await query<{ count: number }>(
-    `SELECT COUNT(*) as count
-     FROM workout_sets
-     WHERE session_id = ?
-       AND exercise_id = ?
-       AND set_type = 'normal'
+       AND set_type IN ('normal', 'rest_pause', 'cluster', 'myo_reps')
        AND completed = 1`,
     [latestSession[0].session_id, exerciseId]
   );
-  if ((normalSetCount[0]?.count ?? 0) === 0) {
+
+  if (workSets.length === 0) {
+    // No work sets logged in this session — skip suggestion.
     return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
+  }
+
+  // Check every work set reached >= 12 reps using the named accessor.
+  for (const ws of workSets) {
+    const segments = await getSegmentsForSet(ws.id);
+    const workingReps = getWorkingRepsForOverloadDecision(
+      { ...ws, set_type: ws.set_type as import("../types").SetType } as import("../types").WorkoutSet,
+      segments,
+    );
+    if (workingReps < 12) {
+      return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
+    }
   }
 
   // Check 4: user has NOT logged next exercise in last 30 days

--- a/lib/db/exercises.ts
+++ b/lib/db/exercises.ts
@@ -6,7 +6,7 @@ import { getDrizzle, query, withTransaction } from "./helpers";
 import { exercises, templateExercises } from "./schema";
 import type { ExerciseRow } from "./schema";
 import { getWorkingRepsForOverloadDecision } from "../sets-accessors";
-import { getSegmentsForSet } from "./sets";
+import type { SetSegment, SetType } from "../types";
 
 function mapRow(row: ExerciseRow): Exercise {
   return {
@@ -309,12 +309,13 @@ export async function getProgressionSuggestion(
   }
 
   // Load all completed work sets (normal + advanced) from the latest session.
-  // BLD-1172: use getWorkingRepsForOverloadDecision() instead of set.reps directly,
-  // because for advanced set types (rest_pause, cluster, myo_reps) set.reps is the
-  // SUM of all mini-set reps, which would incorrectly inflate the progression check.
-  // The accessor returns the first-segment reps (the heaviest working effort) for
-  // advanced types, and set.reps unchanged for normal/warmup/dropset/failure.
-  const workSets = await query<{ id: string; set_type: string; reps: number | null }>(
+  // BLD-1172: Behaviour change from pre-BLD-1168 code: the old guard required
+  // set_type = 'normal'. Now advanced set types (rest_pause, cluster, myo_reps)
+  // also count toward progression, using the first-segment reps via the named
+  // accessor so that the rep count is not inflated by total-segment sums.
+  // This is intentional per PLAN-BLD-1168 §Progression — advanced sets should
+  // qualify a session for progression suggestions just as normal sets do.
+  const workSets = await query<{ id: string; set_type: SetType; reps: number | null }>(
     `SELECT id, set_type, reps
      FROM workout_sets
      WHERE session_id = ?
@@ -329,13 +330,25 @@ export async function getProgressionSuggestion(
     return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
   }
 
+  // Batch-load all segments for the work sets in a single query (avoids N+1).
+  const setIds = workSets.map((ws) => ws.id);
+  const allSegments = await query<SetSegment>(
+    `SELECT * FROM workout_set_segments
+     WHERE set_id IN (${setIds.map(() => "?").join(",")})
+     ORDER BY segment_number`,
+    setIds
+  );
+  const segmentsBySetId = new Map<string, SetSegment[]>();
+  for (const seg of allSegments) {
+    const list = segmentsBySetId.get(seg.set_id) ?? [];
+    list.push(seg);
+    segmentsBySetId.set(seg.set_id, list);
+  }
+
   // Check every work set reached >= 12 reps using the named accessor.
   for (const ws of workSets) {
-    const segments = await getSegmentsForSet(ws.id);
-    const workingReps = getWorkingRepsForOverloadDecision(
-      { ...ws, set_type: ws.set_type as import("../types").SetType } as import("../types").WorkoutSet,
-      segments,
-    );
+    const segments = segmentsBySetId.get(ws.id) ?? [];
+    const workingReps = getWorkingRepsForOverloadDecision(ws, segments);
     if (workingReps < 12) {
       return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
     }

--- a/lib/db/import-export.ts
+++ b/lib/db/import-export.ts
@@ -96,6 +96,7 @@ export const IMPORT_TABLE_ORDER: BackupTableName[] = [
 
 import type { AppSettingRow, AchievementEarnedRow, ProgramScheduleRow } from "./schema";
 export type { AppSettingRow, AchievementEarnedRow, ProgramScheduleRow };
+import { normalizeSetType } from "./sets";
 
 export type BackupV3Data = {
   exercises: unknown[];
@@ -733,7 +734,7 @@ async function insertRow(database: any, tableName: BackupTableName, row: Record<
       return r.changes > 0;
     }
     case "workout_sets": {
-      const setType = row.set_type ?? (row.is_warmup ? "warmup" : "normal");
+      const setType = normalizeSetType(row.set_type ?? (row.is_warmup ? "warmup" : "normal"));
       const r = await database.runAsync(
         "INSERT OR IGNORE INTO workout_sets (id, session_id, exercise_id, set_number, weight, reps, completed, completed_at, rpe, notes, link_id, round, tempo, set_type, duration_seconds, bodyweight_modifier_kg, attachment, mount_position, grip_type, grip_width, stack_id, stack_marker, stack_unit_at_log, stack_name_at_log, pulley_pin) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         [row.id, row.session_id, row.exercise_id, row.set_number, row.weight, row.reps, row.completed, row.completed_at, row.set_rpe ?? row.rpe ?? null, row.set_notes ?? row.notes ?? "", row.link_id ?? null, row.round ?? null, row.tempo ?? null, setType, row.duration_seconds ?? null, row.bodyweight_modifier_kg ?? null, row.attachment ?? null, row.mount_position ?? null, row.grip_type ?? null, row.grip_width ?? null, row.stack_id ?? null, row.stack_marker ?? null, row.stack_unit_at_log ?? null, row.stack_name_at_log ?? null, row.pulley_pin ?? null]

--- a/lib/db/session-sets.ts
+++ b/lib/db/session-sets.ts
@@ -9,6 +9,7 @@ import { uuid } from "../uuid";
 import { getDrizzle, withTransaction, getDatabase } from "./helpers";
 import { workoutSets, exercises, workoutSessions, setMedia } from "./schema";
 import { cascadeDeleteClipsForSets } from "../media/form-clips";
+import { normalizeSetType } from "./sets";
 
 export async function getSessionSets(
   sessionId: string
@@ -70,7 +71,7 @@ export async function getSessionSets(
     round: r.round ?? null,
     tempo: r.tempo ?? null,
     swapped_from_exercise_id: r.swapped_from_exercise_id ?? null,
-    set_type: (r.set_type as SetType) ?? "normal",
+    set_type: normalizeSetType(r.set_type),
     duration_seconds: r.duration_seconds ?? null,
     exercise_position: r.exercise_position ?? 0,
     bodyweight_modifier_kg: r.bodyweight_modifier_kg ?? null,
@@ -140,7 +141,7 @@ export async function getSourceSessionSets(
     link_id: r.link_id,
     tempo: r.tempo,
     exercise_exists: r.exercise_exists != null,
-    set_type: (r.set_type as SetType) ?? "normal",
+    set_type: normalizeSetType(r.set_type),
   }));
 }
 
@@ -680,9 +681,9 @@ export async function getPreviousSets(
 export async function getPreviousSetsBatch(
   exerciseIds: string[],
   currentSessionId: string
-): Promise<Record<string, { set_number: number; weight: number | null; reps: number | null; duration_seconds: number | null; set_type: string | null; completed: boolean; rpe: number | null; pulley_pin: number | null }[]>> {
+): Promise<Record<string, { set_number: number; weight: number | null; reps: number | null; duration_seconds: number | null; set_type: SetType; completed: boolean; rpe: number | null; pulley_pin: number | null }[]>> {
   if (exerciseIds.length === 0) return {};
-  const result: Record<string, { set_number: number; weight: number | null; reps: number | null; duration_seconds: number | null; set_type: string | null; completed: boolean; rpe: number | null; pulley_pin: number | null }[]> = {};
+  const result: Record<string, { set_number: number; weight: number | null; reps: number | null; duration_seconds: number | null; set_type: SetType; completed: boolean; rpe: number | null; pulley_pin: number | null }[]> = {};
   const db = await getDrizzle();
   // Step 1: Find all completed sessions per exercise, ordered by most recent
   const sessionRows = await db
@@ -735,7 +736,7 @@ export async function getPreviousSetsBatch(
     const correctSession = sessionMap[row.exercise_id];
     if (!correctSession || row.session_id !== correctSession) continue;
     if (!result[row.exercise_id]) result[row.exercise_id] = [];
-    result[row.exercise_id].push({ set_number: row.set_number, weight: row.weight, reps: row.reps, duration_seconds: row.duration_seconds, set_type: row.set_type, completed: row.completed === 1, rpe: row.rpe ?? null, pulley_pin: row.pulley_pin ?? null });
+    result[row.exercise_id].push({ set_number: row.set_number, weight: row.weight, reps: row.reps, duration_seconds: row.duration_seconds, set_type: normalizeSetType(row.set_type), completed: row.completed === 1, rpe: row.rpe ?? null, pulley_pin: row.pulley_pin ?? null });
   }
   return result;
 }

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -11,6 +11,7 @@ import {
   stravaSyncLog,
 } from "./schema";
 import { cascadeDeleteClipsForSession } from "../media/form-clips";
+import { normalizeSetType } from "./sets";
 
 // Re-export from split modules for backward compatibility
 export {
@@ -391,7 +392,7 @@ export async function createTemplateFromSession(
         rest_seconds: 90,
         link_id: linkId,
         link_label: "",
-        set_types: JSON.stringify(group.map((s) => s.set_type ?? "normal")),
+        set_types: JSON.stringify(group.map((s) => normalizeSetType(s.set_type))),
       });
     }
   });
@@ -612,7 +613,7 @@ function buildEditInsertRow(
     round: u.round ?? null,
     tempo: u.tempo ?? null,
     swapped_from_exercise_id: u.swapped_from_exercise_id ?? null,
-    set_type: u.set_type ?? "normal",
+    set_type: normalizeSetType(u.set_type),
     duration_seconds: u.duration_seconds ?? null,
     exercise_position: u.exercise_position ?? 0,
     bodyweight_modifier_kg: u.bodyweight_modifier_kg ?? null,

--- a/lib/db/sets.ts
+++ b/lib/db/sets.ts
@@ -26,6 +26,36 @@ export type { SetSegment };
  *  must store reps=0 / cached_volume_kg=0 / cached_e1rm_kg=0 (not legacy parent fallback). */
 export const ADVANCED_SET_TYPES: ReadonlySet<SetType> = new Set(["rest_pause", "cluster", "myo_reps"]);
 
+const VALID_SET_TYPES: ReadonlySet<string> = new Set([
+  "normal", "warmup", "dropset", "failure", "rest_pause", "cluster", "myo_reps",
+]);
+
+/** Tracks whether we've already warned about a given unknown value this process lifetime. */
+const _warnedSetTypes = new Set<unknown>();
+
+/**
+ * Normalises an untrusted `set_type` value (from DB row, CSV, backup, share-link payload)
+ * to a valid `SetType`.
+ *
+ * - Returns `raw` unchanged if it is one of the seven valid set-type strings.
+ * - Coerces any other value (unknown string, null, undefined, "") to "normal".
+ * - Emits a single `console.warn` per unknown value (dev-mode only) on first coercion.
+ *
+ * **Call this at every read boundary** — DB hydration, CSV import, backup restore,
+ * share-payload deserialiser, and UI label lookup — so that unknown values from older
+ * app versions or external sources never reach typed code as an invalid string.
+ */
+export function normalizeSetType(raw: unknown): SetType {
+  if (typeof raw === "string" && VALID_SET_TYPES.has(raw)) {
+    return raw as SetType;
+  }
+  if (__DEV__ && !_warnedSetTypes.has(raw)) {
+    _warnedSetTypes.add(raw);
+    console.warn(`[normalizeSetType] Unknown set_type "${String(raw)}" coerced to "normal"`);
+  }
+  return "normal";
+}
+
 // ─── Pure computation (exported for tests) ─────────────────────────────────
 
 export type SegmentInput = { reps: number; weight: number | null };

--- a/lib/rest-resolver.ts
+++ b/lib/rest-resolver.ts
@@ -243,6 +243,75 @@ async function queryHistoryMedian(
   return { median, sampleCount: sorted.length };
 }
 
+// ─── BLD-1168: IntraMiniSetRest mode ─────────────────────────────────────────
+
+/** Advanced set types that use intra-mini-set rest. */
+export type AdvancedSetType = "rest_pause" | "cluster" | "myo_reps";
+
+/**
+ * Default intra-mini-set rest in seconds per set type.
+ *
+ * myo_reps = 5s  (per Borge Fagerli protocol — 5s non-blocking countdown)
+ * rest_pause = 15s  (typical mid-set pause duration)
+ * cluster   = 30s  (strength protocol: longer intra-cluster rest)
+ *
+ * The MIN_REST_SECONDS=10 floor is advisory in intra-mini-set mode only and
+ * is NEVER enforced here — myo_reps intentionally uses 5s. The floor only
+ * applies to inter-set rest (between parent sets).
+ */
+export const INTRA_MINI_SET_DEFAULTS: Record<AdvancedSetType, number> = {
+  myo_reps: 5,
+  rest_pause: 15,
+  cluster: 30,
+};
+
+export type IntraMiniSetRestResult = {
+  mode: "intra";
+  seconds: number;
+  /** Display badge shown during intra-mini-set rest. N is 1-based completed mini-set count. */
+  badge: string;
+  setType: AdvancedSetType;
+};
+
+export type IntraOrInterRestResult = IntraMiniSetRestResult | { mode: "inter" };
+
+/**
+ * Determine whether to use intra-mini-set or inter-set rest mode.
+ *
+ * Returns `{ mode: "intra", ... }` when a mini-set has just completed mid-parent
+ * (i.e. the parent set is NOT yet complete). Returns `{ mode: "inter" }` when the
+ * parent set is complete, signalling callers to use the regular `resolveRest` path
+ * and enforce the MIN_REST_SECONDS=10 floor.
+ *
+ * @param setType       The parent set's type (must be an AdvancedSetType).
+ * @param parentDone    True when the parent set has been marked complete.
+ * @param completedMiniSets  Count of mini-sets completed so far (≥1 to be mid-parent).
+ * @param totalMiniSets      Total planned mini-sets for the parent (may be unknown; 0 = "?").
+ */
+export function resolveIntraMiniSetRest(
+  setType: AdvancedSetType,
+  parentDone: boolean,
+  completedMiniSets: number,
+  totalMiniSets: number,
+): IntraOrInterRestResult {
+  if (parentDone) {
+    return { mode: "inter" };
+  }
+
+  const seconds = INTRA_MINI_SET_DEFAULTS[setType];
+  const totalLabel = totalMiniSets > 0 ? String(totalMiniSets) : "?";
+  const badge = `Mini-set ${completedMiniSets} of ${totalLabel}`;
+
+  return { mode: "intra", seconds, badge, setType };
+}
+
+/**
+ * Returns true if `setType` uses the intra-mini-set rest mode.
+ */
+export function isAdvancedSetType(setType: string): setType is AdvancedSetType {
+  return setType === "rest_pause" || setType === "cluster" || setType === "myo_reps";
+}
+
 // ─── Mutation: setUserRestSeconds ────────────────────────────────────────────
 
 /**

--- a/lib/sets-accessors.ts
+++ b/lib/sets-accessors.ts
@@ -7,12 +7,16 @@
  * `set.reps` is the SUM of all mini-set reps — using it directly inflates
  * overload decisions and plateau detection.
  *
- * The architecture grep-test (__tests__/architecture-set-write-path.test.ts)
- * enforces this invariant and will fail CI if any file outside
- * lib/db/sets.ts / lib/sets-accessors.ts reads `.reps` on a WorkoutSet.
+ * This invariant will be enforced by the Slice 8 grep-test
+ * (__tests__/architecture-set-write-path.test.ts, BLD-1176), which will fail
+ * CI if any file outside lib/db/sets.ts / lib/sets-accessors.ts reads `.reps`
+ * on a WorkoutSet directly.
  */
-import type { WorkoutSet, SetSegment } from "./types";
+import type { SetType, SetSegment } from "./types";
 import { ADVANCED_SET_TYPES } from "./db/sets";
+
+/** Minimal set fields required by all reps accessors. */
+type SetRepsInput = Pick<{ set_type: SetType; reps: number | null }, "set_type" | "reps">;
 
 /**
  * Returns the reps count to use when deciding whether to increase load
@@ -24,7 +28,7 @@ import { ADVANCED_SET_TYPES } from "./db/sets";
  * Use when asking "did the user achieve the target reps to progress weight?".
  */
 export function getWorkingRepsForOverloadDecision(
-  set: WorkoutSet,
+  set: SetRepsInput,
   segments: SetSegment[],
 ): number {
   if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
@@ -46,7 +50,7 @@ export function getWorkingRepsForOverloadDecision(
  * - normal / warmup / dropset / failure: returns `set.reps`.
  */
 export function getEffortRepsForPlateau(
-  set: WorkoutSet,
+  set: SetRepsInput,
   segments: SetSegment[],
 ): number {
   if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
@@ -65,7 +69,7 @@ export function getEffortRepsForPlateau(
  * load × reps product (combined with segment weight).
  */
 export function getHeaviestSegmentReps(
-  set: WorkoutSet,
+  set: SetRepsInput,
   segments: SetSegment[],
 ): number {
   if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
@@ -82,7 +86,7 @@ export function getHeaviestSegmentReps(
  * Use when computing training volume (total reps × load).
  */
 export function getTotalRepsForVolume(
-  set: WorkoutSet,
+  set: SetRepsInput,
   segments: SetSegment[],
 ): number {
   if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {

--- a/lib/sets-accessors.ts
+++ b/lib/sets-accessors.ts
@@ -1,0 +1,92 @@
+/**
+ * BLD-1172: Named reps accessors for WorkoutSet rows.
+ *
+ * ARCHITECTURE INVARIANT: All callers that need a "reps" value from a
+ * WorkoutSet must use one of the four functions below instead of reading
+ * `set.reps` directly. For advanced set types (rest_pause, cluster, myo_reps)
+ * `set.reps` is the SUM of all mini-set reps — using it directly inflates
+ * overload decisions and plateau detection.
+ *
+ * The architecture grep-test (__tests__/architecture-set-write-path.test.ts)
+ * enforces this invariant and will fail CI if any file outside
+ * lib/db/sets.ts / lib/sets-accessors.ts reads `.reps` on a WorkoutSet.
+ */
+import type { WorkoutSet, SetSegment } from "./types";
+import { ADVANCED_SET_TYPES } from "./db/sets";
+
+/**
+ * Returns the reps count to use when deciding whether to increase load
+ * (overload decision). For advanced set types this is the heaviest
+ * single-segment reps (first segment, which holds the highest rep count for
+ * rest-pause/cluster; activation segment for myo-reps). For legacy types it
+ * returns `set.reps`.
+ *
+ * Use when asking "did the user achieve the target reps to progress weight?".
+ */
+export function getWorkingRepsForOverloadDecision(
+  set: WorkoutSet,
+  segments: SetSegment[],
+): number {
+  if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
+    return set.reps ?? 0;
+  }
+  // First segment (lowest segment_number) holds the working rep count.
+  const sorted = [...segments].sort((a, b) => a.segment_number - b.segment_number);
+  return sorted[0].reps;
+}
+
+/**
+ * Returns the reps count to use for plateau / PR detection.
+ *
+ * - myo_reps: returns activation segment reps (first segment), NOT the total.
+ *   The activation set quality determines effort; the mini-clusters are
+ *   fatigue-extension work.
+ * - cluster / rest_pause: returns the heaviest single-segment reps (first
+ *   segment).
+ * - normal / warmup / dropset / failure: returns `set.reps`.
+ */
+export function getEffortRepsForPlateau(
+  set: WorkoutSet,
+  segments: SetSegment[],
+): number {
+  if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
+    return set.reps ?? 0;
+  }
+  // First segment = activation set (myo_reps) or heaviest cluster (rest_pause/cluster).
+  const sorted = [...segments].sort((a, b) => a.segment_number - b.segment_number);
+  return sorted[0].reps;
+}
+
+/**
+ * Returns the reps of the segment with the most reps (the "heaviest" segment
+ * in terms of rep count). For legacy set types returns `set.reps`.
+ *
+ * Useful for display and for 1RM estimation using the segment with the highest
+ * load × reps product (combined with segment weight).
+ */
+export function getHeaviestSegmentReps(
+  set: WorkoutSet,
+  segments: SetSegment[],
+): number {
+  if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
+    return set.reps ?? 0;
+  }
+  return Math.max(...segments.map((s) => s.reps));
+}
+
+/**
+ * Returns the total reps across all segments (Σ segments.reps). For legacy
+ * set types returns `set.reps` (which equals the total anyway for non-advanced
+ * rows, since there are no segments).
+ *
+ * Use when computing training volume (total reps × load).
+ */
+export function getTotalRepsForVolume(
+  set: WorkoutSet,
+  segments: SetSegment[],
+): number {
+  if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
+    return set.reps ?? 0;
+  }
+  return segments.reduce((sum, s) => sum + s.reps, 0);
+}

--- a/lib/share-payload.ts
+++ b/lib/share-payload.ts
@@ -1,0 +1,33 @@
+/**
+ * BLD-1169 (BLD-1168 Slice 3): Share-payload deserialiser.
+ *
+ * Handles decoding of session workout data received via share link, QR code,
+ * or any out-of-band payload. The normaliseSetType boundary here ensures
+ * forward-compatibility: if a newer client shares a payload containing an
+ * unknown set_type value, older clients coerce it to "normal" rather than
+ * crashing or propagating a bad value into the DB.
+ */
+import { normalizeSetType } from "./db/sets";
+import type { SetType } from "./types";
+
+export type SharePayloadSet = {
+  set_type: SetType;
+  reps: number | null;
+  weight: number | null;
+  rpe?: number | null;
+  notes?: string;
+};
+
+/**
+ * Deserialises a raw set object from a share payload, normalising the
+ * set_type field so unknown future values are coerced to "normal".
+ */
+export function deserializeSharePayloadSet(raw: Record<string, unknown>): SharePayloadSet {
+  return {
+    set_type: normalizeSetType(raw.set_type),
+    reps: typeof raw.reps === "number" ? raw.reps : null,
+    weight: typeof raw.weight === "number" ? raw.weight : null,
+    rpe: typeof raw.rpe === "number" ? raw.rpe : null,
+    notes: typeof raw.notes === "string" ? raw.notes : "",
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -294,7 +294,8 @@ export type WorkoutSession = {
 
 export type SetType = "normal" | "warmup" | "dropset" | "failure" | "rest_pause" | "cluster" | "myo_reps";
 
-export const SET_TYPE_CYCLE: SetType[] = ["normal", "warmup", "dropset", "failure"];
+// BLD-1168: advanced set schemes appended so the cycle selector includes them.
+export const SET_TYPE_CYCLE: SetType[] = ["normal", "warmup", "dropset", "failure", "rest_pause", "cluster", "myo_reps"];
 
 /** BLD-1168: one ordered mini-set within a rest-pause / cluster / myo-reps parent set. */
 export type SetSegment = {


### PR DESCRIPTION
## Summary

Implements BLD-1168 Slice 4: 4 named reps accessors for WorkoutSet rows and fixes the progression check in `lib/db/exercises.ts` to use the named accessor instead of `set.reps` directly.

## Changes

- **`lib/sets-accessors.ts`** (new): 4 named accessors:
  - `getWorkingRepsForOverloadDecision` — first segment for advanced, `set.reps` for legacy
  - `getEffortRepsForPlateau` — activation segment for myo_reps/rest_pause/cluster
  - `getHeaviestSegmentReps` — max segment reps
  - `getTotalRepsForVolume` — sum of all segment reps
- **`lib/db/exercises.ts`**: `getProgressionSuggestion()` now loads segments and calls `getWorkingRepsForOverloadDecision()` instead of comparing `set.reps` to 12 directly (fixes false positives for advanced set types where `set.reps` is the sum of all mini-set reps)
- **`__tests__/set-accessors.test.ts`** (new): 20 unit tests — AC #270 and AC #271 verified

## Testing

- All 20 accessor tests pass
- TSC: 0 errors

## Issue

Resolves BLD-1172