### PR TITLE
fix: restructure stat tile labels to prevent truncation on summary screen (BLD-1993)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
+- **Fix: "Sets" and "Volume" stat labels no longer truncate on the workout summary screen** — the stacked stat-tile captions on the completed-workout summary were clipped with an ellipsis on narrow viewports. The label layout was restructured so each caption renders on a single line at full width. (BLD-1993)
 - **Fix: "Select" link in the Form clips header now meets the 44 dp touch target minimum** — the previous implementation used a small `hitSlop` that only extended the tappable area to ~36 dp, making the control difficult to tap reliably. The tap area is now at least 44×44 dp as required by HIG and Material guidelines. (BLD-1941)
 - **Fix: Pacing bar is now distinguishable under red-green colour blindness** — the "Other" (grey) segment in the post-workout pacing bar now carries a diagonal hatch pattern so it remains separable from the "Working" (coral) segment for users with deuteranopia or protanopia. The hatch is mirrored on the matching legend dot. Full-colour appearance for sighted users is unchanged. (BLD-1939)
 - **Fix: "Sets" stat label no longer truncates on the workout summary screen** — on 390 px viewports the "Sets (9 working)" caption was cut off with an ellipsis because the auto-shrink limit of 80% wasn't enough headroom. The minimum font scale is now 60%, giving the caption enough room to fit on one line. Duration and Volume captions are unchanged. (BLD-1938)

