### PR TITLE
feat(BLD-1175): Slice 7 — MiniSetEditor component + ExerciseGroupRow a11y integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ marker) at release time.
 
 - Progression suggestions now correctly evaluate advanced set types (rest-pause, cluster, myo-reps) using the working-set reps of the activation segment, rather than the inflated total-reps sum.
 - **CSV export/import round-trip for advanced sets**: rest-pause, cluster, and myo-rep set segment data (reps, weights, rests per mini-set) is now preserved when you export and re-import your workout CSV. Unknown set types in imported CSVs are automatically normalised to "normal" instead of being silently dropped.
+- **Advanced set types — Mini-set editor**: Rest-pause, cluster, and myo-rep sets now show an inline mini-set editor during active sessions. Tap to log each sub-rep burst, long-press a mini-set row to delete it, or collapse all mini-sets back into a single normal set. Up to 8 mini-sets per parent set are supported.
 
 ## v0.26.33 — 2026-05-12
 <!-- versionCode: 103 -->

--- a/__tests__/a11y-advanced-sets.test.tsx
+++ b/__tests__/a11y-advanced-sets.test.tsx
@@ -1,0 +1,319 @@
+/**
+ * BLD-1168 Slice 7 — Accessibility tests for advanced set display.
+ *
+ * AC #263 (plan line 263): GIVEN VoiceOver/TalkBack is enabled WHEN focus
+ * reaches an advanced set parent row THEN the announcement includes the set
+ * type and mini-set count (e.g., "Rest-pause set with 3 mini-sets").
+ *
+ * Also covers: compact reps format in history display, proper badge colours
+ * for RP/CL/MR set types.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { ExerciseGroupRow } from "@/components/session/detail/ExerciseGroupRow";
+import type { ExerciseGroup } from "@/hooks/useSessionDetail";
+import type { SetSegment } from "@/lib/types";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock("@/lib/db/sets", () => {
+  const VALID = new Set(["normal", "warmup", "dropset", "rest_pause", "cluster", "myo_reps"]);
+  return {
+    ADVANCED_SET_TYPES: new Set(["rest_pause", "cluster", "myo_reps"]),
+    normalizeSetType: (raw: unknown) => (typeof raw === "string" && VALID.has(raw) ? raw : "normal"),
+  };
+});
+
+const mockColors = {
+  primary: "#6200ee",
+  primaryContainer: "#e8def8",
+  onPrimary: "#ffffff",
+  onPrimaryContainer: "#21005d",
+  secondaryContainer: "#e8def8",
+  onSecondaryContainer: "#1d192b",
+  onSurface: "#1c1b1f",
+  onSurfaceVariant: "#49454f",
+  surface: "#fffbfe",
+  surfaceVariant: "#e7e0ec",
+  tertiaryContainer: "#f8e1e7",
+  onTertiaryContainer: "#31101d",
+  errorContainer: "#ffdad6",
+  onErrorContainer: "#410002",
+  error: "#b3261e",
+  outline: "#79747e",
+  background: "#fffbfe",
+  onError: "#ffffff",
+} as Parameters<typeof ExerciseGroupRow>[0]["colors"];
+
+// ─── Factories ────────────────────────────────────────────────────────────────
+
+let counter = 0;
+function uid() { return `test-${++counter}`; }
+
+function makeSegment(reps: number, num: number): SetSegment {
+  return {
+    id: uid(),
+    set_id: "set-1",
+    segment_number: num,
+    reps,
+    weight: null,
+    rest_after_seconds: null,
+    completed_at: null,
+    created_at: Date.now(),
+  };
+}
+
+function makeGroup(overrides: Partial<ExerciseGroup> = {}): ExerciseGroup {
+  return {
+    exercise_id: uid(),
+    name: "Bench Press",
+    link_id: null,
+    swapped_from_name: null,
+    sets: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => { counter = 0; });
+
+// ─── AC #263: VoiceOver announcement ─────────────────────────────────────────
+
+describe("ExerciseGroupRow — advanced set a11y (AC #263)", () => {
+  it("announces 'Rest-pause set with 3 mini-sets' when 3 segments are present", () => {
+    const segments = [
+      makeSegment(8, 1),
+      makeSegment(3, 2),
+      makeSegment(2, 3),
+    ];
+    const group = makeGroup({
+      sets: [{
+        id: "set-1",
+        session_id: "sess-1",
+        exercise_id: "ex-1",
+        set_number: 1,
+        weight: 100,
+        reps: 13,
+        completed: true,
+        completed_at: Date.now(),
+        rpe: null,
+        notes: "",
+        link_id: null,
+        round: null,
+        tempo: null,
+        swapped_from_exercise_id: null,
+        set_type: "rest_pause",
+        duration_seconds: null,
+        exercise_position: 0,
+        segments,
+      }],
+    });
+
+    const { getByLabelText } = render(
+      <ExerciseGroupRow
+        group={group}
+        groups={[group]}
+        linkIds={[]}
+        palette={[]}
+        colors={mockColors}
+      />,
+    );
+
+    const row = getByLabelText(/Rest-pause set with 3 mini-sets/i);
+    expect(row).toBeTruthy();
+  });
+
+  it("announces 'Rest-pause set with 1 mini-set' (singular) for 1 segment", () => {
+    const segments = [makeSegment(8, 1)];
+    const group = makeGroup({
+      sets: [{
+        id: "set-1",
+        session_id: "sess-1",
+        exercise_id: "ex-1",
+        set_number: 1,
+        weight: 100,
+        reps: 8,
+        completed: true,
+        completed_at: Date.now(),
+        rpe: null,
+        notes: "",
+        link_id: null,
+        round: null,
+        tempo: null,
+        swapped_from_exercise_id: null,
+        set_type: "rest_pause",
+        duration_seconds: null,
+        exercise_position: 0,
+        segments,
+      }],
+    });
+
+    const { getByLabelText } = render(
+      <ExerciseGroupRow
+        group={group}
+        groups={[group]}
+        linkIds={[]}
+        palette={[]}
+        colors={mockColors}
+      />,
+    );
+
+    const row = getByLabelText(/Rest-pause set with 1 mini-set/i);
+    expect(row).toBeTruthy();
+    // Must NOT say "mini-sets" (plural)
+    expect(row.props.accessibilityLabel).not.toContain("mini-sets");
+  });
+
+  it("announces 'Cluster set with 3 mini-sets' for cluster type", () => {
+    const segments = [makeSegment(3, 1), makeSegment(3, 2), makeSegment(2, 3)];
+    const group = makeGroup({
+      sets: [{
+        id: "set-2",
+        session_id: "sess-1",
+        exercise_id: "ex-1",
+        set_number: 1,
+        weight: 100,
+        reps: 8,
+        completed: true,
+        completed_at: Date.now(),
+        rpe: null,
+        notes: "",
+        link_id: null,
+        round: null,
+        tempo: null,
+        swapped_from_exercise_id: null,
+        set_type: "cluster",
+        duration_seconds: null,
+        exercise_position: 0,
+        segments,
+      }],
+    });
+
+    const { getByLabelText } = render(
+      <ExerciseGroupRow
+        group={group}
+        groups={[group]}
+        linkIds={[]}
+        palette={[]}
+        colors={mockColors}
+      />,
+    );
+
+    expect(getByLabelText(/Cluster set with 3 mini-sets/i)).toBeTruthy();
+  });
+
+  it("announces 'Myo-reps set, no mini-sets yet' when no segments", () => {
+    const group = makeGroup({
+      sets: [{
+        id: "set-3",
+        session_id: "sess-1",
+        exercise_id: "ex-1",
+        set_number: 1,
+        weight: 25,
+        reps: 0,
+        completed: true,
+        completed_at: Date.now(),
+        rpe: null,
+        notes: "",
+        link_id: null,
+        round: null,
+        tempo: null,
+        swapped_from_exercise_id: null,
+        set_type: "myo_reps",
+        duration_seconds: null,
+        exercise_position: 0,
+        segments: [],
+      }],
+    });
+
+    const { getByLabelText } = render(
+      <ExerciseGroupRow
+        group={group}
+        groups={[group]}
+        linkIds={[]}
+        palette={[]}
+        colors={mockColors}
+      />,
+    );
+
+    expect(getByLabelText(/Myo-reps set, no mini-sets yet/i)).toBeTruthy();
+  });
+});
+
+// ─── Compact reps display ─────────────────────────────────────────────────────
+
+describe("ExerciseGroupRow — compact reps display", () => {
+  it("shows '8+3+2 (13)' in body text for rest_pause with 3 segments (AC #255)", () => {
+    const segments = [makeSegment(8, 1), makeSegment(3, 2), makeSegment(2, 3)];
+    const group = makeGroup({
+      sets: [{
+        id: "set-1",
+        session_id: "sess-1",
+        exercise_id: "ex-1",
+        set_number: 1,
+        weight: 100,
+        reps: 13,
+        completed: true,
+        completed_at: Date.now(),
+        rpe: null,
+        notes: "",
+        link_id: null,
+        round: null,
+        tempo: null,
+        swapped_from_exercise_id: null,
+        set_type: "rest_pause",
+        duration_seconds: null,
+        exercise_position: 0,
+        segments,
+      }],
+    });
+
+    const { getByText } = render(
+      <ExerciseGroupRow
+        group={group}
+        groups={[group]}
+        linkIds={[]}
+        palette={[]}
+        colors={mockColors}
+      />,
+    );
+
+    expect(getByText(/8\+3\+2 \(13\)/)).toBeTruthy();
+  });
+
+  it("shows plain reps for non-advanced set types", () => {
+    const group = makeGroup({
+      sets: [{
+        id: "set-1",
+        session_id: "sess-1",
+        exercise_id: "ex-1",
+        set_number: 1,
+        weight: 60,
+        reps: 10,
+        completed: true,
+        completed_at: Date.now(),
+        rpe: null,
+        notes: "",
+        link_id: null,
+        round: null,
+        tempo: null,
+        swapped_from_exercise_id: null,
+        set_type: "normal",
+        duration_seconds: null,
+        exercise_position: 0,
+      }],
+    });
+
+    const { getByText } = render(
+      <ExerciseGroupRow
+        group={group}
+        groups={[group]}
+        linkIds={[]}
+        palette={[]}
+        colors={mockColors}
+      />,
+    );
+
+    expect(getByText("60 × 10")).toBeTruthy();
+  });
+});

--- a/__tests__/lib/db/mini-set-editor-regressions.test.ts
+++ b/__tests__/lib/db/mini-set-editor-regressions.test.ts
@@ -27,6 +27,8 @@ jest.mock('expo-sqlite', () => ({
 
 let mockInsertedRows: any[] = [];
 let mockSegmentsForSet: any[] = [];
+let mockUpdatePayloads: any[] = [];
+let mockGetResult: any = undefined;
 
 jest.mock('drizzle-orm/expo-sqlite', () => ({
   drizzle: jest.fn(() => ({
@@ -40,7 +42,7 @@ jest.mock('drizzle-orm/expo-sqlite', () => ({
         orderBy: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
         offset: jest.fn().mockReturnThis(),
-        get: jest.fn(() => undefined),
+        get: jest.fn(() => mockGetResult),
         all: jest.fn(() => mockSegmentsForSet),
         then: (r: any) => Promise.resolve(mockSegmentsForSet).then(r),
       };
@@ -54,7 +56,11 @@ jest.mock('drizzle-orm/expo-sqlite', () => ({
       return c;
     }),
     update: jest.fn(() => {
-      const c: any = { set: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), then: (r: any) => Promise.resolve().then(r) };
+      const c: any = {
+        set: jest.fn((v: any) => { mockUpdatePayloads.push(v); return c; }),
+        where: jest.fn().mockReturnThis(),
+        then: (r: any) => Promise.resolve().then(r),
+      };
       return c;
     }),
     delete: jest.fn(() => {
@@ -66,12 +72,14 @@ jest.mock('drizzle-orm/expo-sqlite', () => ({
 
 jest.mock('../../../lib/uuid', () => ({ uuid: jest.fn(() => 'mock-uuid') }));
 
-import { insertSegment, deleteAllSegmentsForSet, getSegmentsForSets } from '../../../lib/db/sets';
+import { insertSegment, collapseAdvancedSetToNormal, getSegmentsForSets, computeSetCacheValues } from '../../../lib/db/sets';
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockInsertedRows = [];
   mockSegmentsForSet = [];
+  mockUpdatePayloads = [];
+  mockGetResult = undefined;
   mockDb.getAllAsync.mockResolvedValue([]);
   mockDb.getFirstAsync.mockResolvedValue(null);
   mockDb.runAsync.mockResolvedValue({ changes: 1 });
@@ -126,51 +134,98 @@ describe('collapse-to-normal reps sum', () => {
   });
 });
 
-// ── Blocker 3: MAX+1 segment_number strategy avoids collisions ──────────────
-describe('segment_number MAX+1 strategy', () => {
+// ── Blocker 3: deleteSegment renumbers contiguously, so length+1 is safe ────
+describe('post-delete contiguous renumbering strategy', () => {
   it('returns 1 when there are no existing segments', () => {
     const segments: any[] = [];
-    const nextNum = segments.length > 0
-      ? Math.max(...segments.map((s) => s.segment_number)) + 1
-      : 1;
+    const nextNum = segments.length + 1;
     expect(nextNum).toBe(1);
   });
 
-  it('returns MAX+1 for a contiguous list [1,2,3]', () => {
+  it('returns length+1 (=4) for a contiguous list [1,2,3]', () => {
     const segments = [
       { segment_number: 1 }, { segment_number: 2 }, { segment_number: 3 },
     ];
-    const nextNum = segments.length > 0
-      ? Math.max(...segments.map((s) => s.segment_number)) + 1
-      : 1;
+    const nextNum = segments.length + 1;
     expect(nextNum).toBe(4);
   });
 
-  it('returns 9 after deleting segment 4 from [1,2,3,5,6,7,8] (max=8)', () => {
-    // Simulates: had 8 segments (1..8), deleted segment 4 → 7 remain
-    // existingCount would be 7 → 7+1=8 collision! MAX+1 → 8+1=9, safe.
-    const segments = [
+  it('after deleting one of 8, remaining are renumbered to 1..7 and next slot is 8 (never 9)', () => {
+    // Post-deleteSegment invariant: the DB is renumbered to contiguous 1..N.
+    // The hook's view of `set.segments` is reloaded after the delete and reflects
+    // the renumbered state, so length+1 is always the correct next slot.
+    const renumberedAfterDelete = [
       { segment_number: 1 }, { segment_number: 2 }, { segment_number: 3 },
-      { segment_number: 5 }, { segment_number: 6 }, { segment_number: 7 },
-      { segment_number: 8 },
+      { segment_number: 4 }, { segment_number: 5 }, { segment_number: 6 },
+      { segment_number: 7 },
     ];
-    const nextNum = segments.length > 0
-      ? Math.max(...segments.map((s) => s.segment_number)) + 1
-      : 1;
-    expect(nextNum).toBe(9);
-    // Confirm the buggy approach would collide:
-    const buggyNextNum = segments.length + 1; // 7+1 = 8, which already exists!
-    expect(buggyNextNum).toBe(8);
-    expect(segments.some((s) => s.segment_number === buggyNextNum)).toBe(true);
+    const nextNum = renumberedAfterDelete.length + 1;
+    expect(nextNum).toBe(8);
+    // And we never exceed the 8-cap, so labels like "Mini-set 9 of 8" cannot occur.
+    expect(nextNum).toBeLessThanOrEqual(8);
   });
 
-  it('handles gap at start: segments [3,4,5] → next is 6', () => {
-    const segments = [
-      { segment_number: 3 }, { segment_number: 4 }, { segment_number: 5 },
+  it('handles full cap: with 8 segments the next slot is 9 (caller enforces 8-cap before insert)', () => {
+    const segments = Array.from({ length: 8 }, (_, i) => ({ segment_number: i + 1 }));
+    const nextNum = segments.length + 1;
+    expect(nextNum).toBe(9);
+    // The MiniSetEditor refuses to call handleAddSegment when segments.length >= 8.
+  });
+});
+
+// ── Blocker (QD): collapseAdvancedSetToNormal writes Σreps AND legacy caches ─
+describe('collapseAdvancedSetToNormal: cache-correctness', () => {
+  it('computes legacy caches from parent.weight × Σreps via computeSetCacheValues', () => {
+    // The pure-function backbone of collapseAdvancedSetToNormal — proves the
+    // values that get written for `[5,3,2]` collapsed onto a 100kg set.
+    // Σreps=10 stays under the BLD-1183 e1RM validity cap (reps<=12) so the
+    // assertion proves cached_e1rm_kg is non-zero.
+    const summedReps = [5, 3, 2].reduce((s, r) => s + r, 0); // 10
+    const { cachedVolumeKg, cachedE1rmKg, totalReps } = computeSetCacheValues(
+      { weight: 100, reps: summedReps, isAdvancedSet: false },
+      [],
+    );
+    expect(totalReps).toBe(10);
+    expect(cachedVolumeKg).toBe(100 * 10);
+    // Epley: w * (1 + r/30)
+    expect(cachedE1rmKg).toBeCloseTo(100 * (1 + 10 / 30), 6);
+  });
+
+  it('writes set_type=normal AND reps=Σ AND non-zero cached_volume_kg/cached_e1rm_kg in a single UPDATE', async () => {
+    // Parent set: 100kg. Three mini-sets: 5 + 3 + 2 = 10 reps (under BLD-1183 e1RM cap).
+    mockGetResult = { id: 'set-1', weight: 100 };
+    mockSegmentsForSet = [
+      { id: 's1', set_id: 'set-1', segment_number: 1, reps: 5, weight: null },
+      { id: 's2', set_id: 'set-1', segment_number: 2, reps: 3, weight: null },
+      { id: 's3', set_id: 'set-1', segment_number: 3, reps: 2, weight: null },
     ];
-    const nextNum = segments.length > 0
-      ? Math.max(...segments.map((s) => s.segment_number)) + 1
-      : 1;
-    expect(nextNum).toBe(6);
+
+    const summed = await collapseAdvancedSetToNormal('set-1');
+    expect(summed).toBe(10);
+
+    // Find the workout_sets UPDATE payload (the one that includes set_type).
+    const parentUpdate = mockUpdatePayloads.find((p) => p && 'set_type' in p);
+    expect(parentUpdate).toBeDefined();
+    expect(parentUpdate.set_type).toBe('normal');
+    expect(parentUpdate.reps).toBe(10);
+    expect(parentUpdate.cached_volume_kg).toBe(100 * 10);
+    expect(parentUpdate.cached_e1rm_kg).toBeCloseTo(100 * (1 + 10 / 30), 6);
+    // Critical: caches must NOT be zero — that was the QD blocker.
+    expect(parentUpdate.cached_volume_kg).toBeGreaterThan(0);
+    expect(parentUpdate.cached_e1rm_kg).toBeGreaterThan(0);
+  });
+
+  it('returns 0 and writes reps=null when collapsing a set that has no segments', async () => {
+    mockGetResult = { id: 'set-1', weight: 100 };
+    mockSegmentsForSet = [];
+
+    const summed = await collapseAdvancedSetToNormal('set-1');
+    expect(summed).toBe(0);
+
+    const parentUpdate = mockUpdatePayloads.find((p) => p && 'set_type' in p);
+    expect(parentUpdate.set_type).toBe('normal');
+    expect(parentUpdate.reps).toBeNull();
+    expect(parentUpdate.cached_volume_kg).toBe(0);
+    expect(parentUpdate.cached_e1rm_kg).toBe(0);
   });
 });

--- a/__tests__/lib/db/mini-set-editor-regressions.test.ts
+++ b/__tests__/lib/db/mini-set-editor-regressions.test.ts
@@ -1,0 +1,176 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Regression tests for BLD-1175 reviewer Round 3 blockers:
+ *
+ * 1. nextReps param — handleAddSegment uses caller-supplied reps, not hardcoded 1
+ * 2. collapse-to-normal preserves Σreps
+ * 3. segment_number collision — MAX+1 strategy avoids duplicate segment numbers
+ */
+
+const mockStmt = {
+  executeAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  finalizeAsync: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockDb = {
+  execAsync: jest.fn().mockResolvedValue(undefined),
+  getAllAsync: jest.fn().mockResolvedValue([]),
+  getFirstAsync: jest.fn().mockResolvedValue(null),
+  runAsync: jest.fn().mockResolvedValue({ changes: 1 }),
+  withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
+  prepareAsync: jest.fn().mockResolvedValue(mockStmt),
+};
+
+jest.mock('expo-sqlite', () => ({
+  openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+}));
+
+let mockInsertedRows: any[] = [];
+let mockSegmentsForSet: any[] = [];
+
+jest.mock('drizzle-orm/expo-sqlite', () => ({
+  drizzle: jest.fn(() => ({
+    select: jest.fn(() => {
+      const chain: any = {
+        from: jest.fn().mockReturnThis(),
+        leftJoin: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        offset: jest.fn().mockReturnThis(),
+        get: jest.fn(() => undefined),
+        all: jest.fn(() => mockSegmentsForSet),
+        then: (r: any) => Promise.resolve(mockSegmentsForSet).then(r),
+      };
+      return chain;
+    }),
+    insert: jest.fn(() => {
+      const c: any = {
+        values: jest.fn((v: any) => { mockInsertedRows.push(v); return c; }),
+        then: (r: any) => Promise.resolve().then(r),
+      };
+      return c;
+    }),
+    update: jest.fn(() => {
+      const c: any = { set: jest.fn().mockReturnThis(), where: jest.fn().mockReturnThis(), then: (r: any) => Promise.resolve().then(r) };
+      return c;
+    }),
+    delete: jest.fn(() => {
+      const c: any = { where: jest.fn().mockReturnThis(), then: (r: any) => Promise.resolve().then(r) };
+      return c;
+    }),
+  })),
+}));
+
+jest.mock('../../../lib/uuid', () => ({ uuid: jest.fn(() => 'mock-uuid') }));
+
+import { insertSegment, deleteAllSegmentsForSet, getSegmentsForSets } from '../../../lib/db/sets';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockInsertedRows = [];
+  mockSegmentsForSet = [];
+  mockDb.getAllAsync.mockResolvedValue([]);
+  mockDb.getFirstAsync.mockResolvedValue(null);
+  mockDb.runAsync.mockResolvedValue({ changes: 1 });
+  mockDb.withTransactionAsync.mockImplementation(async (cb: () => Promise<void>) => cb());
+});
+
+// ── Blocker 1: insertSegment uses caller-supplied reps (not hardcoded 1) ────
+describe('insertSegment uses caller-supplied reps', () => {
+  it('inserts segment with reps=8 when called with reps=8', async () => {
+    await insertSegment({ setId: 'set-1', segmentNumber: 1, reps: 8, weight: null });
+    expect(mockInsertedRows[0]).toMatchObject({ set_id: 'set-1', segment_number: 1, reps: 8 });
+  });
+
+  it('inserts segment with reps=3 when called with reps=3', async () => {
+    await insertSegment({ setId: 'set-1', segmentNumber: 2, reps: 3, weight: null });
+    expect(mockInsertedRows[0]).toMatchObject({ reps: 3 });
+  });
+
+  it('does NOT default to reps=1 when caller passes reps=5', async () => {
+    await insertSegment({ setId: 'set-1', segmentNumber: 1, reps: 5, weight: null });
+    expect(mockInsertedRows[0].reps).toBe(5);
+    expect(mockInsertedRows[0].reps).not.toBe(1);
+  });
+});
+
+// ── Blocker 2: collapse-to-normal reps sum logic ────────────────────────────
+describe('collapse-to-normal reps sum', () => {
+  it('sums [8, 3, 2] to 13', () => {
+    const segments = [
+      { id: 's1', set_id: 'set-1', segment_number: 1, reps: 8, weight: null },
+      { id: 's2', set_id: 'set-1', segment_number: 2, reps: 3, weight: null },
+      { id: 's3', set_id: 'set-1', segment_number: 3, reps: 2, weight: null },
+    ];
+    const total = segments.reduce((sum, seg) => sum + seg.reps, 0);
+    expect(total).toBe(13);
+  });
+
+  it('sums [6, 4, 2] to 12', () => {
+    const segments = [
+      { id: 's1', set_id: 'set-1', segment_number: 1, reps: 6, weight: null },
+      { id: 's2', set_id: 'set-1', segment_number: 2, reps: 4, weight: null },
+      { id: 's3', set_id: 'set-1', segment_number: 3, reps: 2, weight: null },
+    ];
+    const total = segments.reduce((sum, seg) => sum + seg.reps, 0);
+    expect(total).toBe(12);
+  });
+
+  it('returns 0 for empty segments array', () => {
+    const segments: any[] = [];
+    const total = segments.reduce((sum: number, seg: any) => sum + seg.reps, 0);
+    expect(total).toBe(0);
+  });
+});
+
+// ── Blocker 3: MAX+1 segment_number strategy avoids collisions ──────────────
+describe('segment_number MAX+1 strategy', () => {
+  it('returns 1 when there are no existing segments', () => {
+    const segments: any[] = [];
+    const nextNum = segments.length > 0
+      ? Math.max(...segments.map((s) => s.segment_number)) + 1
+      : 1;
+    expect(nextNum).toBe(1);
+  });
+
+  it('returns MAX+1 for a contiguous list [1,2,3]', () => {
+    const segments = [
+      { segment_number: 1 }, { segment_number: 2 }, { segment_number: 3 },
+    ];
+    const nextNum = segments.length > 0
+      ? Math.max(...segments.map((s) => s.segment_number)) + 1
+      : 1;
+    expect(nextNum).toBe(4);
+  });
+
+  it('returns 9 after deleting segment 4 from [1,2,3,5,6,7,8] (max=8)', () => {
+    // Simulates: had 8 segments (1..8), deleted segment 4 → 7 remain
+    // existingCount would be 7 → 7+1=8 collision! MAX+1 → 8+1=9, safe.
+    const segments = [
+      { segment_number: 1 }, { segment_number: 2 }, { segment_number: 3 },
+      { segment_number: 5 }, { segment_number: 6 }, { segment_number: 7 },
+      { segment_number: 8 },
+    ];
+    const nextNum = segments.length > 0
+      ? Math.max(...segments.map((s) => s.segment_number)) + 1
+      : 1;
+    expect(nextNum).toBe(9);
+    // Confirm the buggy approach would collide:
+    const buggyNextNum = segments.length + 1; // 7+1 = 8, which already exists!
+    expect(buggyNextNum).toBe(8);
+    expect(segments.some((s) => s.segment_number === buggyNextNum)).toBe(true);
+  });
+
+  it('handles gap at start: segments [3,4,5] → next is 6', () => {
+    const segments = [
+      { segment_number: 3 }, { segment_number: 4 }, { segment_number: 5 },
+    ];
+    const nextNum = segments.length > 0
+      ? Math.max(...segments.map((s) => s.segment_number)) + 1
+      : 1;
+    expect(nextNum).toBe(6);
+  });
+});

