### PR TITLE
fix: skip Sentry captureException for network errors in Strava token refresh (BLD-1652)

### DIFF
--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -695,6 +695,68 @@ describe("Strava Integration — Behavioral", () => {
     expect(result.status).toBe("queued");
     expect(db.markSyncFailed).toHaveBeenCalledWith(sessionId, expect.stringContaining("422"));
   });
+
+  // BLD-1652: Sentry REACT-NATIVE-B — network error during Strava token refresh
+  // must NOT be reported to Sentry (benign transient in an offline-first app).
+  describe("(BLD-1652) refreshAccessToken — network error Sentry noise", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require("@sentry/react-native");
+
+    it("network TypeError during token refresh → captureException NOT called, warn log emitted", async () => {
+      db.getStravaConnection.mockResolvedValue({ athlete_id: 1 });
+      db.getSessionSets.mockResolvedValue([
+        { exercise_name: "Bench", weight: 80, reps: 8, completed: true, set_type: "working" },
+      ]);
+      // strava_token_expires_at=0 forces the refresh path in getValidAccessToken
+      SecureStore.getItemAsync.mockImplementation(async (key: string) => {
+        if (key === "strava_token_expires_at") return "0";
+        if (key === "strava_refresh_token") return "some-refresh-token";
+        return null;
+      });
+      // Refresh POST throws a network error (device offline / proxy unreachable)
+      mockFetch.mockRejectedValueOnce(
+        Object.assign(new TypeError("Network request failed"), { name: "TypeError" }),
+      );
+
+      const result = await strava.syncSessionToStrava("bld-1652-net-test");
+
+      // Sync degrades gracefully — upload is queued for later retry
+      expect(result.status).toBe("queued");
+
+      // Core assertion: network error must NOT pollute Sentry
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+
+      // A warn-level log IS emitted so the lifecycle remains observable
+      expect(Sentry.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("network offline"),
+        expect.objectContaining({ flow: "strava_refresh", step: "token_refresh" }),
+      );
+    });
+
+    it("non-network error during token refresh → captureException IS called (real bugs still surface)", async () => {
+      db.getStravaConnection.mockResolvedValue({ athlete_id: 1 });
+      db.getSessionSets.mockResolvedValue([
+        { exercise_name: "Squat", weight: 100, reps: 5, completed: true, set_type: "working" },
+      ]);
+      // Token expired — forces refresh
+      SecureStore.getItemAsync.mockImplementation(async (key: string) => {
+        if (key === "strava_token_expires_at") return "0";
+        if (key === "strava_refresh_token") return "some-refresh-token";
+        return null;
+      });
+      // Refresh POST returns 500 — throws a plain Error (not a network TypeError)
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => "Internal Server Error",
+      });
+
+      await strava.syncSessionToStrava("bld-1652-server-err-test");
+
+      // A real server-side error MUST still reach Sentry
+      expect(Sentry.captureException).toHaveBeenCalled();
+    });
+  });
 });
 
 describe("Strava Integration — Sentry lifecycle logs (BLD-523)", () => {

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -172,8 +172,19 @@ async function refreshAccessToken(): Promise<string | null> {
     stravaLog("info", "strava refresh succeeded", { flow: "strava_refresh", step: "success" });
     return data.access_token;
   } catch (err) {
-    console.error("Strava token refresh failed:", err);
-    captureStravaError(err, "strava_refresh", "token_refresh", { proxyUrl });
+    if (isNetworkError(err)) {
+      // Network outage during token refresh is a benign transient (device offline /
+      // proxy unreachable). Do NOT report to Sentry — it is expected in an offline-
+      // first app and was causing false-positive noise (Sentry REACT-NATIVE-B /
+      // BLD-1652). Just log at warn level so the lifecycle is still observable.
+      stravaLog("warn", "Strava token refresh skipped (network offline)", {
+        flow: "strava_refresh",
+        step: "token_refresh",
+      });
+    } else {
+      console.error("Strava token refresh failed:", err);
+      captureStravaError(err, "strava_refresh", "token_refresh", { proxyUrl });
+    }
     return null;
   }
 }


### PR DESCRIPTION
## Summary

The `refreshAccessToken()` function was calling `captureStravaError()` (→ `Sentry.captureException()`) for ALL errors, including `TypeError: Network request failed`. On an offline-first app, a network error during token refresh is a benign transient — the device was offline or the proxy was momentarily unreachable — and should not pollute Sentry.

This was the root cause of Sentry issue REACT-NATIVE-B (ID 7512898836).

## Root Cause

`lib/strava.ts:174-176` — `refreshAccessToken()` catch block:

```typescript
// Before
} catch (err) {
  console.error("Strava token refresh failed:", err);
  captureStravaError(err, "strava_refresh", "token_refresh", { proxyUrl }); // always fires
  return null;
}
```

The parallel `exchangeCodeForTokens()` function already guarded against this with `isNetworkError()`. This fix applies the same pattern to `refreshAccessToken()`.

## Changes

- `lib/strava.ts`: Add `isNetworkError(err)` guard in `refreshAccessToken` catch block — network errors emit `stravaLog("warn", ...)` only; non-network errors continue to call `captureStravaError`
- `__tests__/lib/strava.test.ts`: Add two regression tests (BLD-1652):
  1. `TypeError: Network request failed` during refresh → `captureException` NOT called, warn log emitted
  2. Server 500 during refresh → `captureException` IS called (real bugs still surface)

## Testing

- All 77 strava tests pass
- TypeScript: no errors
- Regression test added for both network and non-network error paths

## Issue

Resolves BLD-1652