--- a/__tests__/acceptance/summary-stat-tile-single-line.acceptance.test.tsx
+++ b/__tests__/acceptance/summary-stat-tile-single-line.acceptance.test.tsx
@@ -1,16 +1,24 @@
 /**
- * Acceptance test for BLD-1876 / BLD-1873 / BLD-1938:
+ * Acceptance test for BLD-1993 (and prior BLD-1876 / BLD-1873 / BLD-1938):
  * Summary screen stat tile captions must not wrap to multiple lines.
  *
+ * BLD-1993 restructures the labels so they are short static words that always
+ * fit at 390px without any font-shrink tricks:
+ *  - Duration label: "Duration" (unchanged)
+ *  - Sets label:     "Sets"     (parenthetical "(N working)" removed from label)
+ *  - Volume label:   "Volume"   (unit moved to value line, e.g. "2,400 kg")
+ *
  * Verifies:
- *  - All three stat captions (Duration, Sets, Volume) have numberOfLines={1}
- *  - Duration and Volume captions have adjustsFontSizeToFit and minimumFontScale={0.8}
- *  - Sets caption has adjustsFontSizeToFit and minimumFontScale={0.6} (BLD-1938:
- *    lowered from 0.8 so "Sets (9 working)" fits in the ~78px card width at 390px
- *    viewport without truncation)
+ *  - All three stat captions render the exact static text: "Duration" / "Sets" / "Volume"
+ *  - All three captions have numberOfLines={1} (single-line constraint)
+ *  - Captions do NOT use adjustsFontSizeToFit — labels are short enough not to need it
+ *  - The Volume VALUE text contains the unit suffix (e.g. "0 kg")
  *  - The Sets tile accessibilityLabel still exposes the full breakdown text
- *    (screen-reader accessibility must not regress)
- *  - Captions render correctly for both single-type and multi-type set breakdowns
+ *    (screen-reader a11y must not regress — BLD-1993 AC)
+ *  - The mixed-set-type case still has "Sets" as the visible label (no cramming
+ *    long breakdown into label text)
+ *  - Stat VALUE nodes have numberOfLines={1} and adjustsFontSizeToFit so large
+ *    numbers (e.g. "124,500 lb") render on one line
  */
 
 jest.mock('../../lib/db', () => ({
@@ -97,13 +105,13 @@ import Summary from '../../app/session/summary/[id]'
 
 const mockDb = require('../../lib/db') as Record<string, jest.Mock>
 
-describe('Summary stat tile captions — single-line constraint (BLD-1876)', () => {
+describe('Summary stat tile captions — single-line constraint (BLD-1993)', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     resetIds()
   })
 
-  it('Duration caption has numberOfLines=1 and adjustsFontSizeToFit', async () => {
+  it('Duration caption renders the exact static text "Duration" with numberOfLines=1', async () => {
     const { session, exercises, sets } = createCompletedWorkoutFixture()
     mockDb.getSessionById.mockResolvedValue(session)
     mockDb.getSessionSets.mockResolvedValue(sets)
@@ -111,19 +119,17 @@ describe('Summary stat tile captions — single-line constraint (BLD-1876)', () 
 
     const screen = renderScreen(<Summary />)
 
-    // Duration card is identified by its accessibility label
     const durationCard = await screen.findByLabelText(/Duration:/i)
     expect(durationCard).toBeTruthy()
 
-    // Find the Duration caption text node inside the Duration card subtree.
-    // We locate it by its text content.
+    // Exact label text — no parenthetical, no unit suffix
     const durationCaption = await screen.findByText('Duration')
     expect(durationCaption.props.numberOfLines).toBe(1)
-    expect(durationCaption.props.adjustsFontSizeToFit).toBe(true)
-    expect(durationCaption.props.minimumFontScale).toBe(0.8)
+    // BLD-1993: labels are short static words — they should NOT need adjustsFontSizeToFit
+    expect(durationCaption.props.adjustsFontSizeToFit).toBeFalsy()
   })
 
-  it('Sets caption has numberOfLines=1, adjustsFontSizeToFit, and minimumFontScale=0.6 to prevent truncation (BLD-1938)', async () => {
+  it('Sets caption renders the exact static text "Sets" with numberOfLines=1 (no parenthetical)', async () => {
     const { session, exercises, sets } = createCompletedWorkoutFixture({ setCount: 9 })
     mockDb.getSessionById.mockResolvedValue(session)
     mockDb.getSessionSets.mockResolvedValue(sets)
@@ -131,21 +137,23 @@ describe('Summary stat tile captions — single-line constraint (BLD-1876)', () 
 
     const screen = renderScreen(<Summary />)
 
-    // Sets card is identified by its accessibility label
     const setsCard = await screen.findByLabelText(/sets/i)
     expect(setsCard).toBeTruthy()
 
-    // Find the Sets caption — it will be "Sets (9 working)" or plain "Sets"
-    // BLD-1938: minimumFontScale lowered from 0.8 → 0.6 so "Sets (9 working)" fits
-    // in the ~78px available width at 390px viewport without truncation.
-    const setsCaptions = await screen.findAllByText(/^Sets/i)
-    const setsCaption = setsCaptions[0]
-    expect(setsCaption.props.numberOfLines).toBe(1)
-    expect(setsCaption.props.adjustsFontSizeToFit).toBe(true)
-    expect(setsCaption.props.minimumFontScale).toBe(0.6)
+    // BLD-1993: label must be exactly "Sets" — NOT "Sets (9 working)" etc.
+    // Note: SetsCard also renders a "Sets" header (variant="title"), so we use
+    // findAllByText and look for the caption with numberOfLines=1 (the stat tile).
+    const setsCaptions = await screen.findAllByText('Sets')
+    // The stat tile caption has numberOfLines=1; the SetsCard header does not
+    const statCaption = setsCaptions.find((n) => n.props.numberOfLines === 1)
+    expect(statCaption).toBeTruthy()
+    // BLD-1993: static short label — no need for adjustsFontSizeToFit on labels
+    expect(statCaption!.props.adjustsFontSizeToFit).toBeFalsy()
+    // The old minimumFontScale={0.6} band-aid must be gone
+    expect(statCaption!.props.minimumFontScale).toBeFalsy()
   })
 
-  it('Volume caption has numberOfLines=1 and adjustsFontSizeToFit', async () => {
+  it('Volume caption renders the exact static text "Volume" with numberOfLines=1', async () => {
     const { session, exercises, sets } = createCompletedWorkoutFixture()
     mockDb.getSessionById.mockResolvedValue(session)
     mockDb.getSessionSets.mockResolvedValue(sets)
@@ -153,11 +161,31 @@ describe('Summary stat tile captions — single-line constraint (BLD-1876)', () 
 
     const screen = renderScreen(<Summary />)
 
-    // Volume caption text contains "Volume"
-    const volumeCaption = await screen.findByText(/^Volume/i)
+    // BLD-1993: label must be exactly "Volume" — NOT "Volume (kg)" etc.
+    const volumeCaption = await screen.findByText('Volume')
     expect(volumeCaption.props.numberOfLines).toBe(1)
-    expect(volumeCaption.props.adjustsFontSizeToFit).toBe(true)
-    expect(volumeCaption.props.minimumFontScale).toBe(0.8)
+    // BLD-1993: static short label — no need for adjustsFontSizeToFit on labels
+    expect(volumeCaption.props.adjustsFontSizeToFit).toBeFalsy()
+  })
+
+  it('Volume VALUE text contains the unit suffix (e.g. "0 kg")', async () => {
+    const { session, exercises, sets } = createCompletedWorkoutFixture()
+    mockDb.getSessionById.mockResolvedValue(session)
+    mockDb.getSessionSets.mockResolvedValue(sets)
+    mockDb.getExercisesByIds.mockResolvedValue(exercises)
+
+    const screen = renderScreen(<Summary />)
+
+    // The Volume card value should include the unit ("0 kg", "2,400 kg", etc.)
+    // The accessibility label uses "Total volume:" so we can scope to that card
+    const volumeCard = await screen.findByLabelText(/Total volume:/i)
+    expect(volumeCard).toBeTruthy()
+
+    // The value text node inside the card's heading should contain the unit
+    const valueWithUnit = await screen.findByText(/\d.*\s(kg|lb)/i)
+    expect(valueWithUnit).toBeTruthy()
+    expect(valueWithUnit.props.numberOfLines).toBe(1)
+    expect(valueWithUnit.props.adjustsFontSizeToFit).toBe(true)
   })
 
   it('Sets tile accessibilityLabel still exposes full breakdown text (a11y not regressed)', async () => {
@@ -170,17 +198,36 @@ describe('Summary stat tile captions — single-line constraint (BLD-1876)', () 
 
     // The Card accessibilityLabel must contain the set count and a breakdown.
     // With 9 completed working sets: "9 sets: 9 working" or "9 sets completed"
-    // (depending on whether setsBreakdown is populated from getSessionSetCount).
-    // At minimum it must mention the count, not be empty.
     const setsCard = await screen.findByLabelText(/sets/i)
     const label = setsCard.props.accessibilityLabel as string
     expect(label).toBeTruthy()
     expect(label.length).toBeGreaterThan(0)
-    // The label must NOT be the visual caption text — it must be the full spoken version
     expect(label).toMatch(/sets/i)
+    // The a11y label must still mention the count, not just be "Sets" (the short visible label)
+    expect(label).toMatch(/\d+\s*sets/i)
   })
 
-  it('all three captions are present as siblings inside the stats row', async () => {
+  it('Sets tile accessibilityLabel preserves breakdown for mixed set types (a11y no-regression, BLD-1993)', async () => {
+    // Mixed fixture: working + warm-up sets — confirms the long breakdown stays
+    // in the a11y label even though it no longer clutters the visible label.
+    const { session, exercises, sets } = createCompletedWorkoutFixture({ setCount: 8 })
+    mockDb.getSessionById.mockResolvedValue(session)
+    mockDb.getSessionSets.mockResolvedValue(sets)
+    mockDb.getExercisesByIds.mockResolvedValue(exercises)
+
+    const screen = renderScreen(<Summary />)
+
+    const setsCard = await screen.findByLabelText(/sets/i)
+    const label = setsCard.props.accessibilityLabel as string
+    expect(label).toBeTruthy()
+    expect(label).toMatch(/sets/i)
+    // Visible caption must still just be "Sets" (stat tile version, with numberOfLines=1)
+    const setsCaptions = await screen.findAllByText('Sets')
+    const statCaption = setsCaptions.find((n) => n.props.numberOfLines === 1)
+    expect(statCaption).toBeTruthy()
+  })
+
+  it('all three captions are present as siblings inside the stats row with exact static text', async () => {
     const { session, exercises, sets } = createCompletedWorkoutFixture()
     mockDb.getSessionById.mockResolvedValue(session)
     mockDb.getSessionSets.mockResolvedValue(sets)
@@ -188,17 +235,42 @@ describe('Summary stat tile captions — single-line constraint (BLD-1876)', () 
 
     const screen = renderScreen(<Summary />)
 
-    // All three stat captions must be in the tree
+    // All three stat captions must be exact static words — no units, no counts embedded
     const durationCaption = await screen.findByText('Duration')
     expect(durationCaption).toBeTruthy()
 
-    const volumeCaption = await screen.findByText(/^Volume/i)
+    const volumeCaption = await screen.findByText('Volume')
     expect(volumeCaption).toBeTruthy()
 
-    // "Sets (N working)" or plain "Sets" caption is always present in the stat tile.
-    // There may be multiple matches (e.g. SetsCard also contains "Sets" text),
-    // so we use findAllByText and confirm at least one exists.
-    const setsCaptions = await screen.findAllByText(/^Sets/i)
+    // "Sets" (exact) — not "Sets (N working)".
+    // Note: SetsCard also renders a "Sets" heading, so we check at least one
+    // "Sets" node has numberOfLines=1 (the stat tile caption).
+    const setsCaptions = await screen.findAllByText('Sets')
     expect(setsCaptions.length).toBeGreaterThan(0)
+    const statCaption = setsCaptions.find((n) => n.props.numberOfLines === 1)
+    expect(statCaption).toBeTruthy()
+  })
+
+  it('stat value text nodes have numberOfLines=1 and adjustsFontSizeToFit for long values', async () => {
+    const { session, exercises, sets } = createCompletedWorkoutFixture()
+    mockDb.getSessionById.mockResolvedValue(session)
+    mockDb.getSessionSets.mockResolvedValue(sets)
+    mockDb.getExercisesByIds.mockResolvedValue(exercises)
+
+    const screen = renderScreen(<Summary />)
+
+    // Duration value (e.g. "0:00") should have fit handling
+    const durationCard = await screen.findByLabelText(/Duration:/i)
+    expect(durationCard).toBeTruthy()
+
+    // All heading-variant text in the stats row should have single-line fit handling
+    // We verify the Volume value specifically since it gained a new " kg"/" lb" suffix
+    const volumeCard = await screen.findByLabelText(/Total volume:/i)
+    expect(volumeCard).toBeTruthy()
+    // The heading value inside it should exist with the fit props
+    const valueWithUnit = await screen.findByText(/\d.*\s(kg|lb)/i)
+    expect(valueWithUnit.props.numberOfLines).toBe(1)
+    expect(valueWithUnit.props.adjustsFontSizeToFit).toBe(true)
+    expect(valueWithUnit.props.minimumFontScale).toBe(0.7)
   })
 })

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -272,20 +272,20 @@ function SummaryHeader({ colors, session, duration, durationSpokenText, complete
       <View style={styles.stats}>
         <Card style={StyleSheet.flatten([styles.stat, { backgroundColor: colors.surface }])} accessibilityLabel={`Duration: ${durationSpokenText}`}>
           <CardContent style={styles.statInner}>
-            <Text variant="heading" style={{ color: colors.primary }}>{duration}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.8}>Duration</Text>
+            <Text variant="heading" style={{ color: colors.primary }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>{duration}</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1}>Duration</Text>
           </CardContent>
         </Card>
         <Card style={StyleSheet.flatten([styles.stat, { backgroundColor: colors.surface }])} accessibilityLabel={setsBreakdown ? `${completedCount} sets: ${setsBreakdown}` : `${completedCount} sets completed`}>
           <CardContent style={styles.statInner}>
-            <Text variant="heading" style={{ color: colors.primary }}>{completedCount}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.6}>{setsBreakdown ? `Sets (${setsBreakdown})` : "Sets"}</Text>
+            <Text variant="heading" style={{ color: colors.primary }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>{completedCount}</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1}>Sets</Text>
           </CardContent>
         </Card>
         <Card style={StyleSheet.flatten([styles.stat, { backgroundColor: colors.surface }])} accessibilityLabel={`Total volume: ${volumeDisplay.toLocaleString()} ${unit}`}>
           <CardContent style={styles.statInner}>
-            <Text variant="heading" style={{ color: colors.primary }}>{volumeDisplay.toLocaleString()}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.8}>Volume ({unit})</Text>
+            <Text variant="heading" style={{ color: colors.primary }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>{volumeDisplay.toLocaleString()} {unit}</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1}>Volume</Text>
           </CardContent>
         </Card>
       </View>


### PR DESCRIPTION
## Summary

Restructures the three stat tile labels on the completed-workout summary screen so they are short static words that always fit at the 390px mobile viewport — no font-shrink tricks needed.

## Problem

Prior fixes (BLD-1876/1873/1938) added `adjustsFontSizeToFit` + `minimumFontScale` as band-aids. These either still truncated or shrunk labels to ~10px (illegible). Root cause: labels embedded dynamic parenthetical text inside ~78px-wide cards.

## Changes

- **Sets label**: dynamic `Sets (N working)` → static `Sets`. Full breakdown stays in `accessibilityLabel` for screen readers (no a11y regression).
- **Volume label**: `Volume (kg)` → static `Volume`. Unit suffix moves to value line: `2,400 kg`.
- **Value Text nodes**: add `numberOfLines={1}` + `adjustsFontSizeToFit` + `minimumFontScale={0.7}` so large numbers shrink to fit rather than clipping.
- **Label captions**: remove `adjustsFontSizeToFit`/`minimumFontScale` entirely — short static words fit natively.
- **Acceptance test**: updated to assert exact label strings, Volume value contains unit suffix, Sets accessibilityLabel preserves breakdown, new mixed-set-type a11y no-regression case.

## Testing

- All 8 acceptance tests pass (including new BLD-1993 cases)
- Full suite: 4474 tests pass, 0 failures
- `tsc --noEmit`: zero errors
- ShareCard.test.tsx: 14 tests pass (out-of-scope component unaffected)

## Issue

Resolves BLD-1993