### PR TITLE
refactor(settings): extract SettingsLinkRow + SettingsTile primitives (BLD-2032)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Improvement: Settings link rows are more legible and easier to tap** — the Gym Profiles, Advanced Set Types, and Adaptive Macro Coach entries now use a larger, consistent title size and a guaranteed 48 dp minimum touch target, and Settings tiles share a single, consistent density (padding and heading size). No functionality changed — the links open the same screens as before. (BLD-2032)
 
 ## v0.26.42 — 2026-06-27
 <!-- versionCode: 112 -->

--- a/__tests__/settings-link-row.test.tsx
+++ b/__tests__/settings-link-row.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * settings-link-row.test.tsx
+ *
+ * BLD-2032 (epic BLD-2028, P0-4): extract `SettingsLinkRow` + `SettingsTile`.
+ *
+ * Covers the testable acceptance criteria from the plan:
+ *  - SettingsLinkRow renders title + optional caption + chevron.
+ *  - onPress fires when the row is pressed.
+ *  - The row meets the 48px minimum touch target.
+ *  - The caption line is omitted when the caption is empty (but the row keeps
+ *    its min height so an async caption cannot shift the chevron's center).
+ *  - SettingsTile renders an optional `subtitle` title + children and applies
+ *    `spacing.base` padding (one source of truth for density).
+ */
+
+import React from "react";
+import { StyleSheet } from "react-native";
+import { render, fireEvent } from "@testing-library/react-native";
+import { SettingsLinkRow, SETTINGS_LINK_ROW_MIN_HEIGHT } from "@/components/settings/SettingsLinkRow";
+import { SettingsTile } from "@/components/settings/SettingsTile";
+import { Text } from "@/components/ui/text";
+import { spacing } from "@/constants/design-tokens";
+import { lightMockColors } from "./helpers/theme";
+
+const colors = lightMockColors;
+
+/**
+ * Resolves a Pressable's `style` prop, which may be a function of the press
+ * state (`({ pressed }) => ...`), into a flattened style object.
+ */
+function resolveStyle(style: unknown) {
+  const resolved = typeof style === "function" ? (style as (s: { pressed: boolean }) => unknown)({ pressed: false }) : style;
+  return StyleSheet.flatten(resolved ?? {}) as Record<string, unknown>;
+}
+
+describe("SettingsLinkRow (BLD-2032)", () => {
+  it("renders the title and caption", () => {
+    const { getByText } = render(
+      <SettingsLinkRow
+        colors={colors}
+        title="Gym Profiles"
+        caption="Manage gyms, cable stacks, and marker calibrations."
+        accessibilityLabel="Open gym profiles settings"
+        onPress={() => {}}
+      />,
+    );
+
+    expect(getByText("Gym Profiles")).toBeTruthy();
+    expect(getByText("Manage gyms, cable stacks, and marker calibrations.")).toBeTruthy();
+  });
+
+  it("fires onPress when the row is pressed", () => {
+    const onPress = jest.fn();
+    const { getByLabelText } = render(
+      <SettingsLinkRow
+        colors={colors}
+        title="Advanced Set Types"
+        caption="How to use rest-pause, cluster, and myo-rep sets."
+        accessibilityLabel="Open advanced set types help"
+        onPress={onPress}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("Open advanced set types help"));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("meets the 48px minimum touch target", () => {
+    const { getByLabelText } = render(
+      <SettingsLinkRow
+        colors={colors}
+        title="Gym Profiles"
+        accessibilityLabel="Open gym profiles settings"
+        onPress={() => {}}
+      />,
+    );
+
+    const row = getByLabelText("Open gym profiles settings");
+    const flat = resolveStyle(row.props.style);
+
+    expect(SETTINGS_LINK_ROW_MIN_HEIGHT).toBe(48);
+    expect(flat.minHeight).toBeGreaterThanOrEqual(48);
+  });
+
+  it("omits the caption line when the caption is empty, but keeps the row", () => {
+    const { getByLabelText, queryByText } = render(
+      <SettingsLinkRow
+        colors={colors}
+        title="Adaptive Macro Coach"
+        caption=""
+        accessibilityLabel="Open Adaptive Macro Coach settings"
+        onPress={() => {}}
+      />,
+    );
+
+    // Title (and therefore the row) still renders…
+    expect(queryByText("Adaptive Macro Coach")).toBeTruthy();
+    // …and the row still meets its min height so the chevron does not shift
+    // when an async caption arrives later.
+    const row = getByLabelText("Open Adaptive Macro Coach settings");
+    const flat = resolveStyle(row.props.style);
+    expect(flat.minHeight).toBeGreaterThanOrEqual(48);
+  });
+
+  it("exposes the supplied accessibility label with role=button", () => {
+    const { getByLabelText } = render(
+      <SettingsLinkRow
+        colors={colors}
+        title="Gym Profiles"
+        accessibilityLabel="Open gym profiles settings"
+        onPress={() => {}}
+      />,
+    );
+
+    const row = getByLabelText("Open gym profiles settings");
+    expect(row.props.accessibilityRole).toBe("button");
+  });
+});
+
+describe("SettingsTile (BLD-2032)", () => {
+  it("renders the optional title and children", () => {
+    const { getByText } = render(
+      <SettingsTile colors={colors} title="About">
+        <Text>Inner content</Text>
+      </SettingsTile>,
+    );
+
+    expect(getByText("About")).toBeTruthy();
+    expect(getByText("Inner content")).toBeTruthy();
+  });
+
+  it("renders children without a title when none is supplied", () => {
+    const { getByText, queryByText } = render(
+      <SettingsTile colors={colors}>
+        <Text>Just children</Text>
+      </SettingsTile>,
+    );
+
+    expect(getByText("Just children")).toBeTruthy();
+    // No stray heading rendered.
+    expect(queryByText("undefined")).toBeNull();
+  });
+
+  it("applies spacing.base padding as the single source of tile density", () => {
+    const { getByTestId } = render(
+      <SettingsTile colors={colors} testID="tile" title="About">
+        <Text>Inner content</Text>
+      </SettingsTile>,
+    );
+
+    const flat = StyleSheet.flatten(getByTestId("tile").props.style ?? {}) as Record<string, unknown>;
+    expect(flat.padding).toBe(spacing.base);
+  });
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -7,7 +7,6 @@ import {
   View,
 } from 'react-native';
 import { Text } from '@/components/ui/text';
-import { Card, CardContent } from '@/components/ui/card';
 import { useLayout } from '../../lib/layout';
 import { useFloatingTabBarHeight } from '../../components/FloatingTabBar';
 import FlowContainer from '../../components/ui/FlowContainer';
@@ -26,6 +25,8 @@ import UnitsCard from '../../components/settings/UnitsCard';
 import DataManagementCard from '../../components/settings/DataManagementCard';
 import AutoBackupSection from '../../components/settings/AutoBackupSection';
 import { FormClipsStorageRow } from '../../components/settings/FormClipsStorageRow';
+import { SettingsLinkRow } from '../../components/settings/SettingsLinkRow';
+import { SettingsTile } from '../../components/settings/SettingsTile';
 import FeedbackCard from '../../components/settings/FeedbackCard';
 import ReminderSection from '../../components/settings/ReminderSection';
 import ReleaseNotesModal from '../../components/ReleaseNotesModal';
@@ -176,60 +177,39 @@ export default function Settings() {
           fatGoal={fatGoal}
         />
         <AppearanceCard colors={colors} />
-        <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-          <CardContent>
-            <Pressable
-              onPress={() => router.push('/settings/gym-profiles')}
-              accessibilityRole="button"
-              accessibilityLabel="Open gym profiles settings"
-              style={styles.settingsLinkRow}
-            >
-              <View style={styles.settingsLinkMeta}>
-                <Text variant="body" style={[styles.settingsLinkTitle, { color: colors.onSurface }]}>Gym Profiles</Text>
-                <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-                  Manage gyms, cable stacks, and marker calibrations.
-                </Text>
-              </View>
-              <ChevronRight size={18} color={colors.onSurfaceVariant} />
-            </Pressable>
-          </CardContent>
-        </Card>
-        <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-          <CardContent>
-            <Pressable
-              onPress={() => router.push('/settings/advanced-sets')}
-              accessibilityRole="button"
-              accessibilityLabel="Open advanced set types help"
-              style={styles.settingsLinkRow}
-            >
-              <View style={styles.settingsLinkMeta}>
-                <Text variant="body" style={[styles.settingsLinkTitle, { color: colors.onSurface }]}>Advanced Set Types</Text>
-                <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-                  How to use rest-pause, cluster, and myo-rep sets.
-                </Text>
-              </View>
-              <ChevronRight size={18} color={colors.onSurfaceVariant} />
-            </Pressable>
-          </CardContent>
-        </Card>
-        <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-          <CardContent>
-            <Pressable
-              onPress={() => router.push('/settings/macro-coach')}
-              accessibilityRole="button"
-              accessibilityLabel="Open Adaptive Macro Coach settings"
-              style={styles.settingsLinkRow}
-            >
-              <View style={styles.settingsLinkMeta}>
-                <Text variant="body" style={[styles.settingsLinkTitle, { color: colors.onSurface }]}>Adaptive Macro Coach</Text>
-                <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
-                  {macroCoachEnabled === null ? '' : macroCoachEnabled ? 'On — weekly advisory card on Nutrition tab' : 'Off — tap to set up'}
-                </Text>
-              </View>
-              <ChevronRight size={18} color={colors.onSurfaceVariant} />
-            </Pressable>
-          </CardContent>
-        </Card>
+        <SettingsTile colors={colors}>
+          <SettingsLinkRow
+            colors={colors}
+            title="Gym Profiles"
+            caption="Manage gyms, cable stacks, and marker calibrations."
+            accessibilityLabel="Open gym profiles settings"
+            onPress={() => router.push('/settings/gym-profiles')}
+          />
+        </SettingsTile>
+        <SettingsTile colors={colors}>
+          <SettingsLinkRow
+            colors={colors}
+            title="Advanced Set Types"
+            caption="How to use rest-pause, cluster, and myo-rep sets."
+            accessibilityLabel="Open advanced set types help"
+            onPress={() => router.push('/settings/advanced-sets')}
+          />
+        </SettingsTile>
+        <SettingsTile colors={colors}>
+          <SettingsLinkRow
+            colors={colors}
+            title="Adaptive Macro Coach"
+            caption={
+              macroCoachEnabled === null
+                ? ''
+                : macroCoachEnabled
+                  ? 'On — weekly advisory card on Nutrition tab'
+                  : 'Off — tap to set up'
+            }
+            accessibilityLabel="Open Adaptive Macro Coach settings"
+            onPress={() => router.push('/settings/macro-coach')}
+          />
+        </SettingsTile>
         <BodyProfileCard weightUnit={weightUnit} heightUnit={measureUnit} />
         <FrequencyGoalPicker
           colors={colors}
@@ -288,76 +268,71 @@ export default function Settings() {
           onFeature={() => router.push({ pathname: '/feedback', params: { type: 'feature' } })}
           onErrors={() => router.push('/errors')}
         />
-        <Card style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-          <CardContent>
-            <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>
-              About
+        <SettingsTile colors={colors} title="About">
+          <Pressable
+            onPress={() => setReleaseNotesVisible(true)}
+            accessibilityRole="button"
+            accessibilityLabel={`View release notes, current version ${appVersion}`}
+            testID="settings-version-row"
+            android_ripple={{ color: colors.surfaceVariant }}
+            style={({ pressed }) => [
+              styles.versionRow,
+              { opacity: pressed ? 0.7 : 1 },
+            ]}
+          >
+            <Text
+              variant="body"
+              style={{ color: colors.onSurface, fontSize: fontSizes.sm, fontWeight: '600' }}
+            >
+              {`CableSnap v${appVersion}`}
+            </Text>
+            <View style={styles.versionRowRight}>
+              <Text
+                variant="body"
+                style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm, marginRight: 4 }}
+              >
+                What&apos;s new
+              </Text>
+              <ChevronRight size={18} color={colors.onSurfaceVariant} />
+            </View>
+          </Pressable>
+          <View style={styles.aboutBlock}>
+            <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm }}>
+              Free & open-source workout tracker — optimized for cable machines, supports all major exercises.
+            </Text>
+            <Text
+              variant="body"
+              style={{ color: colors.primary, marginTop: 4 }}
+              onPress={() =>
+                Linking.openURL('https://github.com/alankyshum/cablesnap/blob/main/LICENSE')
+              }
+            >
+              AGPL-3.0 License
             </Text>
             <Pressable
-              onPress={() => setReleaseNotesVisible(true)}
-              accessibilityRole="button"
-              accessibilityLabel={`View release notes, current version ${appVersion}`}
-              testID="settings-version-row"
-              android_ripple={{ color: colors.surfaceVariant }}
-              style={({ pressed }) => [
-                styles.versionRow,
-                { opacity: pressed ? 0.7 : 1 },
-              ]}
+              onPress={() => Linking.openURL('https://buymeacoffee.com/alankyshum')}
+              accessibilityRole="link"
+              accessibilityLabel="Buy me a coffee"
+              style={{ marginTop: 8 }}
             >
-              <Text
-                variant="body"
-                style={{ color: colors.onSurface, fontSize: fontSizes.sm, fontWeight: '600' }}
-              >
-                {`CableSnap v${appVersion}`}
-              </Text>
-              <View style={styles.versionRowRight}>
-                <Text
-                  variant="body"
-                  style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm, marginRight: 4 }}
-                >
-                  What&apos;s new
-                </Text>
-                <ChevronRight size={18} color={colors.onSurfaceVariant} />
-              </View>
+              <Image
+                source={require('../../assets/badges/bmc-button.png')}
+                style={{ width: 180, height: 50, resizeMode: 'contain' }}
+              />
             </Pressable>
-            <View style={styles.aboutBlock}>
-              <Text variant="body" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm }}>
-                Free & open-source workout tracker — optimized for cable machines, supports all major exercises.
-              </Text>
-              <Text
-                variant="body"
-                style={{ color: colors.primary, marginTop: 4 }}
-                onPress={() =>
-                  Linking.openURL('https://github.com/alankyshum/cablesnap/blob/main/LICENSE')
-                }
-              >
-                AGPL-3.0 License
-              </Text>
-              <Pressable
-                onPress={() => Linking.openURL('https://buymeacoffee.com/alankyshum')}
-                accessibilityRole="link"
-                accessibilityLabel="Buy me a coffee"
-                style={{ marginTop: 8 }}
-              >
-                <Image
-                  source={require('../../assets/badges/bmc-button.png')}
-                  style={{ width: 180, height: 50, resizeMode: 'contain' }}
-                />
-              </Pressable>
-              <Pressable
-                onPress={() => Linking.openURL('https://thanks.dev/u/gh/alankyshum')}
-                accessibilityRole="link"
-                accessibilityLabel="Sponsor on thanks.dev"
-                style={{ marginTop: 8 }}
-              >
-                <Image
-                  source={require('../../assets/badges/thanks-dev-button.png')}
-                  style={{ width: 180, height: 24, resizeMode: 'contain' }}
-                />
-              </Pressable>
-            </View>
-          </CardContent>
-        </Card>
+            <Pressable
+              onPress={() => Linking.openURL('https://thanks.dev/u/gh/alankyshum')}
+              accessibilityRole="link"
+              accessibilityLabel="Sponsor on thanks.dev"
+              style={{ marginTop: 8 }}
+            >
+              <Image
+                source={require('../../assets/badges/thanks-dev-button.png')}
+                style={{ width: 180, height: 24, resizeMode: 'contain' }}
+              />
+            </Pressable>
+          </View>
+        </SettingsTile>
       </FlowContainer>
       <ReleaseNotesModal
         visible={releaseNotesVisible}
