### PR TITLE
test(e2e): bounded retry for scenario seed under high worker counts (BLD-1796)

### DIFF
--- a/__tests__/lib/db/scenario-seed-retry.test.ts
+++ b/__tests__/lib/db/scenario-seed-retry.test.ts
@@ -1,0 +1,167 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * BLD-1796 — bounded scenario-seed retry gate.
+ *
+ * Under high Playwright worker counts (BLD-1791 gives each worker its OWN cold
+ * WASM-SQLite DB on a SHARED `npx serve` static origin), the scenario seed that
+ * `hooks/useAppInit.ts` runs after DB init flakes transiently while N workers
+ * cold-boot at once: the lazy `test-seed` chunk is dropped ("Failed to fetch")
+ * and/or the seed's drizzle writes hit the BLD-1636 sync busy-wait budget
+ * ("Sync operation timeout"). Either leaves `data-test-ready` unset, timing out
+ * every seed-dependent scenario spec.
+ *
+ * The fix retries the import+seed a bounded number of times — but ONLY under a
+ * WebDriver-controlled browser (`navigator.webdriver === true`), so production
+ * and manual dev-web are byte-for-byte unchanged. These tests pin both halves:
+ *   1. PRODUCTION/native SAFETY — without webdriver the retry is inert (exactly
+ *      one attempt), mirroring the `resolveDbName()` test-gate convention.
+ *   2. Under webdriver — bounded retry fires only on the transient signatures,
+ *      surfaces non-transient errors immediately, and surfaces the original
+ *      error after the budget is exhausted (no new permanent hang / no swallow).
+ *
+ * `react-native` is mocked to web so importing `test-seed` (which pulls
+ * `./helpers` → `./sets`) does not drag in the native SQLite stack.
+ */
+
+import { mockDb, mockDrizzleDb } from "../../helpers/db-test-setup";
+
+function installDbMocks(): void {
+  jest.doMock("expo-sqlite", () => ({
+    openDatabaseAsync: jest.fn(() => Promise.resolve(mockDb)),
+  }));
+  jest.doMock("drizzle-orm/expo-sqlite", () => ({
+    drizzle: jest.fn(() => mockDrizzleDb),
+  }));
+  jest.doMock("react-native", () => ({ Platform: { OS: "web" } }));
+  jest.doMock("../../../lib/seed", () => ({ seedExercises: jest.fn(() => []) }));
+  jest.doMock("expo-crypto", () => ({ randomUUID: jest.fn(() => "test-uuid-1234") }));
+}
+
+describe("scenario-seed retry gate (BLD-1796)", () => {
+  const g = globalThis as any;
+  const originalNavigator = g.navigator;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    installDbMocks();
+    // Default: NOT under webdriver (production-like).
+    g.navigator = { webdriver: false };
+  });
+
+  afterEach(() => {
+    g.navigator = originalNavigator;
+    jest.useRealTimers();
+  });
+
+  function load() {
+    return require("../../../lib/db/test-seed") as typeof import("../../../lib/db/test-seed");
+  }
+
+  // ---- scenarioSeedRetryEnabled(): the production/native safety gate ----
+
+  describe("scenarioSeedRetryEnabled()", () => {
+    it("is false when navigator.webdriver is false (production safety)", () => {
+      g.navigator = { webdriver: false };
+      expect(load().scenarioSeedRetryEnabled()).toBe(false);
+    });
+
+    it("is false when navigator.webdriver is undefined", () => {
+      g.navigator = {};
+      expect(load().scenarioSeedRetryEnabled()).toBe(false);
+    });
+
+    it("is false when navigator is undefined (native / SSR)", () => {
+      g.navigator = undefined;
+      expect(load().scenarioSeedRetryEnabled()).toBe(false);
+    });
+
+    it("is true only under a WebDriver-controlled browser", () => {
+      g.navigator = { webdriver: true };
+      expect(load().scenarioSeedRetryEnabled()).toBe(true);
+    });
+  });
+
+  // ---- isTransientScenarioSeedError(): signature classification ----
+
+  describe("isTransientScenarioSeedError()", () => {
+    it.each([
+      ["Sync operation timeout message", new Error("Sync operation timeout after 5000ms")],
+      ["Failed to fetch (dropped lazy chunk)", new Error("Failed to fetch")],
+      ["Load failed (WebKit fetch wording)", new Error("Load failed")],
+      ["NetworkError", new Error("NetworkError when attempting to fetch resource")],
+    ])("classifies %s as transient", (_label, err) => {
+      expect(load().isTransientScenarioSeedError(err)).toBe(true);
+    });
+
+    it("classifies an error tagged SyncOperationTimeoutError by name", () => {
+      const err = new Error("anything");
+      err.name = "SyncOperationTimeoutError";
+      expect(load().isTransientScenarioSeedError(err)).toBe(true);
+    });
+
+    it("does NOT classify a genuine programming error as transient", () => {
+      expect(load().isTransientScenarioSeedError(new Error("no such table: workout_sets"))).toBe(
+        false,
+      );
+      expect(load().isTransientScenarioSeedError(new TypeError("x is not a function"))).toBe(false);
+    });
+
+    it("does NOT classify non-Error throwables as transient", () => {
+      expect(load().isTransientScenarioSeedError("Failed to fetch")).toBe(false);
+      expect(load().isTransientScenarioSeedError(undefined)).toBe(false);
+      expect(load().isTransientScenarioSeedError(null)).toBe(false);
+    });
+  });
+
+  // ---- runScenarioSeedWithRetry(): bounded retry behavior ----
+
+  describe("runScenarioSeedWithRetry()", () => {
+    it("runs the thunk exactly once on success", async () => {
+      const thunk = jest.fn().mockResolvedValue(undefined);
+      await load().runScenarioSeedWithRetry(thunk);
+      expect(thunk).toHaveBeenCalledTimes(1);
+    });
+
+    it("runs exactly ONE attempt outside webdriver, even on a transient error (production safety)", async () => {
+      g.navigator = { webdriver: false };
+      const thunk = jest.fn().mockRejectedValue(new Error("Failed to fetch"));
+      await expect(load().runScenarioSeedWithRetry(thunk)).rejects.toThrow("Failed to fetch");
+      expect(thunk).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries a transient failure then succeeds under webdriver", async () => {
+      g.navigator = { webdriver: true };
+      const thunk = jest
+        .fn()
+        .mockRejectedValueOnce(new Error("Failed to fetch"))
+        .mockRejectedValueOnce(new Error("Sync operation timeout"))
+        .mockResolvedValueOnce(undefined);
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+      await load().runScenarioSeedWithRetry(thunk);
+      expect(thunk).toHaveBeenCalledTimes(3);
+      warn.mockRestore();
+    });
+
+    it("surfaces a NON-transient error immediately without retrying", async () => {
+      g.navigator = { webdriver: true };
+      const thunk = jest.fn().mockRejectedValue(new Error("no such table: workout_sets"));
+      await expect(load().runScenarioSeedWithRetry(thunk)).rejects.toThrow(
+        "no such table: workout_sets",
+      );
+      expect(thunk).toHaveBeenCalledTimes(1);
+    });
+
+    it("surfaces the original error after the retry budget is exhausted (no hang, no swallow)", async () => {
+      g.navigator = { webdriver: true };
+      const thunk = jest.fn().mockRejectedValue(new Error("Sync operation timeout"));
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+      await expect(load().runScenarioSeedWithRetry(thunk)).rejects.toThrow(
+        "Sync operation timeout",
+      );
+      // Bounded: 5 attempts max (the SCENARIO_SEED_MAX_ATTEMPTS budget).
+      expect(thunk).toHaveBeenCalledTimes(5);
+      warn.mockRestore();
+    });
+  });
+});

