### PR TITLE
fix(advanced-sets): bottom-fade scroll affordance for clipped content (BLD-1916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: Advanced Set Types help screen now hints when there's more to scroll** — on narrow phones (e.g. 320px wide) the last "Myo-reps" section could sit at the bottom edge with no cue that more content existed below. The screen now shows a subtle bottom fade while the list can still be scrolled, and the fade disappears once you reach the end. (BLD-1916)
 
 ## v0.26.40 — 2026-06-24
 <!-- versionCode: 110 -->

--- a/__tests__/advanced-sets-scroll-affordance.test.tsx
+++ b/__tests__/advanced-sets-scroll-affordance.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * BLD-1916 — Bottom scroll-affordance fade for the Advanced Set Types help screen.
+ *
+ * At narrow viewports (e.g. 320×640) the last section ("Myo-reps") is clipped
+ * at the bottom edge with no scroll affordance, so users cannot tell more
+ * content exists below the fold. The screen now overlays a bottom fade gradient
+ * that appears only when the bounded scroll content overflows and the user has
+ * not yet scrolled to the end.
+ *
+ * Coverage:
+ *  1. `isBottomFadeVisible` pure predicate — overflow / at-bottom / fits / edge
+ *     cases (table-driven).
+ *  2. Render smoke — the screen mounts and shows all three section titles, and
+ *     the fade overlay is absent at initial render (dimensions unmeasured = 0).
+ */
+import React from "react";
+import { fireEvent } from "@testing-library/react-native";
+import { renderScreen } from "./helpers/render";
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => require("./helpers/theme").lightMockColors,
+}));
+
+jest.mock("@/lib/layout", () => ({
+  useLayout: () => ({
+    width: 320,
+    windowClass: "compact",
+    compact: true,
+    medium: false,
+    expanded: false,
+    atLeastMedium: false,
+    scale: 1.0,
+    horizontalPadding: 16,
+  }),
+}));
+
+jest.mock("expo-router", () => ({
+  Stack: { Screen: () => null },
+}));
+
+import AdvancedSetsHelpScreen, {
+  isBottomFadeVisible,
+} from "@/app/settings/advanced-sets";
+
+describe("isBottomFadeVisible", () => {
+  // [scrollY, layoutHeight, contentHeight, expected, description]
+  const cases: Array<[number, number, number, boolean, string]> = [
+    // Content overflows and user is at the top → fade shown.
+    [0, 640, 1200, true, "overflow, scrolled to top"],
+    // Content overflows and user is partway → fade shown.
+    [200, 640, 1200, true, "overflow, scrolled partway"],
+    // Content overflows and user is exactly at the bottom → fade hidden.
+    [560, 640, 1200, false, "overflow, scrolled to exact bottom"],
+    // 1px slack: one pixel shy of the bottom still counts as bottom → hidden.
+    [559, 640, 1200, false, "overflow, within 1px slack of bottom"],
+    // Content fits the viewport exactly → no overflow → hidden.
+    [0, 640, 640, false, "content fits exactly"],
+    // Content shorter than viewport → hidden.
+    [0, 640, 400, false, "content shorter than viewport"],
+    // Trivial 1px overflow is within slack → not treated as overflow → hidden.
+    [0, 640, 641, false, "1px overflow within slack"],
+    // Just past the slack threshold → overflow, top → shown.
+    [0, 640, 642, true, "2px overflow, at top"],
+    // Unmeasured layout (initial render) → hidden.
+    [0, 0, 0, false, "unmeasured dimensions"],
+    [0, 0, 1200, false, "unmeasured layout height"],
+    [0, 640, 0, false, "unmeasured content height"],
+  ];
+
+  it.each(cases)(
+    "scrollY=%i layout=%i content=%i → %s (%s)",
+    (scrollY, layoutHeight, contentHeight, expected) => {
+      expect(isBottomFadeVisible(scrollY, layoutHeight, contentHeight)).toBe(
+        expected,
+      );
+    },
+  );
+
+  it("never shows the fade for non-positive dimensions", () => {
+    expect(isBottomFadeVisible(-10, -1, -1)).toBe(false);
+    expect(isBottomFadeVisible(0, -5, 1200)).toBe(false);
+  });
+});
+
+describe("AdvancedSetsHelpScreen — render", () => {
+  it("renders all three advanced set type sections", () => {
+    const { getByText } = renderScreen(<AdvancedSetsHelpScreen />);
+    expect(getByText("Rest-pause")).toBeTruthy();
+    expect(getByText("Cluster")).toBeTruthy();
+    expect(getByText("Myo-reps")).toBeTruthy();
+  });
+
+  it("does not render the bottom fade before scroll dimensions are measured", () => {
+    const { queryByTestId } = renderScreen(<AdvancedSetsHelpScreen />);
+    // Initial render: layoutHeight/contentHeight are 0 → predicate false → no fade.
+    expect(queryByTestId("advanced-sets-bottom-fade")).toBeNull();
+  });
+
+  it("shows the bottom fade once content overflows the viewport and hides it at the end", () => {
+    const { UNSAFE_getByType, queryByTestId } = renderScreen(
+      <AdvancedSetsHelpScreen />,
+    );
+    const { ScrollView } = require("react-native");
+    const scroll = UNSAFE_getByType(ScrollView);
+
+    // Simulate measurement: viewport 640px, content 1200px (overflow), at top.
+    fireEvent(scroll, "layout", {
+      nativeEvent: { layout: { x: 0, y: 0, width: 320, height: 640 } },
+    });
+    fireEvent(scroll, "contentSizeChange", 320, 1200);
+    expect(queryByTestId("advanced-sets-bottom-fade")).toBeTruthy();
+
+    // Scroll to the bottom → fade hides.
+    fireEvent.scroll(scroll, {
+      nativeEvent: {
+        contentOffset: { x: 0, y: 560 },
+        contentSize: { width: 320, height: 1200 },
+        layoutMeasurement: { width: 320, height: 640 },
+      },
+    });
+    expect(queryByTestId("advanced-sets-bottom-fade")).toBeNull();
+  });
+});

