### PR TITLE
fix(tooling): clip.sh wake-agent uses valid source enum (BLD-1981)

### DIFF
--- a/scripts/clip.sh
+++ b/scripts/clip.sh
@@ -321,8 +321,28 @@ case "$cmd" in
     ;;
 
   wake-agent)
+    # BLD-1981: This endpoint is SELF-WAKE ONLY. The server
+    # (POST /agents/:id/wakeup) returns 403 "Agent can only invoke itself"
+    # when an agent actor targets any id other than its own, so this command
+    # can only ever re-wake the caller. It always posts to $AGENT (self).
+    #
+    # Two prior defects fixed here:
+    #   1. It still POSTed `source:"cli"`, which is not in the API enum
+    #      (timer|assignment|on_demand|automation) and 400'd every call.
+    #      Now uses "on_demand".
+    #   2. The original BLD-1981 report expected `wake-agent <UUID> <reason>`
+    #      to wake a *different* agent. That is not achievable for an agent
+    #      caller (403 by design). To avoid the silent-self-wake foot-gun, a
+    #      UUID-shaped first arg is rejected with guidance toward the real
+    #      cross-boundary push path: an @mention on a shared issue.
+    if [[ "${1:-}" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+      echo "ERROR: wake-agent only wakes the calling agent (self). The Paperclip API rejects" >&2
+      echo "       cross-agent wakeups with HTTP 403 \"Agent can only invoke itself\"." >&2
+      echo "       To nudge another agent, @mention it in a comment on an issue it can access." >&2
+      exit 1
+    fi
     reason="${1:-manual wakeup}"
-    api_post "/agents/$AGENT/wakeup" "{\"source\":\"cli\",\"reason\":$(echo "$reason" | jq -Rs '.')}" | jq_or_cat '.'
+    api_post "/agents/$AGENT/wakeup" "{\"source\":\"on_demand\",\"reason\":$(echo "$reason" | jq -Rs '.')}" | jq_or_cat '.'
     ;;
 
   # === Dashboard & Activity ===
@@ -424,7 +444,10 @@ LABELS:
 AGENTS:
   create-agent --name N --model M [--role R] [--instructions-file /skills/AGENTS-X.md]
                Always uses copilot_local adapter (enforced, not overridable)
-  list-agents | get-me | get-agent <ID> | wake-agent [reason]
+  list-agents | get-me | get-agent <ID>
+  wake-agent [reason]        Re-wake the CALLING agent (self only). The API
+                             rejects cross-agent wakeups (403); to nudge
+                             another agent, @mention it on a shared issue.
 
 DASHBOARD:
   dashboard | activity [--agent-id ID] | badges


### PR DESCRIPTION
## Summary

`scripts/clip.sh wake-agent` failed with HTTP 400 on every call (BLD-1981). Two issues:

1. **Invalid `source`** — the request body sent `source: "cli"`, but the API enum only accepts `timer | assignment | on_demand | automation`. Now sends `on_demand`.
2. **Cross-agent wake expectation** — the original report expected `wake-agent <UUID> <reason>` to wake a *different* agent. The server enforces **self-wake-only**: `POST /agents/:id/wakeup` returns `403 "Agent can only invoke itself"` for any cross-agent target (see `server/src/routes/agents.ts` `handleWakeupRoute`). So waking another agent is not achievable for an agent caller. Rather than silently self-wake when a UUID is passed, the command now rejects a UUID-shaped first arg and points at the real cross-boundary push path (an @mention on a shared issue). Help text updated.

## Why not make it target an arbitrary UUID?

Because the server would always 403 it for an agent caller. The bug report's acceptance criterion "wake a different agent and confirm 2xx" is not satisfiable against this endpoint by design — the authorization model only permits self-wake. Pointing the script at `$1` would replace a 400 with a 403 and a confusing failure mode.

## Verification

```
$ bash scripts/clip.sh wake-agent "BLD-1981 verification"
{ "invocationSource": "on_demand", "status": "queued", ... }   # exit 0, was HTTP 400 before

$ bash scripts/clip.sh wake-agent <some-uuid>
ERROR: wake-agent only wakes the calling agent (self)...            # exit 1, clear guidance
```

## Note on the read-only mount

`scripts/clip.sh` in this repo is the source of truth; the host bind-mounts a copy at `/skills/scripts/clip.sh` (read-only inside containers). After merge, the host operator must re-sync the mount for agents to pick up the fix — same as the prior BLD-846 error-handling change, which is already ahead in this repo but not yet synced to the mount.

Fixes BLD-1981.