### PR TITLE
fix(session): raise contrast of Estimated Pacing "Other" legend dot (BLD-1669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: "Other" legend dot in the Estimated Pacing card is now visible** — the dot was near-white against a white card background, making it nearly invisible. It now uses a mid-grey colour with a subtle border so all three legend indicators (Working, Rest, Other) are clearly distinguishable. (BLD-1669)
 
 ## v0.26.37 — 2026-06-22
 <!-- versionCode: 107 -->

--- a/components/session/summary/PacingCard.tsx
+++ b/components/session/summary/PacingCard.tsx
@@ -35,7 +35,7 @@ function useSegmentColors() {
   return {
     working: colors.primary,          // Electric Coral
     rest: colors.heatmapLow,          // Blue (#1E88E5 / dark variant)
-    other: colors.surfaceVariant,     // Muted grey — legible on card background
+    other: colors.onSurfaceVariant,   // Mid grey — legible on card background
   };
 }
 
@@ -202,5 +202,5 @@ const styles = StyleSheet.create({
   barSegment: { height: "100%" },
   labelsRow: { flexDirection: "row", justifyContent: "space-around", flexWrap: "wrap", gap: 4 },
   labelChip: { flexDirection: "row", alignItems: "center", gap: 3 },
-  legendDot: { width: 8, height: 8, borderRadius: 4 },
+  legendDot: { width: 8, height: 8, borderRadius: 4, borderWidth: StyleSheet.hairlineWidth, borderColor: "rgba(0,0,0,0.18)" },
 });


### PR DESCRIPTION
## Summary

Raises contrast of the "Other" legend dot in the Estimated Pacing card. The dot was using `colors.surfaceVariant` (near-white light grey / near-black dark grey), which was nearly invisible against the card background. This changes it to `colors.onSurfaceVariant` (mid-grey) which is clearly legible, and adds a subtle hairline border to all three legend dots for an extra visual anchor.

## Changes

- `components/session/summary/PacingCard.tsx`: `other` segment color changed from `colors.surfaceVariant` → `colors.onSurfaceVariant` in `useSegmentColors()`
- `components/session/summary/PacingCard.tsx`: `styles.legendDot` gains `borderWidth: StyleSheet.hairlineWidth, borderColor: "rgba(0,0,0,0.18)"`

## Testing

- TypeScript typecheck passes (`tsc --noEmit` — zero errors)
- No text/copy changes; source-contracts tests unaffected
- No theme-level changes; fix is local to PacingCard.tsx
- No bar segment borders added (only legend dots)

## Issue

Resolves BLD-1669