--- a/app/settings/advanced-sets.tsx
+++ b/app/settings/advanced-sets.tsx
@@ -3,8 +3,17 @@
  * Copy is descriptive only — no aspirational language.
  * See `__tests__/help-copy-tone.test.ts` for tone enforcement.
  */
-import { useEffect } from "react";
-import { Platform, ScrollView, StyleSheet, View } from "react-native";
+import { useCallback, useEffect, useState } from "react";
+import {
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
+import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 import { Stack } from "expo-router";
 import { Text } from "@/components/ui/text";
 import { Card, CardContent } from "@/components/ui/card";
@@ -12,6 +21,37 @@ import { Separator } from "@/components/ui/separator";
 import { useThemeColors } from "@/hooks/useThemeColors";
 import { useLayout } from "@/lib/layout";
 import { spacing, fontSizes } from "@/constants/design-tokens";
+
+/** Height (px) of the bottom fade gradient hinting at scrollable content below the fold. */
+const BOTTOM_FADE_HEIGHT = 40;
+
+/**
+ * Pure predicate for whether the bottom scroll-affordance fade should be shown.
+ *
+ * The fade is visible only when the content overflows the visible scroll
+ * viewport AND the user has not yet scrolled to the bottom. A 1px slack absorbs
+ * floating-point rounding at the boundary so the fade reliably disappears at the
+ * true end of the list.
+ *
+ * On web the production ScrollView omits `flex: 1` (BLD-1261), so its rendered
+ * height equals the full content height; there `contentHeight ≈ layoutHeight`
+ * and this predicate returns false — no false affordance, and the BLD-1261
+ * fullPage screenshot capture is unaffected.
+ *
+ * @param scrollY      Current vertical scroll offset (contentOffset.y).
+ * @param layoutHeight Height of the visible scroll viewport (layoutMeasurement.height).
+ * @param contentHeight Total scrollable content height (contentSize.height).
+ */
+export function isBottomFadeVisible(
+  scrollY: number,
+  layoutHeight: number,
+  contentHeight: number,
+): boolean {
+  if (layoutHeight <= 0 || contentHeight <= 0) return false;
+  const overflows = contentHeight > layoutHeight + 1;
+  const atBottom = scrollY + layoutHeight >= contentHeight - 1;
+  return overflows && !atBottom;
+}
 
 /** Intro paragraph rendered above the help cards. Exported for copy-tone test coverage. */
 export const ADVANCED_SET_INTRO =
@@ -49,6 +89,27 @@ export default function AdvancedSetsHelpScreen() {
   const colors = useThemeColors();
   const layout = useLayout();
 
+  // Scroll-affordance state: track viewport vs. content height and scroll
+  // offset so the bottom fade hints that more content exists below the fold
+  // at narrow viewports (e.g. 320×640) where the last section is clipped.
+  const [scrollY, setScrollY] = useState(0);
+  const [layoutHeight, setLayoutHeight] = useState(0);
+  const [contentHeight, setContentHeight] = useState(0);
+
+  const onScroll = useCallback((e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    setScrollY(e.nativeEvent.contentOffset.y);
+  }, []);
+
+  const onLayout = useCallback((e: LayoutChangeEvent) => {
+    setLayoutHeight(e.nativeEvent.layout.height);
+  }, []);
+
+  const onContentSizeChange = useCallback((_w: number, h: number) => {
+    setContentHeight(h);
+  }, []);
+
+  const bottomFadeVisible = isBottomFadeVisible(scrollY, layoutHeight, contentHeight);
+
   // Signal readiness for Playwright fullPage screenshots (dev/web only).
   // Combined with the web flex guard below, this lets the e2e spec wait on
   // `body[data-test-ready='true']` before capturing the production route.
@@ -60,51 +121,87 @@ export default function AdvancedSetsHelpScreen() {
   }, []);
 
   return (
-    <ScrollView
-      // BLD-1261: on web, omit flex: 1 so the HTML document height equals
-      // content height — Playwright's fullPage screenshots then capture every
-      // entry at narrow viewports (390 px) where the Myo-reps description
-      // wraps to more lines and total content exceeds 844 px.
-      // On native: keep flex: 1 for the standard screen-filling scroll layout.
-      style={{
-        ...(Platform.OS !== "web" ? { flex: 1 } : {}),
-        backgroundColor: colors.background,
-      }}
-      contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
+    // Outer wrapper is the positioning context for the bottom fade overlay.
+    // On native it fills the screen (flex: 1); on web it grows with content so
+    // the BLD-1261 document-height invariant for fullPage capture is preserved.
+    <View
+      style={[
+        Platform.OS !== "web" ? styles.fill : null,
+        { backgroundColor: colors.background },
+      ]}
     >
-      <Stack.Screen options={{ title: "Advanced Set Types" }} />
+      <ScrollView
+        // BLD-1261: on web, omit flex: 1 so the HTML document height equals
+        // content height — Playwright's fullPage screenshots then capture every
+        // entry at narrow viewports (390 px) where the Myo-reps description
+        // wraps to more lines and total content exceeds 844 px.
+        // On native: keep flex: 1 for the standard screen-filling scroll layout.
+        style={Platform.OS !== "web" ? styles.fill : undefined}
+        contentContainerStyle={[styles.content, { paddingHorizontal: layout.horizontalPadding }]}
+        onScroll={onScroll}
+        scrollEventThrottle={16}
+        onLayout={onLayout}
+        onContentSizeChange={onContentSizeChange}
+      >
+        <Stack.Screen options={{ title: "Advanced Set Types" }} />
 
-      <Text variant="body" style={[styles.intro, { color: colors.onSurface }]}>
-        {ADVANCED_SET_INTRO}
-      </Text>
+        <Text variant="body" style={[styles.intro, { color: colors.onSurface }]}>
+          {ADVANCED_SET_INTRO}
+        </Text>
 
-      {ADVANCED_SET_HELP_ENTRIES.map((entry, index) => (
-        <View key={entry.setType}>
-          {index > 0 && <Separator style={styles.separator} />}
-          <Card style={styles.card}>
-            <CardContent>
-              <Text variant="subtitle" style={[styles.title, { color: colors.onSurface }]}>
-                {entry.title}
-              </Text>
-              <Text variant="body" style={[styles.description, { color: colors.onSurface }]}>
-                {entry.description}
-              </Text>
-              <Text variant="caption" style={[styles.example, { color: colors.onSurfaceVariant }]}>
-                {entry.example}
-              </Text>
-            </CardContent>
-          </Card>
+        {ADVANCED_SET_HELP_ENTRIES.map((entry, index) => (
+          <View key={entry.setType}>
+            {index > 0 && <Separator style={styles.separator} />}
+            <Card style={styles.card}>
+              <CardContent>
+                <Text variant="subtitle" style={[styles.title, { color: colors.onSurface }]}>
+                  {entry.title}
+                </Text>
+                <Text variant="body" style={[styles.description, { color: colors.onSurface }]}>
+                  {entry.description}
+                </Text>
+                <Text variant="caption" style={[styles.example, { color: colors.onSurfaceVariant }]}>
+                  {entry.example}
+                </Text>
+              </CardContent>
+            </Card>
+          </View>
+        ))}
+
+        <Text variant="caption" style={[styles.note, { color: colors.onSurfaceVariant }]}>
+          {ADVANCED_SET_FOOTER}
+        </Text>
+      </ScrollView>
+
+      {/* Bottom fade scroll affordance — overlays the lower edge of the scroll
+          viewport to signal "more content below" when the last section
+          (Myo-reps) is clipped at narrow viewports. Hidden once scrolled to the
+          end, and never shown when content already fits (BLD-1916). */}
+      {bottomFadeVisible && (
+        <View
+          pointerEvents="none"
+          style={[styles.bottomFade, { height: BOTTOM_FADE_HEIGHT }]}
+          testID="advanced-sets-bottom-fade"
+        >
+          <Svg width="100%" height="100%">
+            <Defs>
+              <LinearGradient id="advancedSetsBottomFade" x1="0" y1="0" x2="0" y2="1">
+                <Stop offset="0" stopColor={colors.background} stopOpacity="0" />
+                <Stop offset="1" stopColor={colors.background} stopOpacity="1" />
+              </LinearGradient>
+            </Defs>
+            <Rect x="0" y="0" width="100%" height="100%" fill="url(#advancedSetsBottomFade)" />
+          </Svg>
         </View>
-      ))}
-
-      <Text variant="caption" style={[styles.note, { color: colors.onSurfaceVariant }]}>
-        {ADVANCED_SET_FOOTER}
-      </Text>
-    </ScrollView>
+      )}
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  fill: {
+    flex: 1,
+  },
   content: {
     paddingTop: spacing.xs,
     paddingBottom: spacing.xxxl,
@@ -133,5 +230,11 @@ const styles = StyleSheet.create({
   note: {
     marginTop: spacing.xs,
     textAlign: "center",
+  },
+  bottomFade: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
   },
 });


### PR DESCRIPTION
## Summary

At narrow viewports (e.g. **320×640**) the Advanced Set Types help screen (`/settings` → Advanced Set Types) rendered the last section (**"Myo-reps"**) clipped at the bottom edge with **no scroll affordance**, so users couldn't tell more content existed below the fold. (BLD-1916, from audit BLD-1915.)

This adds a **bottom fade gradient** overlay on the production `ScrollView` that appears only when the bounded scroll content overflows the viewport **and** the user has not scrolled to the end — and disappears at the bottom of the list. It follows the existing SVG `LinearGradient` scroll-affordance pattern from `components/ui/scrollable-tabs.tsx`.

## Approach & fix placement

- **Layer:** UI component only (lowest blast radius, instant rollback).
- **Native (bounded `ScrollView`, `flex:1`):** the real user-facing fix — fade pinned to the scroll viewport's bottom edge, gated by scroll position.
- **Web (document scroll, no `flex:1` per BLD-1261):** the `ScrollView` (and the new wrapper `View`) still omit `flex:1`, so the document height equals content height for Playwright `fullPage` capture. There `contentHeight ≈ layoutHeight`, so the fade predicate returns **false** → no false affordance and the **BLD-1261 audit screenshot is unaffected**.

A `position:fixed` viewport-pinned web fade was deliberately **not** added — it's fragile in React-Native-Web and would risk regressing the BLD-1261 fullPage contract, unjustified for a low/minor cosmetic issue.

## Changes

- `app/settings/advanced-sets.tsx`
  - Extract `isBottomFadeVisible(scrollY, layoutHeight, contentHeight)` pure predicate (overflow + not-at-bottom, 1px slack).
  - Track `onScroll` / `onLayout` / `onContentSizeChange`; wrap the `ScrollView` in a positioning `View`; overlay an SVG bottom-fade (`pointerEvents="none"`).
- `__tests__/advanced-sets-scroll-affordance.test.tsx` (new) — 15 tests: table-driven predicate cases (overflow / at-bottom / fits / zero-dim edges / slack boundaries) + render lifecycle (overflow → show, scroll-to-end → hide).

## Testing

- `jest` — new suite: **15/15 pass**.
- `jest help-copy-tone a11y-advanced-sets advanced-sets` — existing **66/66 pass** (no regression).
- `tsc --noEmit` — clean.
- `eslint` on touched files — clean.
- BLD-1261 `fullPage` web capture invariant preserved (web wrappers keep no `flex:1`).

## Scope

1 production file + 1 test file. No copy/layout changes (those were BLD-1250 / BLD-1261).

Closes BLD-1916.
