### PR TITLE
fix(e2e): capture advanced-sets help screenshot via production nav push flow (BLD-1769)

### DIFF
--- a/e2e/scenarios/advanced-sets.spec.ts
+++ b/e2e/scenarios/advanced-sets.spec.ts
@@ -122,13 +122,20 @@ test.describe("@scenario advanced-sets", () => {
     await expect(page.getByText("Cluster", { exact: true }).first()).toBeVisible();
     await expect(page.getByText("Myo-reps", { exact: true }).first()).toBeVisible();
 
-    // Capture screenshot from the production route — BLD-1261 flex guard
-    // (Platform.OS !== "web") removes the flex: 1 constraint on web so the
-    // HTML document height equals content height and fullPage captures every
-    // entry at narrow viewports (390 px) where Myo-reps text wraps past 844 px.
+    // Capture screenshot via the production navigation push flow so expo-router's Stack
+    // has back-history — the back chevron renders exactly as real users see it.
+    // BLD-1769: direct goto("/settings/advanced-sets") omits back-history, causing the
+    // chevron to be absent in the audit screenshot (false positive). BLD-1261 flex guard
+    // (Platform.OS !== "web") removes flex: 1 on web so fullPage captures all content.
     const viewport = testInfo.project.name;
     const screenshotPath = path.join(OUT_DIR, `advanced-sets-help-${viewport}.png`);
-    await page.goto("/settings/advanced-sets");
+    await page.goto("/settings");
+    await expect(page.locator("body")).toBeVisible({ timeout: 15_000 });
+    await page.waitForTimeout(600);
+    const helpLinkForShot = page.getByText("Advanced Set Types").first();
+    await helpLinkForShot.scrollIntoViewIfNeeded();
+    await expect(helpLinkForShot).toBeVisible({ timeout: 5_000 });
+    await helpLinkForShot.click();
     await expect(page.locator("body[data-test-ready='true']")).toBeVisible({ timeout: 10_000 });
     await page.screenshot({ path: screenshotPath, fullPage: true });
     expect(screenshotPath).toBeTruthy();


### PR DESCRIPTION
## Summary

Fixes the audit-harness false positive where the advanced-sets help screen screenshot was missing the navigation back chevron. The root cause was that the screenshot was captured via a direct `page.goto("/settings/advanced-sets")` which gives expo-router's Stack no back-history, so the back chevron is correctly absent. This PR changes the capture to use the production navigation push flow.

## Changes

- `e2e/scenarios/advanced-sets.spec.ts`: In the "help screen route survives page reload" test, replaced the direct `page.goto("/settings/advanced-sets")` screenshot capture with the production push flow: `/settings` → locate "Advanced Set Types" → `scrollIntoViewIfNeeded()` → `click()`. This mirrors the existing passing pattern in the first test in the file.
- Reload/stability content assertions earlier in the same test are unchanged (no screenshot involved, direct goto is fine there).

## Testing

- `tsc --noEmit` passes with zero errors.
- All existing tests in `advanced-sets.spec.ts` are preserved; no assertions removed.
- To visually verify the back chevron in the screenshot: `npx expo export -p web --dev --no-minify` then `E2E_USE_STATIC=1 npx playwright test e2e/scenarios/advanced-sets.spec.ts --project=mobile` and inspect `.pixelslop/screenshots/scenarios/advanced-sets/advanced-sets-help-mobile.png`.

## Issue

Resolves BLD-1772
Parent: BLD-1769