### PR TITLE
refactor(BLD-1186): route applyEditUpdate through updateSetForSessionEdit — tighten arch test

### DIFF
--- a/__tests__/architecture-set-write-path.test.ts
+++ b/__tests__/architecture-set-write-path.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 /**
- * BLD-1170: Architecture invariants for workout_sets and workout_set_segments write-path.
+ * BLD-1170 / BLD-1186: Architecture invariants for workout_sets and workout_set_segments write-path.
  *
  * These tests enforce the architectural constraint that:
  *   1. Only lib/db/sets.ts may write directly to workout_set_segments (insert/update/delete).
@@ -11,6 +11,9 @@
  *      updateSetsBatch, updateSetWarmup, updateSetType, updateSetStackMarker,
  *      updateSetManualWeight) no longer contain direct db.update(workoutSets) calls —
  *      they delegate to lib/db/sets.ts.
+ *   4. lib/db/sessions.ts db.update(workoutSets) calls are limited to non-volume
+ *      functions only — applyEditUpdate MUST delegate to lib/db/sets.ts
+ *      (updateSetForSessionEdit), not write workoutSets directly.
  *
  * If any of these tests fail, it means a new write site was added without routing
  * through recomputeSetCaches(), which would silently desync cached_volume_kg /
@@ -139,8 +142,13 @@ describe("Architecture: hooks do not bypass DB layer for workout_sets (BLD-1170)
 // AC #267 (BLD-1170 scope — write-path ban): Only lib/db/sets.ts may call
 // db.update(workoutSets) for volume-affecting fields. lib/db/session-sets.ts
 // retains db.update(workoutSets) for NON-volume fields (notes, tempo, rpe,
-// duration, variant, etc.) — explicitly allowed. lib/db/sessions.ts retains
-// db.update(workoutSets) for set renumbering and exercise swaps — also allowed.
+// duration, variant, etc.) — explicitly allowed.
+//
+// lib/db/sessions.ts retains db.update(workoutSets) ONLY for:
+//   - swapExerciseInSession / undoSwapInSession (exercise_id swaps — non-volume)
+//   - renumberSessionSets (set_number only — non-volume)
+// applyEditUpdate MUST NOT contain db.update(workoutSets) — it delegates to
+// updateSetForSessionEdit in lib/db/sets.ts (BLD-1186).
 //
 // Per tech-lead ruling (BLD-1170, 2026-05-11): AC #267 is split between slices:
 //   - BLD-1170 (this slice): write-path ban — db.update(workoutSets) exclusivity
@@ -148,14 +156,13 @@ describe("Architecture: hooks do not bypass DB layer for workout_sets (BLD-1170)
 // The formula ban is out of scope here and will be enforced by BLD-1174.
 
 describe("Architecture: db.update(workoutSets) only from approved files (BLD-1170 AC#267)", () => {
-  it("no file outside lib/db/sets.ts and lib/db/session-sets.ts calls db.update(workoutSets)", () => {
+  it("no file outside lib/db/sets.ts, lib/db/session-sets.ts, and lib/db/sessions.ts calls db.update(workoutSets)", () => {
     // lib/db/session-sets.ts is explicitly allowed because it retains legitimate
     // non-volume writes (notes, tempo, duration, rpe, variant, etc.). The individual
     // volume-write functions in session-sets.ts are verified by Test 3 above.
-    // lib/db/sessions.ts is explicitly allowed because it contains:
-    //   - swapExerciseInSession / undoSwapInSession (exercise_id swaps — non-volume)
-    //   - applyEditUpdate (inside editCompletedSession transaction — recomputed post-TX)
-    //   - set renumbering (set_number — non-volume)
+    // lib/db/sessions.ts is explicitly allowed because it contains non-volume writes
+    // (exercise_id swaps and set_number renumbering). The applyEditUpdate function
+    // in sessions.ts is verified below (Test 5) to have NO db.update(workoutSets).
     const APPROVED_FILES = new Set([
       "lib/db/sets.ts",
       "lib/db/session-sets.ts",
@@ -175,12 +182,74 @@ describe("Architecture: db.update(workoutSets) only from approved files (BLD-117
     if (violations.length > 0) {
       throw new Error(
         "db.update(workoutSets) found outside approved files.\n" +
-        "Only lib/db/sets.ts (volume writes) and lib/db/session-sets.ts (non-volume writes)\n" +
-        "may call db.update(workoutSets). All other callers must use a lib/db/sets.ts helper.\n\n" +
+        "Only lib/db/sets.ts (volume writes), lib/db/session-sets.ts (non-volume writes),\n" +
+        "and lib/db/sessions.ts (swap + renumber only) may call db.update(workoutSets).\n\n" +
         "Violations:\n" + violations.map((v) => `  - ${v}`).join("\n")
       );
     }
   });
+});
+
+// ─── Test 5: sessions.ts applyEditUpdate delegates to sets.ts (BLD-1186) ─────
+//
+// applyEditUpdate is the only function in sessions.ts that writes
+// volume-affecting columns (weight, reps, set_type). After BLD-1186 it must
+// delegate all writes to updateSetForSessionEdit in lib/db/sets.ts, so there
+// is no direct db.update(workoutSets) inside its body.
+//
+// The ALLOWED functions in sessions.ts that may retain db.update(workoutSets):
+//   - swapExerciseInSession   (exercise_id swap — non-volume)
+//   - undoSwapInSession       (exercise_id undo — non-volume)
+//   - renumberSessionSets     (set_number only — non-volume)
+
+describe("Architecture: sessions.ts applyEditUpdate delegates to sets.ts (BLD-1186)", () => {
+  const sessionsContent = readFile("lib/db/sessions.ts");
+
+  function extractFunctionBody(source: string, funcName: string): string {
+    // Match both `export async function foo` and `async function foo`
+    const pattern = new RegExp(
+      `(?:export )?async function ${funcName}\\b[^{]*\\{`,
+    );
+    const match = pattern.exec(source);
+    if (!match) return "";
+
+    let depth = 1;
+    let pos = match.index + match[0].length;
+    const start = pos;
+    while (pos < source.length && depth > 0) {
+      if (source[pos] === "{") depth++;
+      else if (source[pos] === "}") depth--;
+      pos++;
+    }
+    return source.slice(start, pos - 1);
+  }
+
+  it("applyEditUpdate does not contain direct db.update(workoutSets)", () => {
+    const body = extractFunctionBody(sessionsContent, "applyEditUpdate");
+    expect(body).not.toBe(""); // function must exist
+    expect(body).not.toMatch(/\bdb\.update\(workoutSets\)/);
+  });
+
+  it("applyEditUpdate calls updateSetForSessionEdit from lib/db/sets.ts", () => {
+    const body = extractFunctionBody(sessionsContent, "applyEditUpdate");
+    expect(body).not.toBe(""); // function must exist
+    expect(body).toMatch(/\bupdateSetForSessionEdit\b/);
+  });
+
+  // Verify the non-volume functions that are allowed to retain db.update(workoutSets)
+  const ALLOWED_WITH_DIRECT_UPDATE = [
+    "swapExerciseInSession",
+    "undoSwapInSession",
+    "renumberSessionSets",
+  ];
+
+  for (const funcName of ALLOWED_WITH_DIRECT_UPDATE) {
+    it(`${funcName} still uses db.update(workoutSets) for non-volume writes`, () => {
+      const body = extractFunctionBody(sessionsContent, funcName);
+      expect(body).not.toBe(""); // function must exist
+      expect(body).toMatch(/\bdb\.update\(workoutSets\)/);
+    });
+  }
 });
 
 //

--- a/__tests__/lib/db/edit-completed-session.test.ts
+++ b/__tests__/lib/db/edit-completed-session.test.ts
@@ -44,7 +44,7 @@ jest.mock('drizzle-orm/expo-sqlite', () => ({
           orderBy: jest.fn().mockReturnThis(),
           limit: jest.fn().mockReturnThis(),
           offset: jest.fn().mockReturnThis(),
-          get: jest.fn(() => undefined),
+          get: jest.fn(() => (g as any).__mockGetResult ?? undefined),
           all: jest.fn(() => g.__mockSelectResult),
           then: (r: any) => Promise.resolve(g.__mockSelectResult).then(r),
         };
@@ -91,6 +91,7 @@ beforeEach(() => {
   g.__mockDeleteCalls = [];
   g.__mockSelectResult = [];
   g.__mockSelectThrows = false;
+  g.__mockGetResult = null;
   mockDbStub.withTransactionAsync.mockImplementation(async (cb: () => Promise<void>) => cb());
 });
 
@@ -285,5 +286,66 @@ describe('editCompletedSession', () => {
       expect(u.values).not.toHaveProperty('link_id');
       expect(u.values).not.toHaveProperty('round');
     }
+  });
+});
+
+// ─── BLD-1186 regression: cache recompute via editCompletedSession ────────────
+//
+// Verifies that editCompletedSession triggers recomputeSetCaches when a
+// volume-affecting field (weight / reps / set_type) changes, and does NOT
+// trigger it for non-volume-only changes.
+//
+// The mock's get() returns g.__mockGetResult to simulate recomputeSetCaches
+// loading the parent row. The resulting cached_volume_kg update is captured in
+// g.__mockUpdateCalls so we can assert the recompute path ran end-to-end.
+
+describe('BLD-1186: cache recompute on volume change', () => {
+  it('writes cached_volume_kg / cached_e1rm_kg after a weight change', async () => {
+    // Simulate recomputeSetCaches loading the parent row (weight=20, reps=10).
+    // The mock does not persist writes, so get() still returns the pre-update row;
+    // what matters here is that the recompute path is triggered and completes.
+    g.__mockGetResult = { id: 'set-1', weight: 20, reps: 10, set_type: 'normal' };
+
+    await editCompletedSession(
+      'sess-1',
+      { upserts: [{ id: 'set-1', exercise_id: 'e-1', weight: 40 }], deletes: [] },
+    );
+
+    const cacheUpdate = g.__mockUpdateCalls.find(
+      (c: any) => 'cached_volume_kg' in (c.values ?? {}),
+    );
+    expect(cacheUpdate).toBeDefined();
+    // cached_volume_kg = parent.weight(20) × parent.reps(10) = 200 (legacy row, no segments)
+    expect(cacheUpdate.values.cached_volume_kg).toBe(200);
+    expect(cacheUpdate.values.cached_e1rm_kg).toBeCloseTo(20 * (1 + 10 / 30), 5);
+  });
+
+  it('writes cached_volume_kg / cached_e1rm_kg after a reps change', async () => {
+    g.__mockGetResult = { id: 'set-1', weight: 100, reps: 5, set_type: 'normal' };
+
+    await editCompletedSession(
+      'sess-1',
+      { upserts: [{ id: 'set-1', exercise_id: 'e-1', reps: 8 }], deletes: [] },
+    );
+
+    const cacheUpdate = g.__mockUpdateCalls.find(
+      (c: any) => 'cached_volume_kg' in (c.values ?? {}),
+    );
+    expect(cacheUpdate).toBeDefined();
+    // cached_volume_kg = 100 × 5 = 500 (mock returns the pre-update row)
+    expect(cacheUpdate.values.cached_volume_kg).toBe(500);
+  });
+
+  it('does NOT write cache cols for non-volume-only changes (e.g. rpe)', async () => {
+    // Leave g.__mockGetResult = null so if recomputeSetCaches is called it exits early.
+    await editCompletedSession(
+      'sess-1',
+      { upserts: [{ id: 'set-1', exercise_id: 'e-1', rpe: 8 }], deletes: [] },
+    );
+
+    const cacheUpdate = g.__mockUpdateCalls.find(
+      (c: any) => 'cached_volume_kg' in (c.values ?? {}),
+    );
+    expect(cacheUpdate).toBeUndefined();
   });
 });

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -485,8 +485,10 @@ export class EditCompletedSessionError extends Error {
  * transaction so the edit pill appears as soon as the next read happens.
  *
  * BLD-1186: cache recomputation (cached_volume_kg / cached_e1rm_kg) now happens
- * inline via updateSetForSessionEdit / recomputeSetCaches — there is no post-TX
- * recompute loop. The write path is fully owned by lib/db/sets.ts.
+ * inline — updates route through updateSetForSessionEdit (which calls
+ * recomputeSetCaches), and inserts call recomputeSetCaches directly in
+ * applyEditInsert. There is no post-TX recompute loop; lib/db/sets.ts owns the
+ * full write path.
  */
 export async function editCompletedSession(
   sessionId: string,

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -11,7 +11,7 @@ import {
   stravaSyncLog,
 } from "./schema";
 import { cascadeDeleteClipsForSession } from "../media/form-clips";
-import { recomputeSetCaches, normalizeSetType } from "./sets";
+import { recomputeSetCaches, normalizeSetType, updateSetForSessionEdit, type SessionEditUpdateFields } from "./sets";
 
 // Re-export from split modules for backward compatibility
 export {
@@ -484,9 +484,9 @@ export class EditCompletedSessionError extends Error {
  * preserved. `workout_sessions.edited_at` is stamped to `now` inside the same
  * transaction so the edit pill appears as soon as the next read happens.
  *
- * BLD-1170: after the transaction, recomputeSetCaches is called for every set
- * whose weight, reps, or set_type was changed, so cached_volume_kg and
- * cached_e1rm_kg remain in sync.
+ * BLD-1186: cache recomputation (cached_volume_kg / cached_e1rm_kg) now happens
+ * inline via updateSetForSessionEdit / recomputeSetCaches — there is no post-TX
+ * recompute loop. The write path is fully owned by lib/db/sets.ts.
  */
 export async function editCompletedSession(
   sessionId: string,
@@ -527,8 +527,6 @@ export async function editCompletedSession(
   }
 
   const db = await getDrizzle();
-  // BLD-1170: track set IDs that need cache recomputation after the transaction.
-  const recomputeIds: string[] = [];
 
   await withTransaction(async () => {
     if (deletes.length > 0) {
@@ -539,17 +537,9 @@ export async function editCompletedSession(
     }
     for (const u of upserts) {
       if (u.id) {
-        await applyEditUpdate(db, sessionId, u, now);
-        // If weight, reps, or set_type changed, recompute caches after transaction.
-        if (u.weight !== undefined || u.reps !== undefined || u.set_type !== undefined) {
-          recomputeIds.push(u.id);
-        }
+        await applyEditUpdate(sessionId, u, now);
       } else {
-        const newId = await applyEditInsert(db, sessionId, u, now);
-        // New sets with weight/reps need cache priming.
-        if (u.weight != null || u.reps != null) {
-          recomputeIds.push(newId);
-        }
+        await applyEditInsert(db, sessionId, u, now);
       }
     }
     await renumberSessionSets(db, sessionId);
@@ -557,11 +547,6 @@ export async function editCompletedSession(
       .set({ edited_at: now })
       .where(eq(workoutSessions.id, sessionId));
   });
-
-  // BLD-1170: recompute caches outside the transaction (recomputeSetCaches reads back from DB).
-  for (const id of recomputeIds) {
-    await recomputeSetCaches(id);
-  }
 }
 
 const PATCHABLE_COLUMNS: ReadonlyArray<keyof SessionEditSetPatch> = [
@@ -570,15 +555,19 @@ const PATCHABLE_COLUMNS: ReadonlyArray<keyof SessionEditSetPatch> = [
   "duration_seconds", "exercise_position", "bodyweight_modifier_kg",
 ];
 
+/**
+ * Apply an update patch for an existing set, delegating all DB writes through
+ * updateSetForSessionEdit in lib/db/sets.ts. This guarantees recomputeSetCaches()
+ * is called for any volume-affecting change (weight / reps / set_type).
+ */
 async function applyEditUpdate(
-  db: Awaited<ReturnType<typeof getDrizzle>>,
   sessionId: string,
   u: SessionEditSetPatch,
   now: number,
 ): Promise<void> {
-  const updates: Record<string, unknown> = {};
+  const updates: SessionEditUpdateFields = {};
   for (const k of PATCHABLE_COLUMNS) {
-    if (u[k] !== undefined) updates[k as string] = u[k];
+    if (u[k] !== undefined) (updates as Record<string, unknown>)[k] = u[k];
   }
   if (u.exercise_id !== undefined) updates.exercise_id = u.exercise_id;
 
@@ -591,10 +580,7 @@ async function applyEditUpdate(
     updates.completed_at = null;
   }
 
-  if (Object.keys(updates).length === 0) return;
-  await db.update(workoutSets)
-    .set(updates)
-    .where(and(eq(workoutSets.id, u.id!), eq(workoutSets.session_id, sessionId)));
+  await updateSetForSessionEdit(u.id!, sessionId, updates);
 }
 
 async function applyEditInsert(
@@ -602,14 +588,17 @@ async function applyEditInsert(
   sessionId: string,
   u: SessionEditSetPatch,
   now: number,
-): Promise<string> {
+): Promise<void> {
   const completed: 0 | 1 = u.completed ?? 0;
   const completedAt = u.completed_at !== undefined
     ? u.completed_at
     : completed === 1 ? now : null;
   const newRow = buildEditInsertRow(sessionId, u, completed, completedAt);
   await db.insert(workoutSets).values(newRow as never);
-  return newRow.id as string;
+  // Prime caches for new sets that have weight/reps.
+  if (u.weight != null || u.reps != null) {
+    await recomputeSetCaches(newRow.id as string);
+  }
 }
 
 function buildEditInsertRow(

--- a/lib/db/sets.ts
+++ b/lib/db/sets.ts
@@ -435,6 +435,9 @@ export type SessionEditUpdateFields = {
  * editCompletedSession). Centralising the write here guarantees
  * recomputeSetCaches() always runs after a weight / reps / set_type change,
  * eliminating the post-TX recompute loop that previously lived in sessions.ts.
+ *
+ * Must be called from inside `withTransaction` so that recomputeSetCaches()
+ * reads-after-writes see the just-written values within the same SQLite tx.
  */
 export async function updateSetForSessionEdit(
   setId: string,

--- a/lib/db/sets.ts
+++ b/lib/db/sets.ts
@@ -402,6 +402,57 @@ export async function deleteAllSegmentsForSet(setId: string): Promise<void> {
   await recomputeSetCaches(setId);
 }
 
+// ─── Session-edit write path ─────────────────────────────────────────────────
+
+/**
+ * The set of fields that editCompletedSession may update on an existing row.
+ * Mirrors PATCHABLE_COLUMNS in sessions.ts plus exercise_id.
+ */
+export type SessionEditUpdateFields = {
+  set_number?: number;
+  weight?: number | null;
+  reps?: number | null;
+  completed?: 0 | 1;
+  completed_at?: number | null;
+  rpe?: number | null;
+  notes?: string;
+  link_id?: string | null;
+  round?: number | null;
+  tempo?: string | null;
+  swapped_from_exercise_id?: string | null;
+  set_type?: string;
+  duration_seconds?: number | null;
+  exercise_position?: number;
+  bodyweight_modifier_kg?: number | null;
+  exercise_id?: string;
+};
+
+/**
+ * Write all session-edit fields for an existing workout_sets row and recompute
+ * cached_volume_kg / cached_e1rm_kg if any volume-affecting column was provided.
+ *
+ * This is the canonical write path for applyEditUpdate (called from
+ * editCompletedSession). Centralising the write here guarantees
+ * recomputeSetCaches() always runs after a weight / reps / set_type change,
+ * eliminating the post-TX recompute loop that previously lived in sessions.ts.
+ */
+export async function updateSetForSessionEdit(
+  setId: string,
+  sessionId: string,
+  updates: SessionEditUpdateFields,
+): Promise<void> {
+  if (Object.keys(updates).length === 0) return;
+
+  const db = await getDrizzle();
+  await db.update(workoutSets)
+    .set(updates as never)
+    .where(and(eq(workoutSets.id, setId), eq(workoutSets.session_id, sessionId)));
+
+  if (updates.weight !== undefined || updates.reps !== undefined || updates.set_type !== undefined) {
+    await recomputeSetCaches(setId);
+  }
+}
+
 /** Load all segments for a set ordered by segment_number. */
 export async function getSegmentsForSet(setId: string): Promise<SetSegment[]> {
   const db = await getDrizzle();


### PR DESCRIPTION
## Summary

Refactors `applyEditUpdate` in `lib/db/sessions.ts` to delegate all writes through a new `updateSetForSessionEdit` helper in `lib/db/sets.ts`, eliminating the "post-TX recompute loop" footgun and blocking the function in the architecture test.

## Changes

### `lib/db/sets.ts`
- Add `updateSetForSessionEdit(setId, sessionId, updates)`: writes all patchable session-edit fields via `db.update(workoutSets)`, then calls `recomputeSetCaches` when volume-affecting columns (weight/reps/set_type) are included
- Export `SessionEditUpdateFields` type (mirrors `PATCHABLE_COLUMNS` in sessions.ts + exercise_id)

### `lib/db/sessions.ts`
- `applyEditUpdate`: remove direct `db.update(workoutSets)`; build `SessionEditUpdateFields` and call `updateSetForSessionEdit` instead
- `editCompletedSession`: remove post-TX `recomputeIds` loop — recompute now happens inline inside `updateSetForSessionEdit`
- `applyEditInsert`: call `recomputeSetCaches` directly for new sets with weight/reps (insert cache priming, symmetrical with update path)

### `__tests__/architecture-set-write-path.test.ts`
- Update header comment to reference BLD-1186 alongside BLD-1170
- Test 4: keep `lib/db/sessions.ts` in file-level allowlist (swap/renumber still need direct `db.update`) but update comment to reflect applyEditUpdate no longer writes directly
- **Test 5 (new)**: function-body extraction verifies that `applyEditUpdate` body has NO `db.update(workoutSets)` and DOES call `updateSetForSessionEdit`; verifies `swapExerciseInSession`, `undoSwapInSession`, `renumberSessionSets` still retain their legitimate writes

## Testing

- TypeScript: `tsc --noEmit` — 0 errors
- All 33 architecture + edit-completed-session tests pass
- Full `lib/db` test suite: 718/718 pass

## Issue

Resolves BLD-1186