### PR TITLE
fix(ux): allow toast title to wrap 2 lines + guard non-boolean a11y props on web (BLD-1872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ marker) at release time.
 ## Unreleased
 
 - **Fix: Sets stat tile caption no longer wraps to two lines on the summary screen** — on a 390px mobile viewport the "Sets (9 working)" caption wrapped to two lines, while Duration and Volume stayed on one line. All three stat tile captions now auto-shrink the font to fit on a single line (down to 80% of the baseline size), so the three-tile row stays visually consistent regardless of how many set types are present. Screen-reader accessibility labels are unchanged. (BLD-1873)
+- **Fix: Error toasts now show full message** — error toasts that contained long messages (e.g. React runtime warnings) were truncated mid-word due to a single-line limit. Toasts now wrap to two lines so the full message is readable. Also fixed a React web rendering warning ("non-boolean attribute") caused by React Native accessibility props being passed to DOM elements on web, which was the root-cause message appearing in the toast. (BLD-1872)
 
 ## v0.26.39 — 2026-06-24
 <!-- versionCode: 109 -->

--- a/__tests__/components/RatingWidget.test.tsx
+++ b/__tests__/components/RatingWidget.test.tsx
@@ -100,4 +100,39 @@ describe('RatingWidget', () => {
     fireEvent(widget, 'accessibilityAction', { nativeEvent: { actionName: 'increment' } });
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('BLD-1872: star Pressables have accessibilityElementsHidden gated by Platform (false on web, true on native)', () => {
+    // On native (jest runs with Platform.OS = 'ios' or 'android' in tests),
+    // accessibilityElementsHidden should be true. On web it should be false
+    // to avoid the React DOM "Received `true` for a non-boolean attribute" warning.
+    const { Platform } = require('react-native')
+
+    // Read the source tree via toJSON and walk nodes to find views
+    // that carry the accessibilityElementsHidden prop
+    function collectProps(node: Record<string, unknown> | null): Record<string, unknown>[] {
+      if (!node) return []
+      const acc: Record<string, unknown>[] = []
+      if (node.props && typeof (node.props as Record<string, unknown>).accessibilityElementsHidden !== 'undefined') {
+        acc.push(node.props as Record<string, unknown>)
+      }
+      for (const child of ((node.children as unknown[]) ?? [])) {
+        if (child && typeof child === 'object') {
+          acc.push(...collectProps(child as Record<string, unknown>))
+        }
+      }
+      return acc
+    }
+
+    const { toJSON } = renderWidget({ value: 3 })
+    const nodes = collectProps(toJSON() as unknown as Record<string, unknown>)
+    // There should be at least one node with the prop (each star has it)
+    expect(nodes.length).toBeGreaterThan(0)
+    for (const props of nodes) {
+      if (Platform.OS === 'web') {
+        expect(props.accessibilityElementsHidden).not.toBe(true)
+      } else {
+        expect(props.accessibilityElementsHidden).toBe(true)
+      }
+    }
+  })
 });

--- a/__tests__/components/bna-toast.test.tsx
+++ b/__tests__/components/bna-toast.test.tsx
@@ -250,6 +250,52 @@ describe('ToastProvider + useToast', () => {
   })
 })
 
