### PR TITLE
feat(BLD-1172): named reps accessors + exercises.ts progression fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- Progression suggestions now correctly evaluate advanced set types (rest-pause, cluster, myo-reps) using the working-set reps of the activation segment, rather than the inflated total-reps sum.
 
 ## v0.26.33 — 2026-05-12
 <!-- versionCode: 103 -->

--- a/__tests__/lib/db/progression-chain.test.ts
+++ b/__tests__/lib/db/progression-chain.test.ts
@@ -164,7 +164,43 @@ describe("getProgressionSuggestion", () => {
   it("returns shouldSuggest=false when latest session has sets under 12 reps", async () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 1 }]);
+    // BLD-1172: workSets row with 11 reps — explicitly under the 12-rep threshold
+    mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-1", set_type: "normal", reps: 11 }]);
+    // BLD-1172: batch segments query (normal sets have no segments → empty array)
+    mockDb.getAllAsync.mockResolvedValueOnce([]);
+    const result = await getProgressionSuggestion("e2", chain);
+    expect(result.shouldSuggest).toBe(false);
+  });
+
+  it("returns shouldSuggest=true for myo_reps when activation-segment reps >= 12", async () => {
+    // AC #271 variant: myo_reps set with total reps=32 (sum), but activation segment = 15.
+    // getWorkingRepsForOverloadDecision returns 15 (first segment) not 32 (total).
+    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-2", set_type: "myo_reps", reps: 32 }]);
+    // Batch segments: activation segment (15 reps) + 2 mini-clusters (9, 8)
+    mockDb.getAllAsync.mockResolvedValueOnce([
+      { id: "seg-1", set_id: "ws-2", segment_number: 1, reps: 15, created_at: 1 },
+      { id: "seg-2", set_id: "ws-2", segment_number: 2, reps: 9, created_at: 1 },
+      { id: "seg-3", set_id: "ws-2", segment_number: 3, reps: 8, created_at: 1 },
+    ]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]); // nextLogged = 0
+    const result = await getProgressionSuggestion("e2", chain);
+    expect(result.shouldSuggest).toBe(true);
+    expect(result.nextExercise).toEqual({ id: "e3", name: "Diamond Push-Up" });
+  });
+
+  it("returns shouldSuggest=false for rest_pause when first-segment reps < 12", async () => {
+    // AC #270 variant: rest_pause set with total reps=13 but first segment only 8.
+    // getWorkingRepsForOverloadDecision returns 8 (first segment) not 13 (total).
+    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-3", set_type: "rest_pause", reps: 13 }]);
+    // Batch segments: first segment 8 reps (working effort) + rest-pause continuation 5 reps
+    mockDb.getAllAsync.mockResolvedValueOnce([
+      { id: "seg-4", set_id: "ws-3", segment_number: 1, reps: 8, created_at: 1 },
+      { id: "seg-5", set_id: "ws-3", segment_number: 2, reps: 5, created_at: 1 },
+    ]);
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(false);
   });

--- a/__tests__/lib/db/progression-chain.test.ts
+++ b/__tests__/lib/db/progression-chain.test.ts
@@ -172,9 +172,10 @@ describe("getProgressionSuggestion", () => {
   it("returns shouldSuggest=true when all criteria met", async () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 3 }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
+    // BLD-1172: workSets query now returns actual rows {id, set_type, reps}
+    mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-1", set_type: "normal", reps: 15 }]);
+    // getSegmentsForSet uses Drizzle .all() → always [] in tests (mocked via drizzle-orm mock)
+    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]); // nextLogged = 0
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(true);
     expect(result.nextExercise).toEqual({ id: "e3", name: "Diamond Push-Up" });
@@ -184,9 +185,9 @@ describe("getProgressionSuggestion", () => {
   it("returns shouldSuggest=false when next exercise already logged recently", async () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 3 }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 2 }]);
