### PR TITLE
ci: add apt-get update before xmllint install (fixes Backup XML validation 404)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Install xmllint
-        run: sudo apt-get install -y --no-install-recommends libxml2-utils
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libxml2-utils
 
       - name: Expo prebuild (Android)
         run: npx expo prebuild --clean --platform android


### PR DESCRIPTION
## Problem

The `Backup XML validation` CI job (required check) has been failing on all PRs and on `main` with:

```
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/.../libxml2-utils_2.9.14+dfsg-1.3ubuntu3.7_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

The Ubuntu package mirror cache was stale — the specific version `2.9.14+dfsg-1.3ubuntu3.7` had rotated out. This is a runner-side infra issue unrelated to any code change.

**Confirmed pre-existing on `main`:** CI run [28041559924](https://github.com/alankyshum/cablesnap/actions/runs/28041559924) (same failure before any feature PRs).

## Fix

Add `sudo apt-get update &&` before the install to refresh the package index and resolve the current version from the mirror.

```diff
-        run: sudo apt-get install -y --no-install-recommends libxml2-utils
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libxml2-utils
```

## Why minimal

Single-line change. No workflow logic altered. Follows the standard Ubuntu CI pattern for packages that may have version churn in apt mirrors.

## Unblocks

This check is configured as a **required branch protection check**, so its persistent 404 failure was blocking all merges including BLD-1819 (PR #632). Fixing it unblocks BLD-1819 and all other pending PRs.

## Changelog

Not user-facing — no changelog entry needed.