### PR TITLE
fix: DatabaseUnavailableScreen + one-shot init failure on DB NPE (BLD-1257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: App no longer floods crash reports when the workout database fails to open** — on the rare devices where the native SQLite layer can't open the database (one cluster: Galaxy Z Fold 6 on Android 16), the app now shows a recoverable "Workout data can't be opened" screen with a Retry button and an Export-diagnostics action instead of leaving you on a blank/broken screen. Behind the scenes a single diagnostic event is reported per session rather than the previous 12+/minute burst. (#609, BLD-1257)
 
 ## v0.26.35 — 2026-05-16
 <!-- versionCode: 105 -->

--- a/__tests__/components/database-unavailable-diagnostics.test.ts
+++ b/__tests__/components/database-unavailable-diagnostics.test.ts
@@ -1,0 +1,54 @@
+/**
+ * BLD-1257 (QD #4): the exported diagnostics text must include the Sentry
+ * event id, the failure phase, AND a breadcrumb tail (recent buffered
+ * console logs). This is the contract for the "Export diagnostics" CTA on
+ * DatabaseUnavailableScreen — users quote this text in bug reports.
+ */
+import { buildDatabaseDiagnostics } from "@/components/DatabaseUnavailableScreen";
+import { DatabaseUnavailableError } from "@/lib/db/errors";
+import * as buffer from "@/lib/console-log-buffer";
+
+jest.mock("@/lib/console-log-buffer", () => ({
+  getRecentConsoleLogs: jest.fn(),
+  formatConsoleLogs: jest.fn(),
+}));
+
+describe("BLD-1257 — buildDatabaseDiagnostics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("includes phase, error message, Sentry event id, ISO timestamp, and the breadcrumb tail", () => {
+    const fakeEntries = [
+      { level: "info" as const, message: "db init_start", timestamp: 1, args: [] },
+    ];
+    (buffer.getRecentConsoleLogs as jest.Mock).mockReturnValue(fakeEntries);
+    (buffer.formatConsoleLogs as jest.Mock).mockReturnValue(
+      "1. [2026-05-16T05:00:00.000Z] [INFO] db init_start",
+    );
+
+    const err = new DatabaseUnavailableError("open", new Error("NPE"));
+    const out = buildDatabaseDiagnostics(err, "abc123", new Date("2026-05-16T05:00:00.000Z"));
+
+    expect(out).toContain("phase: open");
+    expect(out).toContain("error: ");
+    expect(out).toContain("sentry_event_id: abc123");
+    expect(out).toContain("time: 2026-05-16T05:00:00.000Z");
+    expect(out).toContain("--- breadcrumb tail (recent console logs) ---");
+    expect(out).toContain("db init_start");
+    expect(buffer.getRecentConsoleLogs).toHaveBeenCalled();
+    expect(buffer.formatConsoleLogs).toHaveBeenCalledWith(fakeEntries);
+  });
+
+  it("falls back to '(unavailable)' when no Sentry event id was captured", () => {
+    (buffer.getRecentConsoleLogs as jest.Mock).mockReturnValue([]);
+    (buffer.formatConsoleLogs as jest.Mock).mockReturnValue("No recent console logs");
+
+    const err = new DatabaseUnavailableError("probe", new Error("handle null"));
+    const out = buildDatabaseDiagnostics(err, undefined, new Date("2026-05-16T05:00:00.000Z"));
+
+    expect(out).toContain("sentry_event_id: (unavailable)");
+    expect(out).toContain("phase: probe");
+    expect(out).toContain("No recent console logs");
+  });
+});