--- a/__tests__/lib/db/warmup-sets.test.ts
+++ b/__tests__/lib/db/warmup-sets.test.ts
@@ -200,14 +200,20 @@ tempo: null,
 // ---- SET_TYPE_CYCLE order ----
 
 describe('SET_TYPE_CYCLE', () => {
-  it('has correct cycle order: normal → warmup → dropset → failure', () => {
-    expect(SET_TYPE_CYCLE).toEqual(['normal', 'warmup', 'dropset', 'failure']);
+  it('has correct cycle order: normal → warmup → dropset → failure → rest_pause → cluster → myo_reps', () => {
+    expect(SET_TYPE_CYCLE).toEqual(['normal', 'warmup', 'dropset', 'failure', 'rest_pause', 'cluster', 'myo_reps']);
   });
 
-  it('cycles back to normal after failure', () => {
+  it('cycles back to normal after myo_reps (last type)', () => {
+    const lastIdx = SET_TYPE_CYCLE.length - 1;
+    const next = SET_TYPE_CYCLE[(lastIdx + 1) % SET_TYPE_CYCLE.length];
+    expect(next).toBe('normal');
+  });
+
+  it('cycles from failure to rest_pause (BLD-1173 advanced types follow failure)', () => {
     const failureIdx = SET_TYPE_CYCLE.indexOf('failure');
     const next = SET_TYPE_CYCLE[(failureIdx + 1) % SET_TYPE_CYCLE.length];
-    expect(next).toBe('normal');
+    expect(next).toBe('rest_pause');
   });
 });
 

--- a/__tests__/mini-set-editor.test.tsx
+++ b/__tests__/mini-set-editor.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * BLD-1168 Slice 7 — MiniSetEditor component tests.
+ *
+ * AC #255 (plan line 256): GIVEN a user creates a working set and changes its
+ *   type to rest_pause WHEN they tap "+ mini-set" twice and enter (8, 3, 2)
+ *   reps THEN the parent row displays "8+3+2 (13)" and the segment callbacks
+ *   are called in order.
+ *
+ * AC #262 (plan line 262): GIVEN a user changes an advanced set with 3
+ *   mini-sets back to normal WHEN they confirm the prompt THEN
+ *   onCollapseToNormal is called; WHEN they cancel THEN nothing changes.
+ */
+
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { MiniSetEditor, MAX_MINI_SETS, WARN_MINI_SETS } from "../components/session/MiniSetEditor";
+import { formatMiniSetReps, formatAdvancedSetAccessibilityLabel } from "../lib/format";
+import type { SetSegment } from "@/lib/types";
+
+// ─── Mock: useThemeColors ─────────────────────────────────────────────────────
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#6200ee",
+    primaryContainer: "#e8def8",
+    onPrimary: "#ffffff",
+    onPrimaryContainer: "#21005d",
+    secondaryContainer: "#e8def8",
+    onSecondaryContainer: "#1d192b",
+    onSurface: "#1c1b1f",
+    onSurfaceVariant: "#49454f",
+    surface: "#fffbfe",
+    surfaceVariant: "#e7e0ec",
+    tertiaryContainer: "#f8e1e7",
+    onTertiaryContainer: "#31101d",
+    errorContainer: "#ffdad6",
+    onErrorContainer: "#410002",
+    error: "#b3261e",
+    outline: "#79747e",
+    background: "#fffbfe",
+  }),
+}));
+
+// ─── Mock: Alert (spy on Alert.alert so we can control confirm/cancel) ────────
+
+import { Alert } from "react-native";
+let alertSpy: jest.SpyInstance;
+
+// ─── Helper factory ───────────────────────────────────────────────────────────
+
+let segCounter = 0;
+function makeSegment(overrides: Partial<SetSegment> = {}): SetSegment {
+  return {
+    id: `seg-${++segCounter}`,
+    set_id: "set-1",
+    segment_number: segCounter,
+    reps: 8,
+    weight: null,
+    rest_after_seconds: null,
+    completed_at: null,
+    created_at: Date.now(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  segCounter = 0;
+  alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  alertSpy.mockRestore();
+});
+
+// ─── Pure function: formatMiniSetReps ─────────────────────────────────────────
+
+describe("formatMiniSetReps", () => {
+  it("returns '0' for empty segments", () => {
+    expect(formatMiniSetReps([])).toBe("0");
+  });
+
+  it("returns joined reps without total for 1 segment", () => {
+    expect(formatMiniSetReps([{ reps: 8 }])).toBe("8");
+  });
+
+  it("returns joined reps without total for 2 segments", () => {
+    expect(formatMiniSetReps([{ reps: 8 }, { reps: 3 }])).toBe("8+3");
+  });
+
+  it("returns joined reps WITH total for 3 segments (AC #255)", () => {
+    expect(formatMiniSetReps([{ reps: 8 }, { reps: 3 }, { reps: 2 }])).toBe("8+3+2 (13)");
+  });
+
+  it("returns correct total for 5 myo-rep segments", () => {
+    expect(formatMiniSetReps([
+      { reps: 15 }, { reps: 5 }, { reps: 5 }, { reps: 4 }, { reps: 3 },
+    ])).toBe("15+5+5+4+3 (32)");
+  });
+});
+
+// ─── Pure function: formatAdvancedSetAccessibilityLabel ───────────────────────
+
+describe("formatAdvancedSetAccessibilityLabel", () => {
+  it("returns single mini-set label", () => {
+    expect(formatAdvancedSetAccessibilityLabel("Rest-pause", 1)).toBe(
+      "Rest-pause set with 1 mini-set",
+    );
+  });
+
+  it("returns plural mini-set label for 3 mini-sets (AC #263)", () => {
+    expect(formatAdvancedSetAccessibilityLabel("Rest-pause", 3)).toBe(
+      "Rest-pause set with 3 mini-sets",
+    );
+  });
+
+  it("returns no-mini-sets label when count is 0", () => {
+    expect(formatAdvancedSetAccessibilityLabel("Cluster", 0)).toBe(
+      "Cluster set, no mini-sets yet",
+    );
+  });
+});
+
+// ─── MiniSetEditor component ──────────────────────────────────────────────────
+
+function renderEditor(
+  segments: SetSegment[],
+  {
+    onAddSegment = jest.fn().mockResolvedValue(undefined),
+    onDeleteSegment = jest.fn().mockResolvedValue(undefined),
+    onCollapseToNormal = jest.fn().mockResolvedValue(undefined),
+  }: {
+    onAddSegment?: jest.Mock;
+    onDeleteSegment?: jest.Mock;
+    onCollapseToNormal?: jest.Mock;
+  } = {},
+) {
+  return render(
+    <MiniSetEditor
+      setId="set-1"
+      segments={segments}
+      onAddSegment={onAddSegment}
+      onDeleteSegment={onDeleteSegment}
+      onCollapseToNormal={onCollapseToNormal}
+    />,
+  );
+}
+
+describe("MiniSetEditor — add segment", () => {
+  it("renders the + mini-set button", () => {
+    const { getByTestId } = renderEditor([]);
+    expect(getByTestId("mini-set-add-button")).toBeTruthy();
+  });
+
+  it("calls onAddSegment when + mini-set is tapped", () => {
+    const onAdd = jest.fn().mockResolvedValue(undefined);
+    const { getByTestId } = renderEditor([], { onAddSegment: onAdd });
+    fireEvent.press(getByTestId("mini-set-add-button"));
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows existing segments as rows", () => {
+    const segs = [
+      makeSegment({ reps: 8, segment_number: 1 }),
+      makeSegment({ reps: 3, segment_number: 2 }),
+    ];
+    const { getByTestId } = renderEditor(segs);
+    expect(getByTestId(`mini-set-segment-${segs[0].id}`)).toBeTruthy();
+    expect(getByTestId(`mini-set-segment-${segs[1].id}`)).toBeTruthy();
+  });
+
+  it("AC #255: three segments display total reps correctly", () => {
+    const segs = [
+      makeSegment({ reps: 8, segment_number: 1 }),
+      makeSegment({ reps: 3, segment_number: 2 }),
+      makeSegment({ reps: 2, segment_number: 3 }),
+    ];
+    const { getByText } = renderEditor(segs);
+    // Total should be shown in the action row
+    expect(getByText("Total: 13")).toBeTruthy();
+  });
+
+  it("disables the + button at MAX_MINI_SETS", () => {
+    const segs = Array.from({ length: MAX_MINI_SETS }, (_, i) =>
+      makeSegment({ segment_number: i + 1, reps: 3 }),
+    );
+    const onAdd = jest.fn();
+    const { getByTestId } = renderEditor(segs, { onAddSegment: onAdd });
+    fireEvent.press(getByTestId("mini-set-add-button"));
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it("shows warn text at WARN_MINI_SETS", () => {
+    const segs = Array.from({ length: WARN_MINI_SETS }, (_, i) =>
+      makeSegment({ segment_number: i + 1, reps: 3 }),
+    );
+    const { getByText } = renderEditor(segs);
+    expect(getByText(/One more mini-set remaining/)).toBeTruthy();
+  });
+
+  it("shows max-reached text at MAX_MINI_SETS", () => {
+    const segs = Array.from({ length: MAX_MINI_SETS }, (_, i) =>
+      makeSegment({ segment_number: i + 1, reps: 3 }),
+    );
+    const { getByText } = renderEditor(segs);
+    expect(getByText(/Maximum 8 mini-sets reached/)).toBeTruthy();
+  });
+});
+
+describe("MiniSetEditor — delete segment", () => {
+  it("shows a delete confirmation when a segment row is long-pressed", () => {
+    const seg = makeSegment({ reps: 8, segment_number: 1 });
+    const { getByTestId } = renderEditor([seg]);
+    fireEvent(getByTestId(`mini-set-segment-${seg.id}`), "longPress");
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Delete mini-set?",
+      expect.stringContaining("8 reps"),
+      expect.arrayContaining([
+        expect.objectContaining({ text: "Cancel" }),
+        expect.objectContaining({ text: "Delete" }),
+      ]),
+    );
+  });
+
+  it("calls onDeleteSegment when delete is confirmed", () => {
+    const seg = makeSegment({ reps: 8, segment_number: 1 });
+    const onDelete = jest.fn().mockResolvedValue(undefined);
+    const { getByTestId } = renderEditor([seg], { onDeleteSegment: onDelete });
+
+    // Press long-press → capture the "Delete" action → call its onPress
+    fireEvent(getByTestId(`mini-set-segment-${seg.id}`), "longPress");
+    const [, , buttons] = alertSpy.mock.calls[0];
+    const deleteBtn = buttons.find((b: { text: string }) => b.text === "Delete");
+    deleteBtn.onPress();
+    expect(onDelete).toHaveBeenCalledWith(seg.id);
+  });
+
+  it("does NOT call onDeleteSegment when cancel is pressed (AC #262)", () => {
+    const seg = makeSegment({ reps: 8, segment_number: 1 });
+    const onDelete = jest.fn();
+    const { getByTestId } = renderEditor([seg], { onDeleteSegment: onDelete });
+
+    fireEvent(getByTestId(`mini-set-segment-${seg.id}`), "longPress");
+    const [, , buttons] = alertSpy.mock.calls[0];
+    // Cancel button has no onPress — nothing should fire
+    expect(buttons.find((b: { text: string }) => b.text === "Cancel")).toBeTruthy();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});
+
+describe("MiniSetEditor — collapse to normal (AC #262)", () => {
+  it("shows the Collapse button when segments > 0", () => {
+    const segs = [
+      makeSegment({ reps: 8, segment_number: 1 }),
+      makeSegment({ reps: 3, segment_number: 2 }),
+    ];
+    const { getByTestId } = renderEditor(segs);
+    expect(getByTestId("mini-set-collapse-button")).toBeTruthy();
+  });
+
+  it("hides the Collapse button when segments = 0", () => {
+    const { queryByTestId } = renderEditor([]);
+    expect(queryByTestId("mini-set-collapse-button")).toBeNull();
+  });
+
+  it("shows a confirmation dialog on Collapse press", () => {
+    const segs = [
+      makeSegment({ reps: 8, segment_number: 1 }),
+      makeSegment({ reps: 3, segment_number: 2 }),
+      makeSegment({ reps: 2, segment_number: 3 }),
+    ];
+    const { getByTestId } = renderEditor(segs);
+    fireEvent.press(getByTestId("mini-set-collapse-button"));
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Collapse mini-sets?",
+      expect.stringContaining("13 reps"),
+      expect.arrayContaining([
+        expect.objectContaining({ text: "Cancel" }),
+        expect.objectContaining({ text: "Yes, collapse" }),
+      ]),
+    );
+  });
+
+  it("calls onCollapseToNormal when confirmed (AC #262 — yes path)", () => {
+    const segs = [
+      makeSegment({ reps: 8, segment_number: 1 }),
+      makeSegment({ reps: 3, segment_number: 2 }),
+      makeSegment({ reps: 2, segment_number: 3 }),
+    ];
+    const onCollapse = jest.fn().mockResolvedValue(undefined);
+    const { getByTestId } = renderEditor(segs, { onCollapseToNormal: onCollapse });
+
+    fireEvent.press(getByTestId("mini-set-collapse-button"));
+    const [, , buttons] = alertSpy.mock.calls[0];
+    const confirmBtn = buttons.find((b: { text: string }) => b.text === "Yes, collapse");
+    confirmBtn.onPress();
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call onCollapseToNormal when cancel is pressed (AC #262 — cancel path)", () => {
+    const segs = [makeSegment({ reps: 8, segment_number: 1 })];
+    const onCollapse = jest.fn();
+    const { getByTestId } = renderEditor(segs, { onCollapseToNormal: onCollapse });
+
+    fireEvent.press(getByTestId("mini-set-collapse-button"));
+    // Cancel button has style: "cancel" and no onPress — nothing should fire
+    expect(onCollapse).not.toHaveBeenCalled();
+  });
+});
+
+describe("MiniSetEditor — accessibility", () => {
+  it("each segment row has a descriptive accessibilityLabel", () => {
+    const seg = makeSegment({ reps: 8, segment_number: 1, weight: 100 });
+    const { getByTestId } = renderEditor([seg]);
+    const row = getByTestId(`mini-set-segment-${seg.id}`);
+    expect(row.props.accessibilityLabel).toContain("Mini-set 1");
+    expect(row.props.accessibilityLabel).toContain("8 reps");
+    expect(row.props.accessibilityLabel).toContain("100 kg");
+  });
+
+  it("+ mini-set button has accessibilityRole button", () => {
+    const { getByTestId } = renderEditor([]);
+    const btn = getByTestId("mini-set-add-button");
+    expect(btn.props.accessibilityRole).toBe("button");
+  });
+});

--- a/app/session/[id].tsx
+++ b/app/session/[id].tsx
@@ -187,7 +187,9 @@ export default function ActiveSession() {
     handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes,
     handlePinnedNoteDraftChange, handleSavePinnedNote, handleDismissBackfill, handleLoadBackfill,
     handleMoveUp, handleMoveDown, handlePrefillFromPrevious, handleApplyBreakThrough,
-    handleMarkerConfirm, handleManualWeightSave, finish, cancel,
+    handleMarkerConfirm, handleManualWeightSave,
+    handleAddSegment, handleDeleteSegment, handleCollapseToNormal,
+    finish, cancel,
   } = useSessionActions({ id, groups, setGroups, updateGroupSet, startRest, startRestWithDuration, startRestWithBreakdown, dismissRest, session, showToast, showError, triggerPR, unit, suggestions });
 
   const {
@@ -500,9 +502,12 @@ export default function ActiveSession() {
       captureRpe={captureRpe}
       onRpeChange={handleRpeChange}
       showPulleyPin={pulleyPinTrackingEnabled} gymId={session?.gym_id ?? null} onMarkerConfirm={handleMarkerConfirm} onManualWeightSave={handleManualWeightSave}
+      onAddSegment={handleAddSegment}
+      onDeleteSegment={handleDeleteSegment}
+      onCollapseToNormal={handleCollapseToNormal}
     />
     );
-  }, [step, unit, suggestions, plateauHints, exerciseNotesOpen, exerciseNotesDraft, pinnedNoteDraft, linkIds, groups, palette, handleUpdate, handleCheck, handleDelete, handleAddSet, handleAddWarmups, handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes, handlePinnedNoteDraftChange, handleSavePinnedNote, handleDismissBackfill, handleLoadBackfill, handleCycleSetType, handleLongPressSetType, handleOpenBodyweightModifier, handleClearBodyweightModifier, variant, bodyweightGrip, handleShowDetail, handleSwapOpen, handleDeleteExercise, handleMoveUp, handleMoveDown, handlePrefillFromPrevious, handleApplyBreakThrough, timerExerciseId, timerSetIndex, timerIsRunning, timerDisplaySeconds, handleTimerStart, handleTimerStop, hasClipMap, handleVideoGlyph, handleOpenPulleyPinPicker, hasSetupPhotoMap, setupPhotoUriMap, handleSetupPhotoGlyph, captureRpe, handleRpeChange, pulleyPinTrackingEnabled, session?.gym_id, handleMarkerConfirm, handleManualWeightSave]);
+  }, [step, unit, suggestions, plateauHints, exerciseNotesOpen, exerciseNotesDraft, pinnedNoteDraft, linkIds, groups, palette, handleUpdate, handleCheck, handleDelete, handleAddSet, handleAddWarmups, handleExerciseNotes, handleExerciseNotesDraftChange, toggleExerciseNotes, handlePinnedNoteDraftChange, handleSavePinnedNote, handleDismissBackfill, handleLoadBackfill, handleCycleSetType, handleLongPressSetType, handleOpenBodyweightModifier, handleClearBodyweightModifier, variant, bodyweightGrip, handleShowDetail, handleSwapOpen, handleDeleteExercise, handleMoveUp, handleMoveDown, handlePrefillFromPrevious, handleApplyBreakThrough, timerExerciseId, timerSetIndex, timerIsRunning, timerDisplaySeconds, handleTimerStart, handleTimerStop, hasClipMap, handleVideoGlyph, handleOpenPulleyPinPicker, hasSetupPhotoMap, setupPhotoUriMap, handleSetupPhotoGlyph, captureRpe, handleRpeChange, pulleyPinTrackingEnabled, session?.gym_id, handleMarkerConfirm, handleManualWeightSave, handleAddSegment, handleDeleteSegment, handleCollapseToNormal]);
 
   const listHeader = useMemo(() => (
     <SessionListHeader nextHint={nextHint} gymName={session?.gym_name_at_log ?? null} colors={colors} />

--- a/components/session/ExerciseGroupCard.tsx
+++ b/components/session/ExerciseGroupCard.tsx
@@ -83,6 +83,10 @@ export type GroupCardProps = {
   gymId?: string | null;
   onMarkerConfirm?: (setId: string, result: { stackId: string; stackName: string; marker: number; trueWeight: number; unit: string }) => void;
   onManualWeightSave?: (setId: string, weight: number | null, reps: number | null) => void;
+  /** BLD-1175: Mini-set segment handlers. */
+  onAddSegment?: (setId: string) => Promise<void> | void;
+  onDeleteSegment?: (segmentId: string, setId: string) => Promise<void> | void;
+  onCollapseToNormal?: (setId: string) => Promise<void> | void;
 };
 
 export const ExerciseGroupCard = memo(function ExerciseGroupCard({
@@ -104,6 +108,7 @@ export const ExerciseGroupCard = memo(function ExerciseGroupCard({
   onOpenPulleyPinPicker, showPulleyPin, hasSetupPhotoMap, setupPhotoUriMap, onSetupPhotoGlyph,
   captureRpe, onRpeChange,
   gymId, onMarkerConfirm, onManualWeightSave,
+  onAddSegment, onDeleteSegment, onCollapseToNormal,
 }: GroupCardProps) {
   const colors = useThemeColors();
   // BLD-1130 G3: lift `useActiveCalibration` out of `SetRow` (it was previously
@@ -174,6 +179,9 @@ export const ExerciseGroupCard = memo(function ExerciseGroupCard({
       stacks={stacks}
       onMarkerConfirm={onMarkerConfirm}
       onManualWeightSave={onManualWeightSave}
+      onAddSegment={onAddSegment}
+      onDeleteSegment={onDeleteSegment}
+      onCollapseToNormal={onCollapseToNormal}
     />
   );
 

--- a/components/session/ExerciseGroupCard.tsx
+++ b/components/session/ExerciseGroupCard.tsx
@@ -84,7 +84,7 @@ export type GroupCardProps = {
   onMarkerConfirm?: (setId: string, result: { stackId: string; stackName: string; marker: number; trueWeight: number; unit: string }) => void;
   onManualWeightSave?: (setId: string, weight: number | null, reps: number | null) => void;
   /** BLD-1175: Mini-set segment handlers. */
-  onAddSegment?: (setId: string) => Promise<void> | void;
+  onAddSegment?: (setId: string, reps: number) => Promise<void> | void;
   onDeleteSegment?: (segmentId: string, setId: string) => Promise<void> | void;
   onCollapseToNormal?: (setId: string) => Promise<void> | void;
 };

--- a/components/session/ExerciseGroupSetTable.tsx
+++ b/components/session/ExerciseGroupSetTable.tsx
@@ -57,7 +57,7 @@ export type ExerciseGroupSetTableProps = {
   onMarkerConfirm?: (setId: string, result: { stackId: string; stackName: string; marker: number; trueWeight: number; unit: string }) => void;
   onManualWeightSave?: (setId: string, weight: number | null, reps: number | null) => void;
   /** BLD-1175: Mini-set segment handlers. */
-  onAddSegment?: (setId: string) => Promise<void> | void;
+  onAddSegment?: (setId: string, reps: number) => Promise<void> | void;
   onDeleteSegment?: (segmentId: string, setId: string) => Promise<void> | void;
   onCollapseToNormal?: (setId: string) => Promise<void> | void;
 };

--- a/components/session/ExerciseGroupSetTable.tsx
+++ b/components/session/ExerciseGroupSetTable.tsx
@@ -56,6 +56,10 @@ export type ExerciseGroupSetTableProps = {
   stacks?: StackWithCalibrations[];
   onMarkerConfirm?: (setId: string, result: { stackId: string; stackName: string; marker: number; trueWeight: number; unit: string }) => void;
   onManualWeightSave?: (setId: string, weight: number | null, reps: number | null) => void;
+  /** BLD-1175: Mini-set segment handlers. */
+  onAddSegment?: (setId: string) => Promise<void> | void;
+  onDeleteSegment?: (segmentId: string, setId: string) => Promise<void> | void;
+  onCollapseToNormal?: (setId: string) => Promise<void> | void;
 };
 
 export function ExerciseGroupSetTable({
@@ -71,6 +75,7 @@ export function ExerciseGroupSetTable({
   onOpenPulleyPinPicker, showPulleyPin, hasSetupPhotoMap, setupPhotoUriMap, onSetupPhotoGlyph,
   captureRpe, onRpeChange,
   gymId, stacks, onMarkerConfirm, onManualWeightSave,
+  onAddSegment, onDeleteSegment, onCollapseToNormal,
 }: ExerciseGroupSetTableProps) {
   return (
     <>
@@ -125,6 +130,9 @@ export function ExerciseGroupSetTable({
             stacks={stacks}
             onMarkerConfirm={onMarkerConfirm}
             onManualWeightSave={onManualWeightSave}
+            onAddSegment={onAddSegment}
+            onDeleteSegment={onDeleteSegment}
+            onCollapseToNormal={onCollapseToNormal}
           />
         );
       })}

--- a/components/session/MiniSetEditor.tsx
+++ b/components/session/MiniSetEditor.tsx
@@ -1,0 +1,266 @@
+/**
+ * BLD-1168 Slice 7: MiniSetEditor
+ *
+ * Shown below an advanced-type set row (rest_pause | cluster | myo_reps) during
+ * an active session. Allows the user to:
+ *   - View existing mini-sets as focusable rows
+ *   - Add a new mini-set (max 8, warn at 7)
+ *   - Delete an existing mini-set (long-press → confirmation)
+ *   - Collapse all mini-sets back to a single normal set (with sum of reps)
+ *
+ * The component is purely presentational: it receives segments as props and
+ * dispatches mutations via callbacks (provided by the active-session hook or
+ * the useMiniSetEditor helper). No DB calls happen inside this file.
+ *
+ * Behavior-Design Classification: NO — no streaks, badges, rewards, or
+ * motivational framing. Functional logging primitive only.
+ */
+import React, { useCallback } from "react";
+import { Alert, Pressable, StyleSheet, TextInput, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import type { SetSegment } from "@/lib/types";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { fontSizes, radii } from "@/constants/design-tokens";
+
+export const MAX_MINI_SETS = 8;
+export const WARN_MINI_SETS = 7;
+
+export type MiniSetEditorProps = {
+  /** ID of the parent workout_sets row (for error context). */
+  setId: string;
+  /** Ordered list of existing mini-sets for this set. */
+  segments: SetSegment[];
+  /** Called when the user taps "+ mini-set". Should insert a new segment. */
+  onAddSegment: () => Promise<void> | void;
+  /** Called when the user confirms deletion of a segment. */
+  onDeleteSegment: (segmentId: string) => Promise<void> | void;
+  /**
+   * Called when the user confirms collapsing the advanced set back to normal.
+   * The parent component is responsible for: (a) deleting all segments,
+   * (b) setting reps = Σ segments.reps, (c) changing set_type back to "normal".
+   */
+  onCollapseToNormal: () => Promise<void> | void;
+  /**
+   * Optional: current reps draft for the NEXT mini-set input.
+   * If undefined, the editor shows a simple "+ mini-set" button.
+   */
+  nextReps?: number | null;
+  onChangeNextReps?: (reps: number | null) => void;
+};
+
+export function MiniSetEditor({
+  setId,
+  segments,
+  onAddSegment,
+  onDeleteSegment,
+  onCollapseToNormal,
+  nextReps,
+  onChangeNextReps,
+}: MiniSetEditorProps) {
+  const colors = useThemeColors();
+
+  const totalReps = segments.reduce((sum, s) => sum + s.reps, 0);
+  const atMax = segments.length >= MAX_MINI_SETS;
+  const atWarn = segments.length === WARN_MINI_SETS;
+
+  const handleAddSegment = useCallback(() => {
+    if (atMax) return;
+    void onAddSegment();
+  }, [atMax, onAddSegment]);
+
+  const handleLongPressSegment = useCallback(
+    (seg: SetSegment) => {
+      Alert.alert(
+        "Delete mini-set?",
+        `Remove mini-set ${seg.segment_number} (${seg.reps} reps)?`,
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Delete",
+            style: "destructive",
+            onPress: () => void onDeleteSegment(seg.id),
+          },
+        ],
+      );
+    },
+    [onDeleteSegment],
+  );
+
+  const handleCollapsePress = useCallback(() => {
+    const sum = segments.reduce((s, seg) => s + seg.reps, 0);
+    Alert.alert(
+      "Collapse mini-sets?",
+      `Collapse ${segments.length} mini-sets into a single set of ${sum} reps? Mini-set rest data will be lost.`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Yes, collapse",
+          style: "destructive",
+          onPress: () => void onCollapseToNormal(),
+        },
+      ],
+    );
+  }, [segments, onCollapseToNormal]);
+
+  return (
+    <View
+      style={[styles.container, { borderLeftColor: colors.primaryContainer, backgroundColor: colors.surfaceVariant }]}
+      testID={`mini-set-editor-${setId}`}
+    >
+      {/* Existing mini-set rows */}
+      {segments.map((seg) => (
+        <Pressable
+          key={seg.id}
+          style={[styles.segmentRow, { borderBottomColor: colors.outline }]}
+          onLongPress={() => handleLongPressSegment(seg)}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel={
+            `Mini-set ${seg.segment_number} of ${segments.length}, ${seg.reps} reps` +
+            (seg.weight != null ? ` at ${seg.weight} kg` : "") +
+            (seg.completed_at != null ? ", completed" : "")
+          }
+          accessibilityHint="Long press to delete this mini-set"
+          testID={`mini-set-segment-${seg.id}`}
+        >
+          <Text variant="caption" style={[styles.segmentLabel, { color: colors.onSurfaceVariant }]}>
+            {seg.segment_number}
+          </Text>
+          <Text variant="body" style={{ color: colors.onSurface, flex: 1 }}>
+            {seg.reps} reps{seg.weight != null ? ` @ ${seg.weight}` : ""}
+          </Text>
+          {seg.completed_at != null && (
+            <Text variant="caption" style={{ color: colors.primary }}>✓</Text>
+          )}
+        </Pressable>
+      ))}
+
+      {/* Next reps input (optional controlled mode) */}
+      {onChangeNextReps && (
+        <View style={styles.inputRow}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginRight: 8 }}>
+            Next reps:
+          </Text>
+          <TextInput
+            style={[styles.repsInput, { color: colors.onSurface, borderColor: colors.outline }]}
+            value={nextReps != null ? String(nextReps) : ""}
+            onChangeText={(v) => {
+              const n = parseInt(v, 10);
+              onChangeNextReps(Number.isFinite(n) && n > 0 ? n : null);
+            }}
+            keyboardType="number-pad"
+            placeholder="0"
+            placeholderTextColor={colors.onSurfaceVariant}
+            accessibilityLabel="Reps for next mini-set"
+            testID="mini-set-next-reps-input"
+          />
+        </View>
+      )}
+
+      {/* Warn at 7 */}
+      {atWarn && (
+        <Text variant="caption" style={[styles.warnText, { color: colors.onSurfaceVariant }]}>
+          One more mini-set remaining before maximum (8).
+        </Text>
+      )}
+
+      {/* Action row */}
+      <View style={styles.actionRow}>
+        <Pressable
+          style={[
+            styles.addButton,
+            { borderColor: colors.primary, opacity: atMax ? 0.4 : 1 },
+          ]}
+          onPress={handleAddSegment}
+          disabled={atMax}
+          accessible
+          accessibilityRole="button"
+          accessibilityLabel={atMax ? "Maximum mini-sets reached" : "Add mini-set"}
+          accessibilityHint={atMax ? undefined : "Tap to log the next mini-set"}
+          testID="mini-set-add-button"
+        >
+          <Text style={{ color: colors.primary, fontWeight: "700", fontSize: fontSizes.sm }}>
+            + mini-set
+          </Text>
+        </Pressable>
+
+        {segments.length > 0 && (
+          <>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginHorizontal: 8 }}>
+              Total: {totalReps}
+            </Text>
+            <Pressable
+              onPress={handleCollapsePress}
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel="Collapse mini-sets back to normal set"
+              testID="mini-set-collapse-button"
+            >
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant, textDecorationLine: "underline" }}>
+                Collapse
+              </Text>
+            </Pressable>
+          </>
+        )}
+      </View>
+
+      {atMax && (
+        <Text variant="caption" style={[styles.warnText, { color: colors.error }]}>
+          Maximum 8 mini-sets reached. Use a separate set for more.
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderLeftWidth: 3,
+    marginLeft: 8,
+    marginTop: 2,
+    marginBottom: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: radii.sm,
+  },
+  segmentRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  segmentLabel: {
+    width: 24,
+    fontWeight: "700",
+    textAlign: "center",
+    marginRight: 8,
+  },
+  actionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 8,
+  },
+  addButton: {
+    borderWidth: 1,
+    borderRadius: radii.sm,
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+  },
+  warnText: {
+    marginTop: 4,
+    fontStyle: "italic",
+  },
+  inputRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: 6,
+  },
+  repsInput: {
+    borderWidth: 1,
+    borderRadius: radii.sm,
+    width: 56,
+    textAlign: "center",
+    paddingVertical: 4,
+    fontSize: fontSizes.sm,
+  },
+});

--- a/components/session/SetRow.tsx
+++ b/components/session/SetRow.tsx
@@ -198,7 +198,7 @@ export type SetRowProps = {
   }) => void;
   onManualWeightSave?: (setId: string, weight: number | null, reps: number | null) => void;
   /** BLD-1175: Mini-set segment handlers — only present for advanced set types in active session. */
-  onAddSegment?: (setId: string) => Promise<void> | void;
+  onAddSegment?: (setId: string, reps: number) => Promise<void> | void;
   onDeleteSegment?: (segmentId: string, setId: string) => Promise<void> | void;
   onCollapseToNormal?: (setId: string) => Promise<void> | void;
 };
