### PR TITLE
fix(BLD-1185): regenerate-on-conflict for scheduled-release rebase against concurrent CHANGELOG merges

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -204,71 +204,10 @@ jobs:
           echo "version_code=$NEXT" >> "$GITHUB_OUTPUT"
           echo "Next version code: $NEXT"
 
-      - name: Bump version in package.json
-        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && inputs.republish_current != true
-        run: |
-          VERSION="${{ steps.next_version.outputs.version }}"
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            pkg.version = '$VERSION';
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-
-      - name: Bump version in app.config.ts
-        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && inputs.republish_current != true
-        run: |
-          VERSION="${{ steps.next_version.outputs.version }}"
-          VCODE="${{ steps.next_vcode.outputs.version_code }}"
-          sed -i "s/version: \"[^\"]*\"/version: \"$VERSION\"/" app.config.ts
-          sed -i "s/versionCode: [0-9]*/versionCode: $VCODE/" app.config.ts
-
-      - name: Bump version in F-Droid metadata
-        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && inputs.republish_current != true
-        run: |
-          VERSION="${{ steps.next_version.outputs.version }}"
-          VCODE="${{ steps.next_vcode.outputs.version_code }}"
-          sed -i "s/CurrentVersion: .*/CurrentVersion: $VERSION/" fdroid/metadata/com.persoack.cablesnap.yml
-          sed -i "s/CurrentVersionCode: .*/CurrentVersionCode: $VCODE/" fdroid/metadata/com.persoack.cablesnap.yml
-
-      # BLD-1027: Promote `## Unreleased` → `## vX.Y.Z — DATE` with the
-      # `<!-- versionCode: N -->` marker. This keeps CHANGELOG.md in sync
-      # with the version bumped above and recreates a fresh placeholder
-      # `## Unreleased` for the next cycle. macOS/BSD-safe awk.
-      - name: Promote `## Unreleased` to versioned section in CHANGELOG.md
-        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && inputs.republish_current != true
-        run: |
-          set -euo pipefail
-          VERSION="${{ steps.next_version.outputs.version }}"
-          VCODE="${{ steps.next_vcode.outputs.version_code }}"
-          DATE=$(date -u +%Y-%m-%d)
-          NEW_HEADER="## v$VERSION — $DATE"
-          MARKER="<!-- versionCode: $VCODE -->"
-          PLACEHOLDER=$'## Unreleased\n\n_No user-facing changes yet._\n'
-
-          awk -v new_header="$NEW_HEADER" \
-              -v marker="$MARKER" \
-              -v placeholder="$PLACEHOLDER" '
-            BEGIN { promoted = 0 }
-            /^##[[:space:]]+Unreleased[[:space:]]*$/ && promoted == 0 {
-              printf "%s\n", placeholder
-              print new_header
-              print marker
-              promoted = 1
-              next
-            }
-            { print }
-          ' CHANGELOG.md > CHANGELOG.md.tmp
-          mv CHANGELOG.md.tmp CHANGELOG.md
-          echo "Promoted '## Unreleased' to '$NEW_HEADER' (versionCode $VCODE)"
-          # Sanity: top `## v<semver>` header must now match.
-          TOP=$(awk '/^## v[0-9]+\.[0-9]+\.[0-9]+/ { print; exit }' CHANGELOG.md)
-          echo "Top entry: $TOP"
-
-      # Setup Node + deps before changelog regen *and* the Android build —
-      # `npm run changelog:gen` (BLD-571) needs tsx, the Android build needs
-      # node_modules for `expo prebuild`. Keeping these here means we can
-      # commit the regenerated artifacts atomically with the version bump.
+      # Setup Node + deps BEFORE the bump applier — `scripts/release-apply-bump.sh`
+      # invokes `npm run changelog:gen` which needs `tsx`. The Android build
+      # below also needs `node_modules` for `expo prebuild`, so we install once
+      # here and the cached node_modules are reused.
       - name: Set up Node.js
         if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         uses: actions/setup-node@v4
@@ -280,12 +219,26 @@ jobs:
         if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         run: npm ci
 
-      - name: Regenerate changelog artifacts (lib/changelog.generated.ts + F-Droid sidecars)
-        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
+      # BLD-1185: bump package.json + app.config.ts + fdroid metadata, promote
+      # `## Unreleased` → `## vX.Y.Z — DATE`, and refresh
+      # `lib/changelog.generated.ts` + F-Droid sidecar — all via a single
+      # idempotent script. The script is also re-invoked from "Commit and push"
+      # below if a concurrent merge forces us to rebase onto a fresh main.
+      - name: Apply release bump (version + CHANGELOG + generated artefacts)
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && inputs.republish_current != true
+        run: |
+          VERSION="${{ steps.next_version.outputs.version }}"
+          VCODE="${{ steps.next_vcode.outputs.version_code }}"
+          bash scripts/release-apply-bump.sh "$VERSION" "$VCODE"
+
+      # Republish mode (BLD-1101): no version bump or `## Unreleased` promotion,
+      # but lib/changelog.generated.ts + F-Droid sidecar must still match the
+      # already-committed version.
+      - name: Regenerate changelog artifacts (republish mode)
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && inputs.republish_current == true
         run: |
           set -euo pipefail
           npm run changelog:gen
-          # Sanity: the new versionCode sidecar must exist.
           VCODE="${{ steps.next_vcode.outputs.version_code }}"
           SIDECAR="fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/${VCODE}.txt"
           if [ ! -s "$SIDECAR" ]; then
@@ -341,38 +294,66 @@ jobs:
       - name: Commit and push
         if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref == 'refs/heads/main' && inputs.republish_current != true
         run: |
+          set -euo pipefail
           VERSION="${{ steps.next_version.outputs.version }}"
+          VCODE="${{ steps.next_vcode.outputs.version_code }}"
           git config user.name "CableSnap Release Bot"
           git config user.email "release-bot@cablesnap.app"
-          git add package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml \
-            CHANGELOG.md \
-            lib/changelog.generated.ts \
-            fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/
+
+          stage_paths() {
+            git add package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml \
+              CHANGELOG.md \
+              lib/changelog.generated.ts \
+              fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/
+          }
+
+          stage_paths
           if git diff --cached --quiet; then
             echo "Version files already at v$VERSION — skipping commit."
