### PR TITLE
ci: auto-apply skip-changelog label to Dependabot PRs (BLD-1710)

### DIFF
--- a/.github/workflows/dependabot-skip-changelog.yml
+++ b/.github/workflows/dependabot-skip-changelog.yml
@@ -1,0 +1,42 @@
+name: Dependabot — Auto-apply skip-changelog label
+
+# Automatically applies the `skip-changelog` label to Dependabot PRs so that
+# changelog-gate.yml passes without requiring a human to label each bump.
+#
+# Security: uses `pull_request_target` so the GITHUB_TOKEN has write scope to
+# add labels on Dependabot PRs (a plain `pull_request` event from a bot has a
+# read-only token). The job NEVER checks out or executes any PR-supplied code —
+# it only calls the GitHub Labels API. This keeps the write-token confined to
+# label operations only and is safe per GitHub's security guidance for
+# `pull_request_target`.
+#
+# Idempotent: `gh pr edit --add-label` is a no-op if the label is already present.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-dependabot:
+    name: Apply skip-changelog to Dependabot PRs
+    runs-on: ubuntu-latest
+    # Only act on PRs authored by Dependabot — exact login match.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    timeout-minutes: 3
+    steps:
+      - name: Apply skip-changelog label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Dependabot PR #${PR_NUMBER} — applying skip-changelog label."
+          gh pr edit "$PR_NUMBER" \
+            --repo "$REPO" \
+            --add-label "skip-changelog"
+          echo "Label applied successfully."


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow that automatically applies the `skip-changelog` label to every Dependabot PR, unblocking them from the `changelog-gate.yml` CI check.

## Problem

`changelog-gate.yml` includes `package.json` in `USER_FACING_REGEX` (line 90). Every Dependabot dependency-bump PR touches `package.json`, so all Dependabot PRs are classified as "user-facing" and fail the changelog gate. Dependabot cannot write CHANGELOG entries or apply labels itself — PRs #509, #510, #511, and #512 have all been permanently blocked despite having green Typecheck/Jest/Vocab/bundle checks.

## Fix

New workflow: `.github/workflows/dependabot-skip-changelog.yml`

Key design decisions (per BLD-1710 spec):
- **`pull_request_target`** trigger — required so `GITHUB_TOKEN` has write scope to add labels on Dependabot PRs (a plain `pull_request` event from a fork/bot has a read-only token)
- **Strict guard**: `github.event.pull_request.user.login == 'dependabot[bot]'` — exact match, no human PRs affected
- **Minimal permissions**: `pull-requests: write` + `contents: read` only
- **No checkout, no code execution** — label-only job; the job never touches PR-supplied code (security requirement for `pull_request_target`)
- **Idempotent**: `gh pr edit --add-label` is a no-op if label is already present
- **No changes to `changelog-gate.yml`** — it already honors `skip-changelog` (lines 51–61); this fix is additive only

## Unblocking existing PRs (#509–#512)

Once this workflow lands on `main`, the blocked Dependabot PRs need to be re-triggered to pick up the label. Re-trigger path: close and reopen each PR (or push a trivial commit to the Dependabot branch if accessible). The `pull_request_target` event fires on `reopened`, which will run the new workflow and apply the label.

## Changes

- Added `.github/workflows/dependabot-skip-changelog.yml` (42 lines)

## Testing

- Structural validation: all 9 checks pass (trigger, permission scope, author guard, no-checkout, label name, token safety)
- Label name `skip-changelog` matches exactly what `changelog-gate.yml` checks at line 56
- Human PR regression: guard is `user.login == 'dependabot[bot]'` — human-authored PRs touching `package.json` are unaffected

## Issue

Resolves BLD-1710