+    // BLD-1172: workSets with reps >= 12 so we reach the nextLogged check
+    mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-1", set_type: "normal", reps: 15 }]);
+    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 2 }]); // nextLogged = 2 → recently logged
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(false);
   });
@@ -194,8 +195,8 @@ describe("getProgressionSuggestion", () => {
   it("returns shouldSuggest=false when no normal completed sets exist", async () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 5 }]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
-    mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]);
+    // BLD-1172: empty workSets array → hits workSets.length === 0 early-exit
+    mockDb.getAllAsync.mockResolvedValueOnce([]);
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(false);
   });

--- a/__tests__/lib/db/progression-chain.test.ts
+++ b/__tests__/lib/db/progression-chain.test.ts
@@ -174,7 +174,8 @@ describe("getProgressionSuggestion", () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
     // BLD-1172: workSets query now returns actual rows {id, set_type, reps}
     mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-1", set_type: "normal", reps: 15 }]);
-    // getSegmentsForSet uses Drizzle .all() → always [] in tests (mocked via drizzle-orm mock)
+    // BLD-1172: batch segments query (normal sets have no segments → empty array)
+    mockDb.getAllAsync.mockResolvedValueOnce([]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 0 }]); // nextLogged = 0
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(true);
@@ -187,6 +188,8 @@ describe("getProgressionSuggestion", () => {
     mockDb.getAllAsync.mockResolvedValueOnce([{ session_id: "sess-1" }]);
     // BLD-1172: workSets with reps >= 12 so we reach the nextLogged check
     mockDb.getAllAsync.mockResolvedValueOnce([{ id: "ws-1", set_type: "normal", reps: 15 }]);
+    // BLD-1172: batch segments query (normal sets have no segments → empty array)
+    mockDb.getAllAsync.mockResolvedValueOnce([]);
     mockDb.getAllAsync.mockResolvedValueOnce([{ count: 2 }]); // nextLogged = 2 → recently logged
     const result = await getProgressionSuggestion("e2", chain);
     expect(result.shouldSuggest).toBe(false);

--- a/__tests__/set-accessors.test.ts
+++ b/__tests__/set-accessors.test.ts
@@ -1,0 +1,223 @@
+/**
+ * BLD-1172: Unit tests for lib/sets-accessors.ts named reps accessors.
+ *
+ * AC #270: GIVEN a rest_pause set with parent.reps=13 (segments 8,3,2 @ 100kg)
+ *          WHEN getWorkingRepsForOverloadDecision is called
+ *          THEN it returns 8 (the first segment reps), NOT 13.
+ *
+ * AC #271: GIVEN a myo_reps set with activation 15 reps + clusters 5,5,4,3
+ *          WHEN getEffortRepsForPlateau is called
+ *          THEN it returns 15 (activation segment), NOT 32 (sum) or 5 (heaviest cluster).
+ */
+
+import {
+  getWorkingRepsForOverloadDecision,
+  getEffortRepsForPlateau,
+  getHeaviestSegmentReps,
+  getTotalRepsForVolume,
+} from "../lib/sets-accessors";
+import type { WorkoutSet, SetSegment } from "../lib/types";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeSet(overrides: Partial<WorkoutSet>): WorkoutSet {
+  return {
+    id: "s1",
+    session_id: "sess1",
+    exercise_id: "ex1",
+    set_number: 1,
+    weight: 100,
+    reps: null,
+    completed: true,
+    completed_at: null,
+    rpe: null,
+    notes: "",
+    link_id: null,
+    round: null,
+    tempo: null,
+    swapped_from_exercise_id: null,
+    set_type: "normal",
+    duration_seconds: null,
+    exercise_position: 0,
+    ...overrides,
+  };
+}
+
+function makeSegment(segmentNumber: number, reps: number, weight?: number): SetSegment {
+  return {
+    id: `seg${segmentNumber}`,
+    set_id: "s1",
+    segment_number: segmentNumber,
+    reps,
+    weight: weight ?? null,
+    rest_after_seconds: null,
+    completed_at: null,
+    created_at: Date.now(),
+  };
+}
+
+// ─── getWorkingRepsForOverloadDecision ──────────────────────────────────────
+
+describe("getWorkingRepsForOverloadDecision", () => {
+  it("AC #270 — rest_pause 8+3+2 @ 100kg returns 8 (first segment), not 13 (sum)", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 13, weight: 100 });
+    const segments = [
+      makeSegment(1, 8),
+      makeSegment(2, 3),
+      makeSegment(3, 2),
+    ];
+    expect(getWorkingRepsForOverloadDecision(set, segments)).toBe(8);
+  });
+
+  it("cluster — first segment (4) returned as working reps", () => {
+    const set = makeSet({ set_type: "cluster", reps: 12, weight: 80 });
+    const segments = [
+      makeSegment(1, 4),
+      makeSegment(2, 4),
+      makeSegment(3, 4),
+    ];
+    expect(getWorkingRepsForOverloadDecision(set, segments)).toBe(4);
+  });
+
+  it("myo_reps — activation segment (15) returned", () => {
+    const set = makeSet({ set_type: "myo_reps", reps: 32, weight: 25 });
+    const segments = [
+      makeSegment(1, 15), // activation
+      makeSegment(2, 5),
+      makeSegment(3, 5),
+      makeSegment(4, 4),
+      makeSegment(5, 3),
+    ];
+    expect(getWorkingRepsForOverloadDecision(set, segments)).toBe(15);
+  });
+
+  it("normal set — returns set.reps directly", () => {
+    const set = makeSet({ set_type: "normal", reps: 10 });
+    expect(getWorkingRepsForOverloadDecision(set, [])).toBe(10);
+  });
+
+  it("warmup set — returns set.reps directly", () => {
+    const set = makeSet({ set_type: "warmup", reps: 15 });
+    expect(getWorkingRepsForOverloadDecision(set, [])).toBe(15);
+  });
+
+  it("advanced set with zero segments — falls back to set.reps", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 0 });
+    expect(getWorkingRepsForOverloadDecision(set, [])).toBe(0);
+  });
+
+  it("segments out of order — still picks the segment with lowest segment_number", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 11, weight: 100 });
+    const segments = [
+      makeSegment(3, 2),
+      makeSegment(1, 8),
+      makeSegment(2, 1),
+    ];
+    expect(getWorkingRepsForOverloadDecision(set, segments)).toBe(8);
+  });
+});
+
+// ─── getEffortRepsForPlateau ─────────────────────────────────────────────────
+
+describe("getEffortRepsForPlateau", () => {
+  it("AC #271 — myo_reps activation=15 returns 15, not 32 (sum) or 5 (cluster reps)", () => {
+    const set = makeSet({ set_type: "myo_reps", reps: 32, weight: 25 });
+    const segments = [
+      makeSegment(1, 15), // activation
+      makeSegment(2, 5),
+      makeSegment(3, 5),
+      makeSegment(4, 4),
+      makeSegment(5, 3),
+    ];
+    expect(getEffortRepsForPlateau(set, segments)).toBe(15);
+  });
+
+  it("rest_pause — returns first segment reps for plateau check", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 13, weight: 100 });
+    const segments = [
+      makeSegment(1, 8),
+      makeSegment(2, 3),
+      makeSegment(3, 2),
+    ];
+    expect(getEffortRepsForPlateau(set, segments)).toBe(8);
+  });
+
+  it("cluster — returns first segment reps", () => {
+    const set = makeSet({ set_type: "cluster", reps: 15, weight: 90 });
+    const segments = [makeSegment(1, 5), makeSegment(2, 5), makeSegment(3, 5)];
+    expect(getEffortRepsForPlateau(set, segments)).toBe(5);
+  });
+
+  it("normal set — returns set.reps directly", () => {
+    const set = makeSet({ set_type: "normal", reps: 8 });
+    expect(getEffortRepsForPlateau(set, [])).toBe(8);
+  });
+
+  it("failure set — returns set.reps directly", () => {
+    const set = makeSet({ set_type: "failure", reps: 12 });
+    expect(getEffortRepsForPlateau(set, [])).toBe(12);
+  });
+});
+
+// ─── getHeaviestSegmentReps ──────────────────────────────────────────────────
+
+describe("getHeaviestSegmentReps", () => {
+  it("rest_pause — returns the max segment reps", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 13, weight: 100 });
+    const segments = [makeSegment(1, 8), makeSegment(2, 3), makeSegment(3, 2)];
+    expect(getHeaviestSegmentReps(set, segments)).toBe(8);
+  });
+
+  it("myo_reps with activation=15, clusters=5 — returns 15", () => {
+    const set = makeSet({ set_type: "myo_reps", reps: 32, weight: 25 });
+    const segments = [
+      makeSegment(1, 15),
+      makeSegment(2, 5),
+      makeSegment(3, 5),
+    ];
+    expect(getHeaviestSegmentReps(set, segments)).toBe(15);
+  });
+
+  it("cluster equal reps — returns that rep count", () => {
+    const set = makeSet({ set_type: "cluster", reps: 15, weight: 90 });
+    const segments = [makeSegment(1, 5), makeSegment(2, 5), makeSegment(3, 5)];
+    expect(getHeaviestSegmentReps(set, segments)).toBe(5);
+  });
+
+  it("normal set — returns set.reps", () => {
+    const set = makeSet({ set_type: "normal", reps: 10 });
+    expect(getHeaviestSegmentReps(set, [])).toBe(10);
+  });
+});
+
+// ─── getTotalRepsForVolume ───────────────────────────────────────────────────
+
+describe("getTotalRepsForVolume", () => {
+  it("rest_pause 8+3+2 — returns 13 (sum)", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 13, weight: 100 });
+    const segments = [makeSegment(1, 8), makeSegment(2, 3), makeSegment(3, 2)];
+    expect(getTotalRepsForVolume(set, segments)).toBe(13);
+  });
+
+  it("myo_reps 15+5+5+4+3 — returns 32 (sum)", () => {
+    const set = makeSet({ set_type: "myo_reps", reps: 32, weight: 25 });
+    const segments = [
+      makeSegment(1, 15),
+      makeSegment(2, 5),
+      makeSegment(3, 5),
+      makeSegment(4, 4),
+      makeSegment(5, 3),
+    ];
+    expect(getTotalRepsForVolume(set, segments)).toBe(32);
+  });
+
+  it("normal set — returns set.reps", () => {
+    const set = makeSet({ set_type: "normal", reps: 10 });
+    expect(getTotalRepsForVolume(set, [])).toBe(10);
+  });
+
+  it("advanced set with no segments — returns 0 (set.reps=0)", () => {
+    const set = makeSet({ set_type: "rest_pause", reps: 0 });
+    expect(getTotalRepsForVolume(set, [])).toBe(0);
+  });
+});

