### PR TITLE
fix(e2e): wait for BottomSheet animation before pacing-breakdown-sheet screenshot (BLD-1771)

### DIFF
--- a/e2e/scenarios/session-pacing.spec.ts
+++ b/e2e/scenarios/session-pacing.spec.ts
@@ -115,6 +115,13 @@ test.describe("@scenario session-pacing", () => {
     await expect(page.getByText("Cable Row")).toBeVisible({ timeout: 5000 });
     await expect(page.getByText("Lat Pulldown")).toBeVisible();
 
+    // Let the BottomSheet open animation settle (withSpring translateY + withTiming
+    // opacity, ~300ms) before capturing — otherwise the sheet is screenshotted
+    // mid-travel and appears as a thin sliver peeking from the bottom (BLD-1767).
+    // Consistent with the 500ms pattern in completed-workout.spec.ts:52,
+    // with extra headroom for the spring settling time.
+    await page.waitForTimeout(600);
+
     await page.screenshot({
       path: path.join(OUT_DIR, "pacing-breakdown-sheet.png"),
       fullPage: true,


### PR DESCRIPTION
## Summary

Capture-timing fix for the session-pacing Playwright spec. The `pacing-breakdown-sheet.png` screenshot was taken the moment sheet rows became DOM-visible — before the `withSpring`/`withTiming` open animation settled — causing the sheet to appear as a thin sliver mid-travel from the bottom of the screen.

This is a **test-spec-only fix**. No app or component code was changed.

## Changes

- `e2e/scenarios/session-pacing.spec.ts`: adds `await page.waitForTimeout(600)` after the row-visibility assertions and before `page.screenshot()` for `pacing-breakdown-sheet.png`
  - 600ms provides margin above the 300ms `withTiming` opacity + spring settling time
  - Consistent with the existing `completed-workout.spec.ts:52` pattern (500ms), with extra headroom for the spring

## Root cause

The BottomSheet open animation (`translateY withSpring` + `opacity withTiming 300ms`) runs after mount. The `getByText("Cable Row")` visibility assertion fires as soon as the DOM node mounts — before the animation settles. Without a settle wait, the screenshot captures:
- Backdrop undimmed (opacity animation still in progress)
- Sheet content faded (opacity timing in progress)  
- Sheet frozen ~18% up its travel path

## Testing

- No device or manual AC required — this is a test-spec change only
- QD can verify by running the Playwright `session-pacing` spec (`mobile` project) and confirming the regenerated `pacing-breakdown-sheet.png` shows a settled sheet (backdrop dimmed, full per-exercise table visible at full opacity)
- Alternatively, QD can review the diff confirms the settle-wait insertion matches the `completed-workout.spec.ts:52` pattern

## Issue

Resolves BLD-1771
Closes BLD-1767 (screenshot artifact — not a real product defect)