### PR TITLE
fix: add bottom padding to advanced-sets help sheet (BLD-1250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ marker) at release time.
 ## Unreleased
 
 - **Fix: "Finish Workout" button now responds during rest timer (Android)** — tapping Finish Workout while the rest countdown is active now reliably opens the Complete Workout confirm dialog. Previously the button was unresponsive on Android (especially foldables like Galaxy Z Fold 6) because the footer re-mounted every second during rest ticks. (#600, BLD-1239)
+- **Advanced Set Types help sheet**: Fixed Myo-reps description being clipped mid-sentence on narrow viewports (390 px wide). The help sheet now has sufficient bottom padding so the last card and footer are fully visible with breathing room.
 
 ## v0.26.34 — 2026-05-12
 <!-- versionCode: 104 -->

--- a/app/settings/advanced-sets.tsx
+++ b/app/settings/advanced-sets.tsx
@@ -87,7 +87,8 @@ export default function AdvancedSetsHelpScreen() {
 
 const styles = StyleSheet.create({
   content: {
-    paddingVertical: spacing.xs,
+    paddingTop: spacing.xs,
+    paddingBottom: spacing.xxxl,
     gap: spacing.sm,
   },
   intro: {


### PR DESCRIPTION
## Summary

Add sufficient bottom padding to the advanced-sets help sheet `contentContainerStyle` so the Myo-reps description is not clipped mid-sentence on narrow viewports (390×844).

## Changes

- Split `paddingVertical: spacing.xs` into `paddingTop: spacing.xs` + `paddingBottom: spacing.xxxl` (48px) in `app/settings/advanced-sets.tsx`

## Testing

- TypeScript: `tsc --noEmit` — zero errors
- `__tests__/help-copy-tone.test.ts` — 18/18 passing
- ESLint pre-commit hook — clean

## Issue

Resolves BLD-1250