### PR TITLE
test(e2e): isolate per-worker IndexedDB to fix advanced-sets AC#265 flake (BLD-1791)

### DIFF
--- a/__tests__/lib/db/resolve-db-name.test.ts
+++ b/__tests__/lib/db/resolve-db-name.test.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * BLD-1791 — per-worker IndexedDB name resolution (`resolveDbName`).
+ *
+ * Playwright runs every project/worker against the same web origin
+ * (http://localhost:8081), and IndexedDB is keyed by origin — so a fixed DB
+ * name means all workers share ONE persistent SQLite DB. The scenario seed
+ * (`lib/db/test-seed.ts`) clears `workout_sessions`/`workout_sets` at the start
+ * of every load, so a concurrent worker can wipe another worker's seeded rows
+ * mid-test, flaking the AC #265 kill+relaunch persistence assertion.
+ *
+ * The fix lets the Playwright harness inject `window.__E2E_DB_NAME__`, but ONLY
+ * when `navigator.webdriver === true` — the same hardening as the
+ * `__E2E_EXERCISE_FIXTURE__` escape hatch. These tests pin both halves:
+ *   1. Production routing is UNCHANGED — without webdriver (or without the flag)
+ *      the name is always the `cablesnap.db` constant, even if a (malicious)
+ *      `__E2E_DB_NAME__` is set on `window`.
+ *   2. Under webdriver + a valid flag, each worker gets its injected name.
+ *
+ * Verified both directly (pure `resolveDbName()`) and observably through
+ * `getDatabase()` → the name passed to `openDatabaseAsync`.
+ */
+
+import { mockDb, mockDrizzleDb } from "../../helpers/db-test-setup";
+
+const PROD_DB_NAME = "cablesnap.db";
+
+function installDbMocks(): void {
+  jest.doMock("expo-sqlite", () => ({
+    openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+  }));
+  jest.doMock("drizzle-orm/expo-sqlite", () => ({
+    drizzle: jest.fn(() => mockDrizzleDb),
+  }));
+  jest.doMock("react-native", () => ({ Platform: { OS: "web" } }));
+  jest.doMock("../../../lib/seed", () => ({ seedExercises: jest.fn(() => []) }));
+  jest.doMock("expo-crypto", () => ({ randomUUID: jest.fn(() => "test-uuid-1234") }));
+}
+
+describe("resolveDbName (BLD-1791)", () => {
+  const g = globalThis as any;
+  const originalNavigator = g.navigator;
+  const originalWindow = g.window;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete g.__cablesnap_db;
+    delete g.__cablesnap_drizzle;
+    delete g.__cablesnap_init;
+    delete g.__cablesnap_memfb;
+    delete g.__cablesnap_db_failure;
+    delete g.__cablesnap_db_failure_captured;
+    jest.resetModules();
+    installDbMocks();
+  });
+
+  afterEach(() => {
+    g.navigator = originalNavigator;
+    g.window = originalWindow;
+  });
+
+  function setEnv(opts: { webdriver?: boolean; dbName?: unknown }): void {
+    g.navigator = { webdriver: opts.webdriver };
+    g.window = opts.dbName === undefined ? {} : { __E2E_DB_NAME__: opts.dbName };
+  }
+
+  // ---- Pure-function assertions ----
+
+  it("returns the prod constant when navigator.webdriver is false", () => {
+    setEnv({ webdriver: false, dbName: "cablesnap-e2e-w3.db" });
+    const { resolveDbName } = require("../../../lib/db/helpers");
+    expect(resolveDbName()).toBe(PROD_DB_NAME);
+  });
+
+  it("returns the prod constant when navigator.webdriver is undefined", () => {
+    g.navigator = {};
+    g.window = { __E2E_DB_NAME__: "cablesnap-e2e-w3.db" };
+    const { resolveDbName } = require("../../../lib/db/helpers");
+    expect(resolveDbName()).toBe(PROD_DB_NAME);
+  });
+
+  it("honors __E2E_DB_NAME__ only under webdriver", () => {
+    setEnv({ webdriver: true, dbName: "cablesnap-e2e-w2.db" });
+    const { resolveDbName } = require("../../../lib/db/helpers");
+    expect(resolveDbName()).toBe("cablesnap-e2e-w2.db");
+  });
+
+  it("falls back to the prod constant when the flag is absent under webdriver", () => {
+    setEnv({ webdriver: true });
+    const { resolveDbName } = require("../../../lib/db/helpers");
+    expect(resolveDbName()).toBe(PROD_DB_NAME);
+  });
+
+  it("ignores a non-string / empty flag value", () => {
+    const { resolveDbName } = require("../../../lib/db/helpers");
+
+    setEnv({ webdriver: true, dbName: "" });
+    expect(resolveDbName()).toBe(PROD_DB_NAME);
+
+    setEnv({ webdriver: true, dbName: 42 });
+    expect(resolveDbName()).toBe(PROD_DB_NAME);
+
+    setEnv({ webdriver: true, dbName: { malicious: true } });
+    expect(resolveDbName()).toBe(PROD_DB_NAME);
+  });
+
+  // ---- Observable wiring through getDatabase() ----
+
+  it("opens the per-worker DB under webdriver + valid flag", async () => {
+    setEnv({ webdriver: true, dbName: "cablesnap-e2e-w5.db" });
+    const sqlite = require("expo-sqlite");
+    const dbMod = require("../../../lib/db");
+    await dbMod.getDatabase();
+    expect(sqlite.openDatabaseAsync).toHaveBeenCalledWith("cablesnap-e2e-w5.db");
+  });
+
+  it("opens the prod DB when a flag is set WITHOUT webdriver (production safety)", async () => {
+    // Simulates a real user with a console-injected flag: must be ignored.
+    setEnv({ webdriver: false, dbName: "attacker-controlled.db" });
+    const sqlite = require("expo-sqlite");
+    const dbMod = require("../../../lib/db");
+    await dbMod.getDatabase();
+    expect(sqlite.openDatabaseAsync).toHaveBeenCalledWith(PROD_DB_NAME);
+    expect(sqlite.openDatabaseAsync).not.toHaveBeenCalledWith("attacker-controlled.db");
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -69,6 +69,36 @@ export async function enableExerciseFixture(
 }
 
 /**
+ * Give the current Playwright worker its own origin-local IndexedDB SQLite
+ * database so DB-touching scenario specs don't contend on the shared
+ * `cablesnap.db` (BLD-1791).
+ *
+ * Background: every Playwright project/worker hits the same web origin
+ * (http://localhost:8081), and IndexedDB is keyed by origin — so by default all
+ * workers share ONE persistent SQLite DB. `lib/db/test-seed.ts` clears
+ * `workout_sessions`/`workout_sets` at the start of every scenario load, so a
+ * concurrent worker can wipe another worker's seeded rows mid-test. That flakes
+ * the AC #265 kill+relaunch persistence assertion, which seeds rows and then
+ * reloads expecting them to survive.
+ *
+ * The app honors `window.__E2E_DB_NAME__` ONLY when `navigator.webdriver` is
+ * true (see `resolveDbName()` in lib/db/helpers.ts), the same hardening as the
+ * exercises fixture — production users are never affected.
+ *
+ * Call once per page context, BEFORE the first `goto()` (addInitScript only
+ * applies to subsequent navigations). Pass `testInfo.parallelIndex` so each
+ * worker gets a stable, unique name (it persists across `page.reload()` because
+ * the origin/IndexedDB key is unchanged — only the DB *name* differs per
+ * worker, which is exactly what isolates them).
+ */
+export async function enablePerWorkerDb(page: Page, parallelIndex: number) {
+  const dbName = `cablesnap-e2e-w${parallelIndex}.db`;
+  await page.addInitScript((name) => {
+    (window as unknown as Record<string, unknown>).__E2E_DB_NAME__ = name;
+  }, dbName);
+}
+
+/**
  * Run axe-core and assert zero critical accessibility violations.
  * Serious violations are attached as annotations (warnings) to the test.
  * Critical violations cause a hard failure.

--- a/e2e/scenarios/advanced-sets.spec.ts
+++ b/e2e/scenarios/advanced-sets.spec.ts
@@ -16,6 +16,7 @@
  */
 import { test, expect } from "@playwright/test";
 import * as path from "path";
+import { enablePerWorkerDb } from "../helpers";
 
 const SCENARIO = "advanced-sets";
 const OUT_DIR = path.resolve(
@@ -50,6 +51,14 @@ test.describe("@scenario advanced-sets", () => {
       !process.env.E2E_USE_STATIC,
       "requires E2E_USE_STATIC=1 — dev server lacks COOP/COEP headers, rendering WebUnsupportedScreen instead of the app. See e2e/README.md.",
     );
+  });
+
+  // BLD-1791: isolate each parallel worker's IndexedDB SQLite DB so the AC #265
+  // kill+relaunch persistence test (which seeds rows then reloads expecting them
+  // to survive) is not raced by a sibling spec's seedScenario() clearing the
+  // shared `cablesnap.db` tables. Registers BEFORE any goto in every test.
+  test.beforeEach(async ({ page }, testInfo) => {
+    await enablePerWorkerDb(page, testInfo.parallelIndex);
   });
 
   test("help screen renders all three advanced set type entries", async ({ page }) => {
@@ -184,9 +193,12 @@ test.describe("@scenario advanced-sets", () => {
 
   // AC #265 — kill+relaunch simulation using real page.reload().
   //
-  // The web DB primary path is `openDatabaseAsync("cablesnap.db")` (lib/db/helpers.ts:64)
-  // which uses IndexedDB-backed SQLite on Chromium — data SURVIVES page.reload() within
-  // the same browser context.
+  // The web DB primary path opens an IndexedDB-backed SQLite database via
+  // `openDatabaseAsync(resolveDbName())` (lib/db/helpers.ts) — data SURVIVES
+  // page.reload() within the same browser context. Under Playwright the name is
+  // this worker's isolated `cablesnap-e2e-w<idx>.db` (BLD-1791, via the
+  // beforeEach above), so a concurrent worker's seedScenario() table-clear can't
+  // wipe these rows between the seed and the post-reload assertion.
   //
   // Seed strategy: use page.evaluate() to inject __TEST_SCENARIO__ into the LIVE page
   // BEFORE useAppInit fires (via addInitScript for first load only), then on reload
@@ -246,8 +258,23 @@ test.describe("@scenario advanced-sets", () => {
     // - net result: no __TEST_SCENARIO__ → guardsAllow()=false → seedScenario() no-op
     // - IndexedDB rows from first load persist → useSessionDetail renders them
     await page.reload();
-    // No data-test-ready signal (seedScenario didn't run); wait on actual content.
-    await expect(page.getByText("RP")).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText("100 × 8+3+2 (13)")).toBeVisible();
+
+    // After reload there is NO data-test-ready signal (seedScenario is a no-op
+    // by design), so we must wait on real content. BLD-1791: on reload the
+    // expo-sqlite WASM worker is COLD — useSessionDetail's drizzle sync reads
+    // race the worker warm-up (BLD-1636), and under multi-worker CPU contention
+    // that warm-up + first read can exceed a tight timeout. The failure mode is
+    // NOT data loss (the persisted `workout_sessions` row renders the screen
+    // header immediately); it is the rest_pause set chip rendering a few seconds
+    // later once the cold worker drains the sets query. So we anchor on the
+    // session header first (proves persistence + screen mount), THEN assert the
+    // chip and decomposition with a cold-worker-tolerant timeout.
+    await expect(
+      page.getByRole("heading", { name: "Advanced Sets E2E Session" }),
+    ).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("RP")).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByText("100 × 8+3+2 (13)")).toBeVisible({
+      timeout: 20_000,
+    });
   });
 });

--- a/e2e/scenarios/completed-workout-prefix.spec.ts
+++ b/e2e/scenarios/completed-workout-prefix.spec.ts
@@ -24,6 +24,7 @@
 import { test, expect } from "@playwright/test";
 import * as path from "path";
 import { captureWithCvd } from "./capture-with-cvd";
+import { enablePerWorkerDb } from "../helpers";
 
 const SCENARIO = "bld-480-prefix";
 // Reuse the existing `completed-workout` seed so the fixture route
@@ -44,6 +45,13 @@ test.describe("@scenario bld-480-prefix", () => {
       testInfo.project.name !== "mobile",
       "v1: mobile viewport only (TL#4)",
     );
+  });
+
+  // BLD-1791: per-worker DB isolation so this spec's seedScenario() table-clear
+  // (reuses the `completed-workout` seed) can't race a sibling DB-touching spec
+  // on the shared `cablesnap.db`.
+  test.beforeEach(async ({ page }, testInfo) => {
+    await enablePerWorkerDb(page, testInfo.parallelIndex);
   });
 
   test("captures BLD-480 pre-fix MusclesWorkedCard reproducer", async ({ page }) => {

--- a/e2e/scenarios/completed-workout.spec.ts
+++ b/e2e/scenarios/completed-workout.spec.ts
@@ -16,6 +16,7 @@
 import { test, expect } from "@playwright/test";
 import * as path from "path";
 import { captureWithCvd } from "./capture-with-cvd";
+import { enablePerWorkerDb } from "../helpers";
 
 const SCENARIO = "completed-workout";
 const SESSION_ID = "scenario-session-1";
@@ -33,6 +34,12 @@ test.describe("@scenario completed-workout", () => {
       testInfo.project.name !== "mobile",
       "v1: mobile viewport only (TL#4)",
     );
+  });
+
+  // BLD-1791: per-worker DB isolation so this spec's seedScenario() table-clear
+  // can't race a sibling DB-touching spec on the shared `cablesnap.db`.
+  test.beforeEach(async ({ page }, testInfo) => {
+    await enablePerWorkerDb(page, testInfo.parallelIndex);
   });
 
   test("captures post-workout summary screen", async ({ page }) => {

--- a/e2e/scenarios/workout-history.spec.ts
+++ b/e2e/scenarios/workout-history.spec.ts
@@ -12,6 +12,7 @@
 import { test, expect } from "@playwright/test";
 import * as path from "path";
 import { captureWithCvd } from "./capture-with-cvd";
+import { enablePerWorkerDb } from "../helpers";
 
 const SCENARIO = "workout-history";
 const OUT_DIR = path.resolve(
@@ -27,6 +28,12 @@ test.describe("@scenario workout-history", () => {
       testInfo.project.name !== "mobile",
       "v1: mobile viewport only (TL#4)",
     );
+  });
+
+  // BLD-1791: per-worker DB isolation so this spec's seedScenario() table-clear
+  // can't race a sibling DB-touching spec on the shared `cablesnap.db`.
+  test.beforeEach(async ({ page }, testInfo) => {
+    await enablePerWorkerDb(page, testInfo.parallelIndex);
   });
 
   test("captures populated workout history", async ({ page }) => {

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -106,6 +106,38 @@ function devCountQuery(kind: string): void {
 
 const DB_NAME = "cablesnap.db";
 
+/**
+ * BLD-1791: resolve the IndexedDB database name. In production this is always
+ * the fixed {@link DB_NAME} constant. Under Playwright the web origin (and thus
+ * the IndexedDB store) is shared across all parallel workers, so a fixed name
+ * means every worker hammers ONE persistent SQLite DB. The scenario seed
+ * (`lib/db/test-seed.ts`) clears `workout_sessions`/`workout_sets` at the start
+ * of every load, so a concurrent worker can wipe another worker's seeded rows
+ * mid-test — flaking the AC #265 kill+relaunch persistence assertion.
+ *
+ * To give each worker an isolated origin-local DB we let the test harness inject
+ * a per-worker name via `window.__E2E_DB_NAME__`. The override is honored ONLY
+ * when `navigator.webdriver === true` — the same hardening used by the
+ * `__E2E_EXERCISE_FIXTURE__` escape hatch (lib/db/exercises.ts). A real user
+ * never has `navigator.webdriver`, and a console-injected flag is ignored, so
+ * production data routing is unaffected. `:memory:` is intentionally NOT
+ * overridable here — that fallback path is for crossOriginIsolated failures and
+ * must stay deterministic.
+ *
+ * Exported for unit tests (mirrors the `guardsAllow()` convention in
+ * lib/db/test-seed.ts).
+ */
+export function resolveDbName(): string {
+  if (typeof navigator === "undefined") return DB_NAME;
+  const nav = navigator as Navigator & { webdriver?: boolean };
+  if (!nav.webdriver) return DB_NAME;
+  if (typeof window === "undefined") return DB_NAME;
+  const override = (window as unknown as { __E2E_DB_NAME__?: unknown })
+    .__E2E_DB_NAME__;
+  if (typeof override === "string" && override.length > 0) return override;
+  return DB_NAME;
+}
+
 // Store singleton on globalThis so hot-reload doesn't orphan connections
 const g = globalThis as unknown as {
   __cablesnap_db?: SQLite.SQLiteDatabase;
@@ -187,11 +219,14 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
   let pending = getInit();
   if (!pending) {
     pending = (async () => {
-      dbBreadcrumb("init_start", { db_name: DB_NAME });
+      // BLD-1791: resolve once so the open call and every breadcrumb agree on
+      // the effective name (prod == DB_NAME; under Playwright == per-worker name).
+      const dbName = resolveDbName();
+      dbBreadcrumb("init_start", { db_name: dbName });
       let openedInstance: SQLite.SQLiteDatabase | null = null;
       let currentPhase: DatabaseUnavailablePhase = "open";
       try {
-        openedInstance = await SQLite.openDatabaseAsync(DB_NAME);
+        openedInstance = await SQLite.openDatabaseAsync(dbName);
         const instance = openedInstance;
         // BLD-1257: sanity probe BEFORE any pragma/migration so a null/broken
         // native handle (Sentry REACT-NATIVE-7 NPE) is detected as
@@ -209,7 +244,7 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
         // undoCsvImport prevent dangling rows. Prerequisite for BLD-1092
         // ON DELETE CASCADE on workout_sessions → workout_sets → set_media.
         await instance.execAsync("PRAGMA foreign_keys = ON");
-        dbBreadcrumb("pre_migrate", { db_name: DB_NAME });
+        dbBreadcrumb("pre_migrate", { db_name: dbName });
         currentPhase = "migrate";
         try {
           await migrate(instance);
@@ -217,7 +252,7 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
           const error = migrateErr instanceof Error ? migrateErr : new Error(String(migrateErr));
           throw error;
         }
-        dbBreadcrumb("post_migrate", { db_name: DB_NAME });
+        dbBreadcrumb("post_migrate", { db_name: dbName });
         currentPhase = "seed";
         try {
           await seed(instance);
@@ -303,7 +338,7 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
         const dbError = new DatabaseUnavailableError(currentPhase, rawError);
         const sentryEventId = captureDatabaseFailureOnce(dbError, {
           phase: currentPhase,
-          db_name: DB_NAME,
+          db_name: dbName,
           error_message: rawError.message,
           error_stack: rawError.stack,
         });


### PR DESCRIPTION
## What

Fix the BLD-1791 test-isolation flake: under multi-worker Playwright, the `advanced-sets` AC#265 kill+relaunch persistence test (and its siblings) race on a **shared IndexedDB-backed SQLite DB**.

All scenario specs hit the same web origin (`localhost:8081`), and IndexedDB is keyed by origin — so by default every worker shares ONE persistent `cablesnap.db`. `seedScenario()` (`lib/db/test-seed.ts`) `DELETE`s `workout_sessions`/`workout_sets` at the start of every load, so a concurrent worker can wipe another worker's seeded rows mid-test, flaking the AC#265 reload assertion.

## How

Give each Playwright worker its own origin-local DB:

- **`lib/db/helpers.ts`** — new `resolveDbName()`. Honors `window.__E2E_DB_NAME__` **only when `navigator.webdriver === true`** (the same hardening as the existing `__E2E_EXERCISE_FIXTURE__` escape hatch). Production routing is unchanged: a real user — or a console-injected flag without webdriver — always gets the fixed `cablesnap.db`. `getDatabase()` resolves the name once so the open call and every Sentry breadcrumb agree.
- **`e2e/helpers.ts`** — new `enablePerWorkerDb(page, parallelIndex)` injects `cablesnap-e2e-w<idx>.db` via `addInitScript` before the first `goto()`. The name persists across `page.reload()` (origin/IndexedDB key unchanged — only the DB *name* differs per worker), which is exactly what isolates them while preserving the kill+relaunch semantics.
- **4 DB-touching scenario specs** (`advanced-sets`, `completed-workout`, `completed-workout-prefix`, `workout-history`) add a `beforeEach` calling the helper.
- **AC#265 kill+relaunch test** — anchor on the session header first (proves persistence + mount), then assert the rest_pause chip with cold-worker-tolerant 20s timeouts (defensive vs the BLD-1636 cold WASM worker warm-up).

## Tests

New `__tests__/lib/db/resolve-db-name.test.ts` — 7 cases pinning **production safety** (flag ignored without `webdriver`, non-string/empty rejected) and the override path, verified both directly (`resolveDbName()`) and observably through `getDatabase()` → the name passed to `openDatabaseAsync`.

```
PASS __tests__/lib/db/resolve-db-name.test.ts  (7 passed)
eslint: No issues found
tsc --noEmit: clean
```

### E2E verification (`E2E_USE_STATIC=1`, `mobile`+`mobile-narrow`, the 4 DB-touching specs)

| workers | main (baseline) | this PR |
|--------:|:---------------:|:-------:|
| 1 (CI-canonical) | green | **15 / 15 green** |
| 2 | (fails) | 14 / 15 |
| 4 | **4 pass / ~10 fail** | 10 pass / 5 fail |

The fix takes the canonical CI config (`workers: 1`, `playwright.config.ts:9`) to fully green and is a large improvement under multi-worker dev. The **residual** high-worker failures are a *different* root cause — the expo-sqlite WASM worker cold-boot starving under concurrent `getDatabase()` (BLD-1636 family), where `data-test-ready` never fires. That is independent of data isolation and is tracked as a follow-up; it is **not** in scope for this DB-isolation ticket.

## Scope / safety

- Production data routing is unchanged and unit-pinned.
- No product code behavior change for real users — the only non-test edit (`resolveDbName`) is a no-op outside `navigator.webdriver`.
- Does not touch the unrelated stray `.plans/PLAN-BLD-1643.md` left in the tree.

Closes BLD-1791 (Layer 1). Follow-up filed for Layer 2 (WASM cold-boot).