--- a/__tests__/lib/db/db-unavailable.test.ts
+++ b/__tests__/lib/db/db-unavailable.test.ts
@@ -1,0 +1,161 @@
+/**
+ * BLD-1257: regression tests for the one-shot init failure semantics that
+ * tame the Sentry REACT-NATIVE-7 burst (NPE in NativeDatabase.execAsync on
+ * Android 16 / Galaxy Z Fold 6).
+ *
+ * Invariants under test:
+ *   1. When SQLite.openDatabaseAsync rejects, getDatabase() throws a
+ *      DatabaseUnavailableError with phase=open.
+ *   2. A second getDatabase() call in the same JS session does NOT invoke
+ *      SQLite.openDatabaseAsync again — the cached failure short-circuits.
+ *   3. Sentry.captureException is invoked exactly ONCE per failed session
+ *      even with many downstream callers.
+ *   4. The probe step (SELECT 1) catches a broken native handle as
+ *      phase=probe, so call sites can distinguish open-failed from
+ *      handle-returns-but-rejects-everything.
+ *   5. resetDatabaseInit() clears the cached failure AND the Sentry
+ *      one-shot guard, so a user-initiated Retry CAN emit a fresh
+ *      captureException on the next attempt (treated as a separate
+ *      session attempt per the spec edge case).
+ *
+ * The manual mock at __mocks__/expo-sqlite.ts is re-evaluated on every
+ * jest.resetModules(), which creates fresh jest.fn() instances. So every
+ * test re-requires both modules INSIDE the test body to grab the
+ * current-generation references — otherwise we'd be poking the previous
+ * generation's mock while helpers.ts sees the new one.
+ */
+
+// Reset the global singleton between tests — the helpers module caches
+// state on globalThis so a second test would otherwise see the first
+// test's cached failure / db handle.
+function resetGlobals() {
+  const g = globalThis as unknown as Record<string, unknown>;
+  delete g.__cablesnap_db;
+  delete g.__cablesnap_drizzle;
+  delete g.__cablesnap_init;
+  delete g.__cablesnap_db_failure;
+  delete g.__cablesnap_db_failure_captured;
+}
+
+describe("BLD-1257 — DatabaseUnavailable one-shot init failure", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    resetGlobals();
+  });
+
+  it("rejects with DatabaseUnavailableError (phase=open) when openDatabaseAsync rejects with the NPE message", async () => {
+    const SQLite = require("expo-sqlite") as { openDatabaseAsync: jest.Mock };
+    SQLite.openDatabaseAsync.mockRejectedValue(
+      new Error(
+        "Call to function 'NativeDatabase.execAsync' has been rejected. Caused by java.lang.NullPointerException",
+      ),
+    );
+
+    const { getDatabase, isDatabaseUnavailableError } = require("@/lib/db");
+
+    await expect(getDatabase()).rejects.toMatchObject({
+      name: "DatabaseUnavailableError",
+      phase: "open",
+    });
+
+    let captured: unknown;
+    try {
+      await getDatabase();
+    } catch (err) {
+      captured = err;
+    }
+    expect(isDatabaseUnavailableError(captured)).toBe(true);
+  });
+
+  it("does NOT re-invoke openDatabaseAsync on the second call in the same session", async () => {
+    const SQLite = require("expo-sqlite") as { openDatabaseAsync: jest.Mock };
+    SQLite.openDatabaseAsync.mockRejectedValue(new Error("NPE"));
+
+    const { getDatabase } = require("@/lib/db");
+
+    await expect(getDatabase()).rejects.toBeDefined();
+    await expect(getDatabase()).rejects.toBeDefined();
+    await expect(getDatabase()).rejects.toBeDefined();
+
+    expect(SQLite.openDatabaseAsync.mock.calls.length).toBe(1);
+  });
+
+  it("records exactly one Sentry.captureException across many failed callers in the same session", async () => {
+    const SQLite = require("expo-sqlite") as { openDatabaseAsync: jest.Mock };
+    SQLite.openDatabaseAsync.mockRejectedValue(new Error("NPE"));
+    const Sentry = require("@sentry/react-native") as { captureException: jest.Mock };
+
+    const { getDatabase } = require("@/lib/db");
+
+    // Simulate the burst: many downstream call sites all hit getDatabase().
+    await Promise.all(
+      Array.from({ length: 20 }, () => getDatabase().catch(() => undefined)),
+    );
+
+    expect(Sentry.captureException.mock.calls.length).toBe(1);
+  });
+
+  it("tags phase=probe when openDatabaseAsync resolves but SELECT 1 rejects", async () => {
+    const SQLite = require("expo-sqlite") as { openDatabaseAsync: jest.Mock };
+    const brokenInstance = {
+      execAsync: jest.fn(async (sql: string) => {
+        if (sql === "SELECT 1") {
+          throw new Error(
+            "Call to function 'NativeDatabase.execAsync' has been rejected. NPE",
+          );
+        }
+      }),
+      getAllAsync: jest.fn(),
+      getFirstAsync: jest.fn(),
+      runAsync: jest.fn(),
+      withTransactionAsync: jest.fn(),
+    };
+    SQLite.openDatabaseAsync.mockResolvedValue(brokenInstance);
+
+    const { getDatabase } = require("@/lib/db");
+
+    await expect(getDatabase()).rejects.toMatchObject({
+      name: "DatabaseUnavailableError",
+      phase: "probe",
+    });
+    // PRAGMA / migrate / seed must NOT have been attempted past the probe.
+    const calls = brokenInstance.execAsync.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(["SELECT 1"]);
+  });
+
+  it("resetDatabaseInit() clears the cached failure AND the Sentry guard so a fresh Retry re-attempts open and CAN emit a new captureException", async () => {
+    const SQLite = require("expo-sqlite") as { openDatabaseAsync: jest.Mock };
+    SQLite.openDatabaseAsync.mockRejectedValue(new Error("NPE"));
+    const Sentry = require("@sentry/react-native") as { captureException: jest.Mock };
+
+    const { getDatabase, resetDatabaseInit } = require("@/lib/db");
+
+    await expect(getDatabase()).rejects.toBeDefined();
+    expect(SQLite.openDatabaseAsync.mock.calls.length).toBe(1);
+    expect(Sentry.captureException.mock.calls.length).toBe(1);
+
+    // User taps Retry.
+    resetDatabaseInit();
+
+    await expect(getDatabase()).rejects.toBeDefined();
+    expect(SQLite.openDatabaseAsync.mock.calls.length).toBe(2);
+    // A new "session attempt" — guard reset means a second captureException
+    // is allowed.
+    expect(Sentry.captureException.mock.calls.length).toBe(2);
+  });
+
+  it("getDatabaseFailure() returns the cached error after a failed init and null after Retry", async () => {
+    const SQLite = require("expo-sqlite") as { openDatabaseAsync: jest.Mock };
+    SQLite.openDatabaseAsync.mockRejectedValue(new Error("NPE"));
+
+    const { getDatabase, getDatabaseFailure, resetDatabaseInit } = require("@/lib/db");
+
+    await expect(getDatabase()).rejects.toBeDefined();
+    const failure = getDatabaseFailure();
+    expect(failure).not.toBeNull();
+    expect(failure?.error.phase).toBe("open");
+
+    resetDatabaseInit();
+    expect(getDatabaseFailure()).toBeNull();
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -32,6 +32,8 @@ import { SCREEN_CONFIGS } from "../constants/screen-config";
 import { LayoutToastBridge } from "../components/LayoutToastBridge";
 import { LayoutBanners } from "../components/LayoutBanners";
 import { WebUnsupportedScreen } from "../components/WebUnsupportedScreen";
+import { DatabaseUnavailableScreen } from "../components/DatabaseUnavailableScreen";
+import { useDatabaseStatus } from "../hooks/useDatabaseStatus";
 import { WEB_UNSUPPORTED_MESSAGE } from "../lib/web-support";
 import * as Sentry from '@sentry/react-native';
 import { mediaSurfaceMountCount } from '@/lib/media/replay-gate';
@@ -79,6 +81,12 @@ export default Sentry.wrap(function RootLayout() {
   const isDark = scheme === "dark";
   const themeColors = isDark ? Colors.dark : Colors.light;
   const { banner, setBanner, error, setError, ready, onboarded, setOnboarded, webUnsupported, backupExclusionOk } = useAppInit();
+  // BLD-1257: gate the entire app on DB availability, parallel to the
+  // existing webUnsupported gate. When init fails on native, render the
+  // DatabaseUnavailableScreen INSTEAD of mounting the rest of the tree so
+  // downstream callers cannot retrigger openDatabaseAsync/execAsync and
+  // produce the Sentry REACT-NATIVE-7 burst.
+  const dbStatus = useDatabaseStatus();
   const pathname = usePathname();
   const prev = useRef(pathname);
 
@@ -109,6 +117,24 @@ export default Sentry.wrap(function RootLayout() {
       <GestureHandlerRootView style={{ flex: 1 }}>
         <WebUnsupportedScreen message={WEB_UNSUPPORTED_MESSAGE} themeColors={themeColors} />
         <StatusBar style="auto" />
+      </GestureHandlerRootView>
+    );
+  }
+
+  // BLD-1257: native DB init failure — render the recovery surface in
+  // place of the normal tree. Web failures fall through to the existing
+  // LayoutBanners path (memory fallback or banner-only).
+  if (dbStatus.kind === "unavailable") {
+    return (
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <SafeAreaProvider>
+          <DatabaseUnavailableScreen
+            error={dbStatus.error}
+            sentryEventId={dbStatus.sentryEventId}
+            onRetry={dbStatus.retry}
+          />
+          <StatusBar style="auto" />
+        </SafeAreaProvider>
       </GestureHandlerRootView>
     );
   }

--- a/components/DatabaseUnavailableScreen.tsx
+++ b/components/DatabaseUnavailableScreen.tsx
@@ -5,12 +5,40 @@ import { RotateCcw, Share2 } from "lucide-react-native";
 import { Colors } from "@/theme/colors";
 import { fontSizes } from "@/constants/design-tokens";
 import type { DatabaseUnavailableError } from "@/lib/db";
+import {
+  getRecentConsoleLogs,
+  formatConsoleLogs,
+} from "@/lib/console-log-buffer";
 
 type Props = {
   error: DatabaseUnavailableError;
   sentryEventId?: string;
   onRetry: () => void;
 };
+
+// BLD-1257 (QD requirement #4): exposed as a pure helper so the breadcrumb
+// tail accompanying the Sentry event id is testable without invoking the
+// native Share dialog. Recent console-log buffer is the local proxy for the
+// Sentry breadcrumb stream (Sentry breadcrumbs are write-only from JS, so
+// we attach the buffered console output which captures the same db.* / nav
+// events that feed Sentry).
+export function buildDatabaseDiagnostics(
+  error: DatabaseUnavailableError,
+  sentryEventId: string | undefined,
+  now: Date = new Date(),
+): string {
+  const lines = [
+    "CableSnap diagnostics",
+    `phase: ${error.phase}`,
+    `error: ${error.message}`,
+    sentryEventId ? `sentry_event_id: ${sentryEventId}` : "sentry_event_id: (unavailable)",
+    `time: ${now.toISOString()}`,
+    "",
+    "--- breadcrumb tail (recent console logs) ---",
+    formatConsoleLogs(getRecentConsoleLogs()),
+  ];
+  return lines.join("\n");
+}
 
 /**
  * BLD-1257: Fullscreen recovery surface rendered when getDatabase() init has
@@ -36,14 +64,9 @@ export function DatabaseUnavailableScreen({ error, sentryEventId, onRetry }: Pro
 
   const handleExport = async () => {
     try {
-      const lines = [
-        "CableSnap diagnostics",
-        `phase: ${error.phase}`,
-        `error: ${error.message}`,
-        sentryEventId ? `sentry_event_id: ${sentryEventId}` : "sentry_event_id: (unavailable)",
-        `time: ${new Date().toISOString()}`,
-      ];
-      await Share.share({ message: lines.join("\n") });
+      await Share.share({
+        message: buildDatabaseDiagnostics(error, sentryEventId),
+      });
     } catch {
       // Share dismissed or failed — no recovery path required.
     }

--- a/components/DatabaseUnavailableScreen.tsx
+++ b/components/DatabaseUnavailableScreen.tsx
@@ -1,0 +1,135 @@
+import { Appearance, Share, StyleSheet, View } from "react-native";
+import { Text } from "@/components/ui/text";
+import { Button } from "@/components/ui/button";
+import { RotateCcw, Share2 } from "lucide-react-native";
+import { Colors } from "@/theme/colors";
+import { fontSizes } from "@/constants/design-tokens";
+import type { DatabaseUnavailableError } from "@/lib/db";
+
+type Props = {
+  error: DatabaseUnavailableError;
+  sentryEventId?: string;
+  onRetry: () => void;
+};
+
+/**
+ * BLD-1257: Fullscreen recovery surface rendered when getDatabase() init has
+ * permanently failed for the current JS session (typically Sentry
+ * REACT-NATIVE-7 — NPE inside NativeDatabase.execAsync on Android).
+ *
+ * Mounted in app/_layout.tsx INSTEAD of the normal Stack tree so no
+ * downstream effect / query / event handler can reach getDatabase() and
+ * re-trigger the burst behaviour. Parallels the existing
+ * WebUnsupportedScreen gate.
+ *
+ * Recovery semantics:
+ *   - Retry: calls resetDatabaseInit() (via the parent hook) and re-runs
+ *     getDatabase() on a fresh JS attempt. If the underlying issue was
+ *     transient, the normal layout takes over.
+ *   - Export diagnostics: surfaces the Sentry event id + phase via
+ *     react-native Share so users can quote it in a bug report. No file
+ *     copy required (per spec).
+ */
+export function DatabaseUnavailableScreen({ error, sentryEventId, onRetry }: Props) {
+  const scheme = Appearance.getColorScheme() === "dark" ? "dark" : "light";
+  const t = Colors[scheme];
+
+  const handleExport = async () => {
+    try {
+      const lines = [
+        "CableSnap diagnostics",
+        `phase: ${error.phase}`,
+        `error: ${error.message}`,
+        sentryEventId ? `sentry_event_id: ${sentryEventId}` : "sentry_event_id: (unavailable)",
+        `time: ${new Date().toISOString()}`,
+      ];
+      await Share.share({ message: lines.join("\n") });
+    } catch {
+      // Share dismissed or failed — no recovery path required.
+    }
+  };
+
+  return (
+    <View
+      testID="database-unavailable-screen"
+      style={[styles.container, { backgroundColor: t.background }]}
+    >
+      <View style={[styles.card, { backgroundColor: t.card }]}>
+        <Text variant="heading" style={[styles.title, { color: t.foreground }]}>
+          Workout data can&apos;t be opened right now.
+        </Text>
+        <Text variant="body" style={[styles.body, { color: t.mutedForeground }]}>
+          Your workout database failed to open on this device. Your saved data
+          is still on this phone — we just couldn&apos;t connect to it for this
+          session. Tap Retry to try again. If the problem persists, share the
+          diagnostics below so we can dig in.
+        </Text>
+
+        <View style={[styles.diag, { backgroundColor: t.muted }]}>
+          <Text variant="caption" style={[styles.mono, { color: t.mutedForeground }]}>
+            phase: {error.phase}
+            {"\n"}
+            event id: {sentryEventId ?? "(unavailable)"}
+          </Text>
+        </View>
+
+        <Button
+          variant="default"
+          icon={RotateCcw}
+          onPress={onRetry}
+          style={styles.btn}
+          accessibilityLabel="Retry opening the database"
+          testID="database-unavailable-retry"
+        >
+          Retry
+        </Button>
+        <Button
+          variant="outline"
+          icon={Share2}
+          onPress={handleExport}
+          style={styles.btn}
+          accessibilityLabel="Export diagnostics"
+          testID="database-unavailable-export"
+        >
+          Export diagnostics
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+  },
+  card: {
+    maxWidth: 560,
+    width: "100%",
+    padding: 24,
+    borderRadius: 12,
+  },
+  title: {
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  body: {
+    marginBottom: 16,
+    textAlign: "center",
+  },
+  diag: {
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 16,
+  },
+  mono: {
+    fontFamily: "monospace",
+    fontSize: fontSizes.xs,
+  },
+  btn: {
+    marginBottom: 12,
+    width: "100%",
+  },
+});

--- a/hooks/useDatabaseStatus.ts
+++ b/hooks/useDatabaseStatus.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from "react";
+import { Platform } from "react-native";
+import {
+  getDatabase,
+  getDatabaseFailure,
+  isDatabaseUnavailableError,
+  resetDatabaseInit,
+  type DatabaseUnavailableError,
+} from "../lib/db";
+
+// BLD-1257: status reported by useDatabaseStatus().
+//
+// - "pending"     : initial mount; init has not resolved or rejected yet.
+// - "ready"       : init resolved; the app can render its normal tree.
+// - "unavailable" : init rejected with DatabaseUnavailableError. Caller
+//                   should render DatabaseUnavailableScreen instead of the
+//                   normal app tree. retry() will clear the cached failure
+//                   and re-run init.
+// - "error"       : init rejected with a non-DatabaseUnavailableError
+//                   (legacy path — surfaced to LayoutBanners for parity).
+export type DatabaseStatus =
+  | { kind: "pending" }
+  | { kind: "ready" }
+  | { kind: "unavailable"; error: DatabaseUnavailableError; sentryEventId?: string; retry: () => void }
+  | { kind: "error"; error: Error };
+
+export function useDatabaseStatus(): DatabaseStatus {
+  const [status, setStatus] = useState<DatabaseStatus>({ kind: "pending" });
+  const [attempt, setAttempt] = useState(0);
+
+  const retry = useCallback(() => {
+    resetDatabaseInit();
+    setStatus({ kind: "pending" });
+    setAttempt((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    getDatabase()
+      .then(() => {
+        if (cancelled) return;
+        setStatus({ kind: "ready" });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (isDatabaseUnavailableError(err) && Platform.OS !== "web") {
+          const failure = getDatabaseFailure();
+          setStatus({
+            kind: "unavailable",
+            error: err,
+            sentryEventId: failure?.sentryEventId,
+            retry,
+          });
+          return;
+        }
+        const error = err instanceof Error ? err : new Error(String(err));
+        setStatus({ kind: "error", error });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [attempt, retry]);
+
+  return status;
+}

--- a/lib/db/errors.ts
+++ b/lib/db/errors.ts
@@ -1,0 +1,42 @@
+// BLD-1257: typed error for unrecoverable database init failures.
+//
+// Phases match the init pipeline in lib/db/helpers.ts:getDatabase():
+//   open    → SQLite.openDatabaseAsync rejected (e.g. the Sentry REACT-NATIVE-7
+//             NPE from NativeDatabase on Android 16 / Galaxy Z Fold 6)
+//   probe   → openDatabaseAsync resolved but the SELECT 1 sanity check failed
+//   pragma  → PRAGMA journal_mode = WAL / PRAGMA foreign_keys = ON failed
+//   migrate → migrate() threw (schema migration failure)
+//   seed    → seed() threw (initial data seeding failure)
+//
+// The error is thrown by getDatabase() AND cached on the global singleton so
+// that subsequent callers in the same JS session receive the same rejection
+// without re-attempting openDatabaseAsync/execAsync. The cache is only
+// cleared by an explicit user-initiated retry via resetDatabaseInit().
+
+export type DatabaseUnavailablePhase =
+  | "open"
+  | "probe"
+  | "pragma"
+  | "migrate"
+  | "seed";
+
+export class DatabaseUnavailableError extends Error {
+  readonly phase: DatabaseUnavailablePhase;
+
+  constructor(phase: DatabaseUnavailablePhase, cause: unknown) {
+    const causeMessage =
+      cause instanceof Error ? cause.message : String(cause ?? "unknown");
+    super(`Database unavailable (phase=${phase}): ${causeMessage}`, {
+      cause: cause instanceof Error ? cause : new Error(causeMessage),
+    });
+    this.name = "DatabaseUnavailableError";
+    this.phase = phase;
+    Object.setPrototypeOf(this, DatabaseUnavailableError.prototype);
+  }
+}
+
+export function isDatabaseUnavailableError(
+  err: unknown,
+): err is DatabaseUnavailableError {
+  return err instanceof DatabaseUnavailableError;
+}

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -6,6 +6,10 @@ import { migrate } from "./migrations";
 import { seed } from "./seed";
 import * as schema from "./schema";
 import * as Sentry from "@sentry/react-native";
+import {
+  DatabaseUnavailableError,
+  type DatabaseUnavailablePhase,
+} from "./errors";
 
 // Safe Sentry wrappers — swallow if SDK is not initialized (tests, web fallback).
 function dbBreadcrumb(message: string, data?: Record<string, unknown>): void {
@@ -14,10 +18,11 @@ function dbBreadcrumb(message: string, data?: Record<string, unknown>): void {
   } catch { /* Sentry not ready */ }
 }
 
-function dbCaptureException(err: unknown, context: Record<string, unknown>): void {
+function dbCaptureException(err: unknown, context: Record<string, unknown>): string | undefined {
   try {
-    Sentry.captureException(err, { extra: context });
-  } catch { /* Sentry not ready */ }
+    const id = Sentry.captureException(err, { extra: context });
+    return typeof id === "string" ? id : undefined;
+  } catch { /* Sentry not ready */ return undefined; }
 }
 
 // BLD-560: dev-only query counter — use dynamic require so Metro strips the
@@ -38,6 +43,15 @@ const g = globalThis as unknown as {
   __cablesnap_drizzle?: ExpoSQLiteDatabase<typeof schema>;
   __cablesnap_init?: Promise<SQLite.SQLiteDatabase>;
   __cablesnap_memfb?: boolean;
+  // BLD-1257: cached one-shot init failure for non-web platforms. When set,
+  // every subsequent getDatabase() call resolves with the SAME rejection
+  // without re-invoking openDatabaseAsync/execAsync. Only resetDatabaseInit()
+  // (called by the user-facing Retry CTA) clears this.
+  __cablesnap_db_failure?: { error: DatabaseUnavailableError; sentryEventId?: string };
+  // BLD-1257: per-session guard — true once captureException has fired for
+  // this run. Prevents the burst of identical Sentry events when many
+  // call sites independently invoke getDatabase().
+  __cablesnap_db_failure_captured?: boolean;
 };
 
 function getDb() { return g.__cablesnap_db ?? null; }
@@ -53,15 +67,70 @@ export function isMemoryFallback(): boolean {
   return memoryFallback;
 }
 
+// BLD-1257: surfaces to the UI (useDatabaseStatus) so the
+// DatabaseUnavailableScreen can display the captured Sentry event id.
+export function getDatabaseFailure(): { error: DatabaseUnavailableError; sentryEventId?: string } | null {
+  return g.__cablesnap_db_failure ?? null;
+}
+
+/**
+ * BLD-1257: clear the cached init failure so a fresh getDatabase() attempt
+ * can run. Called only by the user-initiated Retry CTA. The per-session
+ * Sentry guard is ALSO cleared so a fresh failure during the new attempt
+ * is treated as a separate "session attempt" and emits a new
+ * captureException (vs. the burst-suppression behavior during a single
+ * passive boot).
+ */
+export function resetDatabaseInit(): void {
+  g.__cablesnap_db_failure = undefined;
+  g.__cablesnap_db_failure_captured = undefined;
+  setInit(null);
+}
+
+function captureDatabaseFailureOnce(
+  error: DatabaseUnavailableError,
+  context: Record<string, unknown>,
+): string | undefined {
+  if (g.__cablesnap_db_failure_captured) {
+    dbBreadcrumb("init_failure_suppressed", {
+      phase: error.phase,
+      db_name: context.db_name,
+    });
+    return undefined;
+  }
+  g.__cablesnap_db_failure_captured = true;
+  return dbCaptureException(error, context);
+}
+
 export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   const cached = getDb();
   if (cached) return cached;
+
+  // BLD-1257: one-shot init failure semantics — surface the cached
+  // DatabaseUnavailableError to every subsequent caller without retrying
+  // the native open path. resetDatabaseInit() (user Retry) is the only way
+  // out. Web in-memory fallback short-circuits before reaching this branch
+  // (a successful fallback sets __cablesnap_db; a failed fallback throws
+  // through to the catch below and caches the failure too).
+  const failure = g.__cablesnap_db_failure;
+  if (failure) throw failure.error;
+
   let pending = getInit();
   if (!pending) {
     pending = (async () => {
       dbBreadcrumb("init_start", { db_name: DB_NAME });
+      let openedInstance: SQLite.SQLiteDatabase | null = null;
+      let currentPhase: DatabaseUnavailablePhase = "open";
       try {
-        const instance = await SQLite.openDatabaseAsync(DB_NAME);
+        openedInstance = await SQLite.openDatabaseAsync(DB_NAME);
+        const instance = openedInstance;
+        // BLD-1257: sanity probe BEFORE any pragma/migration so a null/broken
+        // native handle (Sentry REACT-NATIVE-7 NPE) is detected as
+        // phase=probe instead of leaking through as a confusing pragma
+        // failure later.
+        currentPhase = "probe";
+        await instance.execAsync("SELECT 1");
+        currentPhase = "pragma";
         await instance.execAsync("PRAGMA journal_mode = WAL");
         // BLD-1094: enable foreign-key enforcement on every connection so
         // the FK declarations in lib/db/tables.ts (strava_sync_log,
@@ -72,29 +141,19 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
         // ON DELETE CASCADE on workout_sessions → workout_sets → set_media.
         await instance.execAsync("PRAGMA foreign_keys = ON");
         dbBreadcrumb("pre_migrate", { db_name: DB_NAME });
+        currentPhase = "migrate";
         try {
           await migrate(instance);
         } catch (migrateErr) {
           const error = migrateErr instanceof Error ? migrateErr : new Error(String(migrateErr));
-          dbCaptureException(error, {
-            phase: "migrate",
-            db_name: DB_NAME,
-            error_message: error.message,
-            error_stack: error.stack,
-          });
           throw error;
         }
         dbBreadcrumb("post_migrate", { db_name: DB_NAME });
+        currentPhase = "seed";
         try {
           await seed(instance);
         } catch (seedErr) {
           const error = seedErr instanceof Error ? seedErr : new Error(String(seedErr));
-          dbCaptureException(error, {
-            phase: "seed",
-            db_name: DB_NAME,
-            error_message: error.message,
-            error_stack: error.stack,
-          });
           throw error;
         }
         setDb(instance);
@@ -137,12 +196,29 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
             setDrizzleDb(drizzle(instance, { schema }));
             return instance;
           } catch (fallbackErr) {
+            // BLD-1257: web in-memory fallback failure — surface as a normal
+            // rejection (the existing LayoutBanners flow handles this on
+            // web). Clear the init promise but do NOT install the
+            // DatabaseUnavailableScreen gate (web has its own escape
+            // hatches: WebUnsupportedScreen + LayoutBanners).
             setInit(null);
             throw fallbackErr;
           }
         }
+        // BLD-1257: native (iOS / Android) path — cache the failure so
+        // every downstream caller short-circuits with the same error
+        // instead of retrying openDatabaseAsync and re-crashing.
+        const rawError = err instanceof Error ? err : new Error(String(err));
+        const dbError = new DatabaseUnavailableError(currentPhase, rawError);
+        const sentryEventId = captureDatabaseFailureOnce(dbError, {
+          phase: currentPhase,
+          db_name: DB_NAME,
+          error_message: rawError.message,
+          error_stack: rawError.stack,
+        });
+        g.__cablesnap_db_failure = { error: dbError, sentryEventId };
         setInit(null);
-        throw err;
+        throw dbError;
       }
     })();
     setInit(pending);

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1,7 +1,9 @@
 // Re-export everything from domain modules for backward compatibility.
 // Consumers can import from "lib/db" as before, or from specific modules.
 
-export { getDatabase, getDrizzle, isMemoryFallback } from "./helpers";
+export { getDatabase, getDrizzle, isMemoryFallback, getDatabaseFailure, resetDatabaseInit } from "./helpers";
+export { DatabaseUnavailableError, isDatabaseUnavailableError } from "./errors";
+export type { DatabaseUnavailablePhase } from "./errors";
 
 export {
   getAllExercises,


### PR DESCRIPTION
## Summary

Tames the Sentry REACT-NATIVE-7 burst (`NativeDatabase.execAsync` NPE on Android 16 / Galaxy Z Fold 6) by giving DB-init failures a one-shot cached-rejection semantics, a single Sentry event per failed session, and a user-visible recovery surface with Retry + Export Diagnostics.

Ticket: BLD-1257
Sentry: https://cablesnap.sentry.io/issues/7456412009/

## What changed

| Area | Change |
|---|---|
| `lib/db/errors.ts` (new) | `DatabaseUnavailableError` with typed `phase` (`open` / `probe` / `pragma` / `migrate` / `seed`) and `Error.cause` |
| `lib/db/helpers.ts` | • Added `SELECT 1` sanity probe BEFORE pragma so a broken native handle is detected as `phase=\"probe\"`<br>• Cached init failure on `globalThis.__cablesnap_db_failure` so every subsequent `getDatabase()` short-circuits without re-invoking `openDatabaseAsync` (this is what fixes the 12-events-in-60s burst)<br>• Per-session Sentry guard (`__cablesnap_db_failure_captured`) so the burst becomes one event with breadcrumbs<br>• New `resetDatabaseInit()` clears both guards for user-initiated Retry — a fresh failure post-Retry IS allowed to emit a new event (separate \"session attempt\" per spec edge case)<br>• Web in-memory fallback path **untouched** |
| `lib/db/index.ts` | Re-exports `DatabaseUnavailableError`, `isDatabaseUnavailableError`, `resetDatabaseInit`, `getDatabaseFailure`, type `DatabaseUnavailablePhase` |
| `hooks/useDatabaseStatus.ts` (new) | Status hook (`pending` / `ready` / `unavailable` / `error`) that surfaces `DatabaseUnavailableError` to the layout and exposes `retry()` |
| `components/DatabaseUnavailableScreen.tsx` (new) | Fullscreen recovery surface — headline, Sentry event id + phase, Retry CTA, Export diagnostics (`react-native` `Share.share` of phase + event id) |
| `app/_layout.tsx` | Gate the whole app on \`dbStatus.kind === \"unavailable\"\` **parallel to the existing** `webUnsupported` gate so no downstream effect / query can re-invoke `getDatabase()` |
| `__tests__/lib/db/db-unavailable.test.ts` (new) | 6 regression cases — see Acceptance Criteria coverage below |

## Acceptance Criteria coverage

- [x] AC1 — Single `openDatabaseAsync` call across many in-session callers + same `DatabaseUnavailableError` for all → test \"does NOT re-invoke openDatabaseAsync on the second call\"
- [x] AC2 — `DatabaseUnavailableScreen` is rendered on init failure with Sentry event id + Retry CTA → \`app/_layout.tsx\` gate + component
- [x] AC3 — Retry on transient failure resumes normal layout → `resetDatabaseInit()` clears caches; \`useDatabaseStatus\` bumps attempt counter and rerenders
- [x] AC4 — \`SELECT 1\` probe rejection ⇒ `phase: \"probe\"` BEFORE pragma/migrate → test \"tags phase=probe\"
- [x] AC5 — Exactly **one** \`captureException\` per failed JS session → test \"records exactly one Sentry.captureException across many failed callers\"
- [x] AC6 — Existing tests + typecheck + lint pass → all 4,367 tests green; \`tsc --noEmit\` clean; \`eslint\` clean
- [x] AC7 — Web in-memory fallback unchanged → no behavior change in the \`Platform.OS === \"web\"\` branch; gate only renders on non-web failures

## Edge Cases (per spec)

| Scenario | Behavior |
|---|---|
| First-launch / fresh install | Normal init path; gate never trips |
| Migration throws | Cached as `phase: \"migrate\"`; existing breadcrumb path preserved |
| Retry succeeds | `resetDatabaseInit()` clears failure → normal layout takes over |
| Retry fails again | Stays on recovery screen; **new** `captureException` (different session attempt) |
| Web (in-memory fallback) | DatabaseUnavailableScreen **not** shown — existing escape hatch preserved |
| Headless Jest harness | All existing DB tests pass; only new test exercises the failure path |

## Test results

\`\`\`
PASS __tests__/lib/db/db-unavailable.test.ts (6 tests, 0 failures)
PASS 361  4,367 tests, 0 failures, full suitesuites 
PASS eslint (changed files) — 0 errors, 0 warnings
PASS tsc --noEmit — clean
\`\`\`

## Out of scope

- Diagnosing the underlying Android 16 / Z Fold 6 native NPE root cause (separate spike)
- Auto-wipe / reset app data flow
- expo-sqlite / expo SDK upgrade
- Caller migration off `getDatabase()` — public surface unchanged

cc @quality- ready for verification once CI is green.director 

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>