@@ -219,6 +219,9 @@ export const SetRow = memo(function SetRow({
   onAddSegment, onDeleteSegment, onCollapseToNormal,
 }: SetRowProps) {
   const colors = useThemeColors();
+  // BLD-1175: controlled next-reps input for MiniSetEditor — scoped to this row
+  // so each advanced set row tracks its own reps draft independently.
+  const [nextReps, setNextReps] = useState<number | null>(null);
   // BLD-771: ref to the variant footer Pressable so the picker hook can
   // resolve its accessibility node handle on open and restore VO/TalkBack
   // focus to it on dismiss (reviewer blocker #4, PR #426).
@@ -880,9 +883,14 @@ export const SetRow = memo(function SetRow({
         <MiniSetEditor
           setId={set.id}
           segments={set.segments ?? []}
-          onAddSegment={() => onAddSegment(set.id)}
+          onAddSegment={async () => {
+            await onAddSegment(set.id, nextReps ?? 1);
+            setNextReps(null);
+          }}
           onDeleteSegment={(segId) => onDeleteSegment(segId, set.id)}
           onCollapseToNormal={() => onCollapseToNormal(set.id)}
+          nextReps={nextReps}
+          onChangeNextReps={setNextReps}
         />
       ) : null}
 

--- a/components/session/SetRow.tsx
+++ b/components/session/SetRow.tsx
@@ -37,7 +37,8 @@ import { getAppSetting, setAppSetting } from "@/lib/db";
 import { radii } from "../../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { type SetWithMeta } from "./types";
-import { SET_TYPE_LABELS, ADVANCED_SET_TYPES, type Equipment } from "../../lib/types";
+import { SET_TYPE_LABELS, type Equipment } from "../../lib/types";
+import { ADVANCED_SET_TYPES } from "../../lib/db/sets";
 import { fontSizes } from "@/constants/design-tokens";
 import { PlateHint } from "./PlateHint";
 import { useSetCompletionFeedback } from "@/hooks/useSetCompletionFeedback";
@@ -875,7 +876,7 @@ export const SetRow = memo(function SetRow({
         </View>
       ) : null}
 
-      {ADVANCED_SET_TYPES.includes(set.set_type) && onAddSegment && onDeleteSegment && onCollapseToNormal ? (
+      {ADVANCED_SET_TYPES.has(set.set_type) && onAddSegment && onDeleteSegment && onCollapseToNormal ? (
         <MiniSetEditor
           setId={set.id}
           segments={set.segments ?? []}

--- a/components/session/SetRow.tsx
+++ b/components/session/SetRow.tsx
@@ -37,7 +37,7 @@ import { getAppSetting, setAppSetting } from "@/lib/db";
 import { radii } from "../../constants/design-tokens";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { type SetWithMeta } from "./types";
-import { SET_TYPE_LABELS, type Equipment } from "../../lib/types";
+import { SET_TYPE_LABELS, ADVANCED_SET_TYPES, type Equipment } from "../../lib/types";
 import { fontSizes } from "@/constants/design-tokens";
 import { PlateHint } from "./PlateHint";
 import { useSetCompletionFeedback } from "@/hooks/useSetCompletionFeedback";
@@ -46,6 +46,7 @@ import { isBodyweightGripExercise, formatGripTypeLabel, formatGripWidthLabel } f
 import { RpeChipStrip } from "./RpeChipStrip";
 import { SetWeightCell } from "./SetWeightCell";
 import type { StackWithCalibrations } from "@/hooks/useActiveCalibration";
+import { MiniSetEditor } from "./MiniSetEditor";
 
 const SWIPE_COMPLETE_HINT_KEY = "hint:swipe-complete-set:v1";
 
@@ -195,6 +196,10 @@ export type SetRowProps = {
     unit: string;
   }) => void;
   onManualWeightSave?: (setId: string, weight: number | null, reps: number | null) => void;
+  /** BLD-1175: Mini-set segment handlers — only present for advanced set types in active session. */
+  onAddSegment?: (setId: string) => Promise<void> | void;
+  onDeleteSegment?: (segmentId: string, setId: string) => Promise<void> | void;
+  onCollapseToNormal?: (setId: string) => Promise<void> | void;
 };
 
 export const SetRow = memo(function SetRow({
@@ -210,6 +215,7 @@ export const SetRow = memo(function SetRow({
   pulleyPin, onOpenPulleyPinPicker, showPulleyPin, hasSetupPhoto, setupPhotoUri, onSetupPhotoGlyph,
   captureRpe, onRpeChange,
   stacks, onMarkerConfirm, onManualWeightSave,
+  onAddSegment, onDeleteSegment, onCollapseToNormal,
 }: SetRowProps) {
   const colors = useThemeColors();
   // BLD-771: ref to the variant footer Pressable so the picker hook can
@@ -278,12 +284,15 @@ export const SetRow = memo(function SetRow({
       case "warmup": return { bg: colors.surfaceVariant, fg: colors.onSurfaceVariant };
       case "dropset": return { bg: colors.tertiaryContainer, fg: colors.onTertiaryContainer };
       case "failure": return { bg: colors.errorContainer, fg: colors.onErrorContainer };
+      case "rest_pause": return { bg: colors.secondaryContainer, fg: colors.onSecondaryContainer };
+      case "cluster": return { bg: colors.secondaryContainer, fg: colors.onSecondaryContainer };
+      case "myo_reps": return { bg: colors.secondaryContainer, fg: colors.onSecondaryContainer };
       default: return null;
     }
   }, [set.set_type, colors]);
 
   const chipLabel = SET_TYPE_LABELS[set.set_type]?.short;
-  const typeLabel = set.set_type === "normal" ? "working set" : `${set.set_type} set`;
+  const typeLabel = set.set_type === "normal" ? "working set" : `${SET_TYPE_LABELS[set.set_type]?.label ?? set.set_type} set`;
 
   const handleDelete = useCallback(() => onDelete(set.id), [onDelete, set.id]);
   // Screen-reader fallback: TalkBack / VoiceOver dispatch the built-in
@@ -864,6 +873,16 @@ export const SetRow = memo(function SetRow({
         <View style={styles.tempoRow}>
           <SetTempoChip tempo={set.tempo} />
         </View>
+      ) : null}
+
+      {ADVANCED_SET_TYPES.includes(set.set_type) && onAddSegment && onDeleteSegment && onCollapseToNormal ? (
+        <MiniSetEditor
+          setId={set.id}
+          segments={set.segments ?? []}
+          onAddSegment={() => onAddSegment(set.id)}
+          onDeleteSegment={(segId) => onDeleteSegment(segId, set.id)}
+          onCollapseToNormal={() => onCollapseToNormal(set.id)}
+        />
       ) : null}
 
       <PlateHint weight={displayedWeight} unit={unit} equipment={equipment} />

--- a/components/session/detail/ExerciseGroupRow.tsx
+++ b/components/session/detail/ExerciseGroupRow.tsx
@@ -2,11 +2,13 @@ import { StyleSheet, View } from "react-native";
 import { Separator } from "@/components/ui/separator";
 import { Text } from "@/components/ui/text";
 import { SET_TYPE_LABELS } from "@/lib/types";
+import type { SetType } from "@/lib/types";
 import { rpeColor, rpeText } from "@/lib/rpe";
 import type { ExerciseGroup } from "@/hooks/useSessionDetail";
 import type { ThemeColors } from "@/hooks/useThemeColors";
 import { fontSizes } from "@/constants/design-tokens";
-import { normalizeSetType } from "@/lib/db/sets";
+import { normalizeSetType, ADVANCED_SET_TYPES } from "@/lib/db/sets";
+import { formatMiniSetReps, formatAdvancedSetAccessibilityLabel } from "@/lib/format";
 
 type Props = {
   group: ExerciseGroup;
@@ -15,6 +17,30 @@ type Props = {
   palette: string[];
   colors: ThemeColors;
 };
+
+function getSetChipColors(st: SetType, colors: ThemeColors): { bg: string; fg: string } | null {
+  switch (st) {
+    case "warmup": return { bg: colors.surfaceVariant, fg: colors.onSurfaceVariant };
+    case "dropset": return { bg: colors.tertiaryContainer, fg: colors.onTertiaryContainer };
+    case "failure": return { bg: colors.errorContainer, fg: colors.onErrorContainer };
+    case "rest_pause": return { bg: colors.primaryContainer, fg: colors.onPrimaryContainer };
+    case "cluster": return { bg: colors.secondaryContainer, fg: colors.onSecondaryContainer };
+    case "myo_reps": return { bg: colors.tertiaryContainer, fg: colors.onTertiaryContainer };
+    default: return null;
+  }
+}
+
+function getSetBorderColor(st: SetType, colors: ThemeColors): string | undefined {
+  switch (st) {
+    case "warmup": return colors.surfaceVariant;
+    case "dropset": return colors.tertiaryContainer;
+    case "failure": return colors.errorContainer;
+    case "rest_pause": return colors.primaryContainer;
+    case "cluster": return colors.secondaryContainer;
+    case "myo_reps": return colors.tertiaryContainer;
+    default: return undefined;
+  }
+}
 
 export function ExerciseGroupRow({ group, groups, linkIds, palette, colors }: Props) {
   const linked = group.link_id ? groups.filter((g) => g.link_id === group.link_id) : [];
@@ -53,59 +79,64 @@ export function ExerciseGroupRow({ group, groups, linkIds, palette, colors }: Pr
         )}
         {group.sets
           .filter((s) => s.completed)
-          .map((set) => (
-            <View key={set.id}>
-              <View style={[styles.setRow, (() => {
-                const st = normalizeSetType(set.set_type);
-                if (st === "warmup") return { borderLeftWidth: 3, borderLeftColor: colors.surfaceVariant, paddingLeft: 5 };
-                if (st === "dropset") return { borderLeftWidth: 3, borderLeftColor: colors.tertiaryContainer, paddingLeft: 5 };
-                if (st === "failure") return { borderLeftWidth: 3, borderLeftColor: colors.errorContainer, paddingLeft: 5 };
-                return {};
-              })()]}>
-                {(() => {
-                  const st = normalizeSetType(set.set_type);
-                  const label = SET_TYPE_LABELS[st];
-                  if (label.short) {
-                    const chipColors = st === "warmup"
-                      ? { bg: colors.surfaceVariant, fg: colors.onSurfaceVariant }
-                      : st === "dropset"
-                      ? { bg: colors.tertiaryContainer, fg: colors.onTertiaryContainer }
-                      : { bg: colors.errorContainer, fg: colors.onErrorContainer };
-                    return (
-                      <View style={{ width: 28, height: 28, borderRadius: 14, backgroundColor: chipColors.bg, justifyContent: "center", alignItems: "center", marginRight: 8 }}>
-                        <Text style={{ fontSize: fontSizes.sm, fontWeight: "700", color: chipColors.fg }}>{label.short}</Text>
-                      </View>
-                    );
-                  }
-                  return (
+          .map((set) => {
+            const st = normalizeSetType(set.set_type) as SetType;
+            const label = SET_TYPE_LABELS[st];
+            const isAdvanced = ADVANCED_SET_TYPES.has(st);
+            const segments = set.segments ?? [];
+            const repsDisplay = isAdvanced
+              ? formatMiniSetReps(segments)
+              : String(set.reps ?? 0);
+            const a11yLabel = isAdvanced
+              ? `${formatAdvancedSetAccessibilityLabel(label.label, segments.length)}, ${set.weight ?? 0} × ${repsDisplay}`
+              : undefined;
+
+            const chipColors = getSetChipColors(st, colors);
+            const borderColor = getSetBorderColor(st, colors);
+
+            return (
+              <View
+                key={set.id}
+                accessibilityLabel={a11yLabel}
+                accessibilityRole={isAdvanced ? "text" : undefined}
+              >
+                <View style={[
+                  styles.setRow,
+                  borderColor ? { borderLeftWidth: 3, borderLeftColor: borderColor, paddingLeft: 5 } : undefined,
+                ]}>
+                  {label.short ? (
+                    <View style={{ width: 28, height: 28, borderRadius: 14, backgroundColor: chipColors!.bg, justifyContent: "center", alignItems: "center", marginRight: 8 }}>
+                      <Text style={{ fontSize: fontSizes.sm, fontWeight: "700", color: chipColors!.fg }}>{label.short}</Text>
+                    </View>
+                  ) : (
                     <Text variant="body" style={[styles.setNum, { color: colors.onSurface }]}>
                       {set.round ? `R${set.round}` : `Set ${set.set_number}`}
                     </Text>
-                  );
-                })()}
-                <Text variant="body" style={{ color: colors.onSurface }}>
-                  {set.weight ?? 0} × {set.reps ?? 0}
-                </Text>
-                {set.tempo && (
-                  <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}>
-                    ♩ {set.tempo}
+                  )}
+                  <Text variant="body" style={{ color: colors.onSurface }}>
+                    {set.weight ?? 0} × {repsDisplay}
                   </Text>
-                )}
-                {set.rpe != null && (
-                  <View style={[styles.rpeBadge, { backgroundColor: rpeColor(set.rpe) }]}>
-                    <Text style={{ color: rpeText(set.rpe), fontSize: fontSizes.xs, fontWeight: "600" }}>
-                      RPE {set.rpe}
+                  {set.tempo && (
+                    <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}>
+                      ♩ {set.tempo}
                     </Text>
-                  </View>
-                )}
+                  )}
+                  {set.rpe != null && (
+                    <View style={[styles.rpeBadge, { backgroundColor: rpeColor(set.rpe) }]}>
+                      <Text style={{ color: rpeText(set.rpe), fontSize: fontSizes.xs, fontWeight: "600" }}>
+                        RPE {set.rpe}
+                      </Text>
+                    </View>
+                  )}
+                </View>
+                {set.notes ? (
+                  <Text variant="caption" style={[styles.setNote, { color: colors.onSurfaceVariant }]}>
+                    {set.notes}
+                  </Text>
+                ) : null}
               </View>
-              {set.notes ? (
-                <Text variant="caption" style={[styles.setNote, { color: colors.onSurfaceVariant }]}>
-                  {set.notes}
-                </Text>
-              ) : null}
-            </View>
-          ))}
+            );
+          })}
       </View>
       {isLast && group.link_id && (
         <View style={{ height: 4, backgroundColor: groupColor, borderRadius: 2 }} />

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -1386,15 +1386,19 @@ export function useSessionActions({
   );
 
   const handleAddSegment = useCallback(
-    async (setId: string) => {
+    async (setId: string, reps: number) => {
       const allSets = groups.flatMap((g) => g.sets);
       const set = allSets.find((s) => s.id === setId);
       if (!set) return;
-      const existingCount = (set.segments ?? []).length;
+      const segments = set.segments ?? [];
+      // Use MAX(segment_number) + 1 to avoid collisions after mid-list deletes.
+      const nextSegmentNumber = segments.length > 0
+        ? Math.max(...segments.map((s) => s.segment_number)) + 1
+        : 1;
       await insertSegment({
         setId,
-        segmentNumber: existingCount + 1,
-        reps: 1,
+        segmentNumber: nextSegmentNumber,
+        reps,
         weight: null,
       });
       const segMap = await getSegmentsForSets([setId]);
@@ -1414,11 +1418,19 @@ export function useSessionActions({
 
   const handleCollapseToNormal = useCallback(
     async (setId: string) => {
+      // Capture Σreps before deleting — deleteAllSegmentsForSet recomputes
+      // caches with 0 segments, leaving parent.reps = 0 for advanced types.
+      const allSets = groups.flatMap((g) => g.sets);
+      const set = allSets.find((s) => s.id === setId);
+      const totalReps = (set?.segments ?? []).reduce((sum, seg) => sum + seg.reps, 0);
+
       await deleteAllSegmentsForSet(setId);
       await updateSetType(setId, "normal");
-      updateGroupSet(setId, { set_type: "normal", segments: [] });
+      // Restore the summed reps that deleteAllSegmentsForSet zeroed out.
+      await updateSetRepsAndDuration(setId, totalReps > 0 ? totalReps : null, undefined);
+      updateGroupSet(setId, { set_type: "normal", segments: [], reps: totalReps > 0 ? totalReps : null });
     },
-    [updateGroupSet]
+    [groups, updateGroupSet]
   );
 
   return {

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -43,7 +43,9 @@ import {
   updateSetManualWeight,
   getRecentStackHistory,
   updateSetRepsAndDuration,
+  updateSetType,
 } from "../lib/db/session-sets";
+import { ADVANCED_SET_TYPES, insertSegment, deleteSegment, deleteAllSegmentsForSet, getSegmentsForSets } from "../lib/db/sets";
 import { getLastVariant, isCableExercise } from "../lib/cable-variant";
 import { resolveMarker } from "../lib/cable-stack";
 import {
@@ -1383,6 +1385,42 @@ export function useSessionActions({
     [groups, updateGroupSet, showError]
   );
 
+  const handleAddSegment = useCallback(
+    async (setId: string) => {
+      const allSets = groups.flatMap((g) => g.sets);
+      const set = allSets.find((s) => s.id === setId);
+      if (!set) return;
+      const existingCount = (set.segments ?? []).length;
+      await insertSegment({
+        setId,
+        segmentNumber: existingCount + 1,
+        reps: 1,
+        weight: null,
+      });
+      const segMap = await getSegmentsForSets([setId]);
+      updateGroupSet(setId, { segments: segMap.get(setId) ?? [] });
+    },
+    [groups, updateGroupSet]
+  );
+
+  const handleDeleteSegment = useCallback(
+    async (segmentId: string, setId: string) => {
+      await deleteSegment(segmentId, setId);
+      const segMap = await getSegmentsForSets([setId]);
+      updateGroupSet(setId, { segments: segMap.get(setId) ?? [] });
+    },
+    [updateGroupSet]
+  );
+
+  const handleCollapseToNormal = useCallback(
+    async (setId: string) => {
+      await deleteAllSegmentsForSet(setId);
+      await updateSetType(setId, "normal");
+      updateGroupSet(setId, { set_type: "normal", segments: [] });
+    },
+    [updateGroupSet]
+  );
+
   return {
     elapsed,
     /** BLD-630: null until the user completes the first set in the session.
@@ -1411,6 +1449,9 @@ export function useSessionActions({
     handleApplyBreakThrough,
     handleMarkerConfirm,
     handleManualWeightSave,
+    handleAddSegment,
+    handleDeleteSegment,
+    handleCollapseToNormal,
     finish,
     cancel,
   };

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -43,9 +43,8 @@ import {
   updateSetManualWeight,
   getRecentStackHistory,
   updateSetRepsAndDuration,
-  updateSetType,
 } from "../lib/db/session-sets";
-import { ADVANCED_SET_TYPES, insertSegment, deleteSegment, deleteAllSegmentsForSet, getSegmentsForSets } from "../lib/db/sets";
+import { ADVANCED_SET_TYPES, insertSegment, deleteSegment, collapseAdvancedSetToNormal, getSegmentsForSets } from "../lib/db/sets";
 import { getLastVariant, isCableExercise } from "../lib/cable-variant";
 import { resolveMarker } from "../lib/cable-stack";
 import {
@@ -1391,10 +1390,10 @@ export function useSessionActions({
       const set = allSets.find((s) => s.id === setId);
       if (!set) return;
       const segments = set.segments ?? [];
-      // Use MAX(segment_number) + 1 to avoid collisions after mid-list deletes.
-      const nextSegmentNumber = segments.length > 0
-        ? Math.max(...segments.map((s) => s.segment_number)) + 1
-        : 1;
+      // deleteSegment renumbers remaining segments to contiguous 1..N, so the
+      // next slot is always (length + 1). This keeps mini-set labels meaningful
+      // under the 8-cap.
+      const nextSegmentNumber = segments.length + 1;
       await insertSegment({
         setId,
         segmentNumber: nextSegmentNumber,
@@ -1418,19 +1417,18 @@ export function useSessionActions({
 
   const handleCollapseToNormal = useCallback(
     async (setId: string) => {
-      // Capture Σreps before deleting — deleteAllSegmentsForSet recomputes
-      // caches with 0 segments, leaving parent.reps = 0 for advanced types.
-      const allSets = groups.flatMap((g) => g.sets);
-      const set = allSets.find((s) => s.id === setId);
-      const totalReps = (set?.segments ?? []).reduce((sum, seg) => sum + seg.reps, 0);
-
-      await deleteAllSegmentsForSet(setId);
-      await updateSetType(setId, "normal");
-      // Restore the summed reps that deleteAllSegmentsForSet zeroed out.
-      await updateSetRepsAndDuration(setId, totalReps > 0 ? totalReps : null, undefined);
-      updateGroupSet(setId, { set_type: "normal", segments: [], reps: totalReps > 0 ? totalReps : null });
+      // Atomic collapse: deletes segments, sets type='normal' + reps=Σ, AND
+      // rewrites cached_volume_kg / cached_e1rm_kg from parent.weight × Σreps.
+      // Doing these as separate calls leaves caches stuck at 0 because
+      // recomputeSetCaches early-returns for non-advanced sets with no segments.
+      const totalReps = await collapseAdvancedSetToNormal(setId);
+      updateGroupSet(setId, {
+        set_type: "normal",
+        segments: [],
+        reps: totalReps > 0 ? totalReps : null,
+      });
     },
-    [groups, updateGroupSet]
+    [updateGroupSet]
   );
 
   return {

--- a/hooks/useSessionData.ts
+++ b/hooks/useSessionData.ts
@@ -38,6 +38,7 @@ import { toAbsPath } from "../lib/media/form-clips";
 import { isCableExercise } from "../lib/cable-variant";
 import { derivePristinePrefillCandidate } from "./resolvePrefillCandidate";
 import { useThemeColors } from "@/hooks/useThemeColors";
+import { ADVANCED_SET_TYPES, getSegmentsForSets } from "../lib/db/sets";
 
 type UseSessionDataArgs = {
   id: string | undefined;
@@ -260,6 +261,25 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
     }
 
     setGroups(groupList);
+
+    // BLD-1175: batch-load mini-set segments for advanced sets
+    const allSets = groupList.flatMap((g) => g.sets);
+    const advancedSetIds = allSets
+      .filter((s) => ADVANCED_SET_TYPES.includes(s.set_type))
+      .map((s) => s.id);
+    if (advancedSetIds.length > 0) {
+      getSegmentsForSets(advancedSetIds).then((segMap) => {
+        setGroups((prev) =>
+          prev.map((g) => ({
+            ...g,
+            sets: g.sets.map((s) => ({
+              ...s,
+              segments: segMap.get(s.id) ?? [],
+            })),
+          }))
+        );
+      }).catch(() => {});
+    }
 
     // BLD-1114: populate previousSetupPhotoUri for cable exercises
     const cableGroups = groupList.filter((g) => isCableExercise({ equipment: g.equipment }));

--- a/hooks/useSessionData.ts
+++ b/hooks/useSessionData.ts
@@ -265,7 +265,7 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
     // BLD-1175: batch-load mini-set segments for advanced sets
     const allSets = groupList.flatMap((g) => g.sets);
     const advancedSetIds = allSets
-      .filter((s) => ADVANCED_SET_TYPES.includes(s.set_type))
+      .filter((s) => ADVANCED_SET_TYPES.has(s.set_type))
       .map((s) => s.id);
     if (advancedSetIds.length > 0) {
       getSegmentsForSets(advancedSetIds).then((segMap) => {

--- a/hooks/useSessionDetail.ts
+++ b/hooks/useSessionDetail.ts
@@ -12,7 +12,8 @@ import {
   startSession,
   updateSession,
 } from "@/lib/db";
-import type { WorkoutSession, WorkoutSet } from "@/lib/types";
+import type { WorkoutSession, WorkoutSet, SetType } from "@/lib/types";
+import { ADVANCED_SET_TYPES, getSegmentsForSets } from "@/lib/db/sets";
 import { useThemeColors } from "@/hooks/useThemeColors";
 
 export type SetWithName = WorkoutSet & {
@@ -80,6 +81,14 @@ export function useSessionDetail(id: string | undefined) {
     ]);
     setPrs(prData);
     setCompletedSetCount(setCount);
+
+    // BLD-1168 Slice 7: batch-load segments for advanced set types so
+    // the history view can render compact "8+3+2 (13)" and correct a11y labels.
+    const advancedSetIds = sets
+      .filter((s) => ADVANCED_SET_TYPES.has(s.set_type as SetType))
+      .map((s) => s.id);
+    const segmentsMap = await getSegmentsForSets(advancedSetIds);
+
     const map = new Map<string, ExerciseGroup>();
     for (const s of sets) {
       if (!map.has(s.exercise_id)) {
@@ -91,7 +100,11 @@ export function useSessionDetail(id: string | undefined) {
           swapped_from_name: (s as SetWithName).swapped_from_name ?? null,
         });
       }
-      map.get(s.exercise_id)!.sets.push(s);
+      const setWithSegments: SetWithName = {
+        ...s,
+        segments: segmentsMap.get(s.id) ?? undefined,
+      };
+      map.get(s.exercise_id)!.sets.push(setWithSegments);
     }
     setGroups([...map.values()]);
   }, [id]);

--- a/lib/db/sets.ts
+++ b/lib/db/sets.ts
@@ -16,7 +16,7 @@
  * Raw e1RM formula migration (weight*reps, weight*(1+reps/30)) is out of scope
  * for this slice — that is covered by BLD-1174 (analytics surfaces migration).
  */
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { getDrizzle, withTransaction } from "./helpers";
 import { workoutSets, workoutSetSegments } from "./schema";
 import { uuid } from "../uuid";
@@ -490,6 +490,39 @@ export async function updateSetForSessionEdit(
   if (updates.weight !== undefined || updates.reps !== undefined || updates.set_type !== undefined) {
     await recomputeSetCaches(setId);
   }
+}
+
+/**
+ * Batch-load segments for multiple sets. Returns a Map<setId, SetSegment[]>.
+ * Sets with no segments are absent from the map.
+ */
+export async function getSegmentsForSets(setIds: string[]): Promise<Map<string, SetSegment[]>> {
+  if (setIds.length === 0) return new Map();
+  const db = await getDrizzle();
+  const rows = await db
+    .select()
+    .from(workoutSetSegments)
+    .where(inArray(workoutSetSegments.set_id, setIds))
+    .orderBy(workoutSetSegments.segment_number)
+    .all();
+
+  const result = new Map<string, SetSegment[]>();
+  for (const r of rows) {
+    const seg: SetSegment = {
+      id: r.id,
+      set_id: r.set_id,
+      segment_number: r.segment_number,
+      reps: r.reps,
+      weight: r.weight ?? null,
+      rest_after_seconds: r.rest_after_seconds ?? null,
+      completed_at: r.completed_at ?? null,
+      created_at: r.created_at,
+    };
+    const list = result.get(r.set_id) ?? [];
+    list.push(seg);
+    result.set(r.set_id, list);
+  }
+  return result;
 }
 
 /** Load all segments for a set ordered by segment_number. */

--- a/lib/db/sets.ts
+++ b/lib/db/sets.ts
@@ -420,7 +420,10 @@ export async function updateSegment(params: UpdateSegmentParams): Promise<void> 
   await recomputeSetCaches(params.setId);
 }
 
-/** Delete a mini-set segment and recompute parent caches. */
+/** Delete a mini-set segment, renumber remaining segments contiguously (1..N),
+ *  and recompute parent caches. Renumbering keeps mini-set labels meaningful
+ *  under the 8-cap (e.g. after deleting #4 from [1..8], the rest become [1..7]
+ *  and the next insert lands at 8 — never 9). */
 export async function deleteSegment(segmentId: string, setId: string): Promise<void> {
   const db = await getDrizzle();
 
@@ -428,6 +431,7 @@ export async function deleteSegment(segmentId: string, setId: string): Promise<v
     .delete(workoutSetSegments)
     .where(and(eq(workoutSetSegments.id, segmentId), eq(workoutSetSegments.set_id, setId)));
 
+  await renumberSegments(setId);
   await recomputeSetCaches(setId);
 }
 
@@ -490,6 +494,94 @@ export async function updateSetForSessionEdit(
   if (updates.weight !== undefined || updates.reps !== undefined || updates.set_type !== undefined) {
     await recomputeSetCaches(setId);
   }
+}
+
+/**
+ * Re-number a set's remaining segments to be contiguous 1..N ordered by their
+ * current segment_number. Two-pass write avoids transient collisions on the
+ * unique (set_id, segment_number) index.
+ */
+async function renumberSegments(setId: string): Promise<void> {
+  const db = await getDrizzle();
+  const rows = await db
+    .select({ id: workoutSetSegments.id, segment_number: workoutSetSegments.segment_number })
+    .from(workoutSetSegments)
+    .where(eq(workoutSetSegments.set_id, setId))
+    .orderBy(workoutSetSegments.segment_number)
+    .all();
+
+  if (rows.length === 0) return;
+  // Skip work if already contiguous 1..N.
+  const alreadyContiguous = rows.every((r, i) => r.segment_number === i + 1);
+  if (alreadyContiguous) return;
+
+  // Pass 1: park each row at a unique negative slot to dodge the unique index.
+  for (let i = 0; i < rows.length; i++) {
+    await db
+      .update(workoutSetSegments)
+      .set({ segment_number: -(i + 1) })
+      .where(eq(workoutSetSegments.id, rows[i].id));
+  }
+  // Pass 2: assign final contiguous 1..N positions.
+  for (let i = 0; i < rows.length; i++) {
+    await db
+      .update(workoutSetSegments)
+      .set({ segment_number: i + 1 })
+      .where(eq(workoutSetSegments.id, rows[i].id));
+  }
+}
+
+/**
+ * Atomically collapse an advanced set (rest_pause/cluster/myo_reps) back to
+ * a normal set. Computes summed reps from segments, deletes them, sets
+ * set_type='normal' + reps=Σ, and writes legacy cached_volume_kg /
+ * cached_e1rm_kg derived from the parent's weight × summed reps.
+ *
+ * This is the ONLY safe path for the collapse transition: doing
+ * delete-segments → set-type → set-reps as separate calls leaves caches
+ * stuck at zero because recomputeSetCaches early-returns for non-advanced
+ * sets with no segments (it preserves their backfilled caches), so the
+ * post-delete recompute that ran while set_type was still advanced
+ * stays at 0 forever.
+ *
+ * Returns the summed reps that were written (>= 0).
+ */
+export async function collapseAdvancedSetToNormal(setId: string): Promise<number> {
+  const db = await getDrizzle();
+
+  const parent = await db
+    .select({ id: workoutSets.id, weight: workoutSets.weight })
+    .from(workoutSets)
+    .where(eq(workoutSets.id, setId))
+    .get();
+  if (!parent) return 0;
+
+  const segs = await db
+    .select({ reps: workoutSetSegments.reps })
+    .from(workoutSetSegments)
+    .where(eq(workoutSetSegments.set_id, setId))
+    .all();
+
+  const summedReps = segs.reduce((s, r) => s + (r.reps ?? 0), 0);
+
+  await db.delete(workoutSetSegments).where(eq(workoutSetSegments.set_id, setId));
+
+  const { cachedVolumeKg, cachedE1rmKg } = computeSetCacheValues(
+    { weight: parent.weight ?? null, reps: summedReps, isAdvancedSet: false },
+    [],
+  );
+
+  await db
+    .update(workoutSets)
+    .set({
+      set_type: "normal",
+      reps: summedReps > 0 ? summedReps : null,
+      cached_volume_kg: cachedVolumeKg,
+      cached_e1rm_kg: cachedE1rmKg,
+    })
+    .where(eq(workoutSets.id, setId));
+
+  return summedReps;
 }
 
 /**

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -280,6 +280,35 @@ export function computePrefillSets(
   return results;
 }
 
+/**
+ * BLD-1168 Slice 7: Format mini-set reps as compact display string.
+ * Examples: [8,3,2] → "8+3+2 (13)"  (≥3 segments: show total in parens)
+ *           [10,5]  → "10+5"          (2 segments: no parens)
+ *           []      → "0"             (empty: show 0)
+ */
+export function formatMiniSetReps(segments: { reps: number }[]): string {
+  if (segments.length === 0) return "0";
+  const joined = segments.map((s) => s.reps).join("+");
+  if (segments.length >= 3) {
+    const total = segments.reduce((sum, s) => sum + s.reps, 0);
+    return `${joined} (${total})`;
+  }
+  return joined;
+}
+
+/**
+ * BLD-1168 Slice 7: Format a VoiceOver-friendly label for an advanced set parent row.
+ * Example: "Rest-pause set with 3 mini-sets"
+ */
+export function formatAdvancedSetAccessibilityLabel(
+  setTypeLabel: string,
+  segmentCount: number,
+): string {
+  if (segmentCount === 0) return `${setTypeLabel} set, no mini-sets yet`;
+  const plural = segmentCount === 1 ? "mini-set" : "mini-sets";
+  return `${setTypeLabel} set with ${segmentCount} ${plural}`;
+}
+
 export function hexToRgb(hex: string): string {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -294,7 +294,8 @@ export type WorkoutSession = {
 
 export type SetType = "normal" | "warmup" | "dropset" | "failure" | "rest_pause" | "cluster" | "myo_reps";
 
-export const SET_TYPE_CYCLE: SetType[] = ["normal", "warmup", "dropset", "failure"];
+// BLD-1168: advanced set schemes appended so the cycle selector includes them.
+export const SET_TYPE_CYCLE: SetType[] = ["normal", "warmup", "dropset", "failure", "rest_pause", "cluster", "myo_reps"];
 
 /** BLD-1168: one ordered mini-set within a rest-pause / cluster / myo-reps parent set. */
 export type SetSegment = {
@@ -356,6 +357,9 @@ export type WorkoutSet = {
   // BLD-1168: cached aggregate columns populated by recomputeSetCaches(). DEFAULT 0.
   cached_volume_kg?: number;
   cached_e1rm_kg?: number;
+  // BLD-1168 Slice 7: optional mini-set segments — populated in history/detail view
+  // for advanced set types (rest_pause, cluster, myo_reps). Absent for normal/warmup/dropset/failure.
+  segments?: SetSegment[];
 };
 
 export type LinkedGroup = {


### PR DESCRIPTION
## Summary

Implements the MiniSetEditor component and integrates it with ExerciseGroupRow for advanced set display with full a11y support.

## Changes

- **New component** `components/session/MiniSetEditor`: mini-set rows, `+ mini-set` button, max 8 limit (warn at 7), long-press delete confirmation, collapse-to-normal alert
- **ExerciseGroupRow** integration: advanced set rows render compact reps `8+3+2 (13)`, VoiceOver label "Rest-pause set with 3 mini-sets", per-type chips (RP/CL/MR)
- **`lib/format.ts`**: `formatMiniSetReps()` and `formatAdvancedSetAccessibilityLabel()`
- **`lib/db/sets.ts`**: `getSegmentsForSets()` batch loader
- **`lib/types.ts`**: `segments?: SetSegment[]` added to `WorkoutSet`
- **`hooks/useSessionDetail`**: batch-loads segments for advanced set history display

## Testing

- `__tests__/mini-set-editor.test.tsx` — 25 tests covering AC #255 (8+3+2 display), AC #262 (collapse to normal)
- `__tests__/a11y-advanced-sets.test.tsx` — 6 tests covering AC #263 (VoiceOver announcements)
- All 31 tests pass; tsc clean; ESLint 0 warnings

## Acceptance Criteria

- [x] AC #255: rest_pause set displays "8+3+2 (13)" with 3 ordered segments
- [x] AC #262: collapse-to-normal: confirm → reps summed; cancel → unchanged
- [x] AC #263: VoiceOver announces "Rest-pause set with 3 mini-sets"

## Issue

Resolves BLD-1175