@@ -391,7 +366,6 @@ export default function Settings() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  flowCard: { padding: spacing.md },
   settingsRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -417,18 +391,5 @@ const styles = StyleSheet.create({
   },
   aboutBlock: {
     marginTop: 4,
-  },
-  settingsLinkRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  settingsLinkMeta: {
-    flex: 1,
-    marginRight: 12,
-  },
-  settingsLinkTitle: {
-    fontSize: fontSizes.sm,
-    fontWeight: '600',
   },
 });

--- a/components/settings/SettingsLinkRow.tsx
+++ b/components/settings/SettingsLinkRow.tsx
@@ -1,0 +1,89 @@
+import { Pressable, StyleSheet, View } from 'react-native';
+import { ChevronRight } from 'lucide-react-native';
+import { Text } from '@/components/ui/text';
+import { spacing } from '@/constants/design-tokens';
+import type { ThemeColors } from '@/hooks/useThemeColors';
+
+/**
+ * Minimum interactive height for a settings link row.
+ *
+ * BLD-2032 (epic BLD-2028, P0-4): the design plan calls for a 48px minimum
+ * touch target on every settings link — larger than the app's older 44px rows —
+ * to improve reachability and meet the "≥48px targets" acceptance criterion of
+ * the declutter epic.
+ */
+export const SETTINGS_LINK_ROW_MIN_HEIGHT = 48;
+
+type Props = {
+  /** Primary label, rendered at `body` scale (17/600). */
+  title: string;
+  /**
+   * Optional secondary line, rendered at `caption` scale (muted). When empty or
+   * omitted the caption line is not rendered, but the row keeps its min height
+   * so an async caption (e.g. Macro Coach enabled-state) cannot shift the
+   * chevron's vertical center.
+   */
+  caption?: string;
+  onPress: () => void;
+  /** Required for screen readers; the row exposes `role="button"`. */
+  accessibilityLabel: string;
+  colors: ThemeColors;
+  testID?: string;
+};
+
+/**
+ * SettingsLinkRow — a single tappable settings entry: title + optional caption
+ * on the left, a trailing chevron on the right.
+ *
+ * Replaces the hand-rolled `Pressable` link markup previously inlined three
+ * times in `app/(tabs)/settings.tsx`. It renders a bare `Pressable` (no Card of
+ * its own) so it can be composed inside a `SettingsTile` without nesting cards.
+ */
+export function SettingsLinkRow({
+  title,
+  caption,
+  onPress,
+  accessibilityLabel,
+  colors,
+  testID,
+}: Props) {
+  const hasCaption = typeof caption === 'string' && caption.length > 0;
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
+      android_ripple={{ color: colors.surfaceVariant }}
+      style={({ pressed }) => [styles.row, { opacity: pressed ? 0.7 : 1 }]}
+    >
+      <View style={styles.meta}>
+        <Text variant="body" style={[styles.title, { color: colors.onSurface }]}>
+          {title}
+        </Text>
+        {hasCaption ? (
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+            {caption}
+          </Text>
+        ) : null}
+      </View>
+      <ChevronRight size={18} color={colors.onSurfaceVariant} />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    minHeight: SETTINGS_LINK_ROW_MIN_HEIGHT,
+  },
+  meta: {
+    flex: 1,
+    marginRight: spacing.md,
+  },
+  title: {
+    fontWeight: '600',
+  },
+});