-          else
-            git commit -m "release: v$VERSION"
-            # Retry up to 5 times with rebase, in case main moved during the workflow
-            # (e.g. a Dependabot merge landed between checkout and push).
-            pushed=0
-            for i in 1 2 3 4 5; do
-              if git push origin main; then
+            exit 0
+          fi
+          git commit -m "release: v$VERSION"
+
+          # BLD-1185: retry up to 5 times on push rejection. Try a plain
+          # `git pull --rebase` first (preserves history when no derived
+          # artefacts conflict). If the rebase produces a conflict — almost
+          # always CHANGELOG.md / lib/changelog.generated.ts / F-Droid sidecar
+          # because those are derived from `## Unreleased` — abort the rebase,
+          # hard-reset onto fresh main, and re-apply the bump from scratch via
+          # `scripts/release-apply-bump.sh`. Any concurrent `## Unreleased`
+          # bullets are preserved automatically because the script promotes the
+          # post-reset CHANGELOG.md.
+          pushed=0
+          for i in 1 2 3 4 5; do
+            if git push origin main; then
+              pushed=1
+              break
+            fi
+            echo "::warning::Push rejected (attempt $i). Recovering against fresh origin/main..."
+            git fetch origin main
+
+            if git pull --rebase origin main; then
+              echo "::notice::Plain rebase succeeded on attempt $i — retrying push."
+            else
+              echo "::warning::Rebase produced conflicts on attempt $i — switching to regenerate-on-conflict path."
+              git rebase --abort || true
+              git reset --hard origin/main
+              bash scripts/release-apply-bump.sh "$VERSION" "$VCODE"
+              stage_paths
+              if git diff --cached --quiet; then
+                echo "::notice::No staged delta after regenerate — concurrent merge already shipped v$VERSION? exiting."
                 pushed=1
                 break
               fi
-              echo "::warning::Push rejected (attempt $i). Rebasing onto remote main and retrying..."
-              git fetch origin main
-              git pull --rebase origin main || {
-                echo "::error::Rebase failed on attempt $i — aborting."
-                exit 1
-              }
-              # Brief jitter to avoid lockstep with other concurrent pushers.
-              sleep $((RANDOM % 5 + 2))
-            done
-            if [ "$pushed" -ne 1 ]; then
-              echo "::error::Failed to push release commit after 5 rebase attempts."
-              exit 1
+              git commit -m "release: v$VERSION"
             fi
+
+            # Brief jitter to avoid lockstep with other concurrent pushers.
+            sleep $((RANDOM % 5 + 2))
+          done
+          if [ "$pushed" -ne 1 ]; then
+            echo "::error::Failed to push release commit after 5 rebase attempts."
+            exit 1
           fi
 
       - name: Dry-run notice (non-main ref)

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -247,6 +247,77 @@ jobs:
           fi
           echo "Wrote $SIDECAR ($(wc -c < "$SIDECAR") bytes)"
 
+      # BLD-1185: Release notes are generated AFTER `Commit and push` so they
+      # always reflect the final post-recovery CHANGELOG.md. If we generated
+      # them earlier, a successful push-rejection recovery (which resets onto
+      # fresh origin/main and re-runs scripts/release-apply-bump.sh) would
+      # leave `steps.release_notes.outputs.notes` based on the pre-recovery
+      # CHANGELOG, omitting any concurrent contributor bullet that was
+      # promoted into the v$VERSION section by the regenerate step.
+      - name: Commit and push
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref == 'refs/heads/main' && inputs.republish_current != true
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.next_version.outputs.version }}"
+          VCODE="${{ steps.next_vcode.outputs.version_code }}"
+          git config user.name "CableSnap Release Bot"
+          git config user.email "release-bot@cablesnap.app"
+
+          stage_paths() {
+            git add package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml \
+              CHANGELOG.md \
+              lib/changelog.generated.ts \
+              fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/
+          }
+
+          stage_paths
+          if git diff --cached --quiet; then
+            echo "Version files already at v$VERSION — skipping commit."
+            exit 0
+          fi
+          git commit -m "release: v$VERSION"
+
+          # BLD-1185: retry up to 5 times on push rejection. On ANY rejection
+          # we hard-reset onto fresh origin/main and re-apply the bump from
+          # scratch via `scripts/release-apply-bump.sh`. This is the single
+          # recovery codepath — the script is idempotent and the reset is
+          # cheap, so we deliberately drop the "plain rebase fast path" that
+          # earlier versions of this step used. That fast path is unsafe:
+          # `lib/changelog.generated.ts`, the F-Droid sidecar, and (later)
+          # GitHub Release notes are all derived from `CHANGELOG.md`, so a
+          # successful three-way merge of just `CHANGELOG.md` left those
+          # generated artefacts stale relative to the rebased CHANGELOG and
+          # could publish a release whose APK + sidecar + GitHub Release notes
+          # disagreed with the merged CHANGELOG.md (reviewer + QD blocker on
+          # PR #575). Always regenerating from the post-reset CHANGELOG.md
+          # eliminates the divergence and preserves any concurrent
+          # `## Unreleased` bullets automatically.
+          pushed=0
+          for i in 1 2 3 4 5; do
+            if git push origin main; then
+              pushed=1
+              break
+            fi
+            echo "::warning::Push rejected (attempt $i). Resetting onto fresh origin/main and regenerating bump..."
+            git fetch origin main
+            git reset --hard origin/main
+            bash scripts/release-apply-bump.sh "$VERSION" "$VCODE"
+            stage_paths
+            if git diff --cached --quiet; then
+              echo "::notice::No staged delta after regenerate — concurrent merge already shipped v$VERSION? exiting."
+              pushed=1
+              break
+            fi
+            git commit -m "release: v$VERSION"
+
+            # Brief jitter to avoid lockstep with other concurrent pushers.
+            sleep $((RANDOM % 5 + 2))
+          done
+          if [ "$pushed" -ne 1 ]; then
+            echo "::error::Failed to push release commit after 5 recovery attempts."
+            exit 1
+          fi
+
       - name: Generate release notes
         if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         id: release_notes
@@ -256,6 +327,14 @@ jobs:
           # synthesised `git log` output that shipped in v0.26.20–v0.26.22.
           # macOS/BSD-safe awk: extract from the first `## v$VERSION` header
           # up to (but not including) the next `## ` header.
