### PR TITLE
fix(BLD-1183): cap legacy e1RM at reps<=12 in computeSetCacheValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **e1RM accuracy**: high-rep sets (more than 12 reps) no longer inflate estimated 1-rep-max in analytics. The live write path now matches the reps ≤ 12 cap applied to historical data, keeping trend charts consistent for AMRAP and burnout sets.
 
 ## v0.26.33 — 2026-05-12
 <!-- versionCode: 103 -->

--- a/__tests__/lib/db/sets-cache-compute.test.ts
+++ b/__tests__/lib/db/sets-cache-compute.test.ts
@@ -1,0 +1,66 @@
+/**
+ * BLD-1183 — computeSetCacheValues: e1RM cap at reps <= 12.
+ *
+ * The migration backfill (lib/db/migrations.ts:261-264) caps cached_e1rm_kg = 0
+ * for legacy sets where reps > 12, restoring the pre-BLD-1168 analytics gate.
+ * The live write path must match this cap so new and legacy sets have identical
+ * cache semantics for identical inputs.
+ */
+
+import { computeSetCacheValues } from "../../../lib/db/sets";
+
+describe("computeSetCacheValues — e1RM reps<=12 cap (BLD-1183)", () => {
+  it("returns cachedE1rmKg = 0 when reps > 12 (high-rep normal set)", () => {
+    const result = computeSetCacheValues(
+      { weight: 100, reps: 15, isAdvancedSet: false },
+      [],
+    );
+    expect(result.cachedVolumeKg).toBe(1500); // volume is always weight * reps
+    expect(result.cachedE1rmKg).toBe(0);       // reps > 12 → capped to 0
+    expect(result.totalReps).toBe(15);
+  });
+
+  it("returns non-zero cachedE1rmKg when reps === 12 (boundary: at cap)", () => {
+    const result = computeSetCacheValues(
+      { weight: 100, reps: 12, isAdvancedSet: false },
+      [],
+    );
+    expect(result.cachedVolumeKg).toBe(1200);
+    expect(result.cachedE1rmKg).toBeCloseTo(100 * (1 + 12 / 30), 4); // 140
+    expect(result.totalReps).toBe(12);
+  });
+
+  it("returns non-zero cachedE1rmKg when reps < 12 (normal working set)", () => {
+    const result = computeSetCacheValues(
+      { weight: 80, reps: 5, isAdvancedSet: false },
+      [],
+    );
+    expect(result.cachedVolumeKg).toBe(400);
+    expect(result.cachedE1rmKg).toBeCloseTo(80 * (1 + 5 / 30), 4);
+    expect(result.totalReps).toBe(5);
+  });
+
+  it("returns cachedE1rmKg = 0 when reps === 0 (guard-rail)", () => {
+    const result = computeSetCacheValues(
+      { weight: 100, reps: 0, isAdvancedSet: false },
+      [],
+    );
+    expect(result.cachedE1rmKg).toBe(0);
+  });
+
+  it("advanced set per-segment e1RM: segment reps <= 12 are not capped", () => {
+    // Segment reps are always small by design — ensure advanced path is unaffected
+    const result = computeSetCacheValues(
+      { weight: 80, reps: null, isAdvancedSet: true },
+      [
+        { weight: 80, reps: 8 },
+        { weight: 80, reps: 3 },
+      ],
+    );
+    // e1RM = max of per-segment Epley values
+    const e1rm8 = 80 * (1 + 8 / 30);
+    const e1rm3 = 80 * (1 + 3 / 30);
+    expect(result.cachedE1rmKg).toBeCloseTo(Math.max(e1rm8, e1rm3), 4);
+    expect(result.totalReps).toBe(11);
+  });
+});

--- a/lib/db/sets.ts
+++ b/lib/db/sets.ts
@@ -59,7 +59,7 @@ export function computeSetCacheValues(
     const r = parent.reps ?? 0;
     return {
       cachedVolumeKg: w * r,
-      cachedE1rmKg: r > 0 ? w * (1 + r / 30) : 0,
+      cachedE1rmKg: r > 0 && r <= 12 ? w * (1 + r / 30) : 0, // BLD-1183: align with backfill cap (reps>12 → 0)
       totalReps: r,
     };
   }


### PR DESCRIPTION
## Summary

Aligns `computeSetCacheValues` live write path with the BLD-1174 migration backfill cap. Without this fix, new normal/dropset/failure sets logged with reps > 12 get `cached_e1rm_kg = weight*(1+reps/30)` while same-shape *legacy* rows were capped to 0 by the migration — silently inflating e1RM trends for AMRAP/burnout sets.

## Changes

- `lib/db/sets.ts:62`: add `r <= 12` guard to the legacy Epley formula (`r > 0 && r <= 12 ? w * (1 + r / 30) : 0`)
- `__tests__/lib/db/sets-cache-compute.test.ts` (new): 5 unit tests — reps>12 cap, boundary (reps=12), normal working set, zero reps, advanced set unaffected

## Testing

- 5 new unit tests: all pass
- Full lib/db suite: 719 tests, 73 suites — 0 failures
- TypeScript: 0 errors

## Issue

Resolves BLD-1183