### PR TITLE
fix(e2e): add __SKIP_ONBOARDING__ to BLD-1261 harness test (BLD-1943)

### DIFF
--- a/e2e/scenarios/advanced-sets.spec.ts
+++ b/e2e/scenarios/advanced-sets.spec.ts
@@ -163,6 +163,15 @@ test.describe("@scenario advanced-sets", () => {
   test("harness renders all help entries including full Myo-reps description (BLD-1261)", async ({
     page,
   }) => {
+    // BLD-1943: `__SKIP_ONBOARDING__` must be set before navigation so the root
+    // layout's `useAppInit` bypasses the DB onboarding check. Without it,
+    // `isOnboardingComplete()` returns false on a fresh worker DB, causing the
+    // root layout to Redirect to /onboarding/welcome — the harness component
+    // never mounts and `data-test-ready` is never set, timing out at 10 s.
+    await page.addInitScript(() => {
+      const w = window as unknown as Record<string, unknown>;
+      w.__SKIP_ONBOARDING__ = true;
+    });
     await page.goto("/__test__/advanced-sets");
     await expect(page.locator("body[data-test-ready='true']")).toBeVisible({ timeout: 10_000 });
 


### PR DESCRIPTION
## Summary

The BLD-1261 harness test (`advanced-sets.spec.ts:163`) was timing out on `body[data-test-ready='true']` because it was missing the `__SKIP_ONBOARDING__` init script that every other test in the file sets.

## Root cause

Without `__SKIP_ONBOARDING__`, `useAppInit` calls `isOnboardingComplete()` against the fresh worker DB (set up by `enablePerWorkerDb` in `beforeEach`). A fresh IndexedDB has no `onboarding_complete=1` row, so `isOnboardingComplete()` returns `false`. The root layout then renders `<Redirect href="/onboarding/welcome" />`, redirecting away from `/__test__/advanced-sets` before the harness component can mount — so `data-test-ready` is never set and the 10 s timeout fires.

## Changes

- `e2e/scenarios/advanced-sets.spec.ts`: Add `page.addInitScript` setting `__SKIP_ONBOARDING__ = true` before `page.goto("/__test__/advanced-sets")` in the BLD-1261 harness test — matching the pattern used by every other test in this spec file.

## Testing

- TypeScript: `tsc --noEmit` passes with zero errors
- Fix follows the identical pattern of all 9 other tests in `advanced-sets.spec.ts`

## Issue

Resolves BLD-1943