### PR TITLE
fix(ux): lower Sets caption minimumFontScale 0.8→0.6 to prevent truncation (BLD-1938)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: "Sets" stat label no longer truncates on the workout summary screen** — on 390 px viewports the "Sets (9 working)" caption was cut off with an ellipsis because the auto-shrink limit of 80% wasn't enough headroom. The minimum font scale is now 60%, giving the caption enough room to fit on one line. Duration and Volume captions are unchanged. (BLD-1938)
 
 ## v0.26.41 — 2026-06-25
 <!-- versionCode: 111 -->

--- a/__tests__/acceptance/summary-stat-tile-single-line.acceptance.test.tsx
+++ b/__tests__/acceptance/summary-stat-tile-single-line.acceptance.test.tsx
@@ -1,11 +1,13 @@
 /**
- * Acceptance test for BLD-1876 / BLD-1873:
+ * Acceptance test for BLD-1876 / BLD-1873 / BLD-1938:
  * Summary screen stat tile captions must not wrap to multiple lines.
  *
  * Verifies:
  *  - All three stat captions (Duration, Sets, Volume) have numberOfLines={1}
- *  - All three captions have adjustsFontSizeToFit and minimumFontScale={0.8}
- *    so long breakdowns shrink instead of wrap
+ *  - Duration and Volume captions have adjustsFontSizeToFit and minimumFontScale={0.8}
+ *  - Sets caption has adjustsFontSizeToFit and minimumFontScale={0.6} (BLD-1938:
+ *    lowered from 0.8 so "Sets (9 working)" fits in the ~78px card width at 390px
+ *    viewport without truncation)
  *  - The Sets tile accessibilityLabel still exposes the full breakdown text
  *    (screen-reader accessibility must not regress)
  *  - Captions render correctly for both single-type and multi-type set breakdowns
@@ -121,7 +123,7 @@ describe('Summary stat tile captions — single-line constraint (BLD-1876)', () 
     expect(durationCaption.props.minimumFontScale).toBe(0.8)
   })
 
-  it('Sets caption has numberOfLines=1 and adjustsFontSizeToFit for single set type (9 working)', async () => {
+  it('Sets caption has numberOfLines=1, adjustsFontSizeToFit, and minimumFontScale=0.6 to prevent truncation (BLD-1938)', async () => {
     const { session, exercises, sets } = createCompletedWorkoutFixture({ setCount: 9 })
     mockDb.getSessionById.mockResolvedValue(session)
     mockDb.getSessionSets.mockResolvedValue(sets)
@@ -134,11 +136,13 @@ describe('Summary stat tile captions — single-line constraint (BLD-1876)', () 
     expect(setsCard).toBeTruthy()
 
     // Find the Sets caption — it will be "Sets (9 working)" or plain "Sets"
+    // BLD-1938: minimumFontScale lowered from 0.8 → 0.6 so "Sets (9 working)" fits
+    // in the ~78px available width at 390px viewport without truncation.
     const setsCaptions = await screen.findAllByText(/^Sets/i)
     const setsCaption = setsCaptions[0]
     expect(setsCaption.props.numberOfLines).toBe(1)
     expect(setsCaption.props.adjustsFontSizeToFit).toBe(true)
-    expect(setsCaption.props.minimumFontScale).toBe(0.8)
+    expect(setsCaption.props.minimumFontScale).toBe(0.6)
   })
 
   it('Volume caption has numberOfLines=1 and adjustsFontSizeToFit', async () => {

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -279,7 +279,7 @@ function SummaryHeader({ colors, session, duration, durationSpokenText, complete
         <Card style={StyleSheet.flatten([styles.stat, { backgroundColor: colors.surface }])} accessibilityLabel={setsBreakdown ? `${completedCount} sets: ${setsBreakdown}` : `${completedCount} sets completed`}>
           <CardContent style={styles.statInner}>
             <Text variant="heading" style={{ color: colors.primary }}>{completedCount}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.8}>{setsBreakdown ? `Sets (${setsBreakdown})` : "Sets"}</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.6}>{setsBreakdown ? `Sets (${setsBreakdown})` : "Sets"}</Text>
           </CardContent>
         </Card>
         <Card style={StyleSheet.flatten([styles.stat, { backgroundColor: colors.surface }])} accessibilityLabel={`Total volume: ${volumeDisplay.toLocaleString()} ${unit}`}>


### PR DESCRIPTION
## Summary

The middle stat card in the workout summary header showed "Sets (9 …" — the label was truncated with an ellipsis at 390px viewport width.

Root cause: each stat card has ~78px of inner content width at 390px. The caption text "Sets (9 working)" at the previous `minimumFontScale={0.8}` floor (~13.6px) still overflows that space. `adjustsFontSizeToFit` couldn't shrink far enough and fell back to ellipsis truncation.

## Changes

- `app/session/summary/[id].tsx`: lower `minimumFontScale` from `0.8` → `0.6` on the Sets stat tile caption only. Duration and Volume keep `0.8` (their text is short enough).
- `__tests__/acceptance/summary-stat-tile-single-line.acceptance.test.tsx`: update BLD-1876/1873 acceptance test to assert the new `0.6` minimum for the Sets caption; add inline comment explaining the geometry.

## Testing

- Acceptance test `summary-stat-tile-single-line.acceptance.test.tsx` — 5/5 pass
- `tsc --noEmit` — zero errors

## Issue

Resolves BLD-1938