### PR TITLE
fix: increase bottom-sheet drag handle contrast for WCAG AA (BLD-1260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ marker) at release time.
 ## Unreleased
 
 - **Fix: App no longer floods crash reports when the workout database fails to open** — on the rare devices where the native SQLite layer can't open the database (one cluster: Galaxy Z Fold 6 on Android 16), the app now shows a recoverable "Workout data can't be opened" screen with a Retry button and an Export-diagnostics action instead of leaving you on a blank/broken screen. Behind the scenes a single diagnostic event is reported per session rather than the previous 12+/minute burst. (#609, BLD-1257)
+- **Fix: Bottom sheet drag handle is now clearly visible** — the small pill at the top of pull-up sheets (e.g. "Pacing by exercise") previously rendered near-invisible (~1.09:1 contrast) in light mode. It now uses a mid-gray meeting WCAG AA for non-text UI components (≥3:1). (#611, BLD-1260)
 
 ## v0.26.35 — 2026-05-16
 <!-- versionCode: 105 -->

--- a/components/ui/bottom-sheet.tsx
+++ b/components/ui/bottom-sheet.tsx
@@ -35,6 +35,7 @@ type BottomSheetContentProps = {
   rBottomSheetStyle: any;
   cardColor: string;
   mutedColor: string;
+  handleColor: string;
   onHandlePress?: () => void;
 };
 
@@ -47,6 +48,7 @@ const BottomSheetContent = ({
   rBottomSheetStyle,
   cardColor,
   mutedColor,
+  handleColor,
   onHandlePress,
 }: BottomSheetContentProps) => {
   return (
@@ -78,7 +80,7 @@ const BottomSheetContent = ({
             style={{
               width: 64,
               height: 6,
-              backgroundColor: mutedColor,
+              backgroundColor: handleColor,
               borderRadius: 999,
             }}
           />
@@ -136,6 +138,8 @@ export function BottomSheet({
 }: BottomSheetProps) {
   const cardColor = useColor('card');
   const mutedColor = useColor('muted');
+  // Use mutedForeground for handle pill — ensures ≥3:1 contrast against card background (WCAG AA for non-text UI)
+  const handleColor = useColor('mutedForeground');
   const { keyboardHeight, isKeyboardVisible } = useKeyboardHeight();
 
   const translateY = useSharedValue(0);
@@ -310,6 +314,7 @@ export function BottomSheet({
               rBottomSheetStyle={rBottomSheetStyle}
               cardColor={cardColor}
               mutedColor={mutedColor}
+              handleColor={handleColor}
               onHandlePress={() => runOnJS(handlePress)()}
             />
           ) : (
@@ -321,6 +326,7 @@ export function BottomSheet({
                 rBottomSheetStyle={rBottomSheetStyle}
                 cardColor={cardColor}
                 mutedColor={mutedColor}
+                handleColor={handleColor}
                 onHandlePress={() => runOnJS(handlePress)()}
               />
             </GestureDetector>

--- a/components/ui/bottom-sheet.tsx
+++ b/components/ui/bottom-sheet.tsx
@@ -34,7 +34,6 @@ type BottomSheetContentProps = {
   style?: ViewStyle;
   rBottomSheetStyle: any;
   cardColor: string;
-  mutedColor: string;
   handleColor: string;
   onHandlePress?: () => void;
 };
@@ -47,7 +46,6 @@ const BottomSheetContent = ({
   style,
   rBottomSheetStyle,
   cardColor,
-  mutedColor,
   handleColor,
   onHandlePress,
 }: BottomSheetContentProps) => {
@@ -137,7 +135,6 @@ export function BottomSheet({
   disablePanGesture = false,
 }: BottomSheetProps) {
   const cardColor = useColor('card');
-  const mutedColor = useColor('muted');
   // Use mutedForeground for handle pill — ensures ≥3:1 contrast against card background (WCAG AA for non-text UI)
   const handleColor = useColor('mutedForeground');
   const { keyboardHeight, isKeyboardVisible } = useKeyboardHeight();
@@ -313,7 +310,6 @@ export function BottomSheet({
               style={style}
               rBottomSheetStyle={rBottomSheetStyle}
               cardColor={cardColor}
-              mutedColor={mutedColor}
               handleColor={handleColor}
               onHandlePress={() => runOnJS(handlePress)()}
             />
@@ -325,7 +321,6 @@ export function BottomSheet({
                 style={style}
                 rBottomSheetStyle={rBottomSheetStyle}
                 cardColor={cardColor}
-                mutedColor={mutedColor}
                 handleColor={handleColor}
                 onHandlePress={() => runOnJS(handlePress)()}
               />


### PR DESCRIPTION
## Summary

The drag handle pill in all bottom sheets used `muted` color (`#E5E7EB`) on the card background (`#F3F4F6`), yielding approximately **1.09:1 contrast** — virtually invisible in light mode. The audit caught this on the "Pacing by exercise" sheet.

## Changes

- Added `handleColor` prop to `BottomSheetContent` (decoupled from `mutedColor`)
- Derive `handleColor` from `mutedForeground` (`#6B7280`) — achieves **~3.94:1 contrast** against card background
- Passes WCAG AA minimum for non-text UI components (3:1 required)
- Applies to all bottom sheets app-wide (the component is shared)

## Contrast before/after

| | Color | Contrast vs `#F3F4F6` |
|---|---|---|
| Before | `#E5E7EB` (muted) | ~1.09:1 ❌ |
| After | `#6B7280` (mutedForeground) | ~3.94:1 ✅ |

## Testing

- TypeScript: `tsc --noEmit` passes with zero errors
- ESLint: passes with zero warnings

## Issue

Resolves BLD-1260