### PR TITLE
fix: wrap finish/cancel in useCallback to prevent Finish Workout button drop on Android (BLD-1239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: "Finish Workout" button now responds during rest timer (Android)** — tapping Finish Workout while the rest countdown is active now reliably opens the Complete Workout confirm dialog. Previously the button was unresponsive on Android (especially foldables like Galaxy Z Fold 6) because the footer re-mounted every second during rest ticks. (#600, BLD-1239)
 
 ## v0.26.34 — 2026-05-12
 <!-- versionCode: 104 -->

--- a/__tests__/hooks/useSessionActions-finish-dismissRest.test.ts
+++ b/__tests__/hooks/useSessionActions-finish-dismissRest.test.ts
@@ -214,4 +214,79 @@ describe("useSessionActions — finish() dismisses rest timer (BLD-1137 AC7)", (
       expect(mockReplace).not.toHaveBeenCalled();
     });
   });
+
+  describe("BLD-1239 — finish() stable reference during rest-timer ticks", () => {
+    /**
+     * Regression: before the fix, `finish` and `cancel` were plain arrow functions
+     * (no useCallback). Every render produced a new function reference, including the
+     * 1-Hz render tick from useRestTimer. The memoised `listFooter` in
+     * app/session/[id].tsx depends on finish/cancel, so it re-created every second.
+     * FlatList on Android can unmount the Pressable between touchDown and touchUp when
+     * ListFooterComponent changes, silently dropping the tap.
+     *
+     * After the fix, finish and cancel are wrapped in useCallback. Their references
+     * must remain === stable across renders that only change the `elapsed` counter.
+     */
+    it("finish reference stays stable when the hook re-renders with a different dismissRest-stable prop", () => {
+      // Simulate the same dismissRest instance across renders (stable prop).
+      const dismissRest = jest.fn();
+      // Use a shared params object so all function references (showToast, showError, etc.)
+      // are identical across rerenders — mirrors the real-app scenario where the parent
+      // component's callbacks are memoised and don't change on rest-timer ticks.
+      const stableParams = createParams({ dismissRest });
+      const { result, rerender } = renderHook(
+        (props: Parameters<typeof useSessionActions>[0]) => useSessionActions(props),
+        { initialProps: stableParams }
+      );
+
+      const firstFinishRef = result.current.finish;
+
+      // Re-render with exactly the same props (simulates a rest tick re-render where only
+      // internal elapsed state changes — props are identical).
+      rerender(stableParams);
+
+      expect(result.current.finish).toBe(firstFinishRef);
+    });
+
+    it("cancel reference stays stable when the hook re-renders with identical props", () => {
+      const stableParams = createParams();
+      const { result, rerender } = renderHook(
+        (props: Parameters<typeof useSessionActions>[0]) => useSessionActions(props),
+        { initialProps: stableParams }
+      );
+
+      const firstCancelRef = result.current.cancel;
+      rerender(stableParams);
+
+      expect(result.current.cancel).toBe(firstCancelRef);
+    });
+
+    it("finish still triggers confirm dialog after a simulated rest tick re-render", async () => {
+      const { confirmAction } = jest.requireMock("../../lib/confirm");
+      mockGetSessionSets.mockResolvedValue([{ id: "s1", completed: true }]);
+
+      const dismissRest = jest.fn();
+      const { result, rerender } = renderHook(
+        (props: Parameters<typeof useSessionActions>[0]) => useSessionActions(props),
+        { initialProps: createParams({ dismissRest }) }
+      );
+
+      // Simulate a rest-timer re-render (props unchanged — mirrors 1-Hz elapsed tick).
+      rerender(createParams({ dismissRest }));
+
+      // Tap Finish Workout immediately after the re-render (the race condition scenario).
+      await act(async () => {
+        result.current.finish();
+        await flush();
+      });
+
+      expect(confirmAction).toHaveBeenCalledWith(
+        "Complete Workout?",
+        expect.any(String),
+        expect.any(Function),
+        false,
+        "Complete"
+      );
+    });
+  });
 });

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines-per-function, max-lines, react-hooks/exhaustive-deps, complexity */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AccessibilityInfo, AppState, Keyboard } from "react-native";
 import { useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
@@ -196,9 +196,26 @@ export function useSessionActions({
   suggestions,
 }: Params) {
   const router = useRouter();
+  // BLD-1239: ref so finish/cancel can access the router without including it in
+  // useCallback deps. In production, useRouter() returns a stable singleton — but
+  // keeping it as a ref removes any dependency on the reference identity of the
+  // router object and makes the hook easier to unit-test.
+  const routerRef = useRef(router);
+  // Sync after every render (useLayoutEffect so the ref is current before any
+  // paint or interaction — avoids the react-hooks/refs render-write lint error).
+  useLayoutEffect(() => {
+    routerRef.current = router;
+  });
 
   // --- local state ---
   const [elapsed, setElapsed] = useState(0);
+  // BLD-1239: keep a ref in sync so finish() can read the latest elapsed without
+  // capturing elapsed as a dependency (which would cause finish to get a new reference
+  // every second, re-mount the memoised listFooter, and drop Android tap events).
+  const elapsedRef = useRef(0);
+  useLayoutEffect(() => {
+    elapsedRef.current = elapsed;
+  });
   // BLD-630: optimistic local mirror of `workout_sessions.clock_started_at`.
   // The DB write inside completeSet is authoritative for persistence/export,
   // but `useSessionDetail` fetches the session once on `[id]` and never
@@ -1084,10 +1101,14 @@ export function useSessionActions({
   // No more hydration-write-storm.
 
 
-  const finish = () => {
+  // BLD-1239: wrap in useCallback so finish's reference is stable across rest-timer ticks.
+  // Previously a plain arrow function → new ref every render → listFooter remounted every
+  // second → Android Pressable could be unmounted between touchDown and touchUp, dropping
+  // the tap. Use elapsedRef.current to read elapsed without adding elapsed to deps.
+  const finish = useCallback(() => {
     confirmAction(
       "Complete Workout?",
-      `Duration: ${formatTime(elapsed)}`,
+      `Duration: ${formatTime(elapsedRef.current)}`,
       async () => {
 
         // BLD-1207 / GH#589: the critical "save the workout" steps must
@@ -1158,7 +1179,7 @@ export function useSessionActions({
             showToast("Strava sync queued — will retry");
           } else if (result.status === "failed") {
             showToast("Strava sync failed — check Settings", {
-              action: { label: "Settings", onPress: () => router.push("/settings/strava") },
+              action: { label: "Settings", onPress: () => routerRef.current.push("/settings/strava") },
               duration: 6000,
             });
           }
@@ -1193,7 +1214,7 @@ export function useSessionActions({
         const allSets = await getSessionSets(id!);
         const done = allSets.filter((s) => s.completed);
         if (done.length === 0) {
-          router.replace("/(tabs)");
+          routerRef.current.replace("/(tabs)");
         } else {
           // Fire-and-forget auto-backup — must never block navigation
           void (async () => {
@@ -1206,15 +1227,17 @@ export function useSessionActions({
               // Silent failure — backup should never block workout completion
             }
           })();
-          router.replace(`/session/summary/${id}`);
+          routerRef.current.replace(`/session/summary/${id}`);
         }
       },
       false,
       "Complete"
     );
-  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- elapsedRef/routerRef are refs (stable); id/dismissRest/flushAllPinnedNotes/showError/showToast are the real deps
+  }, [id, dismissRest, flushAllPinnedNotes, showError, showToast]);
 
-  const cancel = () => {
+  // BLD-1239: wrap in useCallback — cancel had the same re-mount issue as finish.
+  const cancel = useCallback(() => {
     confirmAction(
       "Discard Workout?",
       "All logged sets will be lost.",
@@ -1224,11 +1247,12 @@ export function useSessionActions({
         queryClient.removeQueries({ queryKey: ["home"] });
         // BLD-1122 AC17: cancelled session removes sets from plateau window
         queryClient.invalidateQueries({ queryKey: ["plateau"] });
-        router.back();
+        routerRef.current.back();
       },
       true
     );
-  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- routerRef is a ref (stable); cancelSession/bumpQueryVersion/queryClient are stable module imports
+  }, [id]);
 
   /** BLD-1122: Atomically apply break-through fill updates to a set of rows.
    * Writes via updateSetsBatch (single transaction), then invalidates plateau queries. */


### PR DESCRIPTION
## Summary

Wraps `finish()` and `cancel()` in `useCallback` in `useSessionActions`. These were plain arrow functions, causing new references every render. Since `useRestTimer` ticks every second, the memoised `listFooter` in `app/session/[id].tsx` re-created every second, causing FlatList to re-mount the footer Pressable between `touchDown` and `touchUp` — silently dropping Android taps.

## Changes

- `hooks/useSessionActions.ts`: wrap `finish` in `useCallback([id, dismissRest, flushAllPinnedNotes, showError, showToast])`; wrap `cancel` in `useCallback([id])`
- Use `elapsedRef` and `routerRef` (refs kept in sync each render) to read latest values inside the callbacks without adding them to the dep array
- `__tests__/hooks/useSessionActions-finish-dismissRest.test.ts`: 3 new regression tests — reference stability across re-renders, and confirm dialog fires after a simulated rest-tick re-render

## Testing

- All 9 tests in `useSessionActions-finish-dismissRest.test.ts` pass (including 3 new)
- All 20 tests in `workout-session.acceptance.test.tsx` pass
- TypeScript: 0 errors
- ESLint: `eslint-disable` comment on each useCallback explains the intentional dep-array omissions

## Issue

Resolves BLD-1239 / GitHub #600