### PR TITLE
fix: wrap finish/cancel in useCallback to prevent footer remount during rest timer (BLD-1239)

### DIFF
--- a/__tests__/hooks/useSessionActions-finish-dismissRest.test.ts
+++ b/__tests__/hooks/useSessionActions-finish-dismissRest.test.ts
@@ -214,4 +214,74 @@ describe("useSessionActions — finish() dismisses rest timer (BLD-1137 AC7)", (
       expect(mockReplace).not.toHaveBeenCalled();
     });
   });
+
+  describe("BLD-1239 — finish() stable reference during rest-timer ticks", () => {
+    /**
+     * Regression: before the fix, `finish` and `cancel` were plain arrow functions
+     * (no useCallback). Every render produced a new function reference, including the
+     * 1-Hz render tick from useRestTimer. The memoised `listFooter` in
+     * app/session/[id].tsx depends on finish/cancel, so it re-created every second.
+     * FlatList on Android can unmount the Pressable between touchDown and touchUp when
+     * ListFooterComponent changes, silently dropping the tap.
+     *
+     * After the fix, finish and cancel are wrapped in useCallback. Their references
+     * must remain === stable across renders that only change internal state (elapsed).
+     */
+    it("finish reference stays stable across re-renders with the same prop instances", () => {
+      // Use a single stable params object — mirrors the real-app scenario where the
+      // parent component's callbacks are memoised and don't change on rest-timer ticks.
+      const stableParams = createParams();
+      const { result, rerender } = renderHook(
+        (props: Parameters<typeof useSessionActions>[0]) => useSessionActions(props),
+        { initialProps: stableParams }
+      );
+
+      const firstFinishRef = result.current.finish;
+      // Re-render with exactly the same prop object (simulates elapsed tick).
+      rerender(stableParams);
+
+      expect(result.current.finish).toBe(firstFinishRef);
+    });
+
+    it("cancel reference stays stable across re-renders with the same prop instances", () => {
+      const stableParams = createParams();
+      const { result, rerender } = renderHook(
+        (props: Parameters<typeof useSessionActions>[0]) => useSessionActions(props),
+        { initialProps: stableParams }
+      );
+
+      const firstCancelRef = result.current.cancel;
+      rerender(stableParams);
+
+      expect(result.current.cancel).toBe(firstCancelRef);
+    });
+
+    it("finish still triggers confirm dialog after a simulated rest tick re-render", async () => {
+      const { confirmAction } = jest.requireMock("../../lib/confirm");
+      mockGetSessionSets.mockResolvedValue([{ id: "s1", completed: true }]);
+
+      const stableParams = createParams();
+      const { result, rerender } = renderHook(
+        (props: Parameters<typeof useSessionActions>[0]) => useSessionActions(props),
+        { initialProps: stableParams }
+      );
+
+      // Simulate a rest-timer re-render (props unchanged — mirrors 1-Hz elapsed tick).
+      rerender(stableParams);
+
+      // Tap Finish Workout immediately after the re-render (the race condition scenario).
+      await act(async () => {
+        result.current.finish();
+        await flush();
+      });
+
+      expect(confirmAction).toHaveBeenCalledWith(
+        "Complete Workout?",
+        expect.any(String),
+        expect.any(Function),
+        false,
+        "Complete"
+      );
+    });
+  });
 });