--- a/hooks/useAppInit.ts
+++ b/hooks/useAppInit.ts
@@ -18,6 +18,55 @@ function webNeedsUnsupportedFallback(): boolean {
   return !detectWebSharedMemorySupport().supported;
 }
 
+// BLD-1796: dev/test-only. Load the lazy `test-seed` chunk and run the scenario
+// seed, retrying the DYNAMIC IMPORT on a transient "Failed to fetch" (the chunk
+// dropped by the shared `npx serve` static origin under N concurrently
+// cold-booting Playwright workers). A rejected dynamic import is not cached, so
+// re-`import()`ing genuinely re-fetches the chunk. Once the module is loaded,
+// `runScenarioSeedWithRetry` owns the (also-bounded) retry of `seedScenario()`
+// itself — that covers the "Sync operation timeout" class on the seed's drizzle
+// writes. Both retries are inert outside WebDriver (single attempt), and this
+// whole helper is only reached from an `if (__DEV__)` block, so production is
+// untouched. Kept thin and self-contained: its loop must NOT depend on the lazy
+// module it is trying to load.
+const SEED_IMPORT_MAX_ATTEMPTS = 5;
+const SEED_IMPORT_RETRY_BACKOFF_MS = 150;
+
+function seedImportRetryEnabled(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const nav = navigator as Navigator & { webdriver?: boolean };
+  return nav.webdriver === true;
+}
+
+async function runScenarioSeedWithImportRetry(): Promise<void> {
+  const maxAttempts = seedImportRetryEnabled() ? SEED_IMPORT_MAX_ATTEMPTS : 1;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const mod = await import("../lib/db/test-seed");
+      // Module loaded — delegate to its bounded seedScenario retry (handles the
+      // "Sync operation timeout" class). A non-transient seed error throws out.
+      await mod.runScenarioSeedWithRetry(() => mod.seedScenario());
+      return;
+    } catch (err) {
+      const isFetchFailure =
+        err instanceof Error &&
+        (err.message.includes("Failed to fetch") ||
+          err.message.includes("Load failed") ||
+          err.message.includes("NetworkError"));
+      // Only the IMPORT failure is handled here; once `mod` loaded,
+      // runScenarioSeedWithRetry has already classified/rethrown seed errors, so
+      // any error reaching here after a successful import is non-transient.
+      if (attempt === maxAttempts || !isFetchFailure) throw err;
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[test-seed] transient test-seed import failure (attempt ${attempt}/${maxAttempts}), retrying:`,
+        err.message,
+      );
+      await new Promise((resolve) => setTimeout(resolve, SEED_IMPORT_RETRY_BACKOFF_MS));
+    }
+  }
+}
+
 export function useAppInit() {
   // Capability is a property of the JS runtime + document isolation
   // state; it does not change across re-renders for a given session,
@@ -55,9 +104,21 @@ export function useAppInit() {
         // `__TEST_SCENARIO__` string from production bundles — enforced by
         // `scripts/verify-scenario-hook-not-in-bundle.sh`.
         if (__DEV__) {
+          // BLD-1796: under Playwright (navigator.webdriver) the lazy import +
+          // seed is retried on transient failures — "Failed to fetch" (the lazy
+          // `test-seed` chunk dropped by the shared `npx serve` static origin
+          // under N concurrently cold-booting workers) and "Sync operation
+          // timeout" (the seed's drizzle writes hitting the BLD-1636 sync
+          // busy-wait budget on a still-contended worker). Both otherwise leave
+          // `data-test-ready` unset and flake every seed-dependent scenario spec
+          // at high worker counts. The retry loop wraps the dynamic import
+          // itself, because a REJECTED dynamic import is not cached — a retry
+          // genuinely re-fetches the chunk. Outside WebDriver this is a single
+          // attempt (no behavior change); the whole block is dev-only, so
+          // production is untouched. `seedScenario()` is idempotent
+          // (DELETE-then-reinsert fixed-id rows), so re-running it is safe.
           try {
-            const { seedScenario } = await import("../lib/db/test-seed");
-            await seedScenario();
+            await runScenarioSeedWithImportRetry();
           } catch (err) {
             console.warn("[test-seed] scenario seed failed:", err);
             // Surface seed errors in E2E test runs so error-context snapshots capture the cause.

--- a/lib/db/test-seed.ts
+++ b/lib/db/test-seed.ts
@@ -53,6 +53,104 @@ export function guardsAllow(): boolean {
   return true;
 }
 
+// BLD-1796: bounded retry around the scenario-seed step.
+//
+// Under high Playwright worker counts (BLD-1791 gives each worker its OWN cold
+// WASM-SQLite DB on a SHARED `npx serve` static origin), the scenario seed that
+// `hooks/useAppInit.ts` runs after DB init flakes in two transient ways while N
+// workers cold-boot at once:
+//   1. "Failed to fetch (localhost:8081)" — the lazy `import("./test-seed")`
+//      chunk (or a WASM/asset request) is dropped by the static server under
+//      concurrent request pressure.
+//   2. "Sync operation timeout" — `seedScenario()`'s drizzle writes
+//      (`seedAdvancedSets` → `bulkInsertSegments`, the table-clear DELETEs) hit
+//      the BLD-1636 synchronous busy-wait budget on a still-contended worker.
+// Either leaves `data-test-ready` unset, timing out every seed-dependent spec.
+//
+// `seedScenario()` is idempotent (it DELETEs the scenario-mutable tables then
+// re-inserts fixed-id rows), so re-running the whole import+seed is safe. We
+// retry ONLY on these transient signatures with a short backoff; a genuine
+// programming error (unknown scenario, schema bug) is NOT transient and surfaces
+// immediately on the first attempt.
+const SCENARIO_SEED_MAX_ATTEMPTS = 5;
+const SCENARIO_SEED_RETRY_BACKOFF_MS = 150;
+
+/**
+ * BLD-1796: true only when the bounded scenario-seed retry should be active —
+ * i.e. running under a WebDriver-controlled browser (Playwright sets
+ * `navigator.webdriver === true`). Mirrors the `resolveDbName()` /
+ * `asyncOpen*` test-gate convention: outside WebDriver (manual dev-web, and —
+ * belt-and-suspenders — production, where this whole module is Metro-stripped)
+ * the retry is inert, so behavior is unchanged. Exported for unit tests.
+ */
+export function scenarioSeedRetryEnabled(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const nav = navigator as Navigator & { webdriver?: boolean };
+  return nav.webdriver === true;
+}
+
+/**
+ * BLD-1796: classify an error as a transient, retry-worthy scenario-seed
+ * failure. Matches the two signatures observed under high-worker-count
+ * contention (see {@link SCENARIO_SEED_MAX_ATTEMPTS} comment). Exported for
+ * unit tests.
+ */
+export function isTransientScenarioSeedError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  // BLD-1636 sync busy-wait timeout (the patched expo-sqlite tags the throw with
+  // this name; we also match the message if the patch is ever dropped).
+  if (err.name === "SyncOperationTimeoutError") return true;
+  const msg = err.message;
+  return (
+    msg.includes("Sync operation timeout") ||
+    // Lazy-chunk / WASM / asset fetch dropped by the static server under load.
+    msg.includes("Failed to fetch") ||
+    msg.includes("Load failed") || // Safari/WebKit wording for a failed fetch
+    msg.includes("NetworkError")
+  );
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * BLD-1796: run the scenario-seed thunk (`import + seedScenario`) with a bounded
+ * retry on transient errors. Used by `hooks/useAppInit.ts`. The thunk owns the
+ * dynamic import so a "Failed to fetch" on the lazy chunk itself is retried too.
+ *
+ * - Outside WebDriver: exactly ONE attempt (no behavior change).
+ * - Under WebDriver: up to {@link SCENARIO_SEED_MAX_ATTEMPTS} attempts, retrying
+ *   only when {@link isTransientScenarioSeedError} holds, with a short backoff
+ *   that yields the macrotask so a contended worker / saturated static server
+ *   can recover. A non-transient error, or budget exhaustion, throws so the
+ *   caller still records `data-test-ready`'s absence / `testSeedError` (no new
+ *   permanent hang, no swallowed real bug).
+ *
+ * Exported for unit tests.
+ */
+export async function runScenarioSeedWithRetry(
+  seedThunk: () => Promise<void>,
+): Promise<void> {
+  const maxAttempts = scenarioSeedRetryEnabled() ? SCENARIO_SEED_MAX_ATTEMPTS : 1;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await seedThunk();
+      return;
+    } catch (err) {
+      if (attempt === maxAttempts || !isTransientScenarioSeedError(err)) {
+        throw err;
+      }
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[test-seed] transient scenario-seed failure (attempt ${attempt}/${maxAttempts}), retrying:`,
+        err instanceof Error ? err.message : String(err),
+      );
+      await delay(SCENARIO_SEED_RETRY_BACKOFF_MS);
+    }
+  }
+}
+
 export async function seedScenario(): Promise<void> {
   if (!guardsAllow()) return;
 


### PR DESCRIPTION
## Summary

Under high Playwright worker counts, seed-dependent scenario specs (`completed-workout`, `workout-history`, `completed-workout-prefix`, `advanced-sets`) flake: `body[data-test-ready=true]` never appears because the scenario seed run by `hooks/useAppInit.ts` fails transiently while N workers cold-boot at once.

BLD-1791 (#629) gives each worker its OWN cold WASM-SQLite DB on a SHARED `npx serve` static origin. That correct data-isolation trade exposes two transient failure modes under concurrency:

1. **`Failed to fetch`** — the lazy `import("./test-seed")` chunk is dropped by the static server under concurrent request pressure.
2. **`Sync operation timeout`** — `seedScenario()`'s drizzle writes hit the BLD-1636 synchronous busy-wait budget on a still-contended worker.

Either leaves `data-test-ready` unset, timing out every seed-dependent spec. Measured pre-fix (per issue): workers=1 → 15/15; workers=4 → 10/15.

## Fix

A **bounded retry** of the import+seed, **gated on `navigator.webdriver === true`** (the BLD-1791 convention) so production and manual dev-web are byte-for-byte unchanged.

- The retry wraps the **dynamic import itself** — a rejected dynamic import is not cached, so a retry genuinely re-fetches the dropped chunk.
- Seed-step retry is delegated to `runScenarioSeedWithRetry`, which retries only on the two transient signatures.
- `seedScenario()` is idempotent (DELETE-then-reinsert fixed-id rows), so re-running is safe.
- Retry budget is **finite (5 attempts)**; on exhaustion the original error surfaces → **no new permanent hang, no swallowed real bug**. The existing web `:memory:` fallback / `testSeedError` dataset path is preserved.

## Note on approach (vs. issue scope)

The issue scoped suggested fix #1 (bounded async-open retry inside `getDatabase()` at `helpers.ts:229-236`). Baseline runs surfaced that the *actual* failing signatures are the chunk-fetch drop and the seed's sync-write timeout — the async open/probe was already passing. So the retry is placed at the **seed call site** where the flake manifests. This is the issue's documented "adjust / fall back and note it" path.

## Production / native safety

The whole seed block lives inside `if (__DEV__)` (Metro-stripped in prod). Outside WebDriver the retry is **exactly one attempt** — no behavior change. A unit test asserts `scenarioSeedRetryEnabled()` is `false` when `navigator.webdriver !== true` (and that `runScenarioSeedWithRetry` makes a single attempt off-WebDriver), mirroring the `resolveDbName()` production-safety convention.

## Tests

`__tests__/lib/db/scenario-seed-retry.test.ts` — **16 tests**:
- `scenarioSeedRetryEnabled()` inert off-WebDriver / native / undefined-navigator; true only under WebDriver.
- `isTransientScenarioSeedError()` classification (the 4 message signatures + the `SyncOperationTimeoutError` name; rejects genuine programming errors and non-Error throwables).
- `runScenarioSeedWithRetry()` — single attempt on success; **single attempt off-WebDriver even on transient error** (production safety); retries-then-succeeds under WebDriver; non-transient error surfaces immediately; **original error surfaces after the 5-attempt budget is exhausted**.

## Verification

- ✅ `npm run typecheck` — clean
- ✅ `eslint` (changed files) — 0 warnings / 0 errors
- ✅ Unit suite (db + useAppInit areas): **790/790 across 81 suites**, incl. the 16 new tests
- Bundle-leak gate (`verify-scenario-hook-not-in-bundle.sh`) + the workers=4 ×3 headless Playwright matrix: the import stays behind `if (__DEV__)` (bundle hygiene unchanged) and CI runs the full matrix. Local headless repro results appended to the issue thread.

## Acceptance criteria

- [x] Production/native path provably unchanged (gate off when `navigator.webdriver` false; unit-tested)
- [x] `npm run typecheck` clean, `npm run lint` no new warnings, full unit suite green
- [x] No new permanent-hang / failure surface — finite budget, existing fallback preserved
- [ ] ≥14/15 at workers=4 across 3 runs (CI / headless matrix — see issue thread)
- [ ] workers=1 still 15/15 (zero regression — CI-canonical config)

Refs: BLD-1796. Depends on BLD-1791 (#629, merged).

🤖 Generated with [opencode](https://opencode.ai)