### PR TITLE
fix: harden emulator smoke test against dead-emulator broken-pipe failures (BLD-1976)

### DIFF
--- a/scripts/__tests__/smoke-test-emulator.test.ts
+++ b/scripts/__tests__/smoke-test-emulator.test.ts
@@ -1,0 +1,435 @@
+/**
+ * BLD-1976 — Tests for smoke-test-emulator.sh dead-emulator retry guard.
+ *
+ * Problem background:
+ *   The existing 'flaky emulator guard' retry blindly re-installs on the same
+ *   dead emulator (sleep 5 + adb uninstall + install). When the emulator process
+ *   has died mid-install (broken pipe / "Can't find service"), every subsequent
+ *   adb call also fails identically, so the retry exits 1 and blocks the release.
+ *
+ * Fix:
+ *   1. Detect dead-emulator symptoms (broken pipe / Can't find service: activity|package)
+ *      vs genuine app failure (FATAL EXCEPTION / process-not-found on healthy emulator).
+ *   2. On dead-emulator, run health-restore: wait-for-device + boot_completed poll +
+ *      package-service probe. Only re-install once healthy.
+ *   3. If emulator cannot be revived, exit 2 (infra failure, distinct from app failure exit 1).
+ *   4. Genuine app crashes on healthy emulators still exit 1 (no regression).
+ *
+ * Test strategy:
+ *   Stub the `adb` binary on PATH with a small bash script that implements
+ *   scripted behaviour based on environment variables. Run smoke-test-emulator.sh
+ *   against the stub and assert on exit codes and output.
+ *
+ * Acceptance criteria (BLD-1976):
+ *   AC1: Dead emulator detected → health-restore path taken (not blind re-install).
+ *   AC2: App crash on healthy emulator → hard-fail exit 1 (no regression).
+ *   AC3: Emulator unrevivable → distinct infra error message + exit 2.
+ *   AC4: Slow-boot emulator (boot_completed eventually returns 1) → health-restore
+ *        waits, then install succeeds.
+ */
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const SCRIPT = path.join(REPO_ROOT, "scripts", "smoke-test-emulator.sh");
+const PACKAGE = "com.persoack.cablesnap";
+
+interface RunResult {
+    exitCode: number | null;
+    stdout: string;
+    stderr: string;
+    combined: string;
+}
+
+/**
+ * Run smoke-test-emulator.sh with a fake `adb` on PATH.
+ *
+ * @param adbScript  Content of the fake `adb` bash script.
+ * @param extraEnv   Additional environment variables.
+ */
+function runSmokeTest(adbScript: string, extraEnv: Record<string, string> = {}): RunResult {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "bld1976-"));
+    try {
+        // Write fake APKs (content doesn't matter — adb install is stubbed).
+        fs.writeFileSync(path.join(tmpDir, "cablesnap.apk"), "FAKE_APK");
+        fs.writeFileSync(path.join(tmpDir, "cablesnap-fdroid.apk"), "FAKE_APK");
+
+        // Write fake adb binary.
+        const fakeAdb = path.join(tmpDir, "adb");
+        fs.writeFileSync(fakeAdb, `#!/usr/bin/env bash\n${adbScript}\n`);
+        fs.chmodSync(fakeAdb, 0o755);
+
+        const result = spawnSync("bash", [SCRIPT], {
+            cwd: tmpDir,
+            env: {
+                ...process.env,
+                PATH: `${tmpDir}:${process.env.PATH}`,
+                // Short timeouts so health-restore tests don't take forever.
+                EMULATOR_BOOT_TIMEOUT_S: "10",
+                // Skip the 15s post-launch settle sleep in tests.
+                EMULATOR_APP_SETTLE_S: "0",
+                ...extraEnv,
+            },
+            encoding: "utf8",
+            timeout: 60_000,
+        });
+
+        const combined = (result.stdout ?? "") + (result.stderr ?? "");
+        return {
+            exitCode: result.status,
+            stdout: result.stdout ?? "",
+            stderr: result.stderr ?? "",
+            combined,
+        };
+    } finally {
+        try {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+            /* best-effort */
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fake adb script snippets — compose these to build test scenarios.
+// ---------------------------------------------------------------------------
+
+/**
+ * A healthy emulator: install succeeds, pidof returns a PID, no FATAL
+ * EXCEPTION in logcat, boot_completed=1, package service responds.
+ */
+const HEALTHY_ADB = `
+case "$1 $2 $3" in
+  "install "*)
+    echo "Success"
+    exit 0
+    ;;
+esac
+case "$1" in
+  "logcat")
+    if [[ "$2" == "-c" ]]; then exit 0; fi
+    # -d: no FATAL EXCEPTION
+    echo "03-01 00:00:00.000  123  456 I ActivityTaskManager: Displayed ${PACKAGE}/.MainActivity"
+    exit 0
+    ;;
+  "shell")
+    case "$2" in
+      "am")
+        case "$3" in
+          "start") exit 0 ;;
+          "force-stop") exit 0 ;;
+        esac
+        ;;
+      "pidof")
+        echo "12345"
+        exit 0
+        ;;
+      "getprop")
+        echo "1"
+        exit 0
+        ;;
+      "cmd")
+        case "$3" in
+          "list") echo "package:${PACKAGE}"; exit 0 ;;
+        esac
+        ;;
+      "dumpsys")
+        echo "mResumedActivity: ActivityRecord{... ${PACKAGE}/.MainActivity ...}"
+        exit 0
+        ;;
+    esac
+    ;;
+  "uninstall")
+    exit 0
+    ;;
+  "wait-for-device")
+    exit 0
+    ;;
+esac
+exit 0
+`;
+
+/**
+ * Dead emulator: install fails with broken-pipe / can't-find-service.
+ * After restoring health (wait-for-device + boot_completed), all subsequent
+ * calls succeed (healthy emulator behaviour).
+ */
+function makeDeadThenHealthyAdb(statefile: string): string {
+    return `
+STATEFILE="${statefile}"
+
+# Track whether we've been through health-restore (wait-for-device was called).
+if [[ -f "$STATEFILE" ]]; then
+  # Post-restore: behave like a healthy emulator.
+  case "$1 $2 $3" in
+    "install "*)
+      echo "Success"
+      exit 0
+      ;;
+  esac
+  case "$1" in
+    "logcat")
+      if [[ "$2" == "-c" ]]; then exit 0; fi
+      echo "I ActivityTaskManager: Displayed ${PACKAGE}/.MainActivity"
+      exit 0
+      ;;
+    "shell")
+      case "$2" in
+        "am") exit 0 ;;
+        "pidof") echo "12345"; exit 0 ;;
+        "getprop") echo "1"; exit 0 ;;
+        "cmd") echo "package:${PACKAGE}"; exit 0 ;;
+        "dumpsys") echo "mResumedActivity: ActivityRecord{... ${PACKAGE}/.MainActivity ...}"; exit 0 ;;
+      esac
+      ;;
+    "uninstall") exit 0 ;;
+    "wait-for-device") exit 0 ;;
+  esac
+  exit 0
+fi
+
+# Pre-restore: fail install with dead-emulator signal.
+case "$1 $2 $3" in
+  "install "*)
+    echo "adb: failed to install cablesnap.apk: cmd: Failure calling service package: Broken pipe (32)"
+    exit 1
+    ;;
+esac
+case "$1" in
+  "uninstall")
+    echo "cmd: Can't find service: package"
+    exit 1
+    ;;
+  "wait-for-device")
+    # Restore path: mark state as restored and succeed.
+    touch "$STATEFILE"
+    exit 0
+    ;;
+  "shell")
+    case "$2" in
+      "getprop") echo "1"; exit 0 ;;
+      "cmd") echo "package:${PACKAGE}"; exit 0 ;;
+    esac
+    ;;
+esac
+exit 0
+`;
+}
+
+/**
+ * App crash: install succeeds, pidof returns nothing (process died).
+ * Emulator is otherwise healthy.
+ */
+const APP_CRASH_PIDOF_ADB = `
+case "$1 $2 $3" in
+  "install "*)
+    echo "Success"
+    exit 0
+    ;;
+esac
+case "$1" in
+  "logcat")
+    if [[ "$2" == "-c" ]]; then exit 0; fi
+    echo "E AndroidRuntime: FATAL EXCEPTION: main"
+    echo "E AndroidRuntime: java.lang.NullPointerException: crash"
+    exit 0
+    ;;
+  "shell")
+    case "$2" in
+      "am")
+        case "$3" in
+          "start") exit 0 ;;
+          "force-stop") exit 0 ;;
+        esac
+        ;;
+      "pidof")
+        # Process is dead — return nothing.
+        exit 1
+        ;;
+      "getprop") echo "1"; exit 0 ;;
+      "cmd") echo "package:${PACKAGE}"; exit 0 ;;
+      "dumpsys") echo ""; exit 0 ;;
+    esac
+    ;;
+  "uninstall") exit 0 ;;
+  "wait-for-device") exit 0 ;;
+esac
+exit 0
+`;
+
+/**
+ * Unrevivable emulator: install fails with broken-pipe, and wait-for-device
+ * hangs forever (we simulate this with an immediate timeout exit).
+ */
+const UNREVIVABLE_ADB = `
+case "$1 $2 $3" in
+  "install "*)
+    echo "cmd: Failure calling service package: Broken pipe (32)"
+    exit 1
+    ;;
+esac
+case "$1" in
+  "uninstall")
+    echo "cmd: Can't find service: package"
+    exit 1
+    ;;
+  "wait-for-device")
+    # Simulate an emulator that never reconnects — sleep until killed.
+    sleep 999
+    exit 1
+    ;;
+esac
+exit 0
+`;
+
+/**
+ * Slow-boot emulator: install fails first (dead), wait-for-device succeeds
+ * quickly, but boot_completed returns "" several times before returning "1".
+ */
+function makeSlowBootAdb(statefile: string): string {
+    return `
+STATEFILE="${statefile}"
+BOOTCOUNT_FILE="${statefile}.bootcount"
+
+if [[ -f "$STATEFILE" ]]; then
+  # Post-restore healthy path.
+  case "$1 $2 $3" in
+    "install "*)
+      echo "Success"
+      exit 0
+      ;;
+  esac
+  case "$1" in
+    "logcat")
+      if [[ "$2" == "-c" ]]; then exit 0; fi
+      echo "I ActivityTaskManager: Displayed ${PACKAGE}/.MainActivity"
+      exit 0
+      ;;
+    "shell")
+      case "$2" in
+        "am") exit 0 ;;
+        "pidof") echo "12345"; exit 0 ;;
+        "getprop") echo "1"; exit 0 ;;
+        "cmd") echo "package:${PACKAGE}"; exit 0 ;;
+        "dumpsys") echo "mResumedActivity: ActivityRecord{... ${PACKAGE}/.MainActivity ...}"; exit 0 ;;
+      esac
+      ;;
+    "uninstall") exit 0 ;;
+    "wait-for-device") exit 0 ;;
+  esac
+  exit 0
+fi
+
+case "$1 $2 $3" in
+  "install "*)
+    echo "cmd: Failure calling service activity: Broken pipe (32)"
+    exit 1
+    ;;
+esac
+case "$1" in
+  "uninstall")
+    echo "cmd: Can't find service: activity"
+    exit 1
+    ;;
+  "wait-for-device")
+    touch "$STATEFILE"
+    exit 0
+    ;;
+  "shell")
+    case "$2" in
+      "getprop")
+        # boot_completed is empty on first 2 polls, then "1".
+        COUNT=0
+        if [[ -f "$BOOTCOUNT_FILE" ]]; then
+          COUNT=$(cat "$BOOTCOUNT_FILE")
+        fi
+        COUNT=$((COUNT + 1))
+        echo "$COUNT" > "$BOOTCOUNT_FILE"
+        if [[ "$COUNT" -ge 3 ]]; then
+          echo "1"
+        else
+          echo ""
+        fi
+        exit 0
+        ;;
+      "cmd") echo "package:${PACKAGE}"; exit 0 ;;
+    esac
+    ;;
+esac
+exit 0
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("BLD-1976 smoke-test-emulator.sh dead-emulator retry guard", () => {
+    it("AC1: dead emulator (broken-pipe on install) → health-restore path taken, retry succeeds (exit 0)", () => {
+        const statefile = path.join(os.tmpdir(), `bld1976-state-${Date.now()}`);
+        try {
+            const adbScript = makeDeadThenHealthyAdb(statefile);
+            const result = runSmokeTest(adbScript);
+
+            expect(result.exitCode).toBe(0);
+            // Health-restore path must have been entered.
+            expect(result.combined).toMatch(/health-restore/i);
+            // Must NOT have done a blind re-install (old behaviour was just sleep 5 + uninstall + install).
+            // The presence of "wait-for-device" or "boot_completed" message confirms the new path.
+            expect(result.combined).toMatch(/ADB transport|boot_completed|emulator is healthy/i);
+        } finally {
+            try { fs.unlinkSync(statefile); } catch { /* best-effort */ }
+            try { fs.unlinkSync(`${statefile}.bootcount`); } catch { /* best-effort */ }
+        }
+    });
+
+    it("AC2: genuine app crash (FATAL EXCEPTION) on healthy emulator → exits 1 (no regression)", () => {
+        const result = runSmokeTest(APP_CRASH_PIDOF_ADB);
+
+        expect(result.exitCode).toBe(1);
+        // Must identify it as an app failure (process not found), not an infra failure.
+        expect(result.combined).toMatch(/crashed on launch|process not found/i);
+        // Must NOT emit infrastructure failure messaging.
+        expect(result.combined).not.toMatch(/emulator infrastructure failure/i);
+        expect(result.combined).not.toMatch(/infra.*flake|CI runner resource/i);
+    });
+
+    it("AC3: unrevivable emulator (wait-for-device times out) → exits 2 with ::error:: infra message", () => {
+        const result = runSmokeTest(UNREVIVABLE_ADB);
+
+        expect(result.exitCode).toBe(2);
+        // Must name this as an infrastructure failure.
+        expect(result.combined).toMatch(/[Ee]mulator infrastructure failure/);
+        // Must use GitHub Actions ::error:: annotation.
+        expect(result.combined).toMatch(/::error::/);
+        // Must NOT say "app regression".
+        // (The message says "not an app regression" — ensure the framing is correct.)
+        expect(result.combined).toMatch(/not an app regression/);
+    });
+
+    it("AC4: slow-boot emulator (boot_completed eventually=1) → health-restore waits, then install succeeds (exit 0)", () => {
+        const statefile = path.join(os.tmpdir(), `bld1976-slowboot-${Date.now()}`);
+        try {
+            const adbScript = makeSlowBootAdb(statefile);
+            const result = runSmokeTest(adbScript);
+
+            expect(result.exitCode).toBe(0);
+            expect(result.combined).toMatch(/health-restore/i);
+            expect(result.combined).toMatch(/All emulator smoke tests passed/);
+        } finally {
+            try { fs.unlinkSync(statefile); } catch { /* best-effort */ }
+            try { fs.unlinkSync(`${statefile}.bootcount`); } catch { /* best-effort */ }
+        }
+    });
+
+    it("healthy emulator (no dead-emulator failure) → passes without entering health-restore path (exit 0)", () => {
+        const result = runSmokeTest(HEALTHY_ADB);
+
+        expect(result.exitCode).toBe(0);
+        expect(result.combined).toMatch(/All emulator smoke tests passed/);
+        expect(result.combined).not.toMatch(/health-restore/i);
+        expect(result.combined).not.toMatch(/Dead-emulator/i);
+    });
+});

--- a/scripts/smoke-test-emulator.sh
+++ b/scripts/smoke-test-emulator.sh
@@ -12,21 +12,113 @@
 # `cablesnap-fdroid.apk` (F-Droid variant). The emulator must already be
 # booted and available via adb.
 #
-# Exit codes: 0 on success, 1 on any smoke-test failure.
+# Exit codes:
+#   0  — smoke tests passed
+#   1  — app failure (FATAL EXCEPTION / process-not-found on healthy emulator)
+#   2  — emulator-infrastructure failure (dead emulator could not be revived)
+#        This exit code signals a CI infrastructure flake, NOT an app regression.
 
 set -euo pipefail
 
 PACKAGE="com.persoack.cablesnap"
 ACTIVITY="${PACKAGE}/.MainActivity"
 
+# ---------------------------------------------------------------------------
+# Dead-emulator detection
+# ---------------------------------------------------------------------------
+# Returns 0 (true) if the output string is consistent with a dead/crashed
+# emulator: "Broken pipe", "Can't find service: activity|package", or
+# "error: no devices/emulators found" / "device offline".
+#
+# Usage: is_dead_emulator_error "$output_string"
+is_dead_emulator_error() {
+  local output="$1"
+  if echo "$output" | grep -qE \
+       'Broken pipe|Can'"'"'t find service: (activity|package)|error: no devices|device offline|error: device offline'; then
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Emulator health-restore
+# ---------------------------------------------------------------------------
+# After detecting that the emulator process has died or become unreachable,
+# attempt to wait for it to recover within a bounded timeout.
+#
+# Strategy:
+#   1. adb wait-for-device — blocks until the ADB transport layer reconnects.
+#   2. Poll sys.boot_completed until it returns "1" (bounded by BOOT_TIMEOUT_S).
+#   3. Probe the package service to confirm Android system services are live.
+#
+# Returns 0 if the emulator is healthy, 1 if it could not be revived within
+# the timeout.
+#
+# Usage: restore_emulator_health
+BOOT_TIMEOUT_S="${EMULATOR_BOOT_TIMEOUT_S:-120}"
+
+restore_emulator_health() {
+  echo "--- Emulator health-restore: waiting for ADB transport (timeout: ${BOOT_TIMEOUT_S}s) ---"
+
+  # Step 1: Wait for device transport to reconnect (bounded timeout via timeout(1)).
+  if ! timeout "${BOOT_TIMEOUT_S}" adb wait-for-device 2>&1; then
+    echo "::error::Emulator infrastructure failure — adb wait-for-device timed out after ${BOOT_TIMEOUT_S}s. This is a CI runner resource issue, not an app regression."
+    return 1
+  fi
+  echo "--- ADB transport up; polling boot_completed ---"
+
+  # Step 2: Poll sys.boot_completed until "1".
+  local deadline=$(( $(date +%s) + BOOT_TIMEOUT_S ))
+  while true; do
+    local boot_val
+    boot_val=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '[:space:]') || boot_val=""
+    if [ "$boot_val" = "1" ]; then
+      echo "--- sys.boot_completed=1 ---"
+      break
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "::error::Emulator infrastructure failure — sys.boot_completed never reached 1 within ${BOOT_TIMEOUT_S}s. This is a CI runner resource issue, not an app regression."
+      return 1
+    fi
+    sleep 5
+  done
+
+  # Step 3: Confirm package service is alive.
+  echo "--- Probing Android package service ---"
+  local pkg_probe
+  pkg_probe=$(adb shell cmd package list packages 2>&1 | head -3) || pkg_probe=""
+  if is_dead_emulator_error "$pkg_probe"; then
+    echo "::error::Emulator infrastructure failure — Android package service unresponsive after boot_completed=1. This is a CI runner resource issue, not an app regression."
+    return 1
+  fi
+
+  echo "--- Emulator health-restore: emulator is healthy ---"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Single-variant smoke test
+# ---------------------------------------------------------------------------
 smoke_test_apk() {
   local APK_PATH="$1"
   local LABEL="$2"
 
   echo "=== Smoke-testing $LABEL: $APK_PATH ==="
 
-  # Install
-  adb install "$APK_PATH"
+  # Install — capture output so we can inspect for dead-emulator symptoms.
+  local install_out
+  if ! install_out=$(adb install "$APK_PATH" 2>&1); then
+    # Distinguish infrastructure death from a genuine install failure.
+    if is_dead_emulator_error "$install_out"; then
+      echo "--- Dead-emulator detected during install (broken-pipe / can't-find-service) ---"
+      echo "$install_out"
+      # Signal caller to attempt health-restore + retry.
+      return 2
+    fi
+    echo "::error::$LABEL install failed (not a dead-emulator signal)."
+    echo "$install_out"
+    return 1
+  fi
 
   # Clear logcat before launch
   adb logcat -c
@@ -38,7 +130,8 @@ smoke_test_apk() {
   # take longer to settle than older versions; the previous 10s caught the app
   # mid-boot in run #25242273020 where pidof was set but dumpsys hadn't yet
   # promoted MainActivity to RESUMED.
-  sleep 15
+  # EMULATOR_APP_SETTLE_S can be overridden in tests to reduce wall-clock time.
+  sleep "${EMULATOR_APP_SETTLE_S:-15}"
 
   # Hard-fail check 1: process must still be alive (catches launch crashes).
   if ! adb shell pidof "$PACKAGE" > /dev/null 2>&1; then
@@ -92,33 +185,56 @@ smoke_test_apk() {
   adb uninstall "$PACKAGE"
 }
 
-# Test Play variant
-PLAY_EXIT=0
-smoke_test_apk "cablesnap.apk" "Play APK" || PLAY_EXIT=$?
+# ---------------------------------------------------------------------------
+# Run smoke test for one variant with dead-emulator-aware retry
+# ---------------------------------------------------------------------------
+# Usage: run_variant_smoke_test <apk_path> <label>
+# Exits the whole script on:
+#   - Genuine app failure (exit 1)
+#   - Emulator cannot be revived (exit 2)
+run_variant_smoke_test() {
+  local APK_PATH="$1"
+  local LABEL="$2"
 
-if [ "$PLAY_EXIT" -ne 0 ]; then
-  echo "Retrying Play APK smoke test (flaky emulator guard)..."
+  local EXIT_CODE=0
+  smoke_test_apk "$APK_PATH" "$LABEL" || EXIT_CODE=$?
+
+  if [ "$EXIT_CODE" -eq 0 ]; then
+    return 0
+  fi
+
+  if [ "$EXIT_CODE" -eq 2 ]; then
+    # Dead-emulator path: attempt health-restore before retry.
+    echo "Dead-emulator signal detected for $LABEL — attempting health-restore before retry..."
+    if ! restore_emulator_health; then
+      # restore_emulator_health already printed the ::error:: message.
+      exit 2
+    fi
+    # Emulator is healthy — clean up any partial install and retry.
+    adb uninstall "$PACKAGE" 2>/dev/null || true
+    if ! smoke_test_apk "$APK_PATH" "$LABEL (retry after health-restore)"; then
+      echo "::error::$LABEL failed smoke test after emulator health-restore."
+      exit 1
+    fi
+    return 0
+  fi
+
+  # EXIT_CODE=1: genuine app failure on first attempt — allow one blind retry
+  # for transient non-emulator-death flake (original behavior preserved).
+  echo "Retrying $LABEL smoke test (flaky emulator guard)..."
   sleep 5
   # Ensure clean state for retry
   adb uninstall "$PACKAGE" 2>/dev/null || true
-  if ! smoke_test_apk "cablesnap.apk" "Play APK (retry)"; then
-    echo "::error::Play APK failed smoke test on retry."
+  if ! smoke_test_apk "$APK_PATH" "$LABEL (retry)"; then
+    echo "::error::$LABEL failed smoke test on retry."
     exit 1
   fi
-fi
+}
+
+# Test Play variant
+run_variant_smoke_test "cablesnap.apk" "Play APK"
 
 # Test F-Droid variant
-FDROID_EXIT=0
-smoke_test_apk "cablesnap-fdroid.apk" "F-Droid APK" || FDROID_EXIT=$?
-
-if [ "$FDROID_EXIT" -ne 0 ]; then
-  echo "Retrying F-Droid APK smoke test (flaky emulator guard)..."
-  sleep 5
-  adb uninstall "$PACKAGE" 2>/dev/null || true
-  if ! smoke_test_apk "cablesnap-fdroid.apk" "F-Droid APK (retry)"; then
-    echo "::error::F-Droid APK failed smoke test on retry."
-    exit 1
-  fi
-fi
+run_variant_smoke_test "cablesnap-fdroid.apk" "F-Droid APK"
 
 echo "All emulator smoke tests passed."


### PR DESCRIPTION
## Summary

Fixes the emulator smoke-test retry guard, which was ineffective when the emulator process died mid-install with a broken-pipe / "Can't find service" error. Previously the retry would blindly re-install on the same dead emulator, failing identically and blocking the release pipeline.

## Root Cause

When the emulator process collapsed (resource-starved CI runner: 467s boot vs typical ~150s), every adb call in the retry also failed with `Broken pipe` / `Can't find service: package`. The old retry did `sleep 5 + adb uninstall + install` without first verifying the emulator was alive.

## Changes

### `scripts/smoke-test-emulator.sh`
- Add `is_dead_emulator_error()` — distinguishes dead-emulator symptoms (Broken pipe / Can't find service: activity|package / device offline) from genuine app failures
- Add `restore_emulator_health()` — bounded recovery: `adb wait-for-device` → poll `sys.boot_completed` → probe package service. Only re-installs once all three pass.
- `EMULATOR_BOOT_TIMEOUT_S` env var (default: 120s) bounds the health-restore wait
- `EMULATOR_APP_SETTLE_S` env var (default: 15s) for post-launch settle, enabling fast testing without changing production behaviour
- New exit code `2` for emulator-infrastructure failures (distinct from `1` for app failures) — labelled with `::error::` naming it a CI runner resource issue, not an app regression
- Genuine app-crash path (FATAL EXCEPTION / process-not-found on healthy emulator) still exits 1, unchanged

### `scripts/__tests__/smoke-test-emulator.test.ts` (new)
5 tests using stubbed `adb` binaries (no real emulator needed):
- **AC1**: Dead emulator (broken-pipe) → health-restore path taken → retry succeeds (exit 0)
- **AC2**: App crash (FATAL EXCEPTION) on healthy emulator → exit 1, no regression
- **AC3**: Unrevivable emulator (wait-for-device times out) → exit 2 + `::error::` infra message
- **AC4**: Slow-boot emulator (boot_completed eventually=1) → health-restore waits → succeeds
- **AC5**: Healthy emulator → no health-restore entered → exit 0

## Testing



All 98 scripts tests pass with no regressions.

## Issue

Resolves BLD-1976