### PR TITLE
fix(e2e): exact match for count badge '2' — prevent date substring collision (BLD-1216)

### DIFF
--- a/e2e/scenarios/form-clip-compare.spec.ts
+++ b/e2e/scenarios/form-clip-compare.spec.ts
@@ -159,7 +159,7 @@ test.describe("@scenario form-clip-compare", () => {
     await expect(page.locator("body[data-test-ready='true']")).toBeVisible({ timeout: 15_000 });
 
     // Count badge should show "2".
-    await expect(page.getByText("2")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("2", { exact: true }).first()).toBeVisible({ timeout: 5000 });
 
     await page.screenshot({
       path: path.join(OUT_DIR, "grid-seed.png"),


### PR DESCRIPTION
## Summary

Fixes a strict-mode Playwright failure in the ux-audit form-clip-compare spec where `getByText('2')` matched date strings containing '2' (e.g. 'May 12', 'May 20-29').

## Changes

- `e2e/scenarios/form-clip-compare.spec.ts:162`: changed `getByText('2')` to `getByText('2', { exact: true }).first()`

## Testing

- Single atomic commit, no production code touched
- Follows same pattern as BLD-1176 commit 60544218 (anchor Playwright thumbnail locators)

## Issue

Resolves BLD-1216