--- a/components/settings/SettingsTile.tsx
+++ b/components/settings/SettingsTile.tsx
@@ -1,0 +1,57 @@
+import { StyleSheet } from 'react-native';
+import type { ReactNode } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { Card } from '@/components/ui/card';
+import { Text } from '@/components/ui/text';
+import { spacing } from '@/constants/design-tokens';
+import type { ThemeColors } from '@/hooks/useThemeColors';
+
+type Props = {
+  /**
+   * Optional tile heading, rendered at `subtitle` scale (18/600). Omit for
+   * tiles whose child component supplies its own heading.
+   */
+  title?: string;
+  children: ReactNode;
+  colors: ThemeColors;
+  /** Extra style merged onto the underlying Card (e.g. masonry cell sizing). */
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+};
+
+/**
+ * SettingsTile — the standard flat container for one Settings section.
+ *
+ * BLD-2032 (epic BLD-2028, P0-4): centralizes tile padding (`spacing.base`) and
+ * title type (`subtitle` 18/600) so density is tuned in one place rather than
+ * per-card. The tile *is* the Card — children must not nest another Card inside
+ * (the declutter epic bans card-in-card).
+ */
+export function SettingsTile({ title, children, colors, style, testID }: Props) {
+  return (
+    <Card
+      testID={testID}
+      style={StyleSheet.flatten([
+        styles.tile,
+        { backgroundColor: colors.surface },
+        style,
+      ])}
+    >
+      {title ? (
+        <Text variant="subtitle" style={[styles.title, { color: colors.onSurface }]}>
+          {title}
+        </Text>
+      ) : null}
+      {children}
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  tile: {
+    padding: spacing.base,
+  },
+  title: {
+    marginBottom: spacing.sm,
+  },
+});


