### PR TITLE
refactor(settings): standardize type hierarchy, kill fontSizes.sm one-offs (BLD-2035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- Settings: tidied up text hierarchy so titles, labels, and helper text use consistent sizes and weights for a cleaner, less cluttered look.
 
 ## v0.26.42 — 2026-06-27
 <!-- versionCode: 112 -->

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -30,7 +30,7 @@ import FeedbackCard from '../../components/settings/FeedbackCard';
 import ReminderSection from '../../components/settings/ReminderSection';
 import ReleaseNotesModal from '../../components/ReleaseNotesModal';
 import { useThemeColors } from '@/hooks/useThemeColors';
-import { fontSizes, spacing } from '@/constants/design-tokens';
+import { spacing } from '@/constants/design-tokens';
 import { useSettingsData } from '@/hooks/useSettingsData';
 import BackupCategorySheet from '@/components/settings/BackupCategorySheet';
 import { handleExport, pickImportBackup } from './_settings-handlers';
@@ -185,7 +185,7 @@ export default function Settings() {
               style={styles.settingsLinkRow}
             >
               <View style={styles.settingsLinkMeta}>
-                <Text variant="body" style={[styles.settingsLinkTitle, { color: colors.onSurface }]}>Gym Profiles</Text>
+                <Text variant="subtitle" style={{ color: colors.onSurface }}>Gym Profiles</Text>
                 <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                   Manage gyms, cable stacks, and marker calibrations.
                 </Text>
@@ -203,7 +203,7 @@ export default function Settings() {
               style={styles.settingsLinkRow}
             >
               <View style={styles.settingsLinkMeta}>
-                <Text variant="body" style={[styles.settingsLinkTitle, { color: colors.onSurface }]}>Advanced Set Types</Text>
+                <Text variant="subtitle" style={{ color: colors.onSurface }}>Advanced Set Types</Text>
                 <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                   How to use rest-pause, cluster, and myo-rep sets.
                 </Text>
@@ -221,7 +221,7 @@ export default function Settings() {
               style={styles.settingsLinkRow}
             >
               <View style={styles.settingsLinkMeta}>
-                <Text variant="body" style={[styles.settingsLinkTitle, { color: colors.onSurface }]}>Adaptive Macro Coach</Text>
+                <Text variant="subtitle" style={{ color: colors.onSurface }}>Adaptive Macro Coach</Text>
                 <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
                   {macroCoachEnabled === null ? '' : macroCoachEnabled ? 'On — weekly advisory card on Nutrition tab' : 'Off — tap to set up'}
                 </Text>
@@ -290,7 +290,7 @@ export default function Settings() {
         />
         <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
           <CardContent>
-            <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>
+            <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 8 }}>
               About
             </Text>
             <Pressable
@@ -306,14 +306,14 @@ export default function Settings() {
             >
               <Text
                 variant="body"
-                style={{ color: colors.onSurface, fontSize: fontSizes.sm, fontWeight: '600' }}
+                style={{ color: colors.onSurface, fontWeight: '500' }}
               >
                 {`CableSnap v${appVersion}`}
               </Text>
               <View style={styles.versionRowRight}>
                 <Text
-                  variant="body"
-                  style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm, marginRight: 4 }}
+                  variant="caption"
+                  style={{ marginRight: 4 }}
                 >
                   What&apos;s new
                 </Text>
@@ -321,7 +321,7 @@ export default function Settings() {
               </View>
             </Pressable>
             <View style={styles.aboutBlock}>
-              <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm }}>
+              <Text variant="caption">
                 Free & open-source workout tracker — optimized for cable machines, supports all major exercises.
               </Text>
               <Text
@@ -400,10 +400,6 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.sm,
     minHeight: 44,
   },
-  settingsRowLabel: {
-    fontSize: fontSizes.sm,
-    fontWeight: '600',
-  },
   versionRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -426,9 +422,5 @@ const styles = StyleSheet.create({
   settingsLinkMeta: {
     flex: 1,
     marginRight: 12,
-  },
-  settingsLinkTitle: {
-    fontSize: fontSizes.sm,
-    fontWeight: '600',
   },
 });


### PR DESCRIPTION
## Summary

Standardizes the type hierarchy in **Settings** and eliminates the `fontSizes.sm` (14px) one-off titles that made the screen read as inconsistent/crowded (root-cause finding #6 in the [BLD-2028](https://github.com/alankyshum/cablesnap) epic plan). Every hand-rolled inline font size in `app/(tabs)/settings.tsx` is now mapped onto the shared `Text` variant system, so the hierarchy is tuned in one place.

Implements **BLD-2035** (P1-7).

## Target hierarchy (per ticket spec)

| Role | Spec | Implementation |
|------|------|----------------|
| Tile / link title | subtitle, 18 / 600 | `variant="subtitle"` (`fontSizes.lg`=18, weight 600 — exact) |
| Row label (app version) | body, 17 / 500 | `variant="body"` + `fontWeight: '500'` (`FONT_SIZE`=17; +500 per spec) |
| Helper / caption | caption, muted | `variant="caption"` (17, muted — exact) |

## Changes

- **Tile / link titles → `variant="subtitle"` (18/600):** Gym Profiles, Advanced Set Types, Adaptive Macro Coach, and the "About" tile title.
- **App-version row label → `variant="body"` + `fontWeight: '500'` (17/500).**
- **"What's new" affordance + license blurb → `variant="caption"`** (muted, 17) — drops the manual `onSurfaceVariant` color overrides (the variant supplies the muted color).
- **Removed dead/replaced styles:** `settingsRowLabel` (defined, never referenced) and `settingsLinkTitle` (now superseded by `variant="subtitle"`).
- **Dropped the now-unused `fontSizes` import.**

Net `-18 / +10` LOC. Zero `fontSizes.sm` references remain in `settings.tsx`.

## Scope discipline

- `settingsRow` (unrelated dead style, no `fontSizes.sm`) **left untouched**.
- No IA consolidation / no `SettingsTile` / `SettingsLinkRow` extraction (those are separate tickets) — **type only**.
- `Card` / `CardContent` structure unchanged; **no nested cards** (epic ban honored).
- Logging path untouched; no reveal-transition gating on tile content.

## Verification

- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — `settings.tsx` clean (29 pre-existing errors in unrelated files are out of scope)
- ✅ `__tests__/theme/primary-contrast.test.ts` — AA contrast guard green (size/weight-only change; colors unchanged)
- ✅ `__tests__/acceptance/settings.test.tsx` + `navigation-headers.test.ts` — 29/29 pass
- ✅ Full suite — 4447/4447 tests pass (5 suites OOM-SIGKILLed under high parallel worker count; all pass when re-run serially)

## Design review

@ui-ux-designer — **mandatory design review before merge** per the ticket. This bumps tile titles from 14px→18px (subtitle), makes helper text properly muted (caption), and gives row labels a medium (500) weight. Please confirm the hierarchy reads correctly in Settings.

Draft until design review approval.