### PR TITLE
feat(ui): Card variant prop; declutter Settings tiles to outline (BLD-2030)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Improvement: Settings tiles are lighter and less cluttered** — the Settings screen previously rendered as a vertical stack of drop-shadowed boxes. Each tile now uses a subtle 1px outline instead of a shadow, with slightly tighter padding, so the screen reads as a clean, calm list rather than a column of floating cards. (BLD-2030)
 
 ## v0.26.42 — 2026-06-27
 <!-- versionCode: 112 -->

--- a/__tests__/components/ui/card-variants.test.tsx
+++ b/__tests__/components/ui/card-variants.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * BLD-2030: Lock the style contract for the Card `variant` prop.
+ *
+ * Three surface treatments must stay stable because the declutter epic
+ * (BLD-2028) and downstream tickets opt Settings tiles into `outline`:
+ *
+ * - `elevated` (DEFAULT, omitted prop) — drop shadow + elevation, opaque `card`
+ *   bg. Backwards-compatible with the ~95 existing call sites.
+ * - `outline` — 1px `border` hairline, NO shadow / NO elevation.
+ * - `ghost`   — `muted` surface tint, NO border, NO shadow / NO elevation.
+ *
+ * Shared invariants for every variant: full-width tile, `radii.lg` (12) radius,
+ * `spacing.base` (16) padding.
+ *
+ * Tests resolve to the light theme (default `themeMode: "system"` →
+ * `useColorScheme()` → light), so colors are asserted against `Colors.light`.
+ */
+
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { render } from '@testing-library/react-native';
+import { Card } from '../../../components/ui/card';
+import { radii, spacing } from '../../../constants/design-tokens';
+import { Colors } from '../../../theme/colors';
+
+function flattenCardStyle(testID: string, element: React.ReactElement) {
+  const screen = render(element);
+  const node = screen.getByTestId(testID);
+  return StyleSheet.flatten(node.props.style) ?? {};
+}
+
+describe('Card variant style contract (BLD-2030)', () => {
+  describe('shared invariants (all variants)', () => {
+    it.each(['elevated', 'outline', 'ghost'] as const)(
+      '%s uses radii.lg radius and spacing.base padding, full width',
+      (variant) => {
+        const flat = flattenCardStyle(
+          `card-${variant}`,
+          <Card variant={variant} testID={`card-${variant}`}>
+            {null}
+          </Card>
+        );
+        expect(flat.borderRadius).toBe(radii.lg);
+        expect(flat.padding).toBe(spacing.base);
+        expect(flat.width).toBe('100%');
+      }
+    );
+  });
+
+  describe('elevated (default)', () => {
+    it('omitting the prop renders identically to variant="elevated"', () => {
+      const omitted = flattenCardStyle(
+        'card-omitted',
+        <Card testID="card-omitted">{null}</Card>
+      );
+      const explicit = flattenCardStyle(
+        'card-explicit',
+        <Card variant="elevated" testID="card-explicit">
+          {null}
+        </Card>
+      );
+      expect(omitted).toEqual(explicit);
+    });
+
+    it('renders a drop shadow + elevation on the opaque card surface', () => {
+      const flat = flattenCardStyle(
+        'card-elevated',
+        <Card variant="elevated" testID="card-elevated">
+          {null}
+        </Card>
+      );
+      expect(flat.backgroundColor).toBe(Colors.light.card);
+      expect(flat.shadowColor).toBe(Colors.light.foreground);
+      expect(flat.shadowOpacity).toBeCloseTo(0.05, 5);
+      expect(flat.shadowRadius).toBe(3);
+      expect(flat.elevation).toBe(2);
+      // No border edge on the default treatment.
+      expect(flat.borderWidth).toBeUndefined();
+    });
+  });
+
+  describe('outline', () => {
+    it('renders a 1px border in the border token color', () => {
+      const flat = flattenCardStyle(
+        'card-outline',
+        <Card variant="outline" testID="card-outline">
+          {null}
+        </Card>
+      );
+      expect(flat.backgroundColor).toBe(Colors.light.card);
+      expect(flat.borderWidth).toBe(1);
+      expect(flat.borderColor).toBe(Colors.light.border);
+    });
+
+    it('has no shadow and no elevation', () => {
+      const flat = flattenCardStyle(
+        'card-outline-noshadow',
+        <Card variant="outline" testID="card-outline-noshadow">
+          {null}
+        </Card>
+      );
+      expect(flat.shadowOpacity).toBe(0);
+      expect(flat.shadowRadius).toBe(0);
+      expect(flat.elevation).toBe(0);
+    });
+  });
+
+  describe('ghost', () => {
+    it('renders the muted surface tint with no border', () => {
+      const flat = flattenCardStyle(
+        'card-ghost',
+        <Card variant="ghost" testID="card-ghost">
+          {null}
+        </Card>
+      );
+      expect(flat.backgroundColor).toBe(Colors.light.muted);
+      expect(flat.borderWidth).toBeUndefined();
+    });
+
+    it('has no shadow and no elevation', () => {
+      const flat = flattenCardStyle(
+        'card-ghost-noshadow',
+        <Card variant="ghost" testID="card-ghost-noshadow">
+          {null}
+        </Card>
+      );
+      expect(flat.shadowOpacity).toBe(0);
+      expect(flat.shadowRadius).toBe(0);
+      expect(flat.elevation).toBe(0);
+    });
+  });
+
+  describe('call-site style override', () => {
+    it('applies the caller style after the variant base (override wins)', () => {
+      const flat = flattenCardStyle(
+        'card-override',
+        <Card
+          variant="outline"
+          testID="card-override"
+          style={{ backgroundColor: '#123456', padding: 4 }}
+        >
+          {null}
+        </Card>
+      );
+      // Caller overrides bg + padding…
+      expect(flat.backgroundColor).toBe('#123456');
+      expect(flat.padding).toBe(4);
+      // …but the variant's border treatment is preserved.
+      expect(flat.borderWidth).toBe(1);
+      expect(flat.borderColor).toBe(Colors.light.border);
+    });
+  });
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -176,7 +176,7 @@ export default function Settings() {
           fatGoal={fatGoal}
         />
         <AppearanceCard colors={colors} />
-        <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+        <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
           <CardContent>
             <Pressable
               onPress={() => router.push('/settings/gym-profiles')}
@@ -194,7 +194,7 @@ export default function Settings() {
             </Pressable>
           </CardContent>
         </Card>
-        <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+        <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
           <CardContent>
             <Pressable
               onPress={() => router.push('/settings/advanced-sets')}
@@ -212,7 +212,7 @@ export default function Settings() {
             </Pressable>
           </CardContent>
         </Card>
-        <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+        <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
           <CardContent>
             <Pressable
               onPress={() => router.push('/settings/macro-coach')}
@@ -288,7 +288,7 @@ export default function Settings() {
           onFeature={() => router.push({ pathname: '/feedback', params: { type: 'feature' } })}
           onErrors={() => router.push('/errors')}
         />
-        <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+        <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
           <CardContent>
             <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>
               About

--- a/components/BodyProfileCard.tsx
+++ b/components/BodyProfileCard.tsx
@@ -22,7 +22,7 @@ export default function BodyProfileCard({ weightUnit, heightUnit }: BodyProfileC
 
   if (profile.cardState === "loading") {
     return (
-      <Card style={cardStyle}>
+      <Card variant="outline" style={cardStyle}>
         <CardContent>
           <View style={styles.loadingContainer}>
             <Spinner size="sm" />
@@ -35,7 +35,7 @@ export default function BodyProfileCard({ weightUnit, heightUnit }: BodyProfileC
 
   if (profile.cardState === "error") {
     return (
-      <Card style={cardStyle}>
+      <Card variant="outline" style={cardStyle}>
         <CardContent>
           <Text variant="body" style={{ color: colors.error, marginBottom: 8 }}>Could not load profile</Text>
           <Button variant="outline" onPress={profile.loadProfile} accessibilityLabel="Retry loading profile">Retry</Button>
@@ -45,7 +45,7 @@ export default function BodyProfileCard({ weightUnit, heightUnit }: BodyProfileC
   }
 
   return (
-    <Card style={cardStyle}>
+    <Card variant="outline" style={cardStyle}>
       <CardContent>
         <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Body Profile</Text>
         <BodyProfileForm colors={colors} {...profile} />

--- a/components/settings/AppearanceCard.tsx
+++ b/components/settings/AppearanceCard.tsx
@@ -14,7 +14,7 @@ export default function AppearanceCard({ colors }: Props) {
   const { themeMode, setThemeMode } = useThemeMode();
 
   return (
-    <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
       <CardContent>
         <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Appearance</Text>
         <View style={styles.row}>

--- a/components/settings/AutoBackupSection.tsx
+++ b/components/settings/AutoBackupSection.tsx
@@ -116,7 +116,7 @@ export default function AutoBackupSection({ colors, toast }: Props) {
   if (!ready) return null;
 
   return (
-    <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
       <CardContent>
         <Text
           variant="body"

--- a/components/settings/CSVExportCard.tsx
+++ b/components/settings/CSVExportCard.tsx
@@ -31,7 +31,7 @@ export default function CSVExportCard({ colors }: Props) {
   }, [range]);
 
   return (
-    <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
       <CardContent>
         <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>CSV Export</Text>
         <SegmentedControl value={range} onValueChange={setRange} buttons={RANGE_BUTTONS} style={styles.segment} />

--- a/components/settings/DataManagementCard.tsx
+++ b/components/settings/DataManagementCard.tsx
@@ -23,6 +23,7 @@ export default function DataManagementCard({
 }: Props) {
   return (
     <Card
+      variant="outline"
       style={StyleSheet.flatten([
         styles.flowCard,
         styles.wideCard,

--- a/components/settings/FeedbackCard.tsx
+++ b/components/settings/FeedbackCard.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export default function FeedbackCard({ colors, count, onBug, onFeature, onErrors }: Props) {
   return (
-    <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
       <CardContent>
         <Text
           variant="body"

--- a/components/settings/FrequencyGoalPicker.tsx
+++ b/components/settings/FrequencyGoalPicker.tsx
@@ -20,7 +20,7 @@ export default function FrequencyGoalPicker({ colors, value, onChange }: Props) 
   const canIncrement = value != null && value < MAX_DAYS;
 
   return (
-    <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
       <CardContent>
         <Text variant="body" style={{ color: colors.onSurface, fontWeight: "600", fontSize: fontSizes.sm, marginBottom: 4 }}>
           Weekly Training Goal

--- a/components/settings/HydrationCard.tsx
+++ b/components/settings/HydrationCard.tsx
@@ -127,7 +127,7 @@ export default function HydrationCard({ colors, toast }: Props) {
   };
 
   return (
-    <Card style={StyleSheet.flatten([styles.card, { backgroundColor: colors.surface }])}>
+    <Card variant="outline" style={StyleSheet.flatten([styles.card, { backgroundColor: colors.surface }])}>
       <CardContent>
         <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>
           Hydration

--- a/components/settings/IntegrationsCard.tsx
+++ b/components/settings/IntegrationsCard.tsx
@@ -26,7 +26,7 @@ export default function IntegrationsCard({
 
   return (
     <ErrorBoundary>
-      <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+      <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
         <CardContent>
           <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Integrations</Text>
 

--- a/components/settings/PreferencesCard.tsx
+++ b/components/settings/PreferencesCard.tsx
@@ -141,7 +141,7 @@ export default function PreferencesCard({
   };
 
   return (
-    <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
       <CardContent>
         <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Preferences</Text>
 

--- a/components/settings/UnitsCard.tsx
+++ b/components/settings/UnitsCard.tsx
@@ -29,7 +29,7 @@ export default function UnitsCard({
   fatGoal,
 }: Props) {
   return (
-    <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
       <CardContent>
         <Text
           variant="body"

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -2,37 +2,87 @@
 import { Text } from '@/components/ui/text';
 import { View } from '@/components/ui/view';
 import { useColor } from '@/hooks/useColor';
-import { BORDER_RADIUS } from '@/theme/globals';
+import { radii, spacing } from '@/constants/design-tokens';
 import { Pressable, StyleProp, TextStyle, ViewStyle, type ViewProps } from 'react-native';
+
+/**
+ * Surface treatment for a {@link Card}.
+ *
+ * - `elevated` (default) — opaque `card` background with a soft drop shadow /
+ *   `elevation`. This is the historical Card look; it remains the default so
+ *   the ~95 existing call sites render unchanged.
+ * - `outline` — opaque `card` background with a 1px `border` hairline and no
+ *   shadow / no elevation. Used to declutter dense stacks of tiles (Settings)
+ *   that otherwise read as a column of drop-shadowed boxes (BLD-2030).
+ * - `ghost` — `muted` surface tint, no border, no shadow / no elevation. The
+ *   lightest treatment, for grouping without a visible container edge.
+ */
+export type CardVariant = 'elevated' | 'outline' | 'ghost';
 
 interface CardProps extends Omit<ViewProps, 'style'> {
   children: React.ReactNode;
   style?: StyleProp<ViewStyle>;
   onPress?: () => void;
+  /** Surface treatment. Defaults to `'elevated'` (backwards-compatible). */
+  variant?: CardVariant;
 }
 
-export function Card({ children, style, onPress, ...viewProps }: CardProps) {
+export function Card({
+  children,
+  style,
+  onPress,
+  variant = 'elevated',
+  ...viewProps
+}: CardProps) {
   const cardColor = useColor('card');
+  const mutedColor = useColor('muted');
+  const borderColor = useColor('border');
   const foregroundColor = useColor('foreground');
 
-  const content = (
-    <View
-      {...viewProps}
-      style={[
-        {
-          width: '100%',
-          backgroundColor: cardColor,
-          borderRadius: BORDER_RADIUS,
-          padding: 18,
+  const getVariantStyle = (): ViewStyle => {
+    // Shared across every variant: full-width tile, token radius/padding.
+    const baseStyle: ViewStyle = {
+      width: '100%',
+      borderRadius: radii.lg,
+      padding: spacing.base,
+      backgroundColor: cardColor,
+    };
+
+    switch (variant) {
+      case 'outline':
+        return {
+          ...baseStyle,
+          borderWidth: 1,
+          borderColor,
+          // Explicitly flatten elevation/shadow so an `elevated` style higher
+          // in a merge never bleeds through.
+          shadowOpacity: 0,
+          shadowRadius: 0,
+          elevation: 0,
+        };
+      case 'ghost':
+        return {
+          ...baseStyle,
+          backgroundColor: mutedColor,
+          shadowOpacity: 0,
+          shadowRadius: 0,
+          elevation: 0,
+        };
+      case 'elevated':
+      default:
+        return {
+          ...baseStyle,
           shadowColor: foregroundColor,
           shadowOffset: { width: 0, height: 2 },
           shadowOpacity: 0.05,
           shadowRadius: 3,
           elevation: 2,
-        },
-        style,
-      ]}
-    >
+        };
+    }
+  };
+
+  const content = (
+    <View {...viewProps} style={[getVariantStyle(), style]}>
       {children}
     </View>
   );


### PR DESCRIPTION
## What

Adds a `variant` prop to the `Card` UI primitive — `elevated` | `outline` | `ghost` — and opts every **Settings** tile into `variant="outline"` so the Settings screen stops reading as a stack of drop-shadowed boxes.

Implements **P0-2** of the declutter epic (BLD-2028). Effort: S.

## Why

Settings currently renders ~18 cards, each with the default drop-shadow + elevation. Stacked vertically they read as a noisy column of floating boxes. Switching them to a 1px hairline border (`outline`) removes the shadow/elevation noise while preserving tile grouping and affordance — directly satisfying the acceptance criterion *"Settings no longer reads as stacked drop-shadowed boxes; visual noise drops."*

## How

**Primitive — `components/ui/card.tsx`:**
- New `CardVariant = 'elevated' | 'outline' | 'ghost'` type + `variant?` prop (default `'elevated'`).
- `elevated` (DEFAULT) keeps the **exact** historical shadow/elevation treatment → the ~95 existing call sites render unchanged (backwards-compatible).
- `outline` = opaque `card` bg + 1px `border` token hairline, `shadowOpacity/shadowRadius/elevation = 0`.
- `ghost` = `muted` surface tint, no border, no shadow/elevation.
- Default `padding` → `spacing.base` (16) and radius → `radii.lg` (12), sourced from `@/constants/design-tokens` (replacing magic `18` / `BORDER_RADIUS`). `radii.lg === BORDER_RADIUS === 12`, so radius is unchanged; padding tightens 18 → 16 as a deliberate declutter.
- Pattern mirrors the existing `badge.tsx` `getXxxStyle()` switch.

**Call sites → `variant="outline"`** (mechanical prop add, no refactor):
- 4 inline cards in `app/(tabs)/settings.tsx` (Gym Profiles, Advanced Set Types, Adaptive Macro Coach, About)
- 10 settings sub-cards: Units, Appearance, CSVExport, Preferences, AutoBackup, Feedback, Integrations, Hydration, FrequencyGoal, DataManagement
- `BodyProfileCard` (loading / error / loaded — 3 instances)

Call-site `style` overrides (`backgroundColor: colors.surface`, per-tile padding) are preserved because the variant base style is applied **before** the caller `style` in the merge array.

## Out of scope (intentionally NOT touched)

- **BLD-2029** Masonry primitive / `FlowContainer`
- **BLD-2031** Settings IA consolidation (18 → ~8 tiles)
- **BLD-2032** `SettingsTile` / `SettingsLinkRow` extraction
- Non-settings `<Card>` call sites (progress/nutrition/session/etc.) — keep `elevated`, zero behavior change
- The working-set logging path — untouched

## Tests

New: `__tests__/components/ui/card-variants.test.tsx` (10 cases) locks the style contract:
- shared invariants (radius `12`, padding `16`, full width) for all three variants
- `elevated` shadow/elevation values + **default-equivalence** (omitted prop === `variant="elevated"`)
- `outline` 1px border in `border` token + no shadow/elevation
- `ghost` muted tint + no border + no shadow/elevation
- call-site `style` override wins over variant base (border preserved)

## Verification

- `npx jest __tests__/components/ui/card-variants.test.tsx` → **10/10 pass**
- `tsc --noEmit` → clean
- `eslint` on all changed files → clean
- Existing settings-card regression tests (BodyProfileCard ×2, frequency-goal, water-section) → **37/37 pass**
- a11y-advanced-sets + navigation-headers → **16/16 pass**

## Review

**Reviewer: @ux-designer — mandatory design review before merge.** Please eyeball Settings (outline vs. prior drop-shadow) and confirm the hairline reads cleaner in both light and dark themes.

Epic: BLD-2028 · Ticket: BLD-2030
