### PR TITLE
fix(e2e): derive stack-marker viewport label from project.name (BLD-1673)

### DIFF
--- a/e2e/scenarios/stack-marker.spec.ts
+++ b/e2e/scenarios/stack-marker.spec.ts
@@ -48,7 +48,7 @@ test.describe("@scenario stack-marker", () => {
 
   test("pristine pill renders 'Pick marker', tap commits marker-logged state", async ({
     page,
-  }) => {
+  }, testInfo) => {
     await page.addInitScript((seed) => {
       const w = window as unknown as Record<string, unknown>;
       w.__SKIP_ONBOARDING__ = true;
@@ -67,7 +67,7 @@ test.describe("@scenario stack-marker", () => {
     // AC1 — pristine state: label is "Pick marker"
     await expect(pill).toHaveText("Pick marker");
 
-    const viewport = page.viewportSize()?.width === 375 ? "mobile" : "mobile-narrow";
+    const viewport = testInfo.project.name;
     await captureWithCvd({
       page,
       outDir: OUT_DIR,


### PR DESCRIPTION
## Summary

Fix the viewport label derivation in `e2e/scenarios/stack-marker.spec.ts` so the `mobile` and `mobile-narrow` Playwright projects write to distinct filename stems, and each `*.json` records a matching `viewport`/`viewportSize` pair.

## Problem

Line 70 compared `page.viewportSize()?.width === 375` to pick the label. Neither Playwright project uses 375px (`mobile` = 390px, `mobile-narrow` = 320px), so the expression always returned `"mobile-narrow"`. Result: the `mobile` run's capture overwrote the `mobile-narrow` one, `mobile.png` was never produced, and `mobile-narrow.json` recorded a 390×844 `viewportSize` with the wrong label.

## Changes

- Add `testInfo` as the second fixture argument to the test callback (line 49–51)
- Replace the hardcoded pixel comparison with `testInfo.project.name` (line 70)

This is the same pattern already used by `advanced-sets.spec.ts` and `settings.spec.ts`.

## Testing

- `tsc --noEmit`: zero errors
- `eslint e2e/scenarios/stack-marker.spec.ts`: zero warnings
- Logic: `testInfo.project.name` for the `mobile` project returns `"mobile"`; for `mobile-narrow` returns `"mobile-narrow"` — correct distinct stems

## Issue

Resolves BLD-1673 (parent: BLD-1667)