### PR DESCRIPTION
## What & why

P0-4 of the Settings declutter epic (**BLD-2032** → epic **BLD-2028**). Kills the bespoke link-card markup in `app/(tabs)/settings.tsx` by extracting two reusable primitives and moves tile density / type scale into **one place**.

### New primitives
- **`components/settings/SettingsLinkRow.tsx`** — title (`body` 17/600) + optional caption (`caption`, muted) + trailing chevron. Renders a **bare `Pressable`** (no Card of its own) so it composes inside a tile without nesting cards. **48px min touch target** (`SETTINGS_LINK_ROW_MIN_HEIGHT`). When the caption is empty the caption line is omitted but the row keeps its min height, so the async Macro-Coach caption can't shift the chevron's vertical center.
- **`components/settings/SettingsTile.tsx`** — optional `subtitle` title (18/600) + children, padding from `spacing.base` (16) — the single source of truth for tile density. The tile **is** the `Card`; children never nest another Card.

### `settings.tsx` changes
- The 3 inline `Card > CardContent > Pressable` link rows (Gym Profiles, Advanced Set Types, Adaptive Macro Coach) → 3 `SettingsTile > SettingsLinkRow`.
- The **About** card → `SettingsTile title="About"` carrying its real children (version row + license/sponsor block), exercising the title+children + density path.
- Removed now-dead styles: `flowCard`, `settingsLinkRow`, `settingsLinkMeta`, `settingsLinkTitle`.
- Net **+94 / −133** (−39 LOC). Logging / release-notes path untouched.

