### PR TITLE
fix(BLD-1183): cap legacy e1RM at reps<=12 in computeSetCacheValues

### DIFF
--- a/__tests__/lib/db/sets-cache-compute.test.ts
+++ b/__tests__/lib/db/sets-cache-compute.test.ts
@@ -1,0 +1,63 @@
+// Unit tests for computeSetCacheValues — BLD-1183: reps<=12 e1RM cap alignment with backfill
+import { computeSetCacheValues } from "../../../lib/db/sets";
+
+describe("computeSetCacheValues — legacy single-set branch (no segments)", () => {
+  it("caps cachedE1rmKg to 0 when reps > 12 (aligns with backfill cap)", () => {
+    const result = computeSetCacheValues({ weight: 100, reps: 15, isAdvancedSet: false }, []);
+    expect(result.cachedVolumeKg).toBe(1500);
+    expect(result.cachedE1rmKg).toBe(0);
+    expect(result.totalReps).toBe(15);
+  });
+
+  it("computes e1RM normally when reps === 12 (boundary: still valid)", () => {
+    const result = computeSetCacheValues({ weight: 100, reps: 12, isAdvancedSet: false }, []);
+    expect(result.cachedVolumeKg).toBe(1200);
+    expect(result.cachedE1rmKg).toBeCloseTo(100 * (1 + 12 / 30));
+    expect(result.totalReps).toBe(12);
+  });
+
+  it("computes e1RM normally when reps === 1", () => {
+    const result = computeSetCacheValues({ weight: 100, reps: 1, isAdvancedSet: false }, []);
+    expect(result.cachedVolumeKg).toBe(100);
+    expect(result.cachedE1rmKg).toBeCloseTo(100 * (1 + 1 / 30));
+    expect(result.totalReps).toBe(1);
+  });
+
+  it("returns zero e1RM when reps === 0", () => {
+    const result = computeSetCacheValues({ weight: 100, reps: 0, isAdvancedSet: false }, []);
+    expect(result.cachedVolumeKg).toBe(0);
+    expect(result.cachedE1rmKg).toBe(0);
+    expect(result.totalReps).toBe(0);
+  });
+
+  it("caps cachedE1rmKg to 0 when reps === 13 (first rep above cap)", () => {
+    const result = computeSetCacheValues({ weight: 80, reps: 13, isAdvancedSet: false }, []);
+    expect(result.cachedVolumeKg).toBe(1040);
+    expect(result.cachedE1rmKg).toBe(0);
+    expect(result.totalReps).toBe(13);
+  });
+
+  it("returns zeros for advanced set with no segments (unchanged)", () => {
+    const result = computeSetCacheValues({ weight: 100, reps: 15, isAdvancedSet: true }, []);
+    expect(result.cachedVolumeKg).toBe(0);
+    expect(result.cachedE1rmKg).toBe(0);
+    expect(result.totalReps).toBe(0);
+  });
+});
+
+describe("computeSetCacheValues — segment loop (advanced sets) — e1RM cap not applied", () => {
+  it("segment loop e1RM is not capped (segment reps are typically small)", () => {
+    // Advanced set segments — the cap does not apply here; segments have small reps by design
+    const result = computeSetCacheValues(
+      { weight: 100, reps: null, isAdvancedSet: true },
+      [
+        { reps: 8, weight: 100 },
+        { reps: 6, weight: 100 },
+      ],
+    );
+    expect(result.cachedVolumeKg).toBe(1400);
+    // MAX e1RM across segments: 100 * (1 + 8/30) ≈ 126.67
+    expect(result.cachedE1rmKg).toBeCloseTo(100 * (1 + 8 / 30));
+    expect(result.totalReps).toBe(14);
+  });
+});

--- a/__tests__/parent-segment-invariant.property.test.ts
+++ b/__tests__/parent-segment-invariant.property.test.ts
@@ -91,7 +91,7 @@ function expectedE1rm(parent: { weight: number | null; reps: number | null; isAd
     if (parent.isAdvancedSet) return 0;
     const r = parent.reps ?? 0;
     const w = parent.weight ?? 0;
-    return r > 0 ? w * (1 + r / 30) : 0;
+    return r > 0 && r <= 12 ? w * (1 + r / 30) : 0; // BLD-1183: mirror reps<=12 cap in computeSetCacheValues
   }
   let maxE1rm = 0;
   for (const seg of segments) {

--- a/lib/db/sets.ts
+++ b/lib/db/sets.ts
@@ -59,7 +59,7 @@ export function computeSetCacheValues(
     const r = parent.reps ?? 0;
     return {
       cachedVolumeKg: w * r,
-      cachedE1rmKg: r > 0 ? w * (1 + r / 30) : 0,
+      cachedE1rmKg: r > 0 && r <= 12 ? w * (1 + r / 30) : 0, // BLD-1183: align with backfill cap
       totalReps: r,
     };
   }


### PR DESCRIPTION
## Summary

Aligns the live write path with the BLD-1174 migration backfill cap. Previously, `computeSetCacheValues` would compute a non-zero e1RM for high-rep sets (reps > 12), while the same-shape legacy rows were capped to 0 by the backfill. This caused identical sets to get different cached values depending on when they were logged.

## Changes

- `lib/db/sets.ts`: Change `r > 0 ? w * (1 + r / 30) : 0` → `r > 0 && r <= 12 ? w * (1 + r / 30) : 0` in the legacy single-set branch (~1 LOC)
- `__tests__/lib/db/sets-cache-compute.test.ts`: New test file with 7 unit tests covering the cap boundary, zero reps, advanced set unchanged, segment loop unchanged

## Testing

- 7/7 new tests pass
- `tsc --noEmit` passes with zero errors

## Issue

Resolves BLD-1183