--- a/lib/db/exercises.ts
+++ b/lib/db/exercises.ts
@@ -5,6 +5,8 @@ import { uuid } from "../uuid";
 import { getDrizzle, query, withTransaction } from "./helpers";
 import { exercises, templateExercises } from "./schema";
 import type { ExerciseRow } from "./schema";
+import { getWorkingRepsForOverloadDecision } from "../sets-accessors";
+import { getSegmentsForSet } from "./sets";
 
 function mapRow(row: ExerciseRow): Exercise {
   return {
@@ -306,32 +308,37 @@ export async function getProgressionSuggestion(
     return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
   }
 
-  const failingSet = await query<{ count: number }>(
-    `SELECT COUNT(*) as count
+  // Load all completed work sets (normal + advanced) from the latest session.
+  // BLD-1172: use getWorkingRepsForOverloadDecision() instead of set.reps directly,
+  // because for advanced set types (rest_pause, cluster, myo_reps) set.reps is the
+  // SUM of all mini-set reps, which would incorrectly inflate the progression check.
+  // The accessor returns the first-segment reps (the heaviest working effort) for
+  // advanced types, and set.reps unchanged for normal/warmup/dropset/failure.
+  const workSets = await query<{ id: string; set_type: string; reps: number | null }>(
+    `SELECT id, set_type, reps
      FROM workout_sets
      WHERE session_id = ?
        AND exercise_id = ?
-       AND set_type = 'normal'
-       AND completed = 1
-       AND (reps IS NULL OR reps < 12)`,
-    [latestSession[0].session_id, exerciseId]
-  );
-  if ((failingSet[0]?.count ?? 1) > 0) {
-    return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
-  }
-
-  // Also check there was at least one normal completed set (don't suggest on empty sessions)
-  const normalSetCount = await query<{ count: number }>(
-    `SELECT COUNT(*) as count
-     FROM workout_sets
-     WHERE session_id = ?
-       AND exercise_id = ?
-       AND set_type = 'normal'
+       AND set_type IN ('normal', 'rest_pause', 'cluster', 'myo_reps')
        AND completed = 1`,
     [latestSession[0].session_id, exerciseId]
   );
-  if ((normalSetCount[0]?.count ?? 0) === 0) {
+
+  if (workSets.length === 0) {
+    // No work sets logged in this session — skip suggestion.
     return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
+  }
+
+  // Check every work set reached >= 12 reps using the named accessor.
+  for (const ws of workSets) {
+    const segments = await getSegmentsForSet(ws.id);
+    const workingReps = getWorkingRepsForOverloadDecision(
+      { ...ws, set_type: ws.set_type as import("../types").SetType } as import("../types").WorkoutSet,
+      segments,
+    );
+    if (workingReps < 12) {
+      return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
+    }
   }
 
   // Check 4: user has NOT logged next exercise in last 30 days

--- a/lib/db/exercises.ts
+++ b/lib/db/exercises.ts
@@ -6,7 +6,7 @@ import { getDrizzle, query, withTransaction } from "./helpers";
 import { exercises, templateExercises } from "./schema";
 import type { ExerciseRow } from "./schema";
 import { getWorkingRepsForOverloadDecision } from "../sets-accessors";
-import { getSegmentsForSet } from "./sets";
+import type { SetSegment, SetType } from "../types";
 
 function mapRow(row: ExerciseRow): Exercise {
   return {
@@ -309,12 +309,13 @@ export async function getProgressionSuggestion(
   }
 
   // Load all completed work sets (normal + advanced) from the latest session.
-  // BLD-1172: use getWorkingRepsForOverloadDecision() instead of set.reps directly,
-  // because for advanced set types (rest_pause, cluster, myo_reps) set.reps is the
-  // SUM of all mini-set reps, which would incorrectly inflate the progression check.
-  // The accessor returns the first-segment reps (the heaviest working effort) for
-  // advanced types, and set.reps unchanged for normal/warmup/dropset/failure.
-  const workSets = await query<{ id: string; set_type: string; reps: number | null }>(
+  // BLD-1172: Behaviour change from pre-BLD-1168 code: the old guard required
+  // set_type = 'normal'. Now advanced set types (rest_pause, cluster, myo_reps)
+  // also count toward progression, using the first-segment reps via the named
+  // accessor so that the rep count is not inflated by total-segment sums.
+  // This is intentional per PLAN-BLD-1168 §Progression — advanced sets should
+  // qualify a session for progression suggestions just as normal sets do.
+  const workSets = await query<{ id: string; set_type: SetType; reps: number | null }>(
     `SELECT id, set_type, reps
      FROM workout_sets
      WHERE session_id = ?
@@ -329,13 +330,25 @@ export async function getProgressionSuggestion(
     return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
   }
 
+  // Batch-load all segments for the work sets in a single query (avoids N+1).
+  const setIds = workSets.map((ws) => ws.id);
+  const allSegments = await query<SetSegment>(
+    `SELECT * FROM workout_set_segments
+     WHERE set_id IN (${setIds.map(() => "?").join(",")})
+     ORDER BY segment_number`,
+    setIds
+  );
+  const segmentsBySetId = new Map<string, SetSegment[]>();
+  for (const seg of allSegments) {
+    const list = segmentsBySetId.get(seg.set_id) ?? [];
+    list.push(seg);
+    segmentsBySetId.set(seg.set_id, list);
+  }
+
   // Check every work set reached >= 12 reps using the named accessor.
   for (const ws of workSets) {
-    const segments = await getSegmentsForSet(ws.id);
-    const workingReps = getWorkingRepsForOverloadDecision(
-      { ...ws, set_type: ws.set_type as import("../types").SetType } as import("../types").WorkoutSet,
-      segments,
-    );
+    const segments = segmentsBySetId.get(ws.id) ?? [];
+    const workingReps = getWorkingRepsForOverloadDecision(ws, segments);
     if (workingReps < 12) {
       return { shouldSuggest: false, nextExercise: { id: nextExercise.id, name: nextExercise.name }, isTerminal: false };
     }

--- a/lib/sets-accessors.ts
+++ b/lib/sets-accessors.ts
@@ -7,12 +7,16 @@
  * `set.reps` is the SUM of all mini-set reps — using it directly inflates
  * overload decisions and plateau detection.
  *
- * The architecture grep-test (__tests__/architecture-set-write-path.test.ts)
- * enforces this invariant and will fail CI if any file outside
- * lib/db/sets.ts / lib/sets-accessors.ts reads `.reps` on a WorkoutSet.
+ * This invariant will be enforced by the Slice 8 grep-test
+ * (__tests__/architecture-set-write-path.test.ts, BLD-1176), which will fail
+ * CI if any file outside lib/db/sets.ts / lib/sets-accessors.ts reads `.reps`
+ * on a WorkoutSet directly.
  */
-import type { WorkoutSet, SetSegment } from "./types";
+import type { SetType, SetSegment } from "./types";
 import { ADVANCED_SET_TYPES } from "./db/sets";
+
+/** Minimal set fields required by all reps accessors. */
+type SetRepsInput = Pick<{ set_type: SetType; reps: number | null }, "set_type" | "reps">;
 
 /**
  * Returns the reps count to use when deciding whether to increase load
@@ -24,7 +28,7 @@ import { ADVANCED_SET_TYPES } from "./db/sets";
  * Use when asking "did the user achieve the target reps to progress weight?".
  */
 export function getWorkingRepsForOverloadDecision(
-  set: WorkoutSet,
+  set: SetRepsInput,
   segments: SetSegment[],
 ): number {
   if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
@@ -46,7 +50,7 @@ export function getWorkingRepsForOverloadDecision(
  * - normal / warmup / dropset / failure: returns `set.reps`.
  */
 export function getEffortRepsForPlateau(
-  set: WorkoutSet,
+  set: SetRepsInput,
   segments: SetSegment[],
 ): number {
   if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
@@ -65,7 +69,7 @@ export function getEffortRepsForPlateau(
  * load × reps product (combined with segment weight).
  */
 export function getHeaviestSegmentReps(
-  set: WorkoutSet,
+  set: SetRepsInput,
   segments: SetSegment[],
 ): number {
   if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
@@ -82,7 +86,7 @@ export function getHeaviestSegmentReps(
  * Use when computing training volume (total reps × load).
  */
 export function getTotalRepsForVolume(
-  set: WorkoutSet,
+  set: SetRepsInput,
   segments: SetSegment[],
 ): number {
   if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {

--- a/lib/sets-accessors.ts
+++ b/lib/sets-accessors.ts
@@ -1,0 +1,92 @@
+/**
+ * BLD-1172: Named reps accessors for WorkoutSet rows.
+ *
+ * ARCHITECTURE INVARIANT: All callers that need a "reps" value from a
+ * WorkoutSet must use one of the four functions below instead of reading
+ * `set.reps` directly. For advanced set types (rest_pause, cluster, myo_reps)
+ * `set.reps` is the SUM of all mini-set reps — using it directly inflates
+ * overload decisions and plateau detection.
+ *
+ * The architecture grep-test (__tests__/architecture-set-write-path.test.ts)
+ * enforces this invariant and will fail CI if any file outside
+ * lib/db/sets.ts / lib/sets-accessors.ts reads `.reps` on a WorkoutSet.
+ */
+import type { WorkoutSet, SetSegment } from "./types";
+import { ADVANCED_SET_TYPES } from "./db/sets";
+
+/**
+ * Returns the reps count to use when deciding whether to increase load
+ * (overload decision). For advanced set types this is the heaviest
+ * single-segment reps (first segment, which holds the highest rep count for
+ * rest-pause/cluster; activation segment for myo-reps). For legacy types it
+ * returns `set.reps`.
+ *
+ * Use when asking "did the user achieve the target reps to progress weight?".
+ */
+export function getWorkingRepsForOverloadDecision(
+  set: WorkoutSet,
+  segments: SetSegment[],
+): number {
+  if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
+    return set.reps ?? 0;
+  }
+  // First segment (lowest segment_number) holds the working rep count.
+  const sorted = [...segments].sort((a, b) => a.segment_number - b.segment_number);
+  return sorted[0].reps;
+}
+
+/**
+ * Returns the reps count to use for plateau / PR detection.
+ *
+ * - myo_reps: returns activation segment reps (first segment), NOT the total.
+ *   The activation set quality determines effort; the mini-clusters are
+ *   fatigue-extension work.
+ * - cluster / rest_pause: returns the heaviest single-segment reps (first
+ *   segment).
+ * - normal / warmup / dropset / failure: returns `set.reps`.
+ */
+export function getEffortRepsForPlateau(
+  set: WorkoutSet,
+  segments: SetSegment[],
+): number {
+  if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
+    return set.reps ?? 0;
+  }
+  // First segment = activation set (myo_reps) or heaviest cluster (rest_pause/cluster).
+  const sorted = [...segments].sort((a, b) => a.segment_number - b.segment_number);
+  return sorted[0].reps;
+}
+
+/**
+ * Returns the reps of the segment with the most reps (the "heaviest" segment
+ * in terms of rep count). For legacy set types returns `set.reps`.
+ *
+ * Useful for display and for 1RM estimation using the segment with the highest
+ * load × reps product (combined with segment weight).
+ */
+export function getHeaviestSegmentReps(
+  set: WorkoutSet,
+  segments: SetSegment[],
+): number {
+  if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
+    return set.reps ?? 0;
+  }
+  return Math.max(...segments.map((s) => s.reps));
+}
+
+/**
+ * Returns the total reps across all segments (Σ segments.reps). For legacy
+ * set types returns `set.reps` (which equals the total anyway for non-advanced
+ * rows, since there are no segments).
+ *
+ * Use when computing training volume (total reps × load).
+ */
+export function getTotalRepsForVolume(
+  set: WorkoutSet,
+  segments: SetSegment[],
+): number {
+  if (!ADVANCED_SET_TYPES.has(set.set_type) || segments.length === 0) {
+    return set.reps ?? 0;
+  }
+  return segments.reduce((sum, s) => sum + s.reps, 0);
+}


### PR DESCRIPTION
## Summary

Adds named reps/weight accessors to workout sets and fixes the exercises.ts progression chain to handle advanced set types correctly.

Rebased onto main after BLD-1169 (PR #565) merged.

## Changes

- `lib/sets-accessors.ts`: named accessor functions for set reps/weight
- `lib/db/exercises.ts`: progression chain fix for advanced set types
- `__tests__/set-accessors.test.ts`: unit tests for accessors
- `__tests__/lib/db/progression-chain.test.ts`: strengthened progression chain coverage
- `CHANGELOG.md`: Unreleased bullet

## Testing

- 39/39 tests passing (set-accessors + progression-chain)
- TypeScript: 0 errors

## Issue

Resolves BLD-1172