### PR TITLE
fix: strip onResponder* props from SVG DOM elements (BLD-1770)

### DIFF
--- a/__tests__/patches/react-native-svg-prepare.test.ts
+++ b/__tests__/patches/react-native-svg-prepare.test.ts
@@ -1,0 +1,112 @@
+/**
+ * BLD-1770: Regression test for the react-native-svg prepare() patch.
+ *
+ * Verifies that the patched prepare() function does NOT include React Native
+ * responder-system props (onStartShouldSetResponder, onResponder*) in its
+ * output when called with a truthy onPress handler.
+ *
+ * Background:
+ *   react-native-body-highlighter passes onPress={() => fn?.(part)} to every
+ *   <Path> element. Even when `fn` is undefined, the arrow function is truthy,
+ *   so hasTouchableProperty() returns true. The pre-patch prepare() then spread
+ *   six onResponder* props into the clean object. These fell through
+ *   createDOMProps's domProps spread onto SVG <path> DOM elements, causing
+ *   React's "Unknown event handler property" warning — rendered visually as a
+ *   red error toast in the bld-480-prefix fixture.
+ *
+ *   BLD-1670 patch stripped onPressIn/onPressOut/onLongPress/delay* from
+ *   `...rest` (via props destructuring) but left the 6 onResponder* props that
+ *   are conditionally spread into clean{} via hasTouchableProperty.
+ *
+ *   BLD-1770 patch extends the fix: destructures and discards the 6 responder
+ *   props from clean{} before returning, so they never reach createElement.
+ *
+ * Refs: BLD-1670, BLD-1770.
+ */
+
+// We require the patched commonjs build directly (the ESM module build is
+// not usable in Jest's CommonJS environment without transpilation).
+// patch-package applies the patch before tests run (via the postinstall hook
+// which runs `npx patch-package` — Jest picks up the patched node_modules).
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const { prepare } = require('react-native-svg/lib/commonjs/web/utils/prepare') as { prepare: (...args: never[]) => Record<string, unknown> };
+
+// Minimal WebShape stub — prepare() only reads elementRef and touchable* methods.
+const makeStub = () => ({
+  props: {},
+  elementRef: { current: null },
+  touchableHandleStartShouldSetResponder: jest.fn(),
+  touchableHandleResponderTerminationRequest: jest.fn(),
+  touchableHandleResponderGrant: jest.fn(),
+  touchableHandleResponderMove: jest.fn(),
+  touchableHandleResponderRelease: jest.fn(),
+  touchableHandleResponderTerminate: jest.fn(),
+  _remeasureMetricsOnActivation: jest.fn(),
+});
+
+const RN_RESPONDER_PROPS = [
+  'onStartShouldSetResponder',
+  'onResponderTerminationRequest',
+  'onResponderGrant',
+  'onResponderMove',
+  'onResponderRelease',
+  'onResponderTerminate',
+] as const;
+
+describe('react-native-svg prepare() patch (BLD-1770)', () => {
+  describe('when onPress is a truthy arrow function (body-highlighter pattern)', () => {
+    it('does NOT include any onResponder* prop in the output', () => {
+      const stub = makeStub();
+      // Mimic body-highlighter: () => onBodyPartPress?.(part) — truthy even
+      // when onBodyPartPress is undefined.
+      const onPress = () => (undefined as unknown as (x: unknown) => void)?.(null);
+      const result = prepare(stub as never, { onPress } as never);
+
+      for (const prop of RN_RESPONDER_PROPS) {
+        expect(result).not.toHaveProperty(prop);
+      }
+    });
+
+    it('does NOT include onStartShouldSetResponder specifically', () => {
+      const stub = makeStub();
+      const result = prepare(stub as never, { onPress: () => undefined } as never);
+      expect(result).not.toHaveProperty('onStartShouldSetResponder');
+    });
+
+    it('still maps onPress to onClick', () => {
+      const stub = makeStub();
+      const handler = jest.fn();
+      const result = prepare(stub as never, { onPress: handler } as never);
+      expect(result).toHaveProperty('onClick', handler);
+    });
+  });
+
+  describe('when onPress is not set (no press handler)', () => {
+    it('does NOT include any onResponder* prop in the output', () => {
+      const stub = makeStub();
+      const result = prepare(stub as never, {} as never);
+      for (const prop of RN_RESPONDER_PROPS) {
+        expect(result).not.toHaveProperty(prop);
+      }
+    });
+  });
+
+  describe('BLD-1670 props also remain stripped', () => {
+    it('does NOT include onPressIn/onPressOut/onLongPress in the output', () => {
+      const stub = makeStub();
+      const result = prepare(stub as never, {
+        onPress: () => undefined,
+        onPressIn: jest.fn(),
+        onPressOut: jest.fn(),
+        onLongPress: jest.fn(),
+        delayPressIn: 100,
+        delayPressOut: 100,
+        delayLongPress: 500,
+        disabled: true,
+      } as never);
+      for (const prop of ['onPressIn', 'onPressOut', 'onLongPress', 'delayPressIn', 'delayPressOut', 'delayLongPress', 'disabled']) {
+        expect(result).not.toHaveProperty(prop);
+      }
+    });
+  });
+});

