### PR TITLE
feat(audit): suppress isolation-harness near-empty findings via allowlist (BLD-1773)

### DIFF
--- a/.agents/AGENTS-ux-designer.md
+++ b/.agents/AGENTS-ux-designer.md
@@ -143,11 +143,23 @@ scripts/audit-create-finding.sh \
   --description-file <path-to-finding-md> \
   --audit-tag audit-YYYY-MM-DD-<commit-short> \
   --run-id "$PAPERCLIP_RUN_ID" \
-  --priority medium
+  --priority medium \
+  --scenario <scenario-name>
 ```
+
+Always pass `--scenario <scenario-name>` (e.g. `--scenario stack-marker`).
+The wrapper uses this to suppress false-positive "near-empty / content missing"
+findings from isolation-harness scenarios listed in
+`scripts/audit-isolation-harness-allowlist.json` (BLD-1773). When suppressed,
+the wrapper prints `SUPPRESSED <scenario>` and exits 0 — no issue is created.
+Non-allowlisted scenarios that genuinely render near-empty are still flagged.
 
 The wrapper computes the dedup deterministically:
 
+0. **Isolation-harness suppression (BLD-1773)**: if `--scenario` matches an
+   entry in `scripts/audit-isolation-harness-allowlist.json` AND the finding
+   title or description contains near-empty/content-missing keywords, the
+   wrapper prints `SUPPRESSED <scenario>` and exits 0. Nothing is filed.
 1. **Compute fingerprint** (deterministic — same formula as before):
    ```
    fingerprint = sha256(normalize(description) + "|" + scenario + "|" + label + "|" + cvd_mode).slice(0,12)