--- a/hooks/useSessionActions.ts
+++ b/hooks/useSessionActions.ts
@@ -196,9 +196,20 @@ export function useSessionActions({
   suggestions,
 }: Params) {
   const router = useRouter();
+  // BLD-1239: ref so finish/cancel can access the router without including it in
+  // useCallback deps. In production, useRouter() returns a stable singleton — but
+  // keeping it as a ref removes any dependency on the reference identity of the
+  // router object and makes the hook easier to unit-test.
+  const routerRef = useRef(router);
+  routerRef.current = router;
 
   // --- local state ---
   const [elapsed, setElapsed] = useState(0);
+  // BLD-1239: keep a ref in sync so finish() can read the latest elapsed without
+  // capturing elapsed as a dependency (which would cause finish to get a new reference
+  // every second, re-mount the memoised listFooter, and drop Android tap events).
+  const elapsedRef = useRef(0);
+  elapsedRef.current = elapsed;
   // BLD-630: optimistic local mirror of `workout_sessions.clock_started_at`.
   // The DB write inside completeSet is authoritative for persistence/export,
   // but `useSessionDetail` fetches the session once on `[id]` and never
@@ -1084,10 +1095,15 @@ export function useSessionActions({
   // No more hydration-write-storm.
 
 
-  const finish = () => {
+  // BLD-1239: wrap in useCallback so finish's reference is stable across rest-timer ticks.
+  // Previously a plain arrow function → new ref every render → listFooter remounted every
+  // second → Android Pressable could be unmounted between touchDown and touchUp, dropping
+  // the tap. Uses elapsedRef.current and routerRef.current to read current values without
+  // adding them to deps (they are refs, always up-to-date).
+  const finish = useCallback(() => {
     confirmAction(
       "Complete Workout?",
-      `Duration: ${formatTime(elapsed)}`,
+      `Duration: ${formatTime(elapsedRef.current)}`,
       async () => {
 
         // BLD-1207 / GH#589: the critical "save the workout" steps must
@@ -1158,7 +1174,7 @@ export function useSessionActions({
             showToast("Strava sync queued — will retry");
           } else if (result.status === "failed") {
             showToast("Strava sync failed — check Settings", {
-              action: { label: "Settings", onPress: () => router.push("/settings/strava") },
+              action: { label: "Settings", onPress: () => routerRef.current.push("/settings/strava") },
               duration: 6000,
             });
           }
@@ -1193,7 +1209,7 @@ export function useSessionActions({
         const allSets = await getSessionSets(id!);
         const done = allSets.filter((s) => s.completed);
         if (done.length === 0) {
-          router.replace("/(tabs)");
+          routerRef.current.replace("/(tabs)");
         } else {
           // Fire-and-forget auto-backup — must never block navigation
           void (async () => {
@@ -1206,15 +1222,17 @@ export function useSessionActions({
               // Silent failure — backup should never block workout completion
             }
           })();
-          router.replace(`/session/summary/${id}`);
+          routerRef.current.replace(`/session/summary/${id}`);
         }
       },
       false,
       "Complete"
     );
-  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- elapsedRef/routerRef are refs (stable); id/dismissRest/flushAllPinnedNotes/showError/showToast are the real deps
+  }, [id, dismissRest, flushAllPinnedNotes, showError, showToast]);
 
-  const cancel = () => {
+  // BLD-1239: wrap in useCallback — cancel had the same re-mount issue as finish.
+  const cancel = useCallback(() => {
     confirmAction(
       "Discard Workout?",
       "All logged sets will be lost.",
@@ -1224,11 +1242,12 @@ export function useSessionActions({
         queryClient.removeQueries({ queryKey: ["home"] });
         // BLD-1122 AC17: cancelled session removes sets from plateau window
         queryClient.invalidateQueries({ queryKey: ["plateau"] });
-        router.back();
+        routerRef.current.back();
       },
       true
     );
-  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- routerRef is a ref (stable); cancelSession/bumpQueryVersion/queryClient are stable module imports
+  }, [id]);
 
   /** BLD-1122: Atomically apply break-through fill updates to a set of rows.
    * Writes via updateSetsBatch (single transaction), then invalidates plateau queries. */


### PR DESCRIPTION
## Summary

Fixes a bug where tapping 'Finish Workout' while the rest timer is counting down was silently dropped on Android (especially reproducible on Samsung Z Fold6). The root cause: `finish` and `cancel` in `useSessionActions` were plain arrow functions with no `useCallback`, so they received new function references every render — including the 1-Hz rest-timer tick. This caused the memoised `listFooter` to remount each second, and Android's Pressable can be unmounted between `touchDown` and `touchUp` when `ListFooterComponent` identity changes, silently dropping the tap.

## Changes

- **`hooks/useSessionActions.ts`**:
  - Add `elapsedRef` (a ref tracking `elapsed` state) so `finish` can read the current duration string without depending on `elapsed` in its dep array
  - Add `routerRef` (a ref tracking the `router` object) to avoid depending on router object identity
  - Wrap `finish` in `useCallback([id, dismissRest, flushAllPinnedNotes, showError, showToast])` — reference now stable across 1-Hz ticks
  - Wrap `cancel` in `useCallback([id])` — same stability guarantee
  - Replace all `router.x` calls inside `finish`/`cancel` with `routerRef.current.x`

- **`__tests__/hooks/useSessionActions-finish-dismissRest.test.ts`**:
  - New `BLD-1239` describe block with 3 tests:
    - finish reference stable across same-props rerenders
    - cancel reference stable across same-props rerenders
    - confirm dialog fires after simulated rest-tick rerender (the race condition scenario)
  - All 6 existing BLD-1137/BLD-1207 tests still pass (9 total)

## Testing

- `npx jest __tests__/hooks/useSessionActions-finish-dismissRest.test.ts` — 9/9 pass
- `npx -p typescript tsc --noEmit` — no new errors (2 pre-existing errors in unrelated `duration-sets.test.tsx` remain)
- Full `npx jest` suite — 4346/4346 pass

## Issue

Resolves BLD-1239 / GitHub #600