--- a/patches/react-native-svg+15.15.3.patch
+++ b/patches/react-native-svg+15.15.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js b/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js
-index d57e7c8..493aab7 100644
+index d57e7c8..0b215d3 100644
 --- a/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js
 +++ b/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js
 @@ -32,6 +32,25 @@ const prepare = (self, props = self.props) => {
@@ -28,8 +28,27 @@ index d57e7c8..493aab7 100644
      ...rest
    } = props;
    const clean = {
+@@ -93,7 +112,16 @@ const prepare = (self, props = self.props) => {
+     var _resolveAssetUri;
+     clean.href = (_resolveAssetUri = (0, _resolveAssetUri2.resolveAssetUri)(props.href)) === null || _resolveAssetUri === void 0 ? void 0 : _resolveAssetUri.uri;
+   }
+-  return clean;
++  // BLD-1770: strip RN responder-system props that are not valid DOM event
++  // handlers. When hasTouchableProperty is true (e.g. onPress is any truthy
++  // function), these 6 props are conditionally spread into clean{} above.
++  // They then pass through createDOMProps's domProps spread onto SVG <path>
++  // DOM elements, causing React's "Unknown event handler property" warning.
++  // SVG touch handling on web works via onClick (mapped from onPress above),
++  // not through the RN responder system — so discarding these is safe.
++  // eslint-disable-next-line @typescript-eslint/no-unused-vars
++  const { onStartShouldSetResponder: _ossr, onResponderTerminationRequest: _ortr, onResponderGrant: _org, onResponderMove: _orm, onResponderRelease: _orl, onResponderTerminate: _ort, ...cleanStripped } = clean;
++  return cleanStripped;
+ };
+ exports.prepare = prepare;
+ //# sourceMappingURL=prepare.js.map
+\ No newline at end of file
 diff --git a/node_modules/react-native-svg/lib/module/web/utils/prepare.js b/node_modules/react-native-svg/lib/module/web/utils/prepare.js
-index 113eb2b..0703e34 100644
+index 113eb2b..50428ec 100644
 --- a/node_modules/react-native-svg/lib/module/web/utils/prepare.js
 +++ b/node_modules/react-native-svg/lib/module/web/utils/prepare.js
 @@ -26,6 +26,25 @@ export const prepare = (self, props = self.props) => {
@@ -58,3 +77,21 @@ index 113eb2b..0703e34 100644
      ...rest
    } = props;
    const clean = {
+@@ -87,6 +106,15 @@ export const prepare = (self, props = self.props) => {
+     var _resolveAssetUri;
+     clean.href = (_resolveAssetUri = resolveAssetUri(props.href)) === null || _resolveAssetUri === void 0 ? void 0 : _resolveAssetUri.uri;
+   }
+-  return clean;
++  // BLD-1770: strip RN responder-system props that are not valid DOM event
++  // handlers. When hasTouchableProperty is true (e.g. onPress is any truthy
++  // function), these 6 props are conditionally spread into clean{} above.
++  // They then pass through createDOMProps's domProps spread onto SVG <path>
++  // DOM elements, causing React's "Unknown event handler property" warning.
++  // SVG touch handling on web works via onClick (mapped from onPress above),
++  // not through the RN responder system — so discarding these is safe.
++  // eslint-disable-next-line @typescript-eslint/no-unused-vars
++  const { onStartShouldSetResponder: _ossr, onResponderTerminationRequest: _ortr, onResponderGrant: _org, onResponderMove: _orm, onResponderRelease: _orl, onResponderTerminate: _ort, ...cleanStripped } = clean;
++  return cleanStripped;
+ };
+ //# sourceMappingURL=prepare.js.map
+\ No newline at end of file


### PR DESCRIPTION
## Summary

Extends the BLD-1670 react-native-svg patch to also strip six React Native responder-system props (`onStartShouldSetResponder`, `onResponderTerminationRequest`, `onResponderGrant`, `onResponderMove`, `onResponderRelease`, `onResponderTerminate`) from the `clean{}` object in `prepare()` before it reaches `createElement`.

## Root Cause

The BLD-1670 patch (merged in #619) stripped `onPressIn`/`onPressOut`/`onLongPress`/`delay*`/`disabled` from the props destructuring, preventing them from reaching `...rest`. But six responder-system props are added to `clean{}` **after** the destructuring — they are conditionally spread in when `hasTouchableProperty(props)` is true.

`react-native-body-highlighter`'s `Body` component passes `onPress={() => fn?.(part)}` to every `<Path>`. Even when `fn` is `undefined` (as in `MuscleMap` where no `onBodyPartPress` is passed), the arrow function is truthy. So `hasTouchableProperty` returns true for **all** path elements, and all 6 responder props land in `clean{}`.

These then pass through `createDOMProps`'s `domProps` spread (which does not filter them) onto the native SVG `<path>` DOM elements, causing React's "Unknown event handler property" warning — visible as a red error toast in the `bld-480-prefix` fixture.

## Changes

- `patches/react-native-svg+15.15.3.patch`: extend the patch to destructure and discard the 6 `onResponder*` props from `clean{}` before returning in both `commonjs` and `module` builds of `prepare.js`
- `__tests__/patches/react-native-svg-prepare.test.ts`: regression test verifying the patched `prepare()` does not include any of the 7 problematic prop sets in its output

## Testing

Direct node verification passes:
```
Result keys: [ 'ref', 'style', 'onClick' ]
PASS: onClick present
ALL PASS
```

## Issue

Resolves BLD-1770 (recurrence of BLD-1670)