Type scale unified per plan: **tile title = `subtitle` 18/600**, **row title = `body` 17**.

## Scope guardrails (what this intentionally does NOT do)
- ❌ No IA consolidation (18→8 tiles) — that's **BLD-2031 (P0-3)**.
- ❌ No Card variants — **BLD-2030 (P0-2)**.
- ❌ No Masonry — **BLD-2029 (P0-1)**.
- ❌ No changes to the working-set / logging path.
- Each link stays its own masonry cell (one-card-per-link), matching today's layout.

## Tests
`__tests__/settings-link-row.test.tsx` (8 tests, all green):
- title + caption render; `onPress` fires; **`minHeight >= 48`**; caption omitted when empty (row still ≥48px); a11y label + `role=button`.
- `SettingsTile`: title + children render; children-only (no title); `padding === spacing.base`.

```
tsc --noEmit   ✅ clean
eslint         ✅ clean (changed files)
jest           ✅ 8/8 (settings-link-row)
```

## Acceptance criteria (from plan)
- [x] No bespoke link-card markup remains in `settings.tsx` (the 3 inline `Card>CardContent>Pressable` blocks + their styles are gone).
- [x] `SettingsLinkRow` renders title (17/600), optional caption, chevron, `minHeight >= 48`.
- [x] `SettingsTile` renders optional subtitle title (18/600) + children, `spacing.base` padding, no nested Card.
- [x] The 3 links still navigate to `/settings/gym-profiles`, `/settings/advanced-sets`, `/settings/macro-coach`; a11y labels preserved.
- [x] `tsc` / `eslint` / `jest` green.
- [ ] **@ui-ux-designer design review APPROVE (mandatory before merge).**

## Reviewer
**@ui-ux-designer** — mandatory design review before merge (density, type scale, 48px target, flat tile look).

## Noticed but not touching (out of scope)
- `settings.tsx` still defines `settingsRow` / `settingsRowLabel` styles that were **already dead on `main`** before this change (0 references). Left untouched to keep this PR scoped; happy to file a tiny cleanup ticket.

Closes BLD-2032.
