### PR TITLE
fix(e2e): scroll summary FlatList to bottom before capture (BLD-1774)

### DIFF
--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -162,6 +162,7 @@ function Summary() {
     <>
       <Stack.Screen options={{ title: "Summary" }} />
       <FlatList
+        testID="summary-scroll-view"
         data={listData}
         keyExtractor={(s) => s.key}
         style={StyleSheet.flatten([styles.container, { backgroundColor: colors.background }])}

--- a/e2e/scenarios/completed-workout.spec.ts
+++ b/e2e/scenarios/completed-workout.spec.ts
@@ -51,6 +51,24 @@ test.describe("@scenario completed-workout", () => {
     });
     await page.waitForTimeout(500);
 
+    // Scroll the inner React Native FlatList (not the document) to the bottom
+    // so below-fold content (Estimated pacing card, Sets card, action buttons)
+    // is captured. window.scrollTo() does not move RN's scroll container —
+    // scroll the testID element directly (same fix as settings.spec.ts BLD-1124).
+    const scrollEl = page.getByTestId("summary-scroll-view");
+    await scrollEl.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
+    await page.waitForTimeout(300);
+
+    // scrollIntoViewIfNeeded() as a surgical follow-up handles stale scrollHeight
+    // when content renders after the initial scroll (same pattern as settings spec).
+    const viewDetailsButton = page.getByText("View Details", { exact: true });
+    await viewDetailsButton.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(200);
+
+    // Assert the terminal element is visible before capturing so the spec detects
+    // any future below-fold regression.
+    await expect(viewDetailsButton).toBeInViewport({ timeout: 5_000 });
+
     const viewport = "mobile";
     await captureWithCvd({
       page,


### PR DESCRIPTION
## Summary

Fixes the completed-workout audit screenshot clipping by scrolling the summary screen's React Native FlatList to the bottom before capture, ensuring below-fold content (Estimated pacing card, Sets card, action buttons) is visible in all screenshot variants.

## Changes

- `app/session/summary/[id].tsx`: Add `testID="summary-scroll-view"` to the FlatList (inert — no rendering/behavior change)
- `e2e/scenarios/completed-workout.spec.ts`: After the `data-test-ready` gate, scroll the FlatList container to `scrollHeight`, assert "View Details" button is in viewport via `toBeInViewport()`, then capture — mirrors the established settings.spec.ts pattern from BLD-1124

## Testing

- TypeScript typecheck passes with zero errors (`tsc --noEmit`)
- Follows the exact precedent from `e2e/scenarios/settings.spec.ts:101-131` (BLD-1124) which solved the identical RN-web scroll container problem

## Issue

Resolves BLD-1774 (child of BLD-1768)