### PR TITLE
fix(BLD-1208): rest timer notification spam + WearOS bridging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ marker) at release time.
 
 ## Unreleased
 
+- **Rest timer (Android)**: Fixed notification spam where finishing a set would stack 12–24+ shade entries instead of showing one. The live countdown now dismisses the previous entry before re-presenting, and updates every 15 s instead of every 5 s.
+- **WearOS rest-complete bridging**: The "rest complete" chime now appears on paired Wear OS watches. Previously the notification used a low-importance channel that the Wear OS Companion skips; it now uses a HIGH-importance channel.
 - **Strava connect** (Android): Fixed a silent connection failure on some OEM Android builds (Samsung Z Fold6 and similar) where the OAuth redirect was not intercepted, leaving the connection incomplete.
 - Progression suggestions now correctly evaluate advanced set types (rest-pause, cluster, myo-reps) using the working-set reps of the activation segment, rather than the inflated total-reps sum.
 - **CSV export/import round-trip for advanced sets**: rest-pause, cluster, and myo-rep set segment data (reps, weights, rests per mini-set) is now preserved when you export and re-import your workout CSV. Unknown set types in imported CSVs are automatically normalised to "normal" instead of being silently dropped.

--- a/__tests__/hooks/useRestTimer-smart-rest-coach.test.ts
+++ b/__tests__/hooks/useRestTimer-smart-rest-coach.test.ts
@@ -372,9 +372,9 @@ describe("useRestTimer BLD-1137: Smart Rest Coach", () => {
         const initialCallCount = mockPresentLiveRestCountdown.mock.calls.length;
         expect(initialCallCount).toBeGreaterThanOrEqual(1);
 
-        // Advance fake timers by 5001ms to fire the 5s self-correcting chain (AC4: ±500ms)
+        // Advance fake timers by 15001ms to fire the 15s self-correcting chain (BLD-1208: bumped from 5s)
         await act(async () => {
-          jest.advanceTimersByTime(5001);
+          jest.advanceTimersByTime(15001);
           await Promise.resolve();
         });
 

--- a/__tests__/hooks/useRestTimer.test.ts
+++ b/__tests__/hooks/useRestTimer.test.ts
@@ -420,7 +420,7 @@ describe("useRestTimer", () => {
       if (key === "rest_timer_default_seconds") return "90";
       if (key === "rest_timer_active_state") {
         return JSON.stringify({
-          sessionId: "session-restore",
+          sessionId: "session-1",
           endTimestamp,
           durationSeconds: 90,
           breakdown: {
@@ -441,27 +441,35 @@ describe("useRestTimer", () => {
       return "true";
     });
 
-    const { result } = renderHook(() => useRestTimer(defaultOptions));
+    // Simulate app is in foreground during restore
+    const origCurrentState = AppState.currentState;
+    Object.defineProperty(AppState, "currentState", { value: "active", writable: true, configurable: true });
 
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    try {
+      const { result } = renderHook(() => useRestTimer(defaultOptions));
 
-    // Initial restore call
-    const callsAfterRestore = mockPresentLiveRestCountdown.mock.calls.length;
-    expect(callsAfterRestore).toBeGreaterThanOrEqual(1);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
 
-    // Advance by 5s — should NOT trigger another live countdown call (old 5s cadence)
-    await act(async () => { jest.advanceTimersByTime(5000); });
-    expect(mockPresentLiveRestCountdown.mock.calls.length).toBe(callsAfterRestore);
+      // Initial restore call
+      const callsAfterRestore = mockPresentLiveRestCountdown.mock.calls.length;
+      expect(callsAfterRestore).toBeGreaterThanOrEqual(1);
 
-    // Advance by another 10s (total 15s) — NOW it should fire (15s cadence)
-    await act(async () => { jest.advanceTimersByTime(10000); });
-    expect(mockPresentLiveRestCountdown.mock.calls.length).toBe(callsAfterRestore + 1);
+      // Advance by 5s — should NOT trigger another live countdown call (old 5s cadence)
+      await act(async () => { jest.advanceTimersByTime(5000); });
+      expect(mockPresentLiveRestCountdown.mock.calls.length).toBe(callsAfterRestore);
 
-    // Confirm result is still counting
-    expect(result.current.rest).toBeGreaterThan(0);
+      // Advance by another 10s (total 15s) — NOW it should fire (15s cadence)
+      await act(async () => { jest.advanceTimersByTime(10000); });
+      expect(mockPresentLiveRestCountdown.mock.calls.length).toBe(callsAfterRestore + 1);
+
+      // Confirm result is still counting
+      expect(result.current.rest).toBeGreaterThan(0);
+    } finally {
+      Object.defineProperty(AppState, "currentState", { value: origCurrentState, writable: true, configurable: true });
+    }
   });
 
   it("does not schedule notification when notifications unavailable", async () => {

--- a/__tests__/hooks/useRestTimer.test.ts
+++ b/__tests__/hooks/useRestTimer.test.ts
@@ -414,6 +414,56 @@ describe("useRestTimer", () => {
     expect(result.current.selectedDurationSeconds).toBe(45);
   });
 
+  it("BLD-1208 — cold-start restore path uses LIVE_COUNTDOWN_TICK_MS (15s) cadence, not 5s", async () => {
+    const endTimestamp = Date.now() + 90000;
+    mockGetAppSetting.mockImplementation(async (key: string) => {
+      if (key === "rest_timer_default_seconds") return "90";
+      if (key === "rest_timer_active_state") {
+        return JSON.stringify({
+          sessionId: "session-restore",
+          endTimestamp,
+          durationSeconds: 90,
+          breakdown: {
+            totalSeconds: 90,
+            baseSeconds: 90,
+            factors: [],
+            isDefault: true,
+            reasonShort: "",
+            reasonAccessible: "",
+          },
+          notificationId: "notif-id-restore",
+          liveEnabled: true,
+          previewSnapshot: null,
+          isLastSet: false,
+          cueSeconds: 0,
+        });
+      }
+      return "true";
+    });
+
+    const { result } = renderHook(() => useRestTimer(defaultOptions));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Initial restore call
+    const callsAfterRestore = mockPresentLiveRestCountdown.mock.calls.length;
+    expect(callsAfterRestore).toBeGreaterThanOrEqual(1);
+
+    // Advance by 5s — should NOT trigger another live countdown call (old 5s cadence)
+    await act(async () => { jest.advanceTimersByTime(5000); });
+    expect(mockPresentLiveRestCountdown.mock.calls.length).toBe(callsAfterRestore);
+
+    // Advance by another 10s (total 15s) — NOW it should fire (15s cadence)
+    await act(async () => { jest.advanceTimersByTime(10000); });
+    expect(mockPresentLiveRestCountdown.mock.calls.length).toBe(callsAfterRestore + 1);
+
+    // Confirm result is still counting
+    expect(result.current.rest).toBeGreaterThan(0);
+  });
+
   it("does not schedule notification when notifications unavailable", async () => {
     mockIsAvailable.mockReturnValue(false);
     const { result } = renderHook(() => useRestTimer(defaultOptions));

--- a/__tests__/lib/notifications.test.ts
+++ b/__tests__/lib/notifications.test.ts
@@ -19,7 +19,7 @@ jest.mock("expo-notifications", () => {
     dismissNotificationAsync: jest.fn().mockResolvedValue(undefined),
     scheduleNotificationAsync: jest.fn().mockResolvedValue("notif-id"),
     setNotificationChannelAsync: jest.fn().mockResolvedValue(undefined),
-    AndroidImportance: { LOW: 2 },
+    AndroidImportance: { LOW: 2, HIGH: 4 },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setNotificationHandler: jest.fn((h: any) => { handler = h; }),
     addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
@@ -62,7 +62,7 @@ describe("notifications", () => {
         dismissNotificationAsync: jest.fn().mockResolvedValue(undefined),
         scheduleNotificationAsync: jest.fn().mockResolvedValue("notif-id"),
         setNotificationChannelAsync: jest.fn().mockResolvedValue(undefined),
-        AndroidImportance: { LOW: 2 },
+        AndroidImportance: { LOW: 2, HIGH: 4 },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         setNotificationHandler: jest.fn((h: any) => { handler = h; }),
         addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
@@ -585,6 +585,70 @@ describe("notifications", () => {
       // Rest-complete alone carries sound — pre-end cue and live countdown are both silent
       expect(call.content.sound).toBe("default");
     });
+
+    // BLD-1208: new tests
+    it("BLD-1208 — presentLiveRestCountdown calls dismissNotificationAsync before scheduleNotificationAsync", async () => {
+      const { Platform } = require("react-native");
+      const origOS = Platform.OS;
+      (Platform as { OS: string }).OS = "android";
+      try {
+        const callOrder: string[] = [];
+        (Notifications.dismissNotificationAsync as jest.Mock).mockImplementation(async () => {
+          callOrder.push("dismiss");
+        });
+        (Notifications.scheduleNotificationAsync as jest.Mock).mockImplementation(async () => {
+          callOrder.push("schedule");
+          return "notif-id";
+        });
+
+        await notifications.presentLiveRestCountdown(45, null, "sess-nostack");
+
+        expect(callOrder).toEqual(["dismiss", "schedule"]);
+        expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith("rest-live-sess-nostack");
+        expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith(
+          expect.objectContaining({ identifier: "rest-live-sess-nostack" }),
+        );
+      } finally {
+        (Platform as { OS: string }).OS = origOS;
+      }
+    });
+
+    it("BLD-1208 — scheduleRestComplete sets channelId=REST_COMPLETE_CHANNEL on Android", async () => {
+      const { Platform } = require("react-native");
+      const origOS = Platform.OS;
+      (Platform as { OS: string }).OS = "android";
+      try {
+        await notifications.scheduleRestComplete(60, "sess-ch");
+        const call = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls[0][0];
+        expect(call.content.channelId).toBe(notifications.REST_COMPLETE_CHANNEL);
+      } finally {
+        (Platform as { OS: string }).OS = origOS;
+      }
+    });
+
+    it("BLD-1208 — scheduleRestComplete does not set channelId on iOS", async () => {
+      const { Platform } = require("react-native");
+      const origOS = Platform.OS;
+      (Platform as { OS: string }).OS = "ios";
+      try {
+        await notifications.scheduleRestComplete(60, "sess-ios");
+        const call = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls[0][0];
+        expect(call.content.channelId).toBeUndefined();
+      } finally {
+        (Platform as { OS: string }).OS = origOS;
+      }
+    });
+
+    it("BLD-1208 — setupHandler suppresses rest_live banners in foreground", async () => {
+      notifications.setupHandler();
+      const handler = (Notifications._getHandler as jest.Mock)();
+      const behavior = await handler.handleNotification({
+        request: { content: { data: { type: "rest_live" } } },
+      });
+      expect(behavior.shouldShowBanner).toBe(false);
+      expect(behavior.shouldShowList).toBe(false);
+      expect(behavior.shouldShowAlert).toBe(false);
+    });
   });
 
   // BLD-1137: covers AC16 from PLAN-BLD-1137.md
@@ -628,20 +692,37 @@ describe("notifications", () => {
       }
     });
 
+    it("BLD-1208 — registers REST_COMPLETE_CHANNEL (HIGH importance) on Android", async () => {
+      const { Platform } = require("react-native");
+      const origOS = Platform.OS;
+      (Platform as { OS: string }).OS = "android";
+      try {
+        await notifications.ensureRestChannelsRegistered();
+        expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith(
+          notifications.REST_COMPLETE_CHANNEL,
+          expect.objectContaining({
+            importance: 4, // AndroidImportance.HIGH — required for Wear OS bridging
+          }),
+        );
+      } finally {
+        (Platform as { OS: string }).OS = origOS;
+      }
+    });
+
     it("AC16 — is idempotent: second call registers same channels again without error", async () => {
       const { Platform } = require("react-native");
       const origOS = Platform.OS;
       (Platform as { OS: string }).OS = "android";
       try {
-        // First cold-start call: 2 channels registered
+        // First cold-start call: 3 channels registered (rest-ongoing, rest-cue, rest-complete)
         await notifications.ensureRestChannelsRegistered();
-        expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledTimes(2);
+        expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledTimes(3);
         const firstCallArgs = (Notifications.setNotificationChannelAsync as jest.Mock).mock.calls.map((c: unknown[]) => c[0]);
 
-        // Second call (e.g., process re-init) succeeds without error and registers the same 2 channels
+        // Second call (e.g., process re-init) succeeds without error and registers the same 3 channels
         jest.clearAllMocks();
         await notifications.ensureRestChannelsRegistered();
-        expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledTimes(2);
+        expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledTimes(3);
         const secondCallArgs = (Notifications.setNotificationChannelAsync as jest.Mock).mock.calls.map((c: unknown[]) => c[0]);
 
         // Same channel IDs registered both times — idempotent behavior

--- a/__tests__/lib/notifications.test.ts
+++ b/__tests__/lib/notifications.test.ts
@@ -639,7 +639,7 @@ describe("notifications", () => {
       }
     });
 
-    it("BLD-1208 — setupHandler suppresses rest_live banners in foreground", async () => {
+    it("BLD-1208 — setupHandler suppresses rest_live banners but keeps shade entry visible in foreground", async () => {
       type HandlerFn = (notification: { request: { content: { data: { type: string } } } }) => Promise<{ shouldShowBanner: boolean; shouldShowList: boolean; shouldShowAlert: boolean }>;
       notifications.setupHandler();
       const handler = (Notifications as typeof Notifications & { _getHandler: () => { handleNotification: HandlerFn } })._getHandler();
@@ -647,7 +647,7 @@ describe("notifications", () => {
         request: { content: { data: { type: "rest_live" } } },
       });
       expect(behavior.shouldShowBanner).toBe(false);
-      expect(behavior.shouldShowList).toBe(false);
+      expect(behavior.shouldShowList).toBe(true);
       expect(behavior.shouldShowAlert).toBe(false);
     });
   });
@@ -702,7 +702,7 @@ describe("notifications", () => {
         expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith(
           notifications.REST_COMPLETE_CHANNEL,
           expect.objectContaining({
-            importance: 4, // AndroidImportance.HIGH — required for Wear OS bridging
+            importance: Notifications.AndroidImportance.HIGH,
           }),
         );
       } finally {

--- a/__tests__/lib/notifications.test.ts
+++ b/__tests__/lib/notifications.test.ts
@@ -640,8 +640,9 @@ describe("notifications", () => {
     });
 
     it("BLD-1208 — setupHandler suppresses rest_live banners in foreground", async () => {
+      type HandlerFn = (notification: { request: { content: { data: { type: string } } } }) => Promise<{ shouldShowBanner: boolean; shouldShowList: boolean; shouldShowAlert: boolean }>;
       notifications.setupHandler();
-      const handler = (Notifications._getHandler as jest.Mock)();
+      const handler = (Notifications as typeof Notifications & { _getHandler: () => { handleNotification: HandlerFn } })._getHandler();
       const behavior = await handler.handleNotification({
         request: { content: { data: { type: "rest_live" } } },
       });

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -143,7 +143,7 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
   const endAtRef = useRef<number | null>(null);
   /** BLD-1137: replaces legacy notificationIdRef with three-id object. */
   const notificationIdsRef = useRef<{ preEnd?: string | null; complete?: string | null; liveOngoing?: string | null }>({});
-  /** BLD-1137: setInterval handle for the 5s live countdown re-present. */
+  /** BLD-1137: setInterval handle for the 15 s live countdown re-present (BLD-1208). */
   const liveCountdownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   /** BLD-1137: preview snapshot ref so recomputeActiveRest can re-use without refetching. */
   const previewRef = useRef<NextSetPreview>(null);

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -600,9 +600,9 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
             const rem = Math.max(0, Math.floor((endAtRef.current - Date.now()) / 1000));
             if (rem <= 0) { stopLiveCountdownInterval(); return; }
             void presentLiveRestCountdown(rem, restoredState.previewSnapshot, sessionId).catch(() => {});
-            liveCountdownIntervalRef.current = setTimeout(scheduleNext, 5000) as unknown as ReturnType<typeof setInterval>;
+            liveCountdownIntervalRef.current = setTimeout(scheduleNext, LIVE_COUNTDOWN_TICK_MS) as unknown as ReturnType<typeof setInterval>;
           };
-          liveCountdownIntervalRef.current = setTimeout(scheduleNext, 5000) as unknown as ReturnType<typeof setInterval>;
+          liveCountdownIntervalRef.current = setTimeout(scheduleNext, LIVE_COUNTDOWN_TICK_MS) as unknown as ReturnType<typeof setInterval>;
         }
 
         // BLD-1137: AC12 — Re-schedule OS notifications lost on Android force-kill or device restart.

--- a/hooks/useRestTimer.ts
+++ b/hooks/useRestTimer.ts
@@ -39,6 +39,13 @@ import {
 } from "../lib/notifications";
 import { sessionBreadcrumb } from "../lib/session-breadcrumbs";
 
+/**
+ * Interval between live countdown shade updates (ms).
+ * 15s is frequent enough for human perception during a rest and minimises
+ * shade churn vs the previous 5s cadence (BLD-1208).
+ */
+const LIVE_COUNTDOWN_TICK_MS = 15_000;
+
 export type SetContext = {
   exerciseId: string;
   sessionId: string;
@@ -262,9 +269,9 @@ export function useRestTimer({ sessionId, colors }: UseRestTimerOptions) {
               return;
             }
             void presentLiveRestCountdown(remaining, effectivePreview, sessionId).catch(() => {});
-            liveCountdownIntervalRef.current = setTimeout(scheduleNext, 5000) as unknown as ReturnType<typeof setInterval>;
+            liveCountdownIntervalRef.current = setTimeout(scheduleNext, LIVE_COUNTDOWN_TICK_MS) as unknown as ReturnType<typeof setInterval>;
           };
-          liveCountdownIntervalRef.current = setTimeout(scheduleNext, 5000) as unknown as ReturnType<typeof setInterval>;
+          liveCountdownIntervalRef.current = setTimeout(scheduleNext, LIVE_COUNTDOWN_TICK_MS) as unknown as ReturnType<typeof setInterval>;
         }
       }
 

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -40,6 +40,12 @@ export const REST_ONGOING_CHANNEL = "rest-ongoing";
 export const REST_CUE_CHANNEL = "rest-cue";
 
 /**
+ * Android channel for the rest-complete notification.
+ * HIGH importance so Wear OS Companion bridges it to the watch (BLD-1208).
+ */
+export const REST_COMPLETE_CHANNEL = "rest-complete";
+
+/**
  * Preview of the next set to display on the lock screen.
  * null means no preview available (no next set, or preview disabled by user).
  */
@@ -118,7 +124,8 @@ function formatBodyWeighted(
 }
 
 /**
- * Register the two new Android notification channels for BLD-1137.
+ * Register Android notification channels for the Smart Rest Coach (BLD-1137/BLD-1208).
+ * Three channels: ongoing (LOW), cue (LOW), complete (HIGH — bridges to Wear OS).
  * Idempotent — safe to call on every cold start. No-op on iOS.
  */
 export async function ensureRestChannelsRegistered(): Promise<void> {
@@ -127,7 +134,7 @@ export async function ensureRestChannelsRegistered(): Promise<void> {
   if (!mod) return;
   try {
     if (typeof mod.setNotificationChannelAsync !== "function") return;
-    const AndroidImportance = mod.AndroidImportance ?? { LOW: 2 };
+    const AndroidImportance = mod.AndroidImportance ?? { LOW: 2, HIGH: 4 };
     await mod.setNotificationChannelAsync(REST_ONGOING_CHANNEL, {
       name: "Rest timer (ongoing)",
       importance: AndroidImportance.LOW ?? 2,
@@ -141,6 +148,16 @@ export async function ensureRestChannelsRegistered(): Promise<void> {
       sound: null,
       vibrationPattern: [],
       showBadge: false,
+    });
+    // HIGH importance required so Wear OS Companion bridges this to the watch (BLD-1208).
+    // rest-ongoing stays LOW (unobtrusive ticker — bridging to Wear would be obnoxious).
+    await mod.setNotificationChannelAsync(REST_COMPLETE_CHANNEL, {
+      name: "Rest complete",
+      importance: AndroidImportance.HIGH ?? 4,
+      sound: "default",
+      vibrationPattern: [0, 250, 250, 250],
+      showBadge: false,
+      enableVibrate: true,
     });
   } catch {
     // Non-critical — channel registration is best-effort
@@ -207,7 +224,10 @@ export async function schedulePreEndCue(
 
 /**
  * Present (or re-present) the live ongoing countdown notification on Android.
- * Uses identifier reuse to replace-in-place. No-op on iOS.
+ * Dismisses the previous shade entry before posting a new one (BLD-1208) —
+ * Android does not replace trigger:null notifications in-place even with a
+ * stable identifier, so without the dismiss step every tick stacks a new entry.
+ * No-op on iOS.
  * @param secondsRemaining - Current remaining rest seconds (for display).
  * @param preview - Next set preview (may be null).
  * @param sessionId - Session identifier.
@@ -221,6 +241,12 @@ export async function presentLiveRestCountdown(
   const mod = getModule();
   if (!mod) return null;
   try {
+    const liveId = `rest-live-${sessionId}`;
+    // Dismiss the previous shade entry before posting a new one to prevent stacking.
+    if (typeof mod.dismissNotificationAsync === "function") {
+      try { await mod.dismissNotificationAsync(liveId); } catch { /* not in shade on first call */ }
+    }
+
     const m = Math.floor(secondsRemaining / 60);
     const s = secondsRemaining % 60;
     const timeStr = `${m}:${String(s).padStart(2, "0")}`;
@@ -228,7 +254,7 @@ export async function presentLiveRestCountdown(
     const body = previewBody ?? "Resting\u2026";
 
     const id = await mod.scheduleNotificationAsync({
-      identifier: `rest-live-${sessionId}`,
+      identifier: liveId,
       content: {
         title: `Resting \u00b7 ${timeStr} remaining`,
         body,
@@ -237,7 +263,7 @@ export async function presentLiveRestCountdown(
       },
       trigger: null,
     } as Parameters<typeof mod.scheduleNotificationAsync>[0]);
-    return id ?? `rest-live-${sessionId}`;
+    return id ?? liveId;
   } catch {
     return null;
   }
@@ -393,6 +419,16 @@ export function setupHandler(): void {
             shouldShowList: false,
           };
         }
+        // Suppress live countdown banner in foreground — shade managed by dismiss-before-present.
+        if (data?.type === "rest_live") {
+          return {
+            shouldShowAlert: false,
+            shouldPlaySound: false,
+            shouldSetBadge: false,
+            shouldShowBanner: false,
+            shouldShowList: false,
+          };
+        }
         return {
           shouldShowAlert: true,
           shouldPlaySound: false,
@@ -452,6 +488,7 @@ export async function scheduleRestComplete(
         body,
         sound: "default",
         data: { sessionId, type: "rest_complete" },
+        ...(Platform.OS === "android" ? { channelId: REST_COMPLETE_CHANNEL } : {}),
       },
       trigger: {
         type: mod.SchedulableTriggerInputTypes.TIME_INTERVAL,

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -419,14 +419,14 @@ export function setupHandler(): void {
             shouldShowList: false,
           };
         }
-        // Suppress live countdown banner in foreground — shade managed by dismiss-before-present.
+        // Suppress live countdown banner in foreground — keep shade/list entry visible.
         if (data?.type === "rest_live") {
           return {
             shouldShowAlert: false,
             shouldPlaySound: false,
             shouldSetBadge: false,
             shouldShowBanner: false,
-            shouldShowList: false,
+            shouldShowList: true,
           };
         }
         return {


### PR DESCRIPTION
## Summary

Fixes two related Android notification issues for the rest timer:

1. **Notification stacking**: The live countdown shade notification was accumulating 12-24+ entries per rest period. Fixed by explicitly dismissing the previous entry before posting a new one, and increasing the tick interval from 5s to 15s.

2. **WearOS bridging**: The 'Rest complete' alert was silently skipped by Wear OS Companion because it used the low-importance REST_ONGOING channel. Fixed by introducing a dedicated HIGH-importance REST_COMPLETE_CHANNEL.

## Changes

- lib/notifications.ts: Add REST_COMPLETE_CHANNEL, dismiss-before-post in presentLiveRestCountdown, new dismissLiveRestCountdown helper, suppress rest_live foreground banners in setupHandler, use REST_COMPLETE_CHANNEL in scheduleRestComplete
- hooks/useRestTimer.ts: Bump tick 5s to 15s (LIVE_COUNTDOWN_TICK_MS), dismiss live countdown on foreground, fix sessionId dep
- Tests: 5 new BLD-1208 tests, useRestTimer test updated 5s to 15s
- CHANGELOG.md: Unreleased bullets added

## Issue

Resolves BLD-1208