### PR TITLE
fix: expand advanced-sets scroll view before screenshot to prevent Myo-reps text clipping (BLD-1250)

### DIFF
--- a/app/settings/advanced-sets.tsx
+++ b/app/settings/advanced-sets.tsx
@@ -50,6 +50,7 @@ export default function AdvancedSetsHelpScreen() {
 
   return (
     <ScrollView
+      testID="advanced-sets-scroll-view"
       style={{ flex: 1, backgroundColor: colors.background }}
       contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
     >

--- a/e2e/scenarios/advanced-sets.spec.ts
+++ b/e2e/scenarios/advanced-sets.spec.ts
@@ -122,6 +122,18 @@ test.describe("@scenario advanced-sets", () => {
     await expect(page.getByText("Cluster", { exact: true }).first()).toBeVisible();
     await expect(page.getByText("Myo-reps", { exact: true }).first()).toBeVisible();
 
+    // Expand the RN ScrollView to its full content height before capturing.
+    // On React Native Web, ScrollView renders as a fixed-height overflow:scroll div
+    // equal to the viewport height. Playwright's fullPage:true only expands the
+    // document scroll area — it does NOT expand nested scroll containers. Without this
+    // step, the Myo-reps card can be clipped mid-sentence on narrow viewports (BLD-1250).
+    await page.getByTestId("advanced-sets-scroll-view").evaluate((el) => {
+      const div = el as HTMLElement;
+      div.style.height = `${div.scrollHeight}px`;
+      div.style.overflow = "visible";
+    });
+    await page.waitForTimeout(200);
+
     // Capture screenshot
     const viewport = testInfo.project.name;
     const screenshotPath = path.join(OUT_DIR, `advanced-sets-help-${viewport}.png`);


### PR DESCRIPTION
## Summary

On React Native Web, `ScrollView` renders as a fixed-height `overflow:scroll` div bounded by the viewport height. Playwright's `fullPage:true` only expands the document scroll area — it does NOT expand nested scroll containers. On mobile-narrow (320×640), the Myo-reps card description was clipped mid-sentence at the viewport edge in the audit screenshot.

## Changes

- Added `testID="advanced-sets-scroll-view"` to the ScrollView in `app/settings/advanced-sets.tsx`
- In `e2e/scenarios/advanced-sets.spec.ts`, evaluate the scroll element to set `height=scrollHeight` and `overflow=visible` before screenshot capture so `fullPage:true` captures all card content without clipping

## Testing

- TypeScript: passes clean (`tsc --noEmit`)
- 2 files changed, 13 insertions

## Issue

Resolves BLD-1250