### PR TITLE
fix: gate useDatabaseStatus behind webUnsupported to restore BLD-565 invariant (BLD-1262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ marker) at release time.
 
 - **Fix: App no longer floods crash reports when the workout database fails to open** — on the rare devices where the native SQLite layer can't open the database (one cluster: Galaxy Z Fold 6 on Android 16), the app now shows a recoverable "Workout data can't be opened" screen with a Retry button and an Export-diagnostics action instead of leaving you on a blank/broken screen. Behind the scenes a single diagnostic event is reported per session rather than the previous 12+/minute burst. (#609, BLD-1257)
 - **Fix: Bottom sheet drag handle is now clearly visible** — the small pill at the top of pull-up sheets (e.g. "Pacing by exercise") previously rendered near-invisible (~1.09:1 contrast) in light mode. It now uses a mid-gray meeting WCAG AA for non-text UI components (≥3:1). (#611, BLD-1260)
+- **Fix: Web fallback no longer attempts native database init** — restored the BLD-565 invariant that web hosts without `SharedArrayBuffer` skip every database code path. A regression in the BLD-1257 recovery flow caused the new database-status hook to run `getDatabase()` even on the WebUnsupported screen, surfacing a `ReferenceError: SharedArrayBuffer is not defined`. The hook is now gated behind the same web-support check. (BLD-1262)
 
 ## v0.26.35 — 2026-05-16
 <!-- versionCode: 105 -->

--- a/__tests__/hooks/useDatabaseStatus-web-unsupported.test.tsx
+++ b/__tests__/hooks/useDatabaseStatus-web-unsupported.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * BLD-1262 regression-lock — useDatabaseStatus must NOT invoke
+ * getDatabase() when its caller passes `disabled: true`.
+ *
+ * Background: PR #609 (BLD-1257) introduced a new `useDatabaseStatus`
+ * hook in `app/_layout.tsx`, but its useEffect runs even when the
+ * surrounding component renders WebUnsupportedScreen — re-introducing
+ * the BLD-565 `ReferenceError: SharedArrayBuffer is not defined`
+ * regression on web hosts without cross-origin isolation. This test
+ * locks the contract: when `disabled` is true, the hook is a complete
+ * no-op with respect to lib/db.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+
+const mockGetDatabase = jest.fn();
+const mockGetDatabaseFailure = jest.fn();
+const mockIsDatabaseUnavailableError = jest.fn();
+const mockResetDatabaseInit = jest.fn();
+
+jest.mock("react-native", () => ({
+  Platform: { OS: "web" },
+}));
+
+jest.mock("../../lib/db", () => ({
+  getDatabase: (...args: unknown[]) => mockGetDatabase(...args),
+  getDatabaseFailure: () => mockGetDatabaseFailure(),
+  isDatabaseUnavailableError: (e: unknown) => mockIsDatabaseUnavailableError(e),
+  resetDatabaseInit: () => mockResetDatabaseInit(),
+}));
+
+describe("useDatabaseStatus — BLD-1262 disabled gate", () => {
+  beforeEach(() => {
+    mockGetDatabase.mockReset().mockResolvedValue(undefined);
+    mockGetDatabaseFailure.mockReset().mockReturnValue(null);
+    mockIsDatabaseUnavailableError.mockReset().mockReturnValue(false);
+    mockResetDatabaseInit.mockReset();
+  });
+
+  it("does NOT call getDatabase when disabled=true (web-unsupported host)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useDatabaseStatus } = require("../../hooks/useDatabaseStatus");
+    const { result } = renderHook(() => useDatabaseStatus({ disabled: true }));
+
+    // Let any (incorrectly-scheduled) microtasks drain.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockGetDatabase).not.toHaveBeenCalled();
+    expect(result.current).toEqual({ kind: "disabled" });
+  });
+
+  it("calls getDatabase exactly once when disabled=false (supported host)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useDatabaseStatus } = require("../../hooks/useDatabaseStatus");
+    const { result } = renderHook(() => useDatabaseStatus({ disabled: false }));
+
+    await waitFor(() => {
+      expect(result.current.kind).toBe("ready");
+    });
+    expect(mockGetDatabase).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls getDatabase exactly once with no options (backward-compat default)", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useDatabaseStatus } = require("../../hooks/useDatabaseStatus");
+    const { result } = renderHook(() => useDatabaseStatus());
+
+    await waitFor(() => {
+      expect(result.current.kind).toBe("ready");
+    });
+    expect(mockGetDatabase).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call getDatabase across the entire root-layout render when webUnsupported", async () => {
+    // Render the same wiring the layout uses: pass webUnsupported through
+    // to useDatabaseStatus exactly once per render. This mirrors the
+    // app/_layout.tsx call site and locks the regression at the
+    // composition boundary (AC1 from BLD-1262).
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { useDatabaseStatus } = require("../../hooks/useDatabaseStatus");
+    const webUnsupported = true;
+    const { result, rerender } = renderHook<{ disabled: boolean }, ReturnType<typeof useDatabaseStatus>>(
+      ({ disabled }) => useDatabaseStatus({ disabled }),
+      { initialProps: { disabled: webUnsupported } }
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // Force a re-render to mimic React's commit cycle around the
+    // surrounding WebUnsupportedScreen path.
+    rerender({ disabled: webUnsupported });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetDatabase).not.toHaveBeenCalled();
+    expect(result.current).toEqual({ kind: "disabled" });
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -81,12 +81,13 @@ export default Sentry.wrap(function RootLayout() {
   const isDark = scheme === "dark";
   const themeColors = isDark ? Colors.dark : Colors.light;
   const { banner, setBanner, error, setError, ready, onboarded, setOnboarded, webUnsupported, backupExclusionOk } = useAppInit();
-  // BLD-1257: gate the entire app on DB availability, parallel to the
-  // existing webUnsupported gate. When init fails on native, render the
-  // DatabaseUnavailableScreen INSTEAD of mounting the rest of the tree so
-  // downstream callers cannot retrigger openDatabaseAsync/execAsync and
-  // produce the Sentry REACT-NATIVE-7 burst.
-  const dbStatus = useDatabaseStatus();
+  // BLD-1257 / BLD-1262: gate the entire app on DB availability, parallel
+  // to the existing webUnsupported gate. We pass `disabled: webUnsupported`
+  // so the hook is a no-op on web hosts that lack SharedArrayBuffer —
+  // otherwise its useEffect would still call getDatabase() after the
+  // WebUnsupportedScreen render, re-introducing the BLD-565
+  // `ReferenceError: SharedArrayBuffer is not defined` regression.
+  const dbStatus = useDatabaseStatus({ disabled: webUnsupported });
   const pathname = usePathname();
   const prev = useRef(pathname);
 

--- a/hooks/useDatabaseStatus.ts
+++ b/hooks/useDatabaseStatus.ts
@@ -18,14 +18,35 @@ import {
 //                   and re-run init.
 // - "error"       : init rejected with a non-DatabaseUnavailableError
 //                   (legacy path — surfaced to LayoutBanners for parity).
+// - "disabled"    : BLD-1262. Caller asked the hook to stand down (e.g. on
+//                   web hosts without SharedArrayBuffer, where useAppInit
+//                   already short-circuits DB init per BLD-565). The hook
+//                   MUST NOT call getDatabase() in this state — invoking
+//                   it would risk a `ReferenceError: SharedArrayBuffer is
+//                   not defined` from drizzle/expo-sqlite.
 export type DatabaseStatus =
   | { kind: "pending" }
   | { kind: "ready" }
   | { kind: "unavailable"; error: DatabaseUnavailableError; sentryEventId?: string; retry: () => void }
-  | { kind: "error"; error: Error };
+  | { kind: "error"; error: Error }
+  | { kind: "disabled" };
 
-export function useDatabaseStatus(): DatabaseStatus {
-  const [status, setStatus] = useState<DatabaseStatus>({ kind: "pending" });
+export type UseDatabaseStatusOptions = {
+  /**
+   * BLD-1262: when true, the hook is a no-op — it does NOT invoke
+   * `getDatabase()` and stays in `{ kind: "disabled" }` indefinitely.
+   * Used by `app/_layout.tsx` to gate DB init behind the
+   * `webUnsupported` (no-SharedArrayBuffer) render branch so we don't
+   * regress BLD-565.
+   */
+  disabled?: boolean;
+};
+
+export function useDatabaseStatus(options: UseDatabaseStatusOptions = {}): DatabaseStatus {
+  const { disabled = false } = options;
+  const [status, setStatus] = useState<DatabaseStatus>(() =>
+    disabled ? { kind: "disabled" } : { kind: "pending" }
+  );
   const [attempt, setAttempt] = useState(0);
 
   const retry = useCallback(() => {
@@ -35,6 +56,15 @@ export function useDatabaseStatus(): DatabaseStatus {
   }, []);
 
   useEffect(() => {
+    // BLD-1262: short-circuit BEFORE getDatabase() so we never reach
+    // drizzle/expo-sqlite on web hosts that lack SharedArrayBuffer.
+    // `disabled` is treated as session-stable by callers (useAppInit
+    // computes `webUnsupported` via useMemo on first render), so the
+    // initial state is already `{ kind: "disabled" }` and we simply
+    // skip the init effect — no setState needed inside the effect body.
+    if (disabled) {
+      return;
+    }
     let cancelled = false;
     getDatabase()
       .then(() => {
@@ -59,7 +89,7 @@ export function useDatabaseStatus(): DatabaseStatus {
     return () => {
       cancelled = true;
     };
-  }, [attempt, retry]);
+  }, [attempt, retry, disabled]);
 
   return status;
 }


### PR DESCRIPTION
## Summary
Closes BLD-1262. Fixes the BLD-565 web-fallback regression introduced by PR #609 (BLD-1257) on commit `b0ce3de0`.

PR #609 added `useDatabaseStatus()` in `app/_layout.tsx` whose `useEffect` invoked `getDatabase()` **before** the existing `if (webUnsupported)` render branch took effect. React still ran the effect after rendering `WebUnsupportedScreen`, so on web hosts without `SharedArrayBuffer` we now reached drizzle/expo-sqlite and risked the exact `ReferenceError: SharedArrayBuffer is not defined` BLD-565 was built to prevent. This directly violated BLD-1257 AC #5 ("No behavior change on web in-memory fallback").

## Fix
Option A from the techlead plan:
- `useDatabaseStatus` now accepts an optional `{ disabled?: boolean }` arg.
- New `{ kind: "disabled" }` status kind; the hook initializes to it when `disabled` is true and the effect short-circuits **before** `getDatabase()`.
- `app/_layout.tsx` passes `disabled: webUnsupported` so the hook is a complete no-op on web-unsupported hosts.

## Tests
New `__tests__/hooks/useDatabaseStatus-web-unsupported.test.tsx` locks four contracts:
1. `disabled: true` → `getDatabase` never called; status is `{ kind: "disabled" }` (AC1).
2. `disabled: false` → `getDatabase` called **exactly once**; status transitions to `ready` (AC3).
3. No-args default → `getDatabase` called once (backward-compat).
4. Re-render with `disabled: true` still produces zero `getDatabase` calls (root-layout composition boundary).

Full suite: **4373 / 4373 tests pass**. `npm run lint` and `tsc --noEmit` clean.

## AC mapping (BLD-1262)
- [x] **AC1** `webUnsupported` → 0 `getDatabase` calls (new test).
- [x] **AC2** Native unchanged — `useAppInit` only sets `webUnsupported = true` when `Platform.OS === 'web'`, so native gets `disabled: false` and the prior BLD-1257 behavior.
- [x] **AC3** Supported web → exactly 1 `getDatabase` call (new test).
- [x] **AC4** Regression test added with explicit `expect(getDatabase).not.toHaveBeenCalled()`.
- [x] **AC5** WebUnsupportedScreen path untouched; `useAppInit` still skips DB init the same way.

## Out of scope
- No changes to `useAppInit`, `lib/db`, or `WebUnsupportedScreen`.
- Public API for non-web callers unchanged (options arg is optional).

## Risk
Low. Behavior change is gated by an explicit boolean flag. Default is `false`, preserving PR #609 semantics for every existing caller.

---
Refs: BLD-1262, BLD-1257 (#609), BLD-565

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>