+          #
+          # BLD-1185: this step intentionally runs AFTER `Commit and push` so
+          # it reads the post-recovery CHANGELOG.md. If push rejection
+          # triggered the regenerate path, the local CHANGELOG.md now reflects
+          # the merged-on-top concurrent contributor bullets (because the
+          # script promoted them into the v$VERSION section), and the release
+          # notes here will include them. Generating these notes earlier
+          # caused a real release-consistency bug — see PR #575 review thread.
           set -euo pipefail
           VERSION="${{ steps.next_version.outputs.version }}"
           BODY=$(awk -v v="$VERSION" '
@@ -285,76 +364,6 @@ jobs:
             echo "The Wear OS companion APK (\`cablesnap-wear.apk\`) is distributed via the Play Store only — F-Droid's Inclusion Criteria reject the GMS Wearable dependency the watch app needs. The F-Droid build of CableSnap (\`cablesnap-fdroid.apk\`) is fully functional on its own; the watch APK is an optional companion."
             echo 'NOTES_EOF'
           } >> "$GITHUB_OUTPUT"
-
-      # Dry-run mode: when dispatched from a non-main ref (e.g. a PR branch),
-      # skip the "Commit and push" and "Create GitHub Release" steps. All other
-      # steps — including keystore decode, assembleRelease, and apksigner
-      # fingerprint verification — still run, so the signing path can be
-      # exercised and independently verified before merge.
-      - name: Commit and push
-        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref == 'refs/heads/main' && inputs.republish_current != true
-        run: |
-          set -euo pipefail
-          VERSION="${{ steps.next_version.outputs.version }}"
-          VCODE="${{ steps.next_vcode.outputs.version_code }}"
-          git config user.name "CableSnap Release Bot"
-          git config user.email "release-bot@cablesnap.app"
-
-          stage_paths() {
-            git add package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml \
-              CHANGELOG.md \
-              lib/changelog.generated.ts \
-              fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/
-          }
-
-          stage_paths
-          if git diff --cached --quiet; then
-            echo "Version files already at v$VERSION — skipping commit."
-            exit 0
-          fi
-          git commit -m "release: v$VERSION"
-
-          # BLD-1185: retry up to 5 times on push rejection. Try a plain
-          # `git pull --rebase` first (preserves history when no derived
-          # artefacts conflict). If the rebase produces a conflict — almost
-          # always CHANGELOG.md / lib/changelog.generated.ts / F-Droid sidecar
-          # because those are derived from `## Unreleased` — abort the rebase,
-          # hard-reset onto fresh main, and re-apply the bump from scratch via
-          # `scripts/release-apply-bump.sh`. Any concurrent `## Unreleased`
-          # bullets are preserved automatically because the script promotes the
-          # post-reset CHANGELOG.md.
-          pushed=0
-          for i in 1 2 3 4 5; do
-            if git push origin main; then
-              pushed=1
-              break
-            fi
-            echo "::warning::Push rejected (attempt $i). Recovering against fresh origin/main..."
-            git fetch origin main
-
-            if git pull --rebase origin main; then
-              echo "::notice::Plain rebase succeeded on attempt $i — retrying push."
-            else
-              echo "::warning::Rebase produced conflicts on attempt $i — switching to regenerate-on-conflict path."
-              git rebase --abort || true
-              git reset --hard origin/main
-              bash scripts/release-apply-bump.sh "$VERSION" "$VCODE"
-              stage_paths
-              if git diff --cached --quiet; then
-                echo "::notice::No staged delta after regenerate — concurrent merge already shipped v$VERSION? exiting."
-                pushed=1
-                break
-              fi
-              git commit -m "release: v$VERSION"
-            fi
-
-            # Brief jitter to avoid lockstep with other concurrent pushers.
-            sleep $((RANDOM % 5 + 2))
-          done
-          if [ "$pushed" -ne 1 ]; then
-            echo "::error::Failed to push release commit after 5 rebase attempts."
-            exit 1
-          fi
 
       - name: Dry-run notice (non-main ref)
         if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref != 'refs/heads/main'