+describe('BLD-1872: toast title wrapping', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('title Text has numberOfLines=2 so long error messages are not truncated at one line', () => {
+    const longTitle = 'Received `true` for a non-boolean attribute `accessibilityelementshidden`.'
+    const { getByTestId, UNSAFE_getAllByType } = renderWithToast(
+      <ToastTrigger title={longTitle} variant="error" />
+    )
+    fireEvent.press(getByTestId('show-toast'))
+
+    // Import the RN Text component to query via UNSAFE_getAllByType
+    const { Text: RNText } = require('react-native')
+    const textNodes = UNSAFE_getAllByType(RNText)
+    // Find the title node (it has fontWeight 600 and contains our long text)
+    const titleNode = textNodes.find(
+      (n: { props: { children?: unknown; numberOfLines?: number } }) =>
+        n.props.children === longTitle
+    )
+    expect(titleNode).toBeTruthy()
+    // Contract: numberOfLines must be >= 2 so the message is not cut off mid-word
+    expect(titleNode!.props.numberOfLines).toBeGreaterThanOrEqual(2)
+  })
+
+  it('description Text retains numberOfLines=2', () => {
+    const { getByTestId, UNSAFE_getAllByType } = renderWithToast(
+      <ToastTrigger title="Error" description="Something went wrong with a very long description that should wrap" />
+    )
+    fireEvent.press(getByTestId('show-toast'))
+
+    const { Text: RNText } = require('react-native')
+    const textNodes = UNSAFE_getAllByType(RNText)
+    const descNode = textNodes.find(
+      (n: { props: { children?: unknown; numberOfLines?: number } }) =>
+        n.props.children === 'Something went wrong with a very long description that should wrap'
+    )
+    expect(descNode).toBeTruthy()
+    expect(descNode!.props.numberOfLines).toBeGreaterThanOrEqual(2)
+  })
+})
+
 describe('useToast outside provider', () => {
   it('throws when used outside ToastProvider', () => {
     function BadComponent() {

--- a/components/RatingWidget.tsx
+++ b/components/RatingWidget.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { Pressable, StyleSheet, View } from "react-native";
+import { Platform, Pressable, StyleSheet, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import { useThemeColors } from "@/hooks/useThemeColors";
@@ -96,7 +96,7 @@ export default function RatingWidget({ value, onChange, readOnly = false, size =
               alignItems: "center",
               justifyContent: "center",
             }}
-            accessibilityElementsHidden
+            accessibilityElementsHidden={Platform.OS !== 'web'}
             importantForAccessibility="no"
           >
             <MaterialCommunityIcons

--- a/components/session/summary/PacingCard.tsx
+++ b/components/session/summary/PacingCard.tsx
@@ -14,6 +14,7 @@
 
 import { useState } from "react";
 import {
+  Platform,
   Pressable,
   StyleSheet,
   View,
@@ -118,7 +119,7 @@ export default function PacingCard({ pacing, exerciseNames = {} }: Props) {
               {/* Stacked bar */}
               <View
                 style={styles.barContainer}
-                accessibilityElementsHidden
+                accessibilityElementsHidden={Platform.OS !== 'web'}
               >
                 <View
                   style={[

--- a/components/session/summary/SummaryFooter.tsx
+++ b/components/session/summary/SummaryFooter.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, Dimensions, Modal, StyleSheet, TextInput, View } from "react-native";
+import { ActivityIndicator, Dimensions, Modal, Platform, StyleSheet, TextInput, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import ShareCard from "@/components/ShareCard";
@@ -102,7 +102,7 @@ export default function SummaryFooter({
         transparent
         animationType="fade"
         onRequestClose={() => { setPreviewVisible(false); setImageLoading(false); }}
-        accessibilityViewIsModal
+        {...(Platform.OS !== 'web' ? { accessibilityViewIsModal: true } : {})}
       >
         <View style={styles.previewOverlay} testID="summary-preview-overlay">
           <View style={styles.previewContainer} testID="summary-preview-container">

--- a/components/ui/toast-item.tsx
+++ b/components/ui/toast-item.tsx
@@ -13,7 +13,9 @@ import { fontSizes } from "@/constants/design-tokens";
 
 interface ToastProps extends ToastData { onDismiss: (id: string) => void; index: number; }
 
-const TOAST_HEIGHT = 52;
+// BLD-1872: increased from 52 to 68 to accommodate 2-line titles without
+// adjacent toasts overlapping when text wraps.
+const TOAST_HEIGHT = 68;
 const TOAST_MARGIN = 8;
 // BLD-569: keep toast above primary-action / FAB zone at bottom of screen
 // without overlapping the tab bar or the set-complete button.
@@ -47,7 +49,7 @@ export function Toast({ id, title, description, variant = 'default', onDismiss, 
         <View style={styles.island}>
           {IconComponent && <View style={{ marginRight: 10 }}><IconComponent size={16} color={variantColor} /></View>}
           <View style={{ flex: 1, minWidth: 0 }}>
-            {title && <Text variant='subtitle' style={{ color: Colors.light.onToast, fontSize: fontSizes.sm, fontWeight: '600', marginBottom: description ? 2 : 0 }} numberOfLines={1} ellipsizeMode='tail'>{title}</Text>}
+            {title && <Text variant='subtitle' style={{ color: Colors.light.onToast, fontSize: fontSizes.sm, fontWeight: '600', marginBottom: description ? 2 : 0 }} numberOfLines={2} ellipsizeMode='tail'>{title}</Text>}
             {description && <Text variant='caption' style={{ color: MUTED, fontSize: fontSizes.sm }} numberOfLines={2} ellipsizeMode='tail'>{description}</Text>}
             {action && (
               <TouchableOpacity


### PR DESCRIPTION
## Summary

Fixes two issues found in the completed-workout audit (2026-06-24, commit `8e078793`):

1. **Toast text truncation** — error messages like "Received `true` for a non-boolean attribute" were cut off mid-word because the toast title had `numberOfLines={1}`. Changed to `numberOfLines={2}` and bumped the stacking offset constant (`TOAST_HEIGHT` 52→68) so adjacent toasts don't overlap when the title wraps.

2. **Root-cause non-boolean React DOM warning** — three components on the summary screen passed bare-boolean React Native props to DOM elements on web (`react-native-web` passes unrecognised props through to DOM, causing React to warn "Received `true` for a non-boolean attribute"). Fixed by Platform-gating each prop:
   - `RatingWidget`: `accessibilityElementsHidden={Platform.OS !== 'web'}`
   - `PacingCard`: `accessibilityElementsHidden={Platform.OS !== 'web'}`
   - `SummaryFooter`: `{...(Platform.OS !== 'web' ? { accessibilityViewIsModal: true } : {})}` (react-native-web's Modal already adds `aria-modal` internally)

## Changes

- `components/ui/toast-item.tsx` — title `numberOfLines` 1→2, `TOAST_HEIGHT` 52→68
- `components/RatingWidget.tsx` — Platform-gate `accessibilityElementsHidden`
- `components/session/summary/PacingCard.tsx` — Platform-gate `accessibilityElementsHidden`
- `components/session/summary/SummaryFooter.tsx` — Platform-gate `accessibilityViewIsModal`
- `__tests__/components/bna-toast.test.tsx` — 2 new tests: title `numberOfLines>=2` contract
- `__tests__/components/RatingWidget.test.tsx` — 1 new test: Platform-safe `accessibilityElementsHidden`

## Testing

- `npm test` — 4435/4435 tests pass, 370 suites
- `tsc --noEmit` — zero errors
- New tests: BLD-1872 describe blocks in bna-toast and RatingWidget test files

## Issue

Resolves BLD-1872