### PR TITLE
fix(e2e): retry useSummaryData session load when seed races initial read (BLD-1942)

### DIFF
--- a/__tests__/hooks/useSummaryData-error-state.test.ts
+++ b/__tests__/hooks/useSummaryData-error-state.test.ts
@@ -121,4 +121,35 @@ describe("useSummaryData — defense-in-depth error state (BLD-1636)", () => {
     // Achievement failure is non-fatal — summary still renders, no boundary throw.
     expect(result.current.error).toBeNull();
   });
+
+  // BLD-1942: under Playwright (navigator.webdriver === true) useSummaryData
+  // retries getSessionById up to 10 times with 200ms backoff when it returns
+  // null, because the scenario seed runs concurrently with the initial DB read.
+  // This test exercises the retry path by simulating a null first response
+  // followed by a found session.
+  it("retries getSessionById under webdriver when session is initially null (BLD-1942)", async () => {
+    mockHappyPath();
+    const g = global as unknown as Record<string, unknown>;
+    const originalNavigator = g.navigator;
+
+    // Simulate Playwright's navigator.webdriver flag.
+    g.navigator = { webdriver: true };
+
+    // First call returns null (seed hasn't run yet); second returns the session.
+    db.getSessionById
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({ id: "s1", weight_unit: "kg", duration_seconds: 60 });
+
+    const { result } = renderHook(() => useSummaryData("s1"));
+
+    await waitFor(
+      () => expect(result.current.session).not.toBeNull(),
+      { timeout: 5000 },
+    );
+    // getSessionById was called at least twice — once returning null, then found.
+    expect(db.getSessionById.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(result.current.error).toBeNull();
+
+    g.navigator = originalNavigator;
+  });
 });

--- a/e2e/scenarios/completed-workout.spec.ts
+++ b/e2e/scenarios/completed-workout.spec.ts
@@ -11,7 +11,7 @@
  * as `scenario-session-1`, so this spec can navigate directly to the summary
  * route without first reading the DB.
  *
- * Refs: BLD-494, BLD-481, BLD-744
+ * Refs: BLD-494, BLD-481, BLD-744, BLD-1942
  */
 import { test, expect } from "@playwright/test";
 import * as path from "path";
@@ -63,7 +63,13 @@ test.describe("@scenario completed-workout", () => {
     // is captured. window.scrollTo() does not move RN's scroll container —
     // scroll the testID element directly (same fix as settings.spec.ts BLD-1124).
     // BLD-1768 root cause: FlatList never scrolled, pacing-card clipped at bottom.
+    // BLD-1942: wait for the FlatList to appear before scrolling — useSummaryData
+    // may still be loading the session (seed runs concurrently with the first DB
+    // read; if the hook fired before the seed, session was null and the FlatList
+    // didn't render yet). data-test-ready only signals seed completion, not
+    // React state hydration.
     const scrollEl = page.getByTestId("summary-scroll-view");
+    await expect(scrollEl).toBeVisible({ timeout: 10_000 });
     await scrollEl.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
     await page.waitForTimeout(300);
 

--- a/hooks/useSummaryData.ts
+++ b/hooks/useSummaryData.ts
@@ -32,6 +32,45 @@ type Comparison = {
 
 export type { PR, RepPR, DurationPR, Increase, Comparison };
 
+// BLD-1942: detect Playwright's webdriver flag — used to gate the session-load
+// retry so production behavior is unchanged (single attempt outside webdriver).
+function isUnderWebdriver(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return (navigator as Navigator & { webdriver?: boolean }).webdriver === true;
+}
+
+/**
+ * BLD-1942: bounded poll for the session row.
+ *
+ * Under Playwright the scenario seed runs concurrently with the first
+ * getSessionById call. If this hook fires before the seed inserts the row,
+ * the hook would permanently bail (`if (!sess) return`) and the FlatList
+ * with `testID="summary-scroll-view"` would never render. Poll up to
+ * MAX_ATTEMPTS times with BACKOFF_MS between attempts, but ONLY under
+ * navigator.webdriver — outside webdriver (production, unit tests) this
+ * runs exactly once so behavior is unchanged.
+ */
+const SESSION_POLL_MAX_ATTEMPTS = 10;
+const SESSION_POLL_BACKOFF_MS = 200;
+
+async function pollSessionById(
+  id: string,
+  cancelled: { current: boolean },
+): Promise<Awaited<ReturnType<typeof getSessionById>> | undefined> {
+  const maxAttempts = isUnderWebdriver() ? SESSION_POLL_MAX_ATTEMPTS : 1;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const sess = await getSessionById(id);
+    if (cancelled.current) return undefined;
+    if (sess) return sess;
+    if (attempt < maxAttempts) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, SESSION_POLL_BACKOFF_MS),
+      );
+    }
+  }
+  return undefined;
+}
+
 export function useSummaryData(id: string | undefined) {
   const [session, setSession] = useState<WorkoutSession | null>(null);
   const [sets, setSets] = useState<(WorkoutSet & { exercise_name?: string })[]>([]);
@@ -59,10 +98,14 @@ export function useSummaryData(id: string | undefined) {
   useEffect(() => {
     if (!id) return;
     let cancelled = false;
+    const cancelRef = { current: false };
     (async () => {
       try {
+        // BLD-1942: use pollSessionById to handle the race where the Playwright
+        // scenario seed runs concurrently with this initial DB read. See the
+        // module-level helper for full rationale.
         const [sess, settings] = await Promise.all([
-          getSessionById(id),
+          pollSessionById(id, cancelRef),
           getBodySettings(),
         ]);
         if (cancelled) return;
@@ -134,6 +177,7 @@ export function useSummaryData(id: string | undefined) {
     })();
     return () => {
       cancelled = true;
+      cancelRef.current = true;
     };
   }, [id]);
 


### PR DESCRIPTION
## Summary

Fixes a timing race that caused `completed-workout.spec.ts` to time out on `summary-scroll-view` testId. The scenario seed and `useSummaryData`'s initial DB read run concurrently — if the hook fires first, `getSessionById` returns null and the hook permanently bails, leaving the FlatList unrendered.

## Root Cause

`useSummaryData` (line 69 before this fix): `if (!sess) return;` — if the DB read returns null (seed hasn't run yet), the effect exits and never re-fetches, even after the seed completes and sets `data-test-ready='true'`. The FlatList with `testID='summary-scroll-view'` only renders when `session !== null`.

## Changes

- **`hooks/useSummaryData.ts`**: Extract `pollSessionById()` helper that retries up to 10 times with 200ms backoff under `navigator.webdriver === true` (set automatically by Playwright). Single attempt outside webdriver — zero production behavior change. Matches the BLD-1796 seed-import retry pattern.

- **`e2e/scenarios/completed-workout.spec.ts`**: Add `await expect(scrollEl).toBeVisible({ timeout: 10_000 })` before `evaluate()`. `data-test-ready` signals seed completion, not React state hydration — the spec must wait for the FlatList to actually appear.

- **`__tests__/hooks/useSummaryData-error-state.test.ts`**: New test simulates `navigator.webdriver=true` + null first response followed by found session, asserting the retry path resolves correctly.

## Testing

- 6/6 tests pass in `useSummaryData-error-state.test.ts` (including new BLD-1942 retry test)
- `tsc --noEmit` passes with zero errors
- ESLint passes with zero warnings

## Issue

Resolves BLD-1942