### PR TITLE
fix: changelog-gate self-detect dependabot[bot] author (BLD-1716)

### DIFF
--- a/.github/workflows/changelog-gate.yml
+++ b/.github/workflows/changelog-gate.yml
@@ -48,13 +48,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Honor `skip-changelog` label
+      - name: Honor `skip-changelog` label or Dependabot author
         id: skip_label
         run: |
           set -euo pipefail
           LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          AUTHOR='${{ github.event.pull_request.user.login }}'
           if printf '%s' "$LABELS" | grep -q '"skip-changelog"'; then
             echo "::notice::PR is labeled \`skip-changelog\` — bypassing CHANGELOG gate."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "$AUTHOR" = 'dependabot[bot]' ]; then
+            echo "::notice::PR authored by dependabot[bot] — bypassing CHANGELOG gate."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Extends the `changelog-gate.yml` skip logic to bypass the gate when the PR author is `dependabot[bot]`, eliminating the race condition where the gate runs before the `skip-changelog` label can be applied.

## Root Cause

`dependabot-skip-changelog.yml` (merged in PR #620) correctly applies the `skip-changelog` label, but GitHub's anti-recursion rule means that a `labeled` event triggered by `GITHUB_TOKEN` does **not** create a new workflow run. The only changelog-gate run that fires is the initial `opened`/`reopened`/`synchronize` run — which executes before the label exists, classifies `package.json` as user-facing, and fails.

## Changes

- `.github/workflows/changelog-gate.yml` — Extended the skip_label step to also bypass when `github.event.pull_request.user.login == 'dependabot[bot]'`. Exact string match, so no other bot accounts are inadvertently bypassed.
- Step name updated to reflect the extended logic.

## Logic Summary

| Condition | Result |
|-----------|--------|
| PR has skip-changelog label | Bypass (existing behavior preserved) |
| PR author is dependabot[bot] (exact match) | Bypass via author check (new) |
| Human PR, no skip-changelog label | Gate enforced — no change |
| Other bot (not dependabot[bot]) | Gate enforced — exact match guard |

The label workflow from #620 is retained as belt-and-suspenders.

## Verification

- YAML parsed successfully with js-yaml (structurally valid).
- Pattern checks confirm: AUTHOR capture, elif branch, both skip=true paths, and skip=false fallback are all present.

## Post-merge steps

After merge to main, re-trigger PRs #509-#512 (close+reopen) to confirm changelog-gate flips to SUCCESS via the author-bypass path.

## Issue

Resolves BLD-1716 (parent: BLD-1710)