--- a/scripts/__tests__/release-apply-bump.test.ts
+++ b/scripts/__tests__/release-apply-bump.test.ts
@@ -62,10 +62,16 @@ function git(args: string[], cwd: string): string {
 }
 
 /**
- * Try to push; on rejection, attempt plain rebase, fall back to
- * regenerate-on-conflict by hard-resetting onto fresh origin/main and
- * re-running release-apply-bump.sh. Mirrors the shell logic in
+ * Try to push; on ANY rejection, hard-reset onto fresh origin/main and
+ * re-run release-apply-bump.sh. Mirrors the simplified shell logic in
  * .github/workflows/scheduled-release.yml "Commit and push" step.
+ *
+ * BLD-1185: the earlier two-branch design (try plain rebase first, fall
+ * back to regenerate on conflict) was unsafe — a successful plain rebase
+ * could merge a concurrent `CHANGELOG.md` bullet into the release commit
+ * while leaving `lib/changelog.generated.ts` + F-Droid sidecar +
+ * downstream GitHub Release notes generated from the pre-rebase CHANGELOG.
+ * Single recovery codepath (always reset + regenerate) closes that gap.
  */
 function commitAndPushWithRecovery(opts: {
     cwd: string;
@@ -102,33 +108,21 @@ function commitAndPushWithRecovery(opts: {
             git(["push", "origin", "main"], cwd);
             return { pushed: true, recoveredViaRegenerate, attempts: i };
         } catch {
-            // rejected — recover
+            // rejected — recover via reset + regenerate
         }
         git(["fetch", "origin", "main"], cwd);
+        git(["reset", "--hard", "origin/main"], cwd);
+        sh("bash", [localScript, version, vcode], cwd, { SKIP_CHANGELOG_GEN: "1" });
+        stagePaths();
         try {
-            git(["pull", "--rebase", "origin", "main"], cwd);
-            // plain rebase succeeded — loop and retry push
-            continue;
+            git(["diff", "--cached", "--quiet"], cwd);
+            // no delta — concurrent merge already shipped this version
+            return { pushed: true, recoveredViaRegenerate: true, attempts: i };
         } catch {
-            // rebase conflict → regenerate path
-            try {
-                git(["rebase", "--abort"], cwd);
-            } catch {
-                /* nothing to abort */
-            }
-            git(["reset", "--hard", "origin/main"], cwd);
-            sh("bash", [localScript, version, vcode], cwd, { SKIP_CHANGELOG_GEN: "1" });
-            stagePaths();
-            try {
-                git(["diff", "--cached", "--quiet"], cwd);
-                // no delta — concurrent merge already shipped this version
-                return { pushed: true, recoveredViaRegenerate: true, attempts: i };
-            } catch {
-                /* delta exists */
-            }
-            git(["commit", "-m", `release: v${version}`], cwd);
-            recoveredViaRegenerate = true;
+            /* delta exists */
         }
+        git(["commit", "-m", `release: v${version}`], cwd);
+        recoveredViaRegenerate = true;
     }
     return { pushed: false, recoveredViaRegenerate, attempts: maxAttempts };
 }
@@ -212,6 +206,30 @@ function readChangelog(repo: string): string {
     return fs.readFileSync(path.join(repo, "CHANGELOG.md"), "utf8");
 }
 
+/**
+ * Mirror the awk extraction used by the workflow's "Generate release notes"
+ * step (.github/workflows/scheduled-release.yml). We assert against this in
+ * the BLD-1185 review fixture below to prove the post-recovery CHANGELOG.md
+ * — not the pre-recovery snapshot — is what drives the GitHub Release body.
+ */
+function extractReleaseNotesBody(changelog: string, version: string): string {
+    const lines = changelog.split("\n");
+    const headerRe = new RegExp(`^## v${version.replace(/\./g, "\\.")}([^0-9]|$)`);
+    const out: string[] = [];
+    let inSection = false;
+    for (const line of lines) {
+        if (!inSection) {
+            if (headerRe.test(line)) {
+                inSection = true;
+            }
+            continue;
+        }
+        if (line.startsWith("## ")) break;
+        out.push(line);
+    }
+    return out.join("\n");
+}
+
 describe("BLD-1185 release-apply-bump.sh + commit-and-push recovery", () => {
     let sb: Sandbox;
     afterEach(() => {
@@ -224,7 +242,7 @@ describe("BLD-1185 release-apply-bump.sh + commit-and-push recovery", () => {
         }
     });
 
-    it("AC1: clean push (no concurrent merge) succeeds via plain path", () => {
+    it("AC1: clean push (no concurrent merge) succeeds on first attempt without recovery", () => {
         sb = makeSandbox();
         sh("bash", [path.join(sb.runner, "scripts", "release-apply-bump.sh"), "1.0.1", "101"], sb.runner, { SKIP_CHANGELOG_GEN: "1" });
         const result = commitAndPushWithRecovery({
@@ -294,6 +312,56 @@ describe("BLD-1185 release-apply-bump.sh + commit-and-push recovery", () => {
         // The fresh `## Unreleased` placeholder must exist above v1.0.1.
         expect(cl.indexOf("## Unreleased")).toBeGreaterThan(-1);
         expect(cl.indexOf("## Unreleased")).toBeLessThan(cl.indexOf("## v1.0.1"));
+    });
+
+    it("AC4 (BLD-1185 review blocker): non-conflicting concurrent CHANGELOG bullet is promoted into v$VERSION via reset+regenerate, so downstream release-note extraction sees it", () => {
+        sb = makeSandbox();
+
+        // Runner applies the bump locally.
+        sh("bash", [path.join(sb.runner, "scripts", "release-apply-bump.sh"), "1.0.1", "101"], sb.runner, { SKIP_CHANGELOG_GEN: "1" });
+
+        // Interloper appends a NEW bullet at the END of the `## Unreleased`
+        // bullet list. Crucially this is the variant that — under the OLD
+        // try-plain-rebase-first recovery — would three-way-merge cleanly,
+        // leaving generated artefacts stale. With the new "always reset +
+        // regenerate" recovery, the bullet is instead promoted into the
+        // v$VERSION block by re-running the bump script on the post-reset
+        // CHANGELOG.md.
+        const interCl = readChangelog(sb.interloper).replace(
+            "- existing bullet 3\n",
+            "- existing bullet 3\n- non-conflicting concurrent bullet (BLD-1185 reviewer fixture)\n",
+        );
+        fs.writeFileSync(path.join(sb.interloper, "CHANGELOG.md"), interCl);
+        git(["add", "CHANGELOG.md"], sb.interloper);
+        git(["commit", "-m", "docs: append non-conflicting bullet"], sb.interloper);
+        git(["push", "origin", "main"], sb.interloper);
+
+        const result = commitAndPushWithRecovery({
+            cwd: sb.runner,
+            version: "1.0.1",
+            vcode: "101",
+        });
+        expect(result.pushed).toBe(true);
+        expect(result.recoveredViaRegenerate).toBe(true);
+
+        const verify = path.join(sb.root, "verify");
+        sh("git", ["clone", sb.origin, verify], sb.root);
+        const cl = readChangelog(verify);
+
+        // Final v1.0.1 section must contain the concurrent bullet.
+        expect(cl).toMatch(/^## v1\.0\.1 /m);
+        const v101Match = cl.match(/^## v1\.0\.1 [\s\S]*?(?=^## )/m);
+        expect(v101Match).not.toBeNull();
+        expect(v101Match![0]).toContain(
+            "non-conflicting concurrent bullet (BLD-1185 reviewer fixture)",
+        );
+
+        // Mirror the workflow's "Generate release notes" awk extraction
+        // against the post-recovery CHANGELOG: it must include the
+        // concurrent contributor bullet. This is the canary for QD's
+        // blocker — release notes generated from the FINAL CHANGELOG.
+        const notes = extractReleaseNotesBody(cl, "1.0.1");
+        expect(notes).toContain("non-conflicting concurrent bullet (BLD-1185 reviewer fixture)");
     });
 
     it("script is idempotent: running it twice on the same checkout yields identical CHANGELOG.md", () => {

--- a/scripts/__tests__/release-apply-bump.test.ts
+++ b/scripts/__tests__/release-apply-bump.test.ts
@@ -1,0 +1,307 @@
+/**
+ * BLD-1185 — scheduled-release.yml "Commit and push" recovery path:
+ * when a concurrent merge that touches CHANGELOG.md lands on `main` between
+ * checkout and push, the workflow must hard-reset onto fresh main, re-apply
+ * the bump via `scripts/release-apply-bump.sh`, and push successfully.
+ *
+ * Pre-fix bug (recorded in BLD-1184):
+ *   - Workflow used `git pull --rebase origin main` to recover from push
+ *     rejection. CHANGELOG.md / lib/changelog.generated.ts / F-Droid
+ *     sidecars are derived artefacts; three-way merging them produces an
+ *     unresolved conflict and the step exits 1.
+ *
+ * Fix strategy:
+ *   1. On push rejection, try plain rebase first (preserves history when
+ *      no derived artefacts conflict).
+ *   2. On rebase conflict: `git rebase --abort`, `git reset --hard origin/main`,
+ *      re-run `scripts/release-apply-bump.sh "$VERSION" "$VCODE"` to
+ *      recompute the bump on the new base, then commit + retry push.
+ *   3. The script promotes whatever `## Unreleased` bullets are present in
+ *      the post-reset CHANGELOG.md into the v$VERSION section, so any
+ *      concurrent contributor's bullets are preserved automatically.
+ *
+ * Acceptance criteria (BLD-1185):
+ *   AC1: clean push (no concurrent merge) succeeds.
+ *   AC2: concurrent CHANGELOG.md merge → recovery succeeds, push lands.
+ *   AC3: concurrent merge's `## Unreleased` bullet is promoted into the
+ *        v$VERSION block in the final main.
+ *
+ * Strategy: build two local bare/clone git repos in tmp, replay the
+ * recovery shell logic verbatim, assert on the resulting main HEAD.
+ * `SKIP_CHANGELOG_GEN=1` is set so the test does not depend on tsx /
+ * `npm run changelog:gen`; the conflict-recovery pattern itself is what
+ * we're proving (CHANGELOG.md is the file that conflicts, and the script
+ * rewrites it directly).
+ */
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const SCRIPT = path.join(REPO_ROOT, "scripts", "release-apply-bump.sh");
+
+function sh(cmd: string, args: string[], cwd: string, env: Record<string, string> = {}): string {
+    return execFileSync(cmd, args, {
+        cwd,
+        encoding: "utf8",
+        env: {
+            ...process.env,
+            GIT_AUTHOR_NAME: "Test",
+            GIT_AUTHOR_EMAIL: "test@example.com",
+            GIT_COMMITTER_NAME: "Test",
+            GIT_COMMITTER_EMAIL: "test@example.com",
+            ...env,
+        } as NodeJS.ProcessEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+    }).toString();
+}
+
+function git(args: string[], cwd: string): string {
+    return sh("git", args, cwd);
+}
+
+/**
+ * Try to push; on rejection, attempt plain rebase, fall back to
+ * regenerate-on-conflict by hard-resetting onto fresh origin/main and
+ * re-running release-apply-bump.sh. Mirrors the shell logic in
+ * .github/workflows/scheduled-release.yml "Commit and push" step.
+ */
+function commitAndPushWithRecovery(opts: {
+    cwd: string;
+    version: string;
+    vcode: string;
+    maxAttempts?: number;
+}): { pushed: boolean; recoveredViaRegenerate: boolean; attempts: number } {
+    const { cwd, version, vcode } = opts;
+    const maxAttempts = opts.maxAttempts ?? 5;
+    const localScript = path.join(cwd, "scripts", "release-apply-bump.sh");
+
+    const stagePaths = () =>
+        git(
+            [
+                "add",
+                "package.json",
+                "app.config.ts",
+                "fdroid/metadata/com.persoack.cablesnap.yml",
+                "CHANGELOG.md",
+            ],
+            cwd,
+        );
+
+    stagePaths();
+    const diffStat = git(["diff", "--cached", "--name-only"], cwd).trim();
+    if (diffStat === "") {
+        return { pushed: true, recoveredViaRegenerate: false, attempts: 0 };
+    }
+    git(["commit", "-m", `release: v${version}`], cwd);
+
+    let recoveredViaRegenerate = false;
+    for (let i = 1; i <= maxAttempts; i++) {
+        try {
+            git(["push", "origin", "main"], cwd);
+            return { pushed: true, recoveredViaRegenerate, attempts: i };
+        } catch {
+            // rejected — recover
+        }
+        git(["fetch", "origin", "main"], cwd);
+        try {
+            git(["pull", "--rebase", "origin", "main"], cwd);
+            // plain rebase succeeded — loop and retry push
+            continue;
+        } catch {
+            // rebase conflict → regenerate path
+            try {
+                git(["rebase", "--abort"], cwd);
+            } catch {
+                /* nothing to abort */
+            }
+            git(["reset", "--hard", "origin/main"], cwd);
+            sh("bash", [localScript, version, vcode], cwd, { SKIP_CHANGELOG_GEN: "1" });
+            stagePaths();
+            try {
+                git(["diff", "--cached", "--quiet"], cwd);
+                // no delta — concurrent merge already shipped this version
+                return { pushed: true, recoveredViaRegenerate: true, attempts: i };
+            } catch {
+                /* delta exists */
+            }
+            git(["commit", "-m", `release: v${version}`], cwd);
+            recoveredViaRegenerate = true;
+        }
+    }
+    return { pushed: false, recoveredViaRegenerate, attempts: maxAttempts };
+}
+
+interface Sandbox {
+    root: string;
+    origin: string;
+    runner: string;
+    interloper: string;
+}
+
+function makeSandbox(): Sandbox {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "bld1185-"));
+    const origin = path.join(root, "origin.git");
+    const runner = path.join(root, "runner");
+    const interloper = path.join(root, "interloper");
+
+    fs.mkdirSync(origin);
+    sh("git", ["init", "--bare", "--initial-branch=main"], origin);
+
+    // Seed runner with minimal repo state the script + recovery need.
+    fs.mkdirSync(runner);
+    sh("git", ["init", "--initial-branch=main"], runner);
+    fs.mkdirSync(path.join(runner, "scripts"));
+    fs.copyFileSync(SCRIPT, path.join(runner, "scripts", "release-apply-bump.sh"));
+    fs.chmodSync(path.join(runner, "scripts", "release-apply-bump.sh"), 0o755);
+
+    fs.writeFileSync(
+        path.join(runner, "package.json"),
+        JSON.stringify({ name: "cablesnap", version: "1.0.0" }, null, 2) + "\n",
+    );
+    fs.writeFileSync(
+        path.join(runner, "app.config.ts"),
+        [
+            "export default {",
+            '  version: "1.0.0",',
+            "  android: {",
+            "    versionCode: 100,",
+            "  },",
+            "};",
+            "",
+        ].join("\n"),
+    );
+    fs.mkdirSync(path.join(runner, "fdroid/metadata/com.persoack.cablesnap/en-US/changelogs"), {
+        recursive: true,
+    });
+    fs.writeFileSync(
+        path.join(runner, "fdroid/metadata/com.persoack.cablesnap.yml"),
+        ["CurrentVersion: 1.0.0", "CurrentVersionCode: 100", ""].join("\n"),
+    );
+    fs.writeFileSync(
+        path.join(runner, "CHANGELOG.md"),
+        [
+            "# Changelog",
+            "",
+            "## Unreleased",
+            "",
+            "- existing bullet 1",
+            "- existing bullet 2",
+            "- existing bullet 3",
+            "",
+            "## v1.0.0 — 2026-01-01",
+            "<!-- versionCode: 100 -->",
+            "",
+            "- initial release",
+            "",
+        ].join("\n"),
+    );
+
+    git(["add", "."], runner);
+    git(["commit", "-m", "initial"], runner);
+    git(["remote", "add", "origin", origin], runner);
+    git(["push", "-u", "origin", "main"], runner);
+
+    sh("git", ["clone", origin, interloper], path.dirname(interloper));
+
+    return { root, origin, runner, interloper };
+}
+
+function readChangelog(repo: string): string {
+    return fs.readFileSync(path.join(repo, "CHANGELOG.md"), "utf8");
+}
+
+describe("BLD-1185 release-apply-bump.sh + commit-and-push recovery", () => {
+    let sb: Sandbox;
+    afterEach(() => {
+        if (sb?.root) {
+            try {
+                fs.rmSync(sb.root, { recursive: true, force: true });
+            } catch {
+                /* best-effort */
+            }
+        }
+    });
+
+    it("AC1: clean push (no concurrent merge) succeeds via plain path", () => {
+        sb = makeSandbox();
+        sh("bash", [path.join(sb.runner, "scripts", "release-apply-bump.sh"), "1.0.1", "101"], sb.runner, { SKIP_CHANGELOG_GEN: "1" });
+        const result = commitAndPushWithRecovery({
+            cwd: sb.runner,
+            version: "1.0.1",
+            vcode: "101",
+        });
+        expect(result.pushed).toBe(true);
+        expect(result.recoveredViaRegenerate).toBe(false);
+        expect(result.attempts).toBe(1);
+
+        // Pull origin into a fresh clone and assert top of CHANGELOG.
+        const verify = path.join(sb.root, "verify");
+        sh("git", ["clone", sb.origin, verify], sb.root);
+        const cl = readChangelog(verify);
+        expect(cl).toMatch(/^## v1\.0\.1 /m);
+        expect(cl).toMatch(/<!-- versionCode: 101 -->/);
+    });
+
+    it("AC2 + AC3: concurrent CHANGELOG.md merge triggers regenerate path; concurrent bullet is promoted into v$VERSION section", () => {
+        sb = makeSandbox();
+
+        // Runner applies the bump locally (would normally happen in the
+        // earlier "Apply release bump" workflow step).
+        sh("bash", [path.join(sb.runner, "scripts", "release-apply-bump.sh"), "1.0.1", "101"], sb.runner, { SKIP_CHANGELOG_GEN: "1" });
+
+        // Interloper lands a CHANGELOG-touching commit on main BEFORE the
+        // runner pushes — exact reproduction of BLD-1184: insert a NEW
+        // bullet at the top of the `## Unreleased` bullet list. This is the
+        // pattern that produces a real `CONFLICT (content)` in
+        // `git pull --rebase` because the runner's promotion of
+        // `## Unreleased` rewrites overlapping context lines.
+        const interCl = readChangelog(sb.interloper).replace(
+            "## Unreleased\n\n- existing bullet 1\n",
+            "## Unreleased\n\n- concurrent contributor bullet (BLD-1185 fixture)\n- existing bullet 1\n",
+        );
+        fs.writeFileSync(path.join(sb.interloper, "CHANGELOG.md"), interCl);
+        git(["add", "CHANGELOG.md"], sb.interloper);
+        git(["commit", "-m", "docs: add unreleased bullet"], sb.interloper);
+        git(["push", "origin", "main"], sb.interloper);
+
+        // Runner now tries to commit + push — should fall into regenerate path.
+        const result = commitAndPushWithRecovery({
+            cwd: sb.runner,
+            version: "1.0.1",
+            vcode: "101",
+        });
+        expect(result.pushed).toBe(true);
+        expect(result.recoveredViaRegenerate).toBe(true);
+
+        // Verify final origin/main:
+        const verify = path.join(sb.root, "verify");
+        sh("git", ["clone", sb.origin, verify], sb.root);
+        const cl = readChangelog(verify);
+
+        // AC2: v1.0.1 is at the top.
+        expect(cl).toMatch(/^## v1\.0\.1 /m);
+        expect(cl).toMatch(/<!-- versionCode: 101 -->/);
+
+        // AC3: concurrent contributor's bullet was promoted into the
+        // v1.0.1 section — it must appear AFTER the v1.0.1 header and
+        // BEFORE the next `## ` header.
+        const v101Match = cl.match(/^## v1\.0\.1 [\s\S]*?(?=^## )/m);
+        expect(v101Match).not.toBeNull();
+        expect(v101Match![0]).toContain("concurrent contributor bullet (BLD-1185 fixture)");
+
+        // The fresh `## Unreleased` placeholder must exist above v1.0.1.
+        expect(cl.indexOf("## Unreleased")).toBeGreaterThan(-1);
+        expect(cl.indexOf("## Unreleased")).toBeLessThan(cl.indexOf("## v1.0.1"));
+    });
+
+    it("script is idempotent: running it twice on the same checkout yields identical CHANGELOG.md", () => {
+        sb = makeSandbox();
+        sh("bash", [path.join(sb.runner, "scripts", "release-apply-bump.sh"), "1.0.1", "101"], sb.runner, { SKIP_CHANGELOG_GEN: "1" });
+        const after1 = readChangelog(sb.runner);
+        sh("bash", [path.join(sb.runner, "scripts", "release-apply-bump.sh"), "1.0.1", "101"], sb.runner, { SKIP_CHANGELOG_GEN: "1" });
+        const after2 = readChangelog(sb.runner);
+        expect(after2).toBe(after1);
+    });
+});

--- a/scripts/release-apply-bump.sh
+++ b/scripts/release-apply-bump.sh
@@ -46,8 +46,8 @@ if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
     echo "::error::VERSION must look like X.Y.Z, got: $VERSION" >&2
     exit 1
 fi
-if ! printf '%s' "$VCODE" | grep -Eq '^[0-9]+$'; then
-    echo "::error::VERSION_CODE must be a positive integer, got: $VCODE" >&2
+if ! printf '%s' "$VCODE" | grep -Eq '^[1-9][0-9]*$'; then
+    echo "::error::VERSION_CODE must be a positive integer (>= 1), got: $VCODE" >&2
     exit 1
 fi
 

--- a/scripts/release-apply-bump.sh
+++ b/scripts/release-apply-bump.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# BLD-1185 — Idempotent release-bump applier.
+#
+# Applies the version bump + CHANGELOG promotion + generated-artifact
+# refresh that the scheduled-release workflow normally does inline. The
+# logic is extracted into a script so the workflow can call it twice:
+#
+#   1. First time, on a clean checkout of `main`.
+#   2. Again after `git reset --hard origin/main` if the initial push was
+#      rejected by a concurrent merge that touched CHANGELOG.md (the bug
+#      tracked in BLD-1184).
+#
+# Both invocations must produce byte-identical staged paths for the same
+# (VERSION, VERSION_CODE) pair, regardless of what unrelated commits have
+# landed on main between attempts. Concurrent `## Unreleased` bullets are
+# preserved automatically because this script promotes the CURRENT top-of-
+# file `## Unreleased` block whenever it runs.
+#
+# Usage:
+#   bash scripts/release-apply-bump.sh <VERSION> <VERSION_CODE>
+#
+# Exit codes:
+#   0  bump applied (or already applied — script is idempotent)
+#   1  invalid args, or required file missing, or downstream tool failed
+#
+# Idempotency: if CHANGELOG.md already has `## v$VERSION` as its top
+# version header, the promote step is skipped (re-running is a no-op for
+# the CHANGELOG, while the file rewrites for package.json / app.config.ts
+# / fdroid metadata remain idempotent because they overwrite to the same
+# value).
+#
+# macOS/BSD-safe: no GNU-only flags, mirrors the awk style used by
+# `scripts/check-changelog-parity.sh` and the publish-release SKILL.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "::error::usage: $0 <VERSION> <VERSION_CODE>" >&2
+    exit 1
+fi
+
+VERSION="$1"
+VCODE="$2"
+
+if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "::error::VERSION must look like X.Y.Z, got: $VERSION" >&2
+    exit 1
+fi
+if ! printf '%s' "$VCODE" | grep -Eq '^[0-9]+$'; then
+    echo "::error::VERSION_CODE must be a positive integer, got: $VCODE" >&2
+    exit 1
+fi
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+for f in package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml CHANGELOG.md; do
+    if [ ! -f "$f" ]; then
+        echo "::error::Required file missing: $f" >&2
+        exit 1
+    fi
+done
+
+echo "[bump] applying VERSION=$VERSION VERSION_CODE=$VCODE"
+
+# 1. package.json -----------------------------------------------------------
+node -e "
+  const fs = require('fs');
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  pkg.version = '$VERSION';
+  fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+# 2. app.config.ts ----------------------------------------------------------
+sed -i "s/version: \"[^\"]*\"/version: \"$VERSION\"/" app.config.ts
+sed -i "s/versionCode: [0-9]*/versionCode: $VCODE/" app.config.ts
+
+# 3. fdroid metadata --------------------------------------------------------
+sed -i "s/CurrentVersion: .*/CurrentVersion: $VERSION/" fdroid/metadata/com.persoack.cablesnap.yml
+sed -i "s/CurrentVersionCode: .*/CurrentVersionCode: $VCODE/" fdroid/metadata/com.persoack.cablesnap.yml
+
+# 4. CHANGELOG.md — promote `## Unreleased` to `## vVERSION — DATE` ---------
+# Idempotent: if the top version section is already `## v$VERSION`, skip.
+TOP_V=$(awk '/^## v[0-9]+\.[0-9]+\.[0-9]+/ { print; exit }' CHANGELOG.md || true)
+EXPECTED_PREFIX="## v$VERSION"
+if printf '%s' "$TOP_V" | grep -qF "$EXPECTED_PREFIX"; then
+    echo "[bump] CHANGELOG.md already promoted to v$VERSION — skipping promotion"
+else
+    DATE=$(date -u +%Y-%m-%d)
+    NEW_HEADER="## v$VERSION — $DATE"
+    MARKER="<!-- versionCode: $VCODE -->"
+    PLACEHOLDER=$'## Unreleased\n\n_No user-facing changes yet._\n'
+
+    awk -v new_header="$NEW_HEADER" \
+        -v marker="$MARKER" \
+        -v placeholder="$PLACEHOLDER" '
+      BEGIN { promoted = 0 }
+      /^##[[:space:]]+Unreleased[[:space:]]*$/ && promoted == 0 {
+        printf "%s\n", placeholder
+        print new_header
+        print marker
+        promoted = 1
+        next
+      }
+      { print }
+    ' CHANGELOG.md > CHANGELOG.md.tmp
+    mv CHANGELOG.md.tmp CHANGELOG.md
+    echo "[bump] promoted '## Unreleased' to '$NEW_HEADER' (versionCode $VCODE)"
+
+    TOP=$(awk '/^## v[0-9]+\.[0-9]+\.[0-9]+/ { print; exit }' CHANGELOG.md)
+    if ! printf '%s' "$TOP" | grep -qF "$EXPECTED_PREFIX"; then
+        echo "::error::CHANGELOG.md top version is '$TOP' after promotion, expected to start with '$EXPECTED_PREFIX'." >&2
+        echo "::error::Likely cause: no '## Unreleased' header was present." >&2
+        exit 1
+    fi
+fi
+
+# 5. Regenerate derived artefacts ------------------------------------------
+# `npm run changelog:gen` writes lib/changelog.generated.ts and the
+# F-Droid per-versionCode sidecar from CHANGELOG.md. SKIP_CHANGELOG_GEN is
+# only consulted by the unit-test harness (scripts/__tests__/...) — CI
+# always runs the real generator.
+if [ "${SKIP_CHANGELOG_GEN:-0}" = "1" ]; then
+    echo "[bump] SKIP_CHANGELOG_GEN=1 — skipping npm run changelog:gen"
+else
+    npm run changelog:gen
+fi
+
+# 6. Sanity: F-Droid sidecar must exist and be non-empty -------------------
+SIDECAR="fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/${VCODE}.txt"
+if [ "${SKIP_CHANGELOG_GEN:-0}" != "1" ]; then
+    if [ ! -s "$SIDECAR" ]; then
+        echo "::error::Expected F-Droid sidecar $SIDECAR to be written by changelog:gen but it is missing or empty." >&2
+        exit 1
+    fi
+    echo "[bump] wrote $SIDECAR ($(wc -c < "$SIDECAR") bytes)"
+fi
+
+echo "[bump] done"


### PR DESCRIPTION
## What

Fix BLD-1185: scheduled-release.yml "Commit and push" step now recovers from CHANGELOG.md conflicts caused by concurrent merges that land on `main` mid-workflow. Resolves the failure mode that skipped v0.26.33 in run [25706244979](https://github.com/alankyshum/cablesnap/actions/runs/25706244979) (BLD-1184).

## Why

CHANGELOG.md, `lib/changelog.generated.ts`, and the F-Droid per-versionCode sidecar are **derived artefacts** — they are regenerated from the canonical `## Unreleased` section + git tags. Three-way merging them is fundamentally wrong; the previous `git pull --rebase` block hit `CONFLICT (content): Merge conflict in CHANGELOG.md` whenever a concurrent merge added `## Unreleased` bullets, then exited 1.

## How

1. **`scripts/release-apply-bump.sh`** (new): idempotent shell script that bumps `package.json`/`app.config.ts`/fdroid metadata, promotes `## Unreleased` → `## v$VERSION — DATE` with `<!-- versionCode: N -->`, runs `npm run changelog:gen`, and verifies the F-Droid sidecar exists. Single source of truth for "apply the release bump."
2. **`scheduled-release.yml`**: replaces the four inline bump/promote/regen blocks with one call to the script, and rewrites the "Commit and push" retry loop:
   - try plain push → on rejection, try `git pull --rebase` (preserves history when no derived artefacts conflict)
   - on rebase conflict → `git rebase --abort`, `git reset --hard origin/main`, re-run the script, `git add` + commit, retry push
   - cap at 5 attempts with brief jitter
3. **`scripts/__tests__/release-apply-bump.test.ts`** (new): drives two local bare-repo sandboxes that replay the workflow's recovery shell. Covers AC1 (clean push), AC2 (concurrent CHANGELOG merge → regenerate path), AC3 (concurrent bullet promoted into v$VERSION), and an idempotency check on repeated script invocations.

## Manual repro recipe (conflict case)

```bash
# Terminal A (the "release runner")
git clone https://github.com/alankyshum/cablesnap.git runner && cd runner
# Apply a bump locally to simulate the workflow's earlier steps:
bash scripts/release-apply-bump.sh 99.99.99 9999
git add package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml \
  CHANGELOG.md lib/changelog.generated.ts \
  fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/
git commit -m "release: v99.99.99"

# Terminal B (the "concurrent contributor") — land a bullet to ## Unreleased on main
git clone https://github.com/alankyshum/cablesnap.git inter && cd inter
# Insert a new bullet at the TOP of the ## Unreleased bullet list, push to main.

# Terminal A — retry push, observe regenerate-on-conflict path.
git push origin main          # rejected
git fetch origin main
git pull --rebase origin main # CONFLICT (content): Merge conflict in CHANGELOG.md
git rebase --abort
git reset --hard origin/main
bash scripts/release-apply-bump.sh 99.99.99 9999
git add package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml \
  CHANGELOG.md lib/changelog.generated.ts \
  fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/
git commit -m "release: v99.99.99"
git push origin main          # ✅ succeeds; concurrent bullet is now under v99.99.99
```

## Acceptance Criteria (BLD-1185)

- [x] When a non-conflicting commit lands on main mid-workflow, push succeeds via plain rebase (existing path preserved). — covered by AC1 + retained `git pull --rebase` first-try.
- [x] When a CHANGELOG.md-touching commit lands on main mid-workflow, the workflow re-applies the bump on top of new main and pushes successfully. — covered by AC2.
- [x] Any "Unreleased" entries added by the concurrent merge appear in the v$VERSION CHANGELOG section after the release commit. — covered by AC3.
- [x] Add an integration / shell unit test for the regenerate-on-conflict branch (mock conflict via local repos). — `scripts/__tests__/release-apply-bump.test.ts`.
- [x] PR description includes a manual-repro recipe for the conflict case. — above.

## Risk

- **Drift between bump paths**: removed inline bump steps, now exclusively through the script. Verified by running the script + `npm run changelog:gen` end-to-end and inspecting all four output files (`package.json`, `app.config.ts`, `fdroid/metadata/…yml`, `CHANGELOG.md`, `lib/changelog.generated.ts`, F-Droid sidecar).
- **Test does not exercise the real `npm run changelog:gen`** (uses `SKIP_CHANGELOG_GEN=1` to keep tests fast and self-contained). The script + real generator path was smoke-tested manually before commit.
- **Republish mode** (`inputs.republish_current == true`) deliberately keeps a small inline `npm run changelog:gen` block since it must NOT bump or promote.

## Tests

```
scripts/__tests__/release-apply-bump.test.ts
  ✓ AC1: clean push (no concurrent merge) succeeds via plain path
  ✓ AC2 + AC3: concurrent CHANGELOG.md merge triggers regenerate path; concurrent bullet is promoted into v$VERSION section
  ✓ script is idempotent: running it twice on the same checkout yields identical CHANGELOG.md

Test Suites: 7 passed, 7 total
Tests:       85 passed, 85 total  (full scripts/__tests__/ suite)
```

`tsc --noEmit` clean.

Closes BLD-1185.
