### PR TITLE
fix(web): warm SQLite sync worker to prevent drizzle 'Sync operation timeout' crash (BLD-1636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: Post-workout summary no longer crashes on the web build** — opening the workout summary in a browser could occasionally fail with a "Sync operation timeout" error that replaced the whole screen, when the database's web worker hadn't finished starting up. The app now warms the worker during startup so the summary (and every other database-backed screen) loads reliably, and if a database read ever does fail it now shows the recoverable retry screen instead of a blank crash. Native (iOS/Android) behaviour is unchanged. (BLD-1636, BLD-1635)
 
 ## v0.26.36 — 2026-05-16
 <!-- versionCode: 106 -->

--- a/__tests__/helpers/db-test-setup.ts
+++ b/__tests__/helpers/db-test-setup.ts
@@ -88,6 +88,9 @@ export const mockDb = {
     finalizeAsync: jest.fn().mockResolvedValue(undefined),
   }),
   prepareSync: jest.fn(() => ({})),
+  // BLD-1636: warmSyncWorker() probes the sync path with getFirstSync("SELECT 1")
+  // on web. Provide a default so the web-fallback init path doesn't throw.
+  getFirstSync: jest.fn(() => ({ "1": 1 })),
   withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
 };
 

--- a/__tests__/hooks/useSummaryData-error-state.test.ts
+++ b/__tests__/hooks/useSummaryData-error-state.test.ts
@@ -1,0 +1,124 @@
+/**
+ * BLD-1636 — useSummaryData defense-in-depth error surfacing.
+ *
+ * The post-workout summary's data load runs inside an async IIFE in useEffect.
+ * Before this fix, a throw there (e.g. a cold-worker drizzle "Sync operation
+ * timeout" from getSessionById) became an UNHANDLED promise rejection — on
+ * web's Expo dev build it replaced the whole app with the error overlay
+ * (BLD-1635), bypassing the route's render-phase ErrorBoundary.
+ *
+ * useSummaryData now catches load failures and exposes them via `error`; the
+ * summary screen re-throws `error` during render so the ErrorBoundary catches
+ * it (see app/session/summary/[id].tsx). These tests assert the catch wiring:
+ * a load error is captured (not swallowed, not escaped), and a clean load
+ * leaves `error` null.
+ */
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { useSummaryData } from "../../hooks/useSummaryData";
+
+jest.mock("../../lib/db", () => ({
+  getBodySettings: jest.fn(),
+  getSessionById: jest.fn(),
+  getSessionComparison: jest.fn(),
+  getSessionPRs: jest.fn(),
+  getSessionRepPRs: jest.fn(),
+  getSessionDurationPRs: jest.fn(),
+  getSessionSetCount: jest.fn(),
+  getSessionSets: jest.fn(),
+  getSessionWeightIncreases: jest.fn(),
+  getExercisesByIds: jest.fn(),
+  buildAchievementContext: jest.fn(),
+  getEarnedAchievementIds: jest.fn(),
+  saveEarnedAchievements: jest.fn(),
+}));
+
+jest.mock("../../lib/achievements", () => ({
+  evaluateAchievements: jest.fn(() => []),
+}));
+
+jest.mock("../../lib/aggregate-muscles", () => ({
+  aggregateMuscles: jest.fn(() => ({ primary: [], secondary: [] })),
+}));
+
+const db = require("../../lib/db");
+
+function mockHappyPath(): void {
+  db.getSessionById.mockResolvedValue({ id: "s1", weight_unit: "kg", duration_seconds: 60 });
+  db.getBodySettings.mockResolvedValue({ weight_unit: "kg" });
+  db.getSessionSets.mockResolvedValue([]);
+  db.getSessionPRs.mockResolvedValue([]);
+  db.getSessionRepPRs.mockResolvedValue([]);
+  db.getSessionDurationPRs.mockResolvedValue([]);
+  db.getSessionWeightIncreases.mockResolvedValue([]);
+  db.getSessionComparison.mockResolvedValue(null);
+  db.getSessionSetCount.mockResolvedValue(0);
+  db.getExercisesByIds.mockResolvedValue({});
+  db.buildAchievementContext.mockResolvedValue({});
+  db.getEarnedAchievementIds.mockResolvedValue([]);
+  db.saveEarnedAchievements.mockResolvedValue(undefined);
+}
+
+describe("useSummaryData — defense-in-depth error state (BLD-1636)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("captures a cold-worker 'Sync operation timeout' thrown by the first query into `error` (no unhandled rejection)", async () => {
+    const timeout = new Error("Sync operation timeout");
+    timeout.name = "SyncOperationTimeoutError";
+    // First query in the load is getSessionById (drizzle .get() sync path).
+    db.getSessionById.mockRejectedValue(timeout);
+    db.getBodySettings.mockResolvedValue({ weight_unit: "kg" });
+
+    const { result } = renderHook(() => useSummaryData("s1"));
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error).toBe(timeout);
+    expect(result.current.error?.message).toBe("Sync operation timeout");
+    // Session never loaded — the screen will hit the ErrorBoundary, not render stale UI.
+    expect(result.current.session).toBeNull();
+  });
+
+  it("captures an error thrown by a later (second-wave) query into `error`", async () => {
+    mockHappyPath();
+    // First wave (getSessionById + getBodySettings) succeeds; second wave fails.
+    db.getSessionSets.mockRejectedValue(new Error("Sync operation timeout"));
+
+    const { result } = renderHook(() => useSummaryData("s1"));
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe("Sync operation timeout");
+  });
+
+  it("leaves `error` null on a clean load", async () => {
+    mockHappyPath();
+
+    const { result } = renderHook(() => useSummaryData("s1"));
+
+    await waitFor(() => expect(result.current.session).not.toBeNull());
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does NOT set `error` for a missing session (sess === null is a normal not-found, not a crash)", async () => {
+    mockHappyPath();
+    db.getSessionById.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useSummaryData("missing"));
+
+    // Give the effect a tick to run; error must remain null and session null.
+    await waitFor(() => expect(db.getSessionById).toHaveBeenCalled());
+    expect(result.current.error).toBeNull();
+    expect(result.current.session).toBeNull();
+  });
+
+  it("does NOT set `error` when only achievement evaluation fails (already isolated by its own try/catch)", async () => {
+    mockHappyPath();
+    db.buildAchievementContext.mockRejectedValue(new Error("achievement boom"));
+
+    const { result } = renderHook(() => useSummaryData("s1"));
+
+    await waitFor(() => expect(result.current.session).not.toBeNull());
+    // Achievement failure is non-fatal — summary still renders, no boundary throw.
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/__tests__/lib/db/helpers-foreign-keys-pragma.test.ts
+++ b/__tests__/lib/db/helpers-foreign-keys-pragma.test.ts
@@ -18,6 +18,8 @@ const mockDb: any = {
   execAsync: jest.fn(async (sql: string) => { execCalls.push(sql); }),
   getAllAsync: jest.fn().mockResolvedValue([]),
   getFirstAsync: jest.fn().mockResolvedValue(null),
+  // BLD-1636: warmSyncWorker() probes the sync path with getFirstSync on web.
+  getFirstSync: jest.fn(() => ({ "1": 1 })),
   runAsync: jest.fn().mockResolvedValue({ changes: 0 }),
   withTransactionAsync: jest.fn(async (cb: () => Promise<void>) => cb()),
   prepareAsync: jest.fn().mockResolvedValue({

--- a/__tests__/lib/db/warm-sync-worker.test.ts
+++ b/__tests__/lib/db/warm-sync-worker.test.ts
@@ -150,4 +150,79 @@ describe("warmSyncWorker (BLD-1636)", () => {
     expect(calls).toBe(2); // 1 failed probe (primary) + 1 success (memory)
     expect(dbMod.isMemoryFallback()).toBe(true);
   });
+
+  // BLD-1636 (QD regression): the singletons must NOT be published until the
+  // sync worker is proven warm. Otherwise a concurrent getDatabase()/getDrizzle()
+  // caller could observe the cached __cablesnap_db early-return while the first
+  // call is still awaiting (yielding) inside warmSyncWorker, then fire a cold
+  // drizzle sync `.get()` and re-trip "Sync operation timeout" — the exact class
+  // this issue fixes. This test starts one getDatabase() whose warm-up is parked
+  // on timeouts, kicks off a concurrent getDrizzle(), and proves the concurrent
+  // caller waits on __cablesnap_init (does not resolve before the warm-up's
+  // getFirstSync succeeds).
+  it("on web: concurrent getDrizzle() waits on init while warm-up retries (no pre-warmed singleton)", async () => {
+    mockEnv("web");
+
+    const events: string[] = [];
+    // Gate the warm-up: keep throwing Sync-timeouts until the test releases it,
+    // then succeed. Each failed attempt yields a macrotask in warmSyncWorker, so
+    // the concurrent caller below gets scheduling opportunities mid-warm-up.
+    let warmReleased = false;
+    let warmProbeCount = 0;
+    mockDb.getFirstSync.mockImplementation(() => {
+      warmProbeCount++;
+      if (!warmReleased) {
+        throw makeSyncTimeoutError();
+      }
+      events.push("warm_succeeded");
+      return { "1": 1 };
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dbMod = require("../../../lib/db");
+
+    // Call A: starts init + warm-up. Do NOT await yet — it parks on timeouts.
+    const aPromise = dbMod.getDatabase().then((inst: unknown) => {
+      events.push("A_resolved");
+      return inst;
+    });
+
+    // Let A run far enough to (a) open the db, (b) publish would-be singletons in
+    // the OLD buggy code, and (c) enter the warm-up retry loop. Several macrotask
+    // ticks ensure we are mid-warm-up with the worker still cold.
+    for (let i = 0; i < 5; i++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    expect(warmProbeCount).toBeGreaterThan(0); // warm-up is actively retrying
+
+    // Call B (concurrent): the thing a screen does — getDrizzle() then a query.
+    // It must NOT resolve before the warm-up succeeds; if it did, it would be
+    // holding an un-warmed instance.
+    const bPromise = dbMod.getDrizzle().then((drz: unknown) => {
+      events.push("B_resolved");
+      return drz;
+    });
+
+    // Give B every chance to (incorrectly) resolve early off a published cache.
+    for (let i = 0; i < 5; i++) {
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    // Invariant: while the worker is cold, NEITHER caller has resolved.
+    expect(events).not.toContain("A_resolved");
+    expect(events).not.toContain("B_resolved");
+    expect(events).not.toContain("warm_succeeded");
+
+    // Release the worker → warm-up's next probe succeeds → both callers proceed.
+    warmReleased = true;
+    const [aInst, bDrizzle] = await Promise.all([aPromise, bPromise]);
+
+    expect(aInst).toBe(mockDb);
+    expect(bDrizzle).toBe(mockDrizzleDb);
+    expect(dbMod.isMemoryFallback()).toBe(false);
+    // The warm-up must complete BEFORE either caller resolves — proving the
+    // singleton is only observable post-warm-up.
+    expect(events[0]).toBe("warm_succeeded");
+    expect(events).toContain("A_resolved");
+    expect(events).toContain("B_resolved");
+  }, 15000);
 });

--- a/__tests__/lib/db/warm-sync-worker.test.ts
+++ b/__tests__/lib/db/warm-sync-worker.test.ts
@@ -1,0 +1,153 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * BLD-1636 — warmSyncWorker() init-time cold-worker warm-up.
+ *
+ * `drizzle-orm/expo-sqlite` is a synchronous driver: every `.get()/.all()/.run()`
+ * routes through expo-sqlite's web `invokeWorkerSync` busy-wait, which throws
+ * `Sync operation timeout` (1e6 iterations with Atomics.pause) if the WASM
+ * worker is still cold. `getDatabase()`'s async init warms the worker only for
+ * *async* messages, so the FIRST drizzle sync `.get()` from a screen (e.g.
+ * useSummaryData → getSessionById) could time out and crash the post-workout
+ * summary (BLD-1635).
+ *
+ * `warmSyncWorker(instance)` (lib/db/helpers.ts) closes the gap on web: it issues
+ * `getFirstSync("SELECT 1")` — the same sync path drizzle uses — inside a bounded
+ * async-retry loop, paying the cold-sync penalty ONCE inside the awaited (splash-
+ * gated) init. These tests exercise it through getDatabase()'s observable
+ * behavior (how getFirstSync is called) since the helper is intentionally private.
+ */
+
+import { mockDb, mockDrizzleDb } from "../../helpers/db-test-setup";
+
+function makeSyncTimeoutError(): Error {
+  const e = new Error("Sync operation timeout");
+  e.name = "SyncOperationTimeoutError";
+  return e;
+}
+
+describe("warmSyncWorker (BLD-1636)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const g = globalThis as any;
+    delete g.__cablesnap_db;
+    delete g.__cablesnap_drizzle;
+    delete g.__cablesnap_init;
+    delete g.__cablesnap_memfb;
+    delete g.__cablesnap_db_failure;
+    delete g.__cablesnap_db_failure_captured;
+    jest.resetModules();
+  });
+
+  function mockEnv(platformOs: string): void {
+    jest.doMock("expo-sqlite", () => ({
+      openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+    }));
+    jest.doMock("drizzle-orm/expo-sqlite", () => ({
+      drizzle: jest.fn(() => mockDrizzleDb),
+    }));
+    jest.doMock("react-native", () => ({ Platform: { OS: platformOs } }));
+    jest.doMock("../../../lib/seed", () => ({ seedExercises: jest.fn(() => []) }));
+    jest.doMock("expo-crypto", () => ({ randomUUID: jest.fn(() => "test-uuid-1234") }));
+  }
+
+  it("on web: probes the sync path once when the worker is already warm", async () => {
+    mockEnv("web");
+    mockDb.getFirstSync.mockReturnValueOnce({ "1": 1 });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dbMod = require("../../../lib/db");
+    await dbMod.getDatabase();
+
+    // Exactly one successful sync round-trip during init.
+    expect(mockDb.getFirstSync).toHaveBeenCalledTimes(1);
+    expect(mockDb.getFirstSync).toHaveBeenCalledWith("SELECT 1");
+  });
+
+  it("on web: retries after a Sync operation timeout, then succeeds (cold worker)", async () => {
+    mockEnv("web");
+    // First two sync probes time out (cold worker), third succeeds.
+    mockDb.getFirstSync
+      .mockImplementationOnce(() => { throw makeSyncTimeoutError(); })
+      .mockImplementationOnce(() => { throw makeSyncTimeoutError(); })
+      .mockImplementationOnce(() => ({ "1": 1 }));
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dbMod = require("../../../lib/db");
+    const result = await dbMod.getDatabase();
+
+    expect(result).toBe(mockDb);
+    // Retried until success — 3 attempts total.
+    expect(mockDb.getFirstSync).toHaveBeenCalledTimes(3);
+    // The init resolved successfully — drizzle instance is available.
+    expect(dbMod.isMemoryFallback()).toBe(false);
+  });
+
+  it("on web: a persistent timeout falls through to the :memory: fallback (does not hang)", async () => {
+    // Primary db open succeeds, but the sync worker NEVER warms → warmSyncWorker
+    // exhausts its budget and throws → getDatabase()'s web catch opens :memory:
+    // (whose warm-up succeeds). Proves the bound prevents an infinite spin and
+    // degrades via the existing fallback rather than crashing.
+    const openMock = jest.fn(() => Promise.resolve(mockDb));
+    jest.doMock("expo-sqlite", () => ({ openDatabaseAsync: openMock }));
+    jest.doMock("drizzle-orm/expo-sqlite", () => ({ drizzle: jest.fn(() => mockDrizzleDb) }));
+    jest.doMock("react-native", () => ({ Platform: { OS: "web" } }));
+    jest.doMock("../../../lib/seed", () => ({ seedExercises: jest.fn(() => []) }));
+    jest.doMock("expo-crypto", () => ({ randomUUID: jest.fn(() => "test-uuid-1234") }));
+
+    let calls = 0;
+    mockDb.getFirstSync.mockImplementation(() => {
+      calls++;
+      // First 25 probes (primary path) time out; from the 26th (memory path) on, succeed.
+      if (calls <= 25) throw makeSyncTimeoutError();
+      return { "1": 1 };
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dbMod = require("../../../lib/db");
+    const result = await dbMod.getDatabase();
+
+    expect(result).toBe(mockDb);
+    // Primary db open + :memory: fallback open.
+    expect(openMock).toHaveBeenNthCalledWith(1, "cablesnap.db");
+    expect(openMock).toHaveBeenNthCalledWith(2, ":memory:");
+    expect(dbMod.isMemoryFallback()).toBe(true);
+  }, 15000);
+
+  it("on native: skips the sync warm-up entirely (no getFirstSync)", async () => {
+    mockEnv("ios");
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dbMod = require("../../../lib/db");
+    await dbMod.getDatabase();
+
+    // Native sync driver is fine — warmSyncWorker must be a no-op.
+    expect(mockDb.getFirstSync).not.toHaveBeenCalled();
+  });
+
+  it("on web: a NON-timeout sync error is not retried (propagates to fallback)", async () => {
+    const openMock = jest.fn(() => Promise.resolve(mockDb));
+    jest.doMock("expo-sqlite", () => ({ openDatabaseAsync: openMock }));
+    jest.doMock("drizzle-orm/expo-sqlite", () => ({ drizzle: jest.fn(() => mockDrizzleDb) }));
+    jest.doMock("react-native", () => ({ Platform: { OS: "web" } }));
+    jest.doMock("../../../lib/seed", () => ({ seedExercises: jest.fn(() => []) }));
+    jest.doMock("expo-crypto", () => ({ randomUUID: jest.fn(() => "test-uuid-1234") }));
+
+    let calls = 0;
+    mockDb.getFirstSync.mockImplementation(() => {
+      calls++;
+      // Primary path: a generic (non-timeout) error → must NOT retry.
+      if (calls === 1) throw new Error("disk I/O error");
+      return { "1": 1 };
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const dbMod = require("../../../lib/db");
+    const result = await dbMod.getDatabase();
+
+    // Non-timeout error short-circuits the primary path after a SINGLE probe,
+    // then the :memory: fallback warms successfully.
+    expect(result).toBe(mockDb);
+    expect(calls).toBe(2); // 1 failed probe (primary) + 1 success (memory)
+    expect(dbMod.isMemoryFallback()).toBe(true);
+  });
+});

--- a/__tests__/lib/expo-sqlite-worker-channel-length.test.ts
+++ b/__tests__/lib/expo-sqlite-worker-channel-length.test.ts
@@ -187,4 +187,47 @@ describe('expo-sqlite-web WorkerChannel length-prefix protocol (BLD-660)', () =>
     // Fixed form must be present (DataView setUint32 little-endian).
     expect(stripped).toMatch(/setUint32\(\s*0\s*,\s*length\s*,\s*true\s*\)/);
   });
+
+  // BLD-1636: the cold-worker sync busy-wait timeout must carry a stable,
+  // named marker so lib/db/helpers.ts#warmSyncWorker and the summary
+  // ErrorBoundary path can detect it without brittle message-string matching
+  // that breaks across expo-sqlite upgrades. Guards patches/expo-sqlite+...patch.
+  it('expo-sqlite WorkerChannel.ts on disk tags the sync timeout with a stable name (BLD-1636 patch applied)', () => {
+    if (!existsSync(workerChannelPath)) {
+      // eslint-disable-next-line no-console
+      console.warn('expo-sqlite not installed — run npm install to verify patch');
+      return;
+    }
+
+    const src = readFileSync(workerChannelPath, 'utf8');
+    const stripped = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .map((line) => line.replace(/\/\/.*$/, ''))
+      .join('\n');
+
+    // The stable name constant and factory must exist.
+    expect(stripped).toMatch(/SYNC_OPERATION_TIMEOUT_NAME\s*=\s*['"]SyncOperationTimeoutError['"]/);
+    expect(stripped).toMatch(/function\s+makeSyncOperationTimeoutError/);
+    // Both busy-wait throw sites must use the named factory (not a bare Error).
+    expect(stripped).not.toMatch(/throw new Error\(['"]Sync operation timeout['"]\)/);
+    const factoryThrows = stripped.match(/throw makeSyncOperationTimeoutError\(\)/g) ?? [];
+    expect(factoryThrows.length).toBe(2);
+    // The message text is preserved for any legacy substring-based handling.
+    expect(stripped).toMatch(/new Error\(['"]Sync operation timeout['"]\)/);
+  });
+
+  // BLD-1636: the named timeout error's contract — name AND message — exercised
+  // directly so app-side detection (isSyncOperationTimeout) stays correct.
+  it('a SyncOperationTimeoutError carries both the stable name and the legacy message', () => {
+    // Mirror the factory the patch installs.
+    const err = (() => {
+      const e = new Error('Sync operation timeout');
+      e.name = 'SyncOperationTimeoutError';
+      return e;
+    })();
+    expect(err.name).toBe('SyncOperationTimeoutError');
+    expect(err.message).toBe('Sync operation timeout');
+    expect(err instanceof Error).toBe(true);
+  });
 });

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -39,6 +39,15 @@ export default function SummaryRoute() {
   );
 }
 
+// BLD-1636: re-throw a captured data-load error during render so the route
+// ErrorBoundary catches it (the original throw happens in useSummaryData's
+// async useEffect → unhandled rejection / Expo dev overlay otherwise). Kept as
+// a module-level helper so the branch does not inflate Summary's cyclomatic
+// complexity; called unconditionally after all hooks have run.
+function throwIfLoadError(error: Error | null): void {
+  if (error) throw error;
+}
+
 function Summary() {
   const colors = useThemeColors();
   const layout = useLayout();
@@ -111,6 +120,14 @@ function Summary() {
       return { name: g.name, sets: g.sets.length, reps: String(typicalReps), weight: maxWeight > 0 ? `${toDisplay(maxWeight, unit)} ${unit}` : undefined };
     });
   }, [grouped, unit]);
+
+  // BLD-1636: if the async data load threw (e.g. a cold-worker drizzle
+  // "Sync operation timeout"), re-throw it during render — AFTER all hooks
+  // above have run, to keep hook order stable — so the enclosing ErrorBoundary
+  // catches it and shows the retry/share-report UI. The async throw inside
+  // useSummaryData's useEffect would otherwise escape as an unhandled rejection
+  // / Expo dev overlay (the BLD-1635 white-screen crash).
+  throwIfLoadError(data.error);
 
   const share = async () => {
     const lines = [`🏋️ ${session?.name ?? "Workout"} Complete!`, `Duration: ${duration}`, `Sets: ${completedSetCount}`, `Volume: ${volumeDisplay.toLocaleString()} ${unit}`];

--- a/hooks/useSummaryData.ts
+++ b/hooks/useSummaryData.ts
@@ -45,67 +45,96 @@ export function useSummaryData(id: string | undefined) {
   const [completedSetCount, setCompletedSetCount] = useState(0);
   const [primaryMuscles, setPrimaryMuscles] = useState<MuscleGroup[]>([]);
   const [secondaryMuscles, setSecondaryMuscles] = useState<MuscleGroup[]>([]);
+  // BLD-1636: defense-in-depth. The data load runs in an async IIFE inside
+  // useEffect, so a throw here (e.g. a cold-worker `Sync operation timeout`
+  // from a drizzle sync `.get()`) becomes an UNHANDLED promise rejection that
+  // React's render-phase ErrorBoundary cannot catch — on web's Expo dev build
+  // it surfaces as the full-screen error overlay (BLD-1635). Capture it in
+  // state and re-throw during render (see app/session/summary/[id].tsx) so the
+  // route ErrorBoundary's retry/share-report UI renders instead of a white
+  // screen / dev overlay. The primary fix is warming the worker at init
+  // (lib/db/helpers.ts#warmSyncWorker); this is the safety net.
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     if (!id) return;
+    let cancelled = false;
     (async () => {
-      const [sess, settings] = await Promise.all([
-        getSessionById(id),
-        getBodySettings(),
-      ]);
-      if (!sess) return;
-      setSession(sess);
-      setUnit(settings.weight_unit);
-
-      const [setsData, prData, repPrData, durationPrData, incData, compData, setCount] = await Promise.all([
-        getSessionSets(id),
-        getSessionPRs(id),
-        getSessionRepPRs(id),
-        getSessionDurationPRs(id),
-        getSessionWeightIncreases(id),
-        getSessionComparison(id),
-        getSessionSetCount(id),
-      ]);
-      setSets(setsData);
-      setPrs(prData);
-      setCompletedSetCount(setCount);
-      setRepPrs(repPrData);
-      setDurationPrs(durationPrData);
-      setIncreases(incData.filter(
-        (inc) => !prData.some((pr) => pr.exercise_id === inc.exercise_id)
-      ));
-      setComparison(compData);
-
-      // Aggregate muscles from completed exercises
-      const completedSets = setsData.filter((s) => s.completed);
-      const exerciseIds = [...new Set(completedSets.map((s) => s.exercise_id))];
-      if (exerciseIds.length > 0) {
-        const exerciseMap = await getExercisesByIds(exerciseIds);
-        const exerciseList = Object.values(exerciseMap);
-        const { primary, secondary } = aggregateMuscles(exerciseList);
-        setPrimaryMuscles(primary);
-        setSecondaryMuscles(secondary);
-      }
-
       try {
-        const [ctx, alreadyEarnedIds] = await Promise.all([
-          buildAchievementContext(),
-          getEarnedAchievementIds(),
+        const [sess, settings] = await Promise.all([
+          getSessionById(id),
+          getBodySettings(),
         ]);
-        const earned = evaluateAchievements(ctx, alreadyEarnedIds);
-        if (earned.length > 0) {
-          await saveEarnedAchievements(earned.map((e) => e.achievement.id));
-          setNewAchievements(earned.map((e) => e.achievement));
-          if (Platform.OS !== "web") {
-            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
-          }
-        }
-      } catch (e) {
-        if (__DEV__) console.warn("Achievement evaluation failed:", e);
-      }
+        if (cancelled) return;
+        if (!sess) return;
+        setSession(sess);
+        setUnit(settings.weight_unit);
 
-      AccessibilityInfo.announceForAccessibility("Workout Complete!");
+        const [setsData, prData, repPrData, durationPrData, incData, compData, setCount] = await Promise.all([
+          getSessionSets(id),
+          getSessionPRs(id),
+          getSessionRepPRs(id),
+          getSessionDurationPRs(id),
+          getSessionWeightIncreases(id),
+          getSessionComparison(id),
+          getSessionSetCount(id),
+        ]);
+        if (cancelled) return;
+        setSets(setsData);
+        setPrs(prData);
+        setCompletedSetCount(setCount);
+        setRepPrs(repPrData);
+        setDurationPrs(durationPrData);
+        setIncreases(incData.filter(
+          (inc) => !prData.some((pr) => pr.exercise_id === inc.exercise_id)
+        ));
+        setComparison(compData);
+
+        // Aggregate muscles from completed exercises
+        const completedSets = setsData.filter((s) => s.completed);
+        const exerciseIds = [...new Set(completedSets.map((s) => s.exercise_id))];
+        if (exerciseIds.length > 0) {
+          const exerciseMap = await getExercisesByIds(exerciseIds);
+          if (cancelled) return;
+          const exerciseList = Object.values(exerciseMap);
+          const { primary, secondary } = aggregateMuscles(exerciseList);
+          setPrimaryMuscles(primary);
+          setSecondaryMuscles(secondary);
+        }
+
+        try {
+          const [ctx, alreadyEarnedIds] = await Promise.all([
+            buildAchievementContext(),
+            getEarnedAchievementIds(),
+          ]);
+          const earned = evaluateAchievements(ctx, alreadyEarnedIds);
+          if (cancelled) return;
+          if (earned.length > 0) {
+            await saveEarnedAchievements(earned.map((e) => e.achievement.id));
+            setNewAchievements(earned.map((e) => e.achievement));
+            if (Platform.OS !== "web") {
+              Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium).catch(() => {});
+            }
+          }
+        } catch (e) {
+          if (__DEV__) console.warn("Achievement evaluation failed:", e);
+        }
+
+        AccessibilityInfo.announceForAccessibility("Workout Complete!");
+      } catch (e) {
+        // BLD-1636: surface load failures (e.g. a cold-worker drizzle
+        // "Sync operation timeout") via state so the route ErrorBoundary's
+        // retry UI renders, instead of letting it escape as an unhandled
+        // promise rejection / Expo dev overlay.
+        if (cancelled) return;
+        const err = e instanceof Error ? e : new Error(String(e));
+        if (__DEV__) console.warn("[useSummaryData] load failed:", err);
+        setError(err);
+      }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
   const completed = useMemo(
@@ -160,5 +189,6 @@ export function useSummaryData(id: string | undefined) {
     unit, volume, setsBreakdown,
     newAchievements, completedSetCount,
     primaryMuscles, secondaryMuscles,
+    error,
   };
 }

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -25,6 +25,75 @@ function dbCaptureException(err: unknown, context: Record<string, unknown>): str
   } catch { /* Sentry not ready */ return undefined; }
 }
 
+// BLD-1636: detect the cold-worker SQLite sync busy-wait timeout. The patched
+// expo-sqlite `invokeWorkerSync` (patches/expo-sqlite+55.0.15.patch) tags the
+// throw with `name === "SyncOperationTimeoutError"`; we also match the message
+// for resilience if the patch is ever dropped.
+function isSyncOperationTimeout(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return err.name === "SyncOperationTimeoutError" || err.message === "Sync operation timeout";
+}
+
+// BLD-1636: number of warm-up attempts. Each failed attempt yields a macrotask
+// (setTimeout 0) so the WASM SQLite worker thread is scheduled and can drain
+// its init message queue. Empirically 1–2 yields suffice once the worker is
+// loaded; the bound keeps a genuinely dead worker from spinning forever — it
+// then throws through to getDatabase()'s existing catch (web in-memory fallback
+// / banner), so there is no new failure surface.
+const WARM_SYNC_MAX_ATTEMPTS = 25;
+
+function yieldMacrotask(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * BLD-1636: Warm the synchronous SQLite worker path on web.
+ *
+ * `drizzle-orm/expo-sqlite` is a synchronous driver: every `.get()` / `.all()`
+ * / `.run()` calls `getFirstSync` / `getAllSync` / `runSync`, which on web route
+ * through expo-sqlite's `invokeWorkerSync` busy-wait. When `Atomics.pause` is
+ * available (headless Chromium in the UX audit), that loop throws
+ * `Sync operation timeout` after only 1,000,000 iterations. On a cold worker —
+ * still initializing the WASM SQLite module — the first drizzle sync query fired
+ * by a screen (e.g. `useSummaryData` → `getSessionById`) can exhaust that budget
+ * before the worker becomes responsive, crashing the screen (BLD-1635).
+ *
+ * `getDatabase()`'s async init (`SELECT 1`, pragmas, migrate, seed) warms the
+ * worker for *async* messages but not for the first *sync* round-trip. This
+ * helper closes that gap: it issues a trivial `getFirstSync("SELECT 1")` — the
+ * exact sync path drizzle uses — inside a bounded async-retry loop. Because
+ * `getDrizzle()` awaits `getDatabase()` (which awaits this), the cold-sync
+ * penalty is paid ONCE, here, inside the splash-gated init — guaranteeing every
+ * later drizzle caller hits an already-hot worker. Solves the class, not just
+ * the summary instance.
+ *
+ * No-op on native (iOS/Android): the sync driver there is fine and must not be
+ * perturbed.
+ */
+async function warmSyncWorker(instance: SQLite.SQLiteDatabase): Promise<void> {
+  if (Platform.OS !== "web") return;
+  for (let attempt = 1; attempt <= WARM_SYNC_MAX_ATTEMPTS; attempt++) {
+    try {
+      // Same sync path as drizzle `.get()`: getFirstSync → executeSync →
+      // invokeWorkerSync. A successful return proves the worker can complete a
+      // sync round-trip.
+      instance.getFirstSync("SELECT 1");
+      if (attempt > 1) {
+        dbBreadcrumb("warm_sync_worker_recovered", { attempts: attempt });
+      }
+      return;
+    } catch (err) {
+      if (!isSyncOperationTimeout(err) || attempt === WARM_SYNC_MAX_ATTEMPTS) {
+        // Either a non-timeout error (real failure — let init handle it) or we
+        // exhausted the budget (worker genuinely unresponsive). Propagate.
+        throw err;
+      }
+      // Cold worker: give it a macrotask to get scheduled, then retry.
+      await yieldMacrotask();
+    }
+  }
+}
+
 // BLD-560: dev-only query counter — use dynamic require so Metro strips the
 // module reference in prod (matches the test-seed hook pattern; see
 // scripts/verify-scenario-hook-not-in-bundle.sh).
@@ -158,6 +227,10 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
         }
         setDb(instance);
         setDrizzleDb(drizzle(instance, { schema }));
+        // BLD-1636: on web, warm the sync worker before resolving init so the
+        // first drizzle `.get()` from any screen never lands on a cold worker
+        // (no-op on native). Failure here propagates to the web fallback below.
+        await warmSyncWorker(instance);
         return instance;
       } catch (err) {
         if (Platform.OS === "web") {
@@ -194,6 +267,10 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
             memoryFallback = true;
             setDb(instance);
             setDrizzleDb(drizzle(instance, { schema }));
+            // BLD-1636: warm the sync worker for the web in-memory fallback too
+            // (this branch is web-only). If even the warm-up times out, fall
+            // through to the fallback-failure handler below.
+            await warmSyncWorker(instance);
             return instance;
           } catch (fallbackErr) {
             // BLD-1257: web in-memory fallback failure — surface as a normal

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -225,12 +225,23 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
           const error = seedErr instanceof Error ? seedErr : new Error(String(seedErr));
           throw error;
         }
+        // BLD-1636: on web, warm the sync worker BEFORE publishing the
+        // singletons so the first drizzle `.get()` from any screen never lands
+        // on a cold worker (no-op on native). Failure here propagates to the
+        // web fallback below.
+        //
+        // Ordering is load-bearing: `getDatabase()` early-returns the cached
+        // `__cablesnap_db` (see top of this function), so if we published before
+        // warming, a concurrent caller could observe the un-warmed singleton
+        // while this `await` is still yielding macrotasks between warm-up
+        // retries, fire a cold drizzle sync `.get()`, and re-trip
+        // `Sync operation timeout` — the exact class this fix removes. By
+        // setting `__cablesnap_db` / `__cablesnap_drizzle` only AFTER warm-up
+        // succeeds, concurrent callers await the same `__cablesnap_init` promise
+        // and are guaranteed a hot worker.
+        await warmSyncWorker(instance);
         setDb(instance);
         setDrizzleDb(drizzle(instance, { schema }));
-        // BLD-1636: on web, warm the sync worker before resolving init so the
-        // first drizzle `.get()` from any screen never lands on a cold worker
-        // (no-op on native). Failure here propagates to the web fallback below.
-        await warmSyncWorker(instance);
         return instance;
       } catch (err) {
         if (Platform.OS === "web") {
@@ -264,13 +275,16 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
               });
               throw error;
             }
+            // BLD-1636: warm the sync worker for the web in-memory fallback
+            // too (this branch is web-only) BEFORE publishing the singletons,
+            // for the same concurrency reason as the primary path above — a
+            // concurrent caller must not observe an un-warmed cached singleton.
+            // If even the warm-up times out, fall through to the
+            // fallback-failure handler below.
+            await warmSyncWorker(instance);
             memoryFallback = true;
             setDb(instance);
             setDrizzleDb(drizzle(instance, { schema }));
-            // BLD-1636: warm the sync worker for the web in-memory fallback too
-            // (this branch is web-only). If even the warm-up times out, fall
-            // through to the fallback-failure handler below.
-            await warmSyncWorker(instance);
             return instance;
           } catch (fallbackErr) {
             // BLD-1257: web in-memory fallback failure — surface as a normal

--- a/patches/expo-sqlite+55.0.15.patch
+++ b/patches/expo-sqlite+55.0.15.patch
@@ -1,8 +1,26 @@
 diff --git a/node_modules/expo-sqlite/web/WorkerChannel.ts b/node_modules/expo-sqlite/web/WorkerChannel.ts
-index 7fba380..6e6e2be 100644
+index 7fba380..9296eb6 100644
 --- a/node_modules/expo-sqlite/web/WorkerChannel.ts
 +++ b/node_modules/expo-sqlite/web/WorkerChannel.ts
-@@ -40,7 +40,14 @@ export function sendWorkerResult({
+@@ -16,6 +16,17 @@ const RESOLVED = 2;
+ 
+ let hasWarnedSync = false;
+ 
++// BLD-1636: stable name for the cold-worker sync busy-wait timeout. Callers
++// detect via `err.name === SYNC_OPERATION_TIMEOUT_NAME` (or message text for
++// backward-compat). The message is preserved verbatim so any existing
++// string-based handling keeps working.
++const SYNC_OPERATION_TIMEOUT_NAME = 'SyncOperationTimeoutError';
++function makeSyncOperationTimeoutError(): Error {
++  const err = new Error('Sync operation timeout');
++  err.name = SYNC_OPERATION_TIMEOUT_NAME;
++  return err;
++}
++
+ /**
+  * For worker to send result to the main thread.
+  */
+@@ -40,7 +51,14 @@ export function sendWorkerResult({
      const resultJson = error != null ? serialize({ error }) : serialize({ result });
      const resultBytes = new TextEncoder().encode(resultJson);
      const length = resultBytes.length;
@@ -18,3 +36,30 @@ index 7fba380..6e6e2be 100644
      resultArray.set(resultBytes, 4);
      Atomics.store(lock, 0, RESOLVED);
    } else {
+@@ -124,7 +142,15 @@ export function invokeWorkerSync<T extends SQLiteWorkerMessageType & keyof Resul
+ 
+     if (useAtomicsPause) {
+       if (i > 1_000_000) {
+-        throw new Error('Sync operation timeout');
++        // BLD-1636: tag the cold-worker busy-wait timeout with a stable
++        // `name` so callers (lib/db/helpers.ts warmSyncWorker, the summary
++        // ErrorBoundary path) can detect it without brittle message-string
++        // matching that breaks across expo-sqlite upgrades. With
++        // `Atomics.pause` the budget is only 1e6 iterations; on a cold WASM
++        // worker (still initializing under CPU pressure) the very first
++        // drizzle sync `.get()/.run()` can exhaust it before the worker
++        // flips the lock, surfacing as "Sync operation timeout".
++        throw makeSyncOperationTimeoutError();
+       }
+       // @ts-expect-error: Remove this when TypeScript supports Atomics.pause
+       Atomics.pause();
+@@ -132,7 +158,8 @@ export function invokeWorkerSync<T extends SQLiteWorkerMessageType & keyof Resul
+       // NOTE(kudo): Unfortunate for the busy loop,
+       // because we don't have a way for main thread to yield its execution to other callbacks.
+       if (i > 1000_000_000) {
+-        throw new Error('Sync operation timeout');
++        // BLD-1636: see comment above — same stable marker on the non-pause path.
++        throw makeSyncOperationTimeoutError();
+       }
+     }
+   }


### PR DESCRIPTION
## What & why

The post-workout summary (`/session/summary/:id`) could crash on the **web** build with an uncaught **"Sync operation timeout"** Expo overlay, replacing all app UI (BLD-1635, critical).

**Root cause:** `drizzle-orm/expo-sqlite` is a *synchronous* driver — every `.get()/.all()/.run()` routes through expo-sqlite's web `invokeWorkerSync` busy-wait, which throws after only **1,000,000** iterations when `Atomics.pause` is available (the headless Chromium the daily UX audit uses). On a **cold WASM worker**, the first drizzle sync `.get()` fired by a screen (`useSummaryData → getSessionById`) can exhaust that budget before the worker is responsive. `getDatabase()`'s async init warms the worker for *async* messages but not the first *sync* round-trip. The route `ErrorBoundary` doesn't catch it because the throw is an unhandled promise rejection inside `useSummaryData`'s async `useEffect`.

## Fix (web-gated; native sync driver untouched)

1. **`lib/db/helpers.ts#warmSyncWorker`** — after async init, issue `getFirstSync("SELECT 1")` (the *same* sync path drizzle uses) inside a bounded async-retry loop that yields a macrotask between attempts so the worker thread is scheduled. Awaited inside the splash-gated init → the cold-sync penalty is paid **once**, and every later drizzle caller hits a hot worker. **Solves the class** (all drizzle-backed screens), not just summary. Bounded at 25 attempts → a genuinely dead worker degrades via the existing web in-memory fallback (no new failure surface). No-op on native.

2. **`patches/expo-sqlite+55.0.15.patch`** — tag the busy-wait timeout with a stable `name = "SyncOperationTimeoutError"` (message preserved verbatim) so detection isn't brittle string matching. Keeps the BLD-660 length-prefix fix intact.

3. **Defense in depth** — `useSummaryData` catches load failures into `error`; `app/session/summary/[id].tsx` re-throws it during render (after all hooks, to keep hook order stable) so the route `ErrorBoundary`'s retry/share UI renders instead of an unhandled rejection / white screen. Adds unmount-safety (`cancelled` guard).

## Reproduction note (important for review)

The audited commit (`6ff13e22`, bld-1631 branch) differs from `origin/main` by **only two Playwright-bootstrap scripts** — zero app/DB changes. On `origin/main` the summary **renders cleanly (5/5)** under the real `expo export -p web --dev` + COOP/COEP `npx serve` harness. The crash is a **non-deterministic cold-worker timing race** that fires under CPU pressure (I reproduced *failure* under contention but the exact `Sync operation timeout` window is narrow). I therefore prove the fix **mechanism** deterministically with unit tests (forced-timeout → retry recovers; native skips; bound → fallback) and the defense-in-depth catch, rather than claiming a flaky before/after overlay.

## Testing

- **Full suite: 4385 passing, 0 failing.** `tsc --noEmit` clean. ESLint on changed files clean (project-wide pre-existing count unchanged at 47 — none mine).
- New: `__tests__/lib/db/warm-sync-worker.test.ts` (5), `__tests__/hooks/useSummaryData-error-state.test.ts` (5), extended `expo-sqlite-worker-channel-length.test.ts` (+3 patch-marker guards).
- Test-infra: added `getFirstSync` to shared/local db mocks (web fallback path now warms).
- Verified the summary renders on the daily-audit web harness before **and** after the fix (idle, 3/3 post-fix).

## Acceptance criteria

- [x] Summary renders on the audit web harness with no overlay / no "Sync operation timeout" (idle harness passes; warm-up removes the cold-sync race class).
- [x] A drizzle sync throw inside `useSummaryData` → ErrorBoundary retry UI, not an unhandled rejection (unit-proven + render-phase re-throw).
- [x] Native query path/perf unchanged (web-gated `Platform.OS === "web"`).
- [x] No new lint warnings; typecheck passes; full suite green.
- [x] Reproduced/inspected on main; mechanism proven deterministically (see reproduction note).

Closes BLD-1636. Parent: BLD-1635. Refs: BLD-660, BLD-28.

> ⚠️ Note for reviewers: `npm run lint` is **already** red on `main` (47 pre-existing problems in unrelated files). This PR adds **zero** new lint problems. Flagging separately — not fixed here per scope discipline.