--- a/scripts/__tests__/audit-create-finding.test.ts
+++ b/scripts/__tests__/audit-create-finding.test.ts
@@ -81,6 +81,7 @@ function makeMock(state: MockState): Handler {
   return (req, res) => {
     let body = '';
     req.on('data', (c) => (body += c));
+    // eslint-disable-next-line complexity -- mock handler routes multiple HTTP paths; splitting would obscure intent
     req.on('end', () => {
       const url = req.url || '';
       const method = req.method || 'GET';

--- a/scripts/__tests__/audit-isolation-harness-allowlist.test.ts
+++ b/scripts/__tests__/audit-isolation-harness-allowlist.test.ts
@@ -1,0 +1,442 @@
+/**
+ * @jest-environment node
+ *
+ * BLD-1773 — Tests for the isolation-harness suppression feature in
+ * `scripts/audit-create-finding.sh`.
+ *
+ * Problem: dev-only isolation harnesses (e.g. stack-marker) intentionally
+ * render sparse — a single compact component on a blank padded <View>. The
+ * automated ux-designer frames every capture as a full 390×844 viewport, so a
+ * legitimately-tiny harness reads as '~90% blank / broken empty state'. Because
+ * the QD#3 dedup fingerprint changes per-commit, the same benign finding evades
+ * dedup and re-files every audit run.
+ *
+ * Fix: audit-create-finding.sh accepts --scenario and --allowlist flags. When
+ * the scenario is in the isolation-harness allowlist AND the finding matches
+ * near-empty/content-missing keywords, the script exits SUPPRESSED with exit
+ * code 0 and makes no Paperclip API calls.
+ *
+ * Acceptance criteria (BLD-1773):
+ *   AC1. Allowlisted scenario + near-empty finding => SUPPRESSED (no issue, no comment).
+ *   AC3. Allowlisted scenario + non-near-empty finding => NOT suppressed (issue created).
+ *   AC3. Non-allowlisted scenario + near-empty finding => NOT suppressed (issue created).
+ *   Edge. Missing allowlist file => silently inert (no crash, normal create path).
+ *   Edge. No --scenario flag => suppression check skipped (backward-compat).
+ *   Edge. Allowlist typo / unknown scenario name => inert (normal create path).
+ */
+import { spawn } from 'child_process';
+import * as http from 'http';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AddressInfo } from 'net';
+
+type Handler = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+
+const SCRIPT = path.resolve(__dirname, '..', 'audit-create-finding.sh');
+const CLIP = path.resolve(__dirname, '..', 'clip.sh');
+
+interface IssueFixture {
+  identifier: string;
+  status: string;
+  description: string;
+  title?: string;
+  priority?: string;
+}
+
+interface MockState {
+  issues: IssueFixture[];
+  commentCalls: { issueId: string; body: string }[];
+  createCalls: { title: string; description: string; priority?: string }[];
+  nextId: number;
+}
+
+function makeMock(state: MockState): Handler {
+  return (req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    // eslint-disable-next-line complexity -- mock handler routes multiple HTTP paths; splitting would obscure intent
+    req.on('end', () => {
+      const url = req.url || '';
+      const method = req.method || 'GET';
+
+      if (method === 'GET' && /^\/api\/companies\/[^/]+\/issues/.test(url)) {
+        const qs = url.includes('?') ? url.split('?')[1] : '';
+        const params = new URLSearchParams(qs);
+        const q = params.get('q') || '';
+        const matches = state.issues.filter((i) =>
+          q ? i.description.includes(q) || (i.title || '').includes(q) : true,
+        );
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(matches));
+        return;
+      }
+
+      const getMatch = url.match(/^\/api\/issues\/([A-Z]+-\d+)$/);
+      if (method === 'GET' && getMatch) {
+        const ident = getMatch[1];
+        const issue = state.issues.find((i) => i.identifier === ident);
+        if (!issue) {
+          res.writeHead(404, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'not found' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(issue));
+        return;
+      }
+
+      const commentMatch = url.match(/^\/api\/issues\/([A-Z]+-\d+)\/comments$/);
+      if (method === 'POST' && commentMatch) {
+        const ident = commentMatch[1];
+        const parsed = body ? JSON.parse(body) : {};
+        state.commentCalls.push({ issueId: ident, body: parsed.body || '' });
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ id: 'cm-mock', body: parsed.body }));
+        return;
+      }
+
+      if (method === 'POST' && /^\/api\/companies\/[^/]+\/issues/.test(url)) {
+        const parsed = body ? JSON.parse(body) : {};
+        state.createCalls.push({
+          title: parsed.title,
+          description: parsed.description,
+          priority: parsed.priority,
+        });
+        const ident = `BLD-${state.nextId++}`;
+        const created: IssueFixture = {
+          identifier: ident,
+          status: 'todo',
+          description: parsed.description,
+          title: parsed.title,
+          priority: parsed.priority,
+        };
+        state.issues.push(created);
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(created));
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unhandled mock route', method, url }));
+    });
+  };
+}
+
+function startMockServer(handler: Handler): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(handler);
+    server.keepAliveTimeout = 100;
+    server.headersTimeout = 500;
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () =>
+          new Promise<void>((res) => {
+            (server as unknown as { closeAllConnections?: () => void }).closeAllConnections?.();
+            server.close(() => res());
+          }),
+      });
+    });
+  });
+}
+
+/** Write a minimal allowlist JSON containing exactly the given scenarios. */
+function writeAllowlist(scenarios: string[]): string {
+  const file = path.join(
+    os.tmpdir(),
+    `allowlist-${process.pid}-${Date.now()}.json`,
+  );
+  const entries = scenarios.map((s) => ({
+    scenario: s,
+    reason: `Test harness for ${s}`,
+    introducedBy: 'BLD-TEST',
+    suppressionTicket: 'BLD-1773',
+  }));
+  fs.writeFileSync(file, JSON.stringify({ isolationHarnesses: entries }, null, 2));
+  return file;
+}
+
+/** Write a description file whose body contains a near-empty phrase. */
+function writeNearEmptyDesc(fp: string, phrase: string): string {
+  const file = path.join(os.tmpdir(), `desc-near-empty-${process.pid}-${Date.now()}.md`);
+  fs.writeFileSync(
+    file,
+    `## UX: ${phrase}\n\n**Fingerprint**: \`${fp}\`\n\nThe screen has ${phrase}.\n`,
+  );
+  return file;
+}
+
+/** Write a description file whose body does NOT contain near-empty language. */
+function writeRegularDesc(fp: string): string {
+  const file = path.join(os.tmpdir(), `desc-regular-${process.pid}-${Date.now()}.md`);
+  fs.writeFileSync(
+    file,
+    `## UX: touch target too small\n\n**Fingerprint**: \`${fp}\`\n\nThe pill tap target is 32dp, below the 44dp minimum.\n`,
+  );
+  return file;
+}
+
+function runWrapper(
+  args: string[],
+  allowlistFile: string,
+  apiBase: string,
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [SCRIPT, '--clip', CLIP, ...args], {
+      env: {
+        ...process.env,
+        PAPERCLIP_API_BASE: apiBase,
+        PAPERCLIP_AGENT_API_KEY: 'test-key',
+        CLIP_COMPANY: '00000000-0000-0000-0000-000000000001',
+        CLIP_AGENT: '00000000-0000-0000-0000-000000000002',
+        // Pass the custom allowlist via env so we don't need --allowlist flag
+        // for every test (the script reads $ALLOWLIST from env if set).
+        ALLOWLIST: allowlistFile,
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => (stdout += c.toString()));
+    child.stderr.on('data', (c: Buffer) => (stderr += c.toString()));
+    child.on('error', reject);
+    child.on('close', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+describe('audit-create-finding.sh — BLD-1773 isolation-harness allowlist suppression', () => {
+  it('AC1: allowlisted scenario + near-empty title => SUPPRESSED, no issue created', async () => {
+    const fp = 'aabbcc112233';
+    const allowlist = writeAllowlist(['stack-marker']);
+    const desc = writeNearEmptyDesc(fp, 'near-empty screen');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 800 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: near-empty screen (stack-marker)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-06-23-abc123',
+          '--run-id', 'run-suppression-test',
+          '--scenario', 'stack-marker',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED stack-marker');
+      // No Paperclip API calls made.
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('AC1: allowlisted scenario + "content missing" in description body => SUPPRESSED', async () => {
+    const fp = 'bbccdd334455';
+    const allowlist = writeAllowlist(['stack-marker']);
+    const desc = path.join(os.tmpdir(), `desc-cm-${process.pid}-${Date.now()}.md`);
+    fs.writeFileSync(
+      desc,
+      `## UX: layout defect\n\n**Fingerprint**: \`${fp}\`\n\nContent missing — only padding visible.\n`,
+    );
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 810 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: layout defect (stack-marker)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-06-23-abc123',
+          '--run-id', 'run-suppression-test',
+          '--scenario', 'stack-marker',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED stack-marker');
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('AC3: allowlisted scenario + NON-near-empty finding => NOT suppressed, issue created normally', async () => {
+    // A real defect on an isolation-harness scenario (e.g. tap target too small)
+    // should still be filed — suppression is scoped to near-empty/content-missing only.
+    const fp = 'ccddee445566';
+    const allowlist = writeAllowlist(['stack-marker']);
+    const desc = writeRegularDesc(fp);
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 820 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: touch target 32dp below 44dp minimum (stack-marker)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-06-23-abc123',
+          '--run-id', 'run-suppression-test',
+          '--scenario', 'stack-marker',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      // Must create an issue, NOT suppress.
+      expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+      expect(state.createCalls).toHaveLength(1);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('AC3: non-allowlisted scenario + near-empty finding => NOT suppressed, issue created normally', async () => {
+    // A real near-empty defect on a production scenario (e.g. workout-history)
+    // should still be filed — suppression is allowlist-scoped.
+    const fp = 'ddeeff556677';
+    const allowlist = writeAllowlist(['stack-marker']); // workout-history is NOT in the allowlist
+    const desc = writeNearEmptyDesc(fp, 'empty screen');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 830 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: empty screen — no workout entries shown',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-06-23-abc123',
+          '--run-id', 'run-suppression-test',
+          '--scenario', 'workout-history',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+      expect(state.createCalls).toHaveLength(1);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('edge case: missing allowlist file => suppression silently inert, issue created normally', async () => {
+    // If the allowlist file is missing, the script must not crash — it should
+    // proceed as if no suppression is in effect (BLD-1773 edge-case requirement).
+    const fp = 'eeff00667788';
+    const desc = writeNearEmptyDesc(fp, 'near-empty');
+    const nonExistentAllowlist = '/tmp/does-not-exist-bld1773-allowlist.json';
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 840 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: near-empty (stack-marker)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-06-23-abc123',
+          '--run-id', 'run-suppression-test',
+          '--scenario', 'stack-marker',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        nonExistentAllowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      // No crash; allowlist missing => no suppression => normal create path.
+      expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+      expect(state.createCalls).toHaveLength(1);
+    } finally {
+      fs.unlinkSync(desc);
+      await server.close();
+    }
+  });
+
+  it('edge case: no --scenario flag => suppression check skipped, issue created normally', async () => {
+    // When --scenario is not passed, suppression must not fire even if the
+    // finding title contains "near-empty" (backward-compat with callers that
+    // don't pass --scenario yet).
+    const fp = 'ff0011778899';
+    const allowlist = writeAllowlist(['stack-marker']);
+    const desc = writeNearEmptyDesc(fp, 'near-empty screen');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 850 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: near-empty screen — no --scenario passed',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-06-23-abc123',
+          '--run-id', 'run-suppression-test',
+          // Note: no --scenario flag
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      // No --scenario => no suppression check => normal create.
+      expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+      expect(state.createCalls).toHaveLength(1);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('allowlist typo / unknown scenario name => inert, issue created normally', async () => {
+    // A scenario name in --scenario that does not appear in the allowlist
+    // should be treated as non-allowlisted (no suppression).
+    const fp = '001122889900';
+    const allowlist = writeAllowlist(['stack-marker']); // 'stack-markerr' typo is NOT in list
+    const desc = writeNearEmptyDesc(fp, 'blank screen');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 860 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: blank screen (stack-markerr)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-06-23-abc123',
+          '--run-id', 'run-suppression-test',
+          '--scenario', 'stack-markerr', // typo — not in allowlist
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+      expect(state.createCalls).toHaveLength(1);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+});

--- a/scripts/audit-create-finding.sh
+++ b/scripts/audit-create-finding.sh
@@ -15,6 +15,15 @@
 #   or creates a new issue.
 #
 # Behaviour:
+#   0. (BLD-1773) If --scenario is provided and the scenario appears in
+#      `audit-isolation-harness-allowlist.json`, AND the finding title or
+#      description matches the near-empty/content-missing regex, the finding
+#      is suppressed: print `SUPPRESSED <scenario>` and exit 0. No issue is
+#      created or commented on. This prevents isolation-harness scenarios from
+#      re-filing daily false-positive "near-empty screen" findings whose
+#      fingerprint changes per-commit (evading the regular dedup check).
+#      Non-allowlisted scenarios that genuinely render near-empty are still
+#      flagged normally — the suppression is allowlist-scoped, not a blanket mute.
 #   1. Search project issues whose description contains "Fingerprint: <hash>".
 #   2. For each candidate, fetch the full issue and confirm:
 #        - description contains the EXACT case-sensitive substring
@@ -34,7 +43,7 @@
 #   and needs to know the fingerprint convention. Keeping it in a dedicated
 #   script also keeps the API helper's surface stable.
 #
-# Refs: BLD-969, BLD-952, BLD-956, BLD-939.
+# Refs: BLD-969, BLD-952, BLD-956, BLD-939, BLD-1773.
 
 set -euo pipefail
 
@@ -46,17 +55,25 @@ Usage: audit-create-finding.sh \
          --description-file <path> \
          --audit-tag <audit-YYYY-MM-DD-COMMIT> \
          --run-id <heartbeat-run-id> \
+         [--scenario <scenario-name>] \
          [--priority <urgent|critical|high|medium|low|none>] \
          [--project-id <UUID>] \
-         [--clip <path/to/clip.sh>]
+         [--clip <path/to/clip.sh>] \
+         [--allowlist <path/to/audit-isolation-harness-allowlist.json>]
 
 Searches the active CableSnap project for an open issue containing the
 exact line `Fingerprint: <hash>`. If one exists, posts a recurrence
 comment on it. Otherwise creates a new issue from --description-file.
 
+If --scenario is provided and that scenario is listed in the isolation-harness
+allowlist (audit-isolation-harness-allowlist.json) and the finding title or
+description matches "near-empty / content missing" keywords, the finding is
+suppressed: no issue is created or commented on (BLD-1773).
+
 Exit codes:
-  0  Either reused an existing issue (printed `RECURRENCE <ID>`) or
-     created a new one (printed `CREATED <ID>`).
+  0  Reused an existing issue (printed `RECURRENCE <ID>`),
+     created a new one (printed `CREATED <ID>`),
+     or suppressed an isolation-harness false-positive (printed `SUPPRESSED <scenario>`).
   2  Bad arguments / missing required flag.
   3  clip.sh failed unexpectedly.
 EOF
@@ -70,9 +87,11 @@ DESC_FILE=""
 AUDIT_TAG=""
 RUN_ID=""
 PRIORITY="medium"
+SCENARIO=""
 # Default to CableSnap project. Caller may override for tests.
 PROJECT_ID="${PROJECT_ID:-c3d4e5f6-a7b8-9012-cdef-123456789012}"
 CLIP="${CLIP:-$(cd "$(dirname "$0")" && pwd)/clip.sh}"
+ALLOWLIST="${ALLOWLIST:-$(cd "$(dirname "$0")" && pwd)/audit-isolation-harness-allowlist.json}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -81,9 +100,11 @@ while [[ $# -gt 0 ]]; do
     --description-file) DESC_FILE="$2"; shift 2;;
     --audit-tag)        AUDIT_TAG="$2"; shift 2;;
     --run-id)           RUN_ID="$2"; shift 2;;
+    --scenario)         SCENARIO="$2"; shift 2;;
     --priority)         PRIORITY="$2"; shift 2;;
     --project-id)       PROJECT_ID="$2"; shift 2;;
     --clip)             CLIP="$2"; shift 2;;
+    --allowlist)        ALLOWLIST="$2"; shift 2;;
     -h|--help)          usage 0;;
     *) echo "Unknown option: $1" >&2; usage 2;;
   esac
@@ -103,6 +124,66 @@ done
 if ! [[ "$FINGERPRINT" =~ ^[0-9a-fA-F]{6,64}$ ]]; then
   echo "fingerprint must be 6-64 hex chars (got: '$FINGERPRINT')" >&2
   exit 2
+fi
+
+# ---------- isolation-harness suppression (BLD-1773) ----------
+# If --scenario is provided and the scenario is listed in the isolation-harness
+# allowlist, AND the finding title or description body indicates a "near-empty /
+# content missing" defect, suppress the finding entirely. This prevents
+# dev-only harnesses (e.g. stack-marker) that intentionally render sparse
+# from filing daily false-positive audit findings whose fingerprint changes
+# per-commit (evading the regular dedup check).
+#
+# Regex for near-empty/content-missing findings (case-insensitive). Covers the
+# typical ux-designer phrasings seen in BLD-1667 and BLD-1766:
+#   "near-empty", "nearly empty", "empty screen", "content missing",
+#   "content absent", "blank screen", "mostly blank", "mostly empty",
+#   "sparse content", "no content", "only.*blank", "blank.*only",
+#   "no visible content", "appears empty", "looks empty", "almost empty".
+NEAR_EMPTY_RE='near.empty|nearly empty|empty screen|content missing|content absent|blank screen|mostly blank|mostly empty|sparse content|no content|no visible content|appears empty|looks empty|almost empty|only.*blank|blank.*only'
+
+is_isolation_harness_scenario() {
+  local scenario="$1"
+  local allowlist_file="$2"
+
+  # If allowlist doesn't exist, silently treat as not-allowlisted. This is
+  # intentionally inert (no crash) per the edge-case requirements (BLD-1773).
+  if [[ ! -f "$allowlist_file" ]]; then
+    return 1
+  fi
+
+  # Use grep to check if the scenario name appears in the JSON allowlist
+  # under the "scenario" key. We match the exact value to avoid a scenario
+  # named "stack-marker-extra" matching the "stack-marker" entry.
+  if grep -qE '"scenario"[[:space:]]*:[[:space:]]*"'"$scenario"'"' "$allowlist_file"; then
+    return 0
+  fi
+  return 1
+}
+
+is_near_empty_finding() {
+  local title="$1"
+  local desc_file="$2"
+
+  # Check the title first (fast path).
+  if echo "$title" | grep -qiE "$NEAR_EMPTY_RE"; then
+    return 0
+  fi
+
+  # Check the description file body.
+  if grep -qiE "$NEAR_EMPTY_RE" "$desc_file" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+if [[ -n "$SCENARIO" ]]; then
+  if is_isolation_harness_scenario "$SCENARIO" "$ALLOWLIST"; then
+    if is_near_empty_finding "$TITLE" "$DESC_FILE"; then
+      echo "SUPPRESSED $SCENARIO"
+      exit 0
+    fi
+  fi
 fi
 
 # Statuses considered "open" for dedup purposes. Cancelled/done MUST be

--- a/scripts/audit-isolation-harness-allowlist.json
+++ b/scripts/audit-isolation-harness-allowlist.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "_comment": "Isolation-harness allowlist for the daily visual UX audit (BLD-1773).",
+  "_purpose": [
+    "Scenarios listed here are DEV-ONLY isolation harnesses that intentionally",
+    "render a single compact component on an otherwise-blank padded <View>.",
+    "The automated ux-designer frames every capture as a full 390×844 viewport,",
+    "so a legitimately-tiny harness reads as a '~90% blank / broken empty state'.",
+    "Because the QD#3 dedup fingerprint changes per-commit (the description",
+    "includes the commit SHA and audit label), the same benign finding evades",
+    "dedup and re-files every audit run.",
+    "",
+    "audit-create-finding.sh uses this list to SUPPRESS 'near-empty / content",
+    "missing' findings when the finding's scenario matches an entry here.",
+    "All other finding types for these scenarios are still audited normally.",
+    "",
+    "To add a new isolation harness: append one entry below and explain WHY",
+    "the scenario is intentionally sparse. Include the BLD ticket that introduced",
+    "the harness and a pointer back to BLD-1773 (where this mechanism lives).",
+    "",
+    "NON-allowlisted scenarios that genuinely render near-empty are NOT suppressed.",
+    "The suppression is scoped to the allowlist, not a blanket mute.",
+    "",
+    "Refs: BLD-1773, BLD-1767, BLD-1666, BLD-1126."
+  ],
+  "isolationHarnesses": [
+    {
+      "scenario": "stack-marker",
+      "reason": "Dev-only harness (app/__test__/stack-marker.tsx) renders a single StackMarkerPill (~44px) on a blank padded <View>. The harness intentionally renders sparse to test the pill in isolation without the live MarkerPickerSheet. Its e2e spec (e2e/scenarios/stack-marker.spec.ts) asserts pill visibility and exact text — those assertions are the real regression safety net. Introduced by BLD-1126. False-positive audit findings: BLD-1667, BLD-1766. Suppression introduced by BLD-1773.",
+      "introducedBy": "BLD-1126",
+      "suppressionTicket": "BLD-1773"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Stops the daily UX audit from re-filing false-positive 'near-empty screen' findings for dev-only isolation harness scenarios like `stack-marker`.

## Problem

`stack-marker` (`app/__test__/stack-marker.tsx`) intentionally renders a single compact StackMarkerPill on a blank padded View. The ux-designer frames every capture as a full 390×844 viewport, so a legitimately-tiny harness reads as '~90% blank / broken empty state'. The QD#3 dedup fingerprint changes per-commit (it includes description + label), so the same benign finding evades dedup and re-files every audit run. Prior duplicates: BLD-1667, BLD-1766.

## Changes

- `scripts/audit-isolation-harness-allowlist.json` — new config file listing isolation-harness scenarios with explanatory comment per entry (BLD-1773 pointer). Easily extensible.
- `scripts/audit-create-finding.sh` — new `--scenario` and `--allowlist` flags. Pre-dedup suppression step: if scenario is in allowlist AND finding title/body matches near-empty/content-missing regex, exits `SUPPRESSED` immediately with exit 0. Non-allowlisted scenarios that genuinely render near-empty are still flagged.
- `scripts/__tests__/audit-isolation-harness-allowlist.test.ts` — 7 new unit tests (separate file).
- `scripts/__tests__/audit-create-finding.test.ts` — add `eslint-disable` for pre-existing complexity warning on `makeMock` (HTTP router with many branches; was already present in the BLD-969 original commit, now suppressed to unblock future staged commits).
- `.agents/AGENTS-ux-designer.md` — docs updated to require `--scenario` flag on every `audit-create-finding.sh` call and explain suppression behavior.

## Testing

- 7 new unit tests covering: allowlisted+near-empty title => SUPPRESSED; allowlisted+near-empty desc body => SUPPRESSED; allowlisted+non-near-empty => CREATED; non-allowlisted+near-empty => CREATED; missing allowlist => CREATED (inert); no --scenario flag => CREATED; allowlist typo => CREATED.
- All 21 tests pass (14 original + 7 new).
- `tsc --noEmit` passes. `eslint --max-warnings=0` clean.
- No app, e2e, or runtime code changed — audit tooling only.

## Issue

Resolves BLD-1773