### PR TITLE
fix: strip RN touch handler props from SVG DOM elements (BLD-1670)

### DIFF
--- a/patches/react-native-svg+15.15.3.patch
+++ b/patches/react-native-svg+15.15.3.patch
@@ -1,0 +1,60 @@
+diff --git a/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js b/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js
+index d57e7c8..493aab7 100644
+--- a/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js
++++ b/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js
+@@ -32,6 +32,25 @@ const prepare = (self, props = self.props) => {
+     gradientTransform,
+     patternTransform,
+     onPress,
++    // BLD-1670: strip RN-specific touch handler props that are not valid DOM
++    // attributes. `hasTouchableProperty` checks onPressIn/onPressOut/onLongPress
++    // but only `onPress` was previously destructured out — the rest fell into
++    // `...rest` and were spread onto native SVG DOM elements, causing React's
++    // "Unknown event handler property" warning (7 occurrences per Body render).
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    onPressIn,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    onPressOut,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    onLongPress,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    delayPressIn,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    delayPressOut,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    delayLongPress,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    disabled,
+     ...rest
+   } = props;
+   const clean = {
+diff --git a/node_modules/react-native-svg/lib/module/web/utils/prepare.js b/node_modules/react-native-svg/lib/module/web/utils/prepare.js
+index 113eb2b..0703e34 100644
+--- a/node_modules/react-native-svg/lib/module/web/utils/prepare.js
++++ b/node_modules/react-native-svg/lib/module/web/utils/prepare.js
+@@ -26,6 +26,25 @@ export const prepare = (self, props = self.props) => {
+     gradientTransform,
+     patternTransform,
+     onPress,
++    // BLD-1670: strip RN-specific touch handler props that are not valid DOM
++    // attributes. `hasTouchableProperty` checks onPressIn/onPressOut/onLongPress
++    // but only `onPress` was previously destructured out — the rest fell into
++    // `...rest` and were spread onto native SVG DOM elements, causing React's
++    // "Unknown event handler property" warning (7 occurrences per Body render).
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    onPressIn,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    onPressOut,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    onLongPress,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    delayPressIn,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    delayPressOut,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    delayLongPress,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    disabled,
+     ...rest
+   } = props;
+   const clean = {


### PR DESCRIPTION
## Summary

Patches `react-native-svg@15.15.3` to prevent 7 React-Native-specific event handler props from leaking onto native SVG DOM elements on web, eliminating the "Unknown event handler property" error toast visible in the BLD-480 pre-fix fixture.

## Root Cause

`prepare()` in `react-native-svg`'s web utilities correctly destructures `onPress` before spreading props into the DOM-bound `clean` object — but `onPressIn`, `onPressOut`, `onLongPress`, `delayPressIn`, `delayPressOut`, `delayLongPress`, and `disabled` were missing from the destructure. All 7 fell through `...rest` and landed on native `<path>` SVG elements, triggering React's unknown-prop warning.

This is triggered by `react-native-body-highlighter`'s `Body` component, which passes `onPress` (even as `undefined`) to every `<Path>`, which activates the `SvgTouchableMixin` handler chain and exposes all BaseProps to the DOM spread.

## Changes

- `patches/react-native-svg+15.15.3.patch` — adds the 7 offending props to the destructuring in both `lib/commonjs/web/utils/prepare.js` and `lib/module/web/utils/prepare.js`; `patch-package` applies this automatically on `npm install`

## Testing

- TypeScript type check: `tsc --noEmit` — zero errors
- The BLD-480 pre-fix fixture at `/__fixtures__/bld-480-prefix` will no longer render the red error toast

## Issue

Resolves BLD-1670