### PR TITLE
feat(safety): make worktree rule unconditional + add guard preflight (BLD-2040)

### DIFF
--- a/.agents/CONCURRENT-AGENT-SAFETY.md
+++ b/.agents/CONCURRENT-AGENT-SAFETY.md
@@ -1,27 +1,41 @@
 # Concurrent-Agent Safety — CableSnap
 
 > **Canonical doctrine for any agent working on `/projects/cablesnap`.**
-> Source ticket: BLD-765 (incident origin: BLD-743).
+> Source tickets: BLD-765 (incident origin: BLD-743), BLD-2039 (recurrence),
+> BLD-2040 (rule made unconditional + `guard` preflight added).
 
 ## TL;DR
 
 `/projects/cablesnap` is a single shared filesystem mount across agent
-containers. If two agents are active at the same time and either of them
-runs `git checkout`, the other's branch context is silently yanked and
-any **untracked** artefacts in the working tree (image gen output, builds,
+containers. If two agents are active at the same time and either runs
+`git checkout` or `git switch`, the other's branch context is silently yanked
+and any untracked artefacts in the working tree (image gen output, builds,
 snapshots, dev-server state) are corrupted or lost.
 
-**Rule:** Use a per-branch git worktree whenever the work
-1. generates untracked artefacts (image generation, builds, snapshots, dev server), OR
-2. requires a stable branch checkout while another CableSnap agent might be active.
+**Rule (unconditional):** For ANY CableSnap implementation work — any
+`git checkout`/`git switch`/`git branch`-then-edit, any file edit, any
+build/test/artefact generation — you MUST work inside a per-ticket worktree
+under `/tmp/wt-<branch>` created via `scripts/agent-worktree.sh start`.
 
-When in doubt, use a worktree. The cost is sub-second; the upside is no clobbered work.
+The ONLY operations permitted directly in `/projects/cablesnap` are read-only
+inspection of `origin/main`:
+- `git fetch origin`
+- `git log origin/main`
+- Reading files (`cat`, `grep`, `ls`, etc.)
+
+**NEVER run `git checkout <branch>` or `git switch` in `/projects/cablesnap`.**
+
+Use `guard` as a preflight check to fail fast if you are about to work in the
+wrong directory.
 
 ## The Helper Script
 
-`scripts/agent-worktree.sh` is the canonical interface. Use it, don't roll your own.
+`scripts/agent-worktree.sh` is the canonical interface. Use it; don't roll your own.
 
 ```bash
+# Preflight: refuse immediately if you are in the shared primary checkout
+./scripts/agent-worktree.sh guard
+
 # Start (idempotent — reuses if a worktree for this branch already exists)
 eval "$(./scripts/agent-worktree.sh start bld-N-feature)"
 cd "$AGENT_WORKTREE_DIR"
@@ -44,6 +58,7 @@ Subcommands:
 
 | Command | Behaviour |
 |---|---|
+| `guard [<dir>]` | **Preflight.** Exits 3 with a clear error if `<dir>` (default `$PWD`) is the shared primary checkout `/projects/cablesnap`. Exits 0 if safe. Set `CABLESNAP_PRIMARY_CHECKOUT` to override the primary path (for tests). |
 | `start <branch>` | Create or reuse `/tmp/wt-<branch>`. Fetches from origin if branch is missing. Recovers stale lockfiles. |
 | `stop <branch> [--force]` | Remove worktree. No-op if missing. Refuses dirty without `--force`. |
 | `status [<branch>]` | Show one worktree (or all). |
@@ -58,29 +73,58 @@ git fetch origin
 # `git branch` does NOT switch the shared working tree — safe to run here.
 git branch bld-<N>-<description> origin/main
 
+# Preflight: make sure you are still in /projects/cablesnap before spinning up
+./scripts/agent-worktree.sh guard  # exits 3 here — confirms you need the worktree
+
 # Spin up your isolated worktree and move into it for ALL real work.
 eval "$(./scripts/agent-worktree.sh start bld-<N>-<description>)"
 cd "$AGENT_WORKTREE_DIR"
+
+# Optional: verify you are safe now
+./scripts/agent-worktree.sh guard  # exits 0 — you are inside a worktree
 
 # Implement, run npm test, generate artefacts, commit, push, open PR.
 # Use `git push -u origin bld-<N>-<description>` from inside the worktree.
 
 # Done — clean up.
-eval "$(./scripts/agent-worktree.sh stop bld-<N>-<description>)"
+eval "$(./scripts/agent-worktree.sh stop bld-N-feature)"
 ```
 
 ## What `git checkout` in `/projects/cablesnap` is OK for
 
 Almost nothing. Acceptable cases:
 
-- Reading the current `main` (no switch): `git fetch origin && git log origin/main`.
-- Quick read-only inspection where you can guarantee no other agent is active (rare — assume there always is one).
+- Fetching origin state: `git fetch origin && git log origin/main`.
+- Reading files as-is (no branch switch; no writes).
 
-If you find yourself typing `git checkout <branch>` in `/projects/cablesnap`, stop and use the helper instead.
+If you find yourself typing `git checkout <branch>` or `git switch` in
+`/projects/cablesnap`, **stop** and use the helper instead. Run `guard` first
+to confirm you need to start a worktree.
 
 ## What `git checkout` in a worktree is fine for
 
-Inside `/tmp/wt-<your-branch>`, you have your own working tree. `git checkout`, `git switch`, `git rebase`, `git reset` are all safe and don't affect any other agent. Just don't switch your worktree to a branch another agent is using in *their* worktree (git itself enforces this — it'll refuse).
+Inside `/tmp/wt-<your-branch>`, you have your own working tree. `git checkout`,
+`git switch`, `git rebase`, `git reset` are all safe and don't affect any other
+agent. Just don't switch your worktree to a branch another agent is using in
+*their* worktree (git itself enforces this — it'll refuse).
+
+## Why This Rule Is Unconditional (BLD-2039 Recurrence)
+
+The previous rule said *"use a worktree whenever … OR another agent **might**
+be active"*. An agent doing pure source edits read condition (1) as not
+applying and gambled on condition (2) ("probably no peer is active"). That
+gamble lost during BLD-2029: another run's `git checkout` in `/projects/cablesnap`
+silently wiped uncommitted `Masonry.tsx` + `FlowContainer` edits. The conditional
+loophole is closed as of BLD-2040. Worktrees are now mandatory for all
+implementation work, unconditionally.
+
+## `guard` Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Safe — the directory is NOT the primary checkout |
+| 2 | Usage / argument error |
+| 3 | REFUSED — the directory IS the primary checkout |
 
 ## Edge Cases
 
@@ -100,14 +144,21 @@ Inside `/tmp/wt-<your-branch>`, you have your own working tree. `git checkout`, 
 - Ephemeral by design — survives crashes (recovered via stale-lock detection) but doesn't accumulate forever.
 - Matches the workaround that already worked in BLD-743.
 
+## Future Hardening (deferred, not in scope for BLD-2040)
+
+A `post-checkout` git hook (`core.hooksPath`) wired to call `guard` could
+catch accidental `git checkout` in the shared mount at the git layer rather
+than relying on agents to call `guard` manually. Deferred because per-clone
+hooks in a shared mount are fragile to update. Track on a future BLD ticket if
+needed.
+
 ## When This Doesn't Apply
 
 - **Solo OpenCode work** (`/projects/opencode`) — no shared-mount concurrency issue documented there yet. Use plain `git checkout`.
-- **Single-agent CableSnap maintenance** with full certainty no peer is active — still cheap enough to use a worktree, but not strictly required.
 
 ## Related
 
 - Helper script: [`scripts/agent-worktree.sh`](../scripts/agent-worktree.sh)
 - Project CLAUDE.md: [`.claude/CLAUDE.md`](../.claude/CLAUDE.md) → "Concurrent-Agent Safety"
 - Learning: [`.learnings/process/quality-pipeline.md`](../.learnings/process/quality-pipeline.md) → "Per-Agent Git Worktrees Are Mandatory for Concurrent CableSnap Work"
-- Tickets: BLD-743 (incident), BLD-765 (this fix)
+- Tickets: BLD-743 (incident), BLD-765 (first fix), BLD-2039 (recurrence), BLD-2040 (unconditional rule + guard)

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,24 +19,33 @@ CableSnap is licensed under **AGPL-3.0-or-later**. All agents MUST comply:
 - **Styling:** React Native StyleSheet
 - **Testing:** Jest (unit), Playwright (e2e), Maestro (mobile e2e)
 
-## Concurrent-Agent Safety (MANDATORY for parallel work)
+## Concurrent-Agent Safety (MANDATORY — unconditional as of BLD-2040)
 
 `/projects/cablesnap` is a single shared filesystem mount across agent
 containers. When two agents work in parallel, `git checkout` on one yanks
 the working tree out from under the other — silently — and corrupts any
 untracked artefacts (image gen output, build outputs, snapshots, dev-server
 state). See `.learnings/INDEX.md` → "Concurrent-Agent Safety" and BLD-765.
+Rule made unconditional after recurrence in BLD-2039; fixed in BLD-2040.
 
-**Rule:** Use a per-branch git worktree whenever the work
-- generates untracked artefacts (image gen, builds, snapshots), OR
-- requires a stable branch checkout while another CableSnap agent might be active.
+**Rule (unconditional):** For ANY CableSnap implementation work — any
+`git checkout`/`git switch`/`git branch`-then-edit, any file edit, any
+build/test/artefact generation — you MUST work inside a per-ticket worktree
+under `/tmp/wt-<branch>` created via `scripts/agent-worktree.sh start`.
 
-When in doubt, use a worktree. The cost is sub-second; the upside is no clobbered work.
+The ONLY operations permitted directly in `/projects/cablesnap` are read-only
+inspection of `origin/main` (`git fetch origin`, `git log origin/main`, reading
+files). **NEVER run `git checkout <branch>` or `git switch` in `/projects/cablesnap`.**
 
 ```bash
+# Preflight: refuse immediately if you are in the shared primary checkout
+./scripts/agent-worktree.sh guard   # exits 3 in /projects/cablesnap (correct)
+
 # Start (idempotent — reuses if the worktree already exists)
 eval "$(./scripts/agent-worktree.sh start bld-N-feature)"
 cd "$AGENT_WORKTREE_DIR"
+
+./scripts/agent-worktree.sh guard   # exits 0 inside worktree (safe)
 
 # ... do work, run tests, generate artefacts ...
 
@@ -45,6 +54,7 @@ eval "$(./scripts/agent-worktree.sh stop bld-N-feature)"
 ```
 
 Subcommands:
+- `guard [<dir>]` — **preflight**: exits 3 with error if `<dir>` (default `$PWD`) is the shared primary checkout; exits 0 if safe.
 - `start <branch>` — create or reuse `/tmp/wt-<branch>`. Fetches from origin if missing.
 - `stop <branch> [--force]` — remove worktree. No-op if missing. Refuses dirty without `--force`.
 - `status [<branch>]` — show one or all worktrees.

--- a/.learnings/INDEX.md
+++ b/.learnings/INDEX.md
@@ -37,14 +37,23 @@ agents are active at the same time, `git checkout` on one **silently**
 yanks the working tree out from under the other and corrupts untracked
 artefacts (image gen, builds, snapshots, dev-server state).
 
-**Rule:** Use a per-branch git worktree whenever the work generates
-untracked artefacts OR another CableSnap agent might be active. When in
-doubt, use a worktree.
+**Rule (unconditional — BLD-2040):** For ANY CableSnap implementation
+work — any file edit, build, test, artefact generation, or git
+checkout/switch — you MUST work inside a per-ticket worktree under
+`/tmp/wt-<branch>`. The ONLY operations permitted directly in
+`/projects/cablesnap` are read-only inspection of `origin/main`
+(`git fetch origin`, `git log origin/main`, reading files).
+**NEVER run `git checkout <branch>` or `git switch` in `/projects/cablesnap`.**
 
 ```bash
+# Preflight: fail fast if you are in the shared primary checkout
+./scripts/agent-worktree.sh guard   # exits 3 in /projects/cablesnap
+
 # Start an isolated worktree
 eval "$(./scripts/agent-worktree.sh start bld-N-feature)"
 cd "$AGENT_WORKTREE_DIR"
+
+./scripts/agent-worktree.sh guard   # exits 0 inside worktree (safe)
 
 # ... do work ...
 
@@ -52,8 +61,8 @@ cd "$AGENT_WORKTREE_DIR"
 eval "$(./scripts/agent-worktree.sh stop bld-N-feature)"
 ```
 
-See BLD-765 learning in `process/quality-pipeline.md` for the full
-incident and pattern. The script is idempotent, recovers stale locks,
+See BLD-765 + BLD-2039 learnings in `process/quality-pipeline.md` for the
+full incidents and pattern. The script is idempotent, recovers stale locks,
 and refuses to remove dirty worktrees without `--force`.
 
 Full doctrine: [`/projects/cablesnap/.agents/CONCURRENT-AGENT-SAFETY.md`](../.agents/CONCURRENT-AGENT-SAFETY.md).

--- a/scripts/__tests__/agent-worktree-guard.test.ts
+++ b/scripts/__tests__/agent-worktree-guard.test.ts
@@ -1,0 +1,188 @@
+/**
+ * BLD-2040 — agent-worktree.sh `guard` subcommand regression test
+ *
+ * The `guard` subcommand was added to close the loophole that caused the
+ * BLD-2039 race (conditional language allowed agents to skip worktrees for
+ * "pure source edits"). Guard is a preflight check agents call before working
+ * in /projects/cablesnap to fail fast if they are in the shared primary
+ * checkout.
+ *
+ * Test pattern mirrors scripts/__tests__/npmrc-devdeps-bld998.test.ts:
+ * invoke the script via execFileSync with controlled cwd + env.
+ *
+ * Acceptance criteria covered:
+ *   AC1: guard refuses when cwd == primary checkout → exits 3 with stderr message
+ *   AC2: guard passes when cwd is NOT the primary checkout → exits 0
+ *   AC3: guard is listed in the usage/help output
+ *   AC6 (partial): bash -n syntax check passes; start/stop/list/status exit codes unchanged
+ */
+
+import { spawnSync } from 'child_process';
+import { mkdtempSync, rmdirSync } from 'fs';
+import { resolve } from 'path';
+import { tmpdir } from 'os';
+
+const SCRIPT = resolve(__dirname, '..', 'agent-worktree.sh');
+
+/** Run `bash <SCRIPT> guard [args]` and return exit code + combined output */
+function runGuard(
+  cwd: string,
+  env: Record<string, string> = {},
+  guardArgs: string[] = [],
+): { code: number; out: string } {
+  const result = spawnSync('bash', [SCRIPT, 'guard', ...guardArgs], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const out = (result.stderr ?? '') + (result.stdout ?? '');
+  return { code: result.status ?? 1, out };
+}
+
+describe('BLD-2040: agent-worktree.sh guard subcommand', () => {
+  // A temporary directory that is definitely NOT the primary checkout
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(resolve(tmpdir(), 'bld2040-guard-test-'));
+  });
+
+  afterAll(() => {
+    try {
+      rmdirSync(tmpDir);
+    } catch {
+      // ignore — tmpdir cleanup failure shouldn't fail tests
+    }
+  });
+
+  // ─── AC1 ────────────────────────────────────────────────────────────────────
+
+  describe('AC1: guard refuses when directory is the shared primary checkout', () => {
+    it('exits 3 when CABLESNAP_PRIMARY_CHECKOUT points at cwd', () => {
+      const { code } = runGuard(tmpDir, { CABLESNAP_PRIMARY_CHECKOUT: tmpDir });
+      expect(code).toBe(3);
+    });
+
+    it('prints a REFUSING message on stderr when in the primary checkout', () => {
+      const { out } = runGuard(tmpDir, { CABLESNAP_PRIMARY_CHECKOUT: tmpDir });
+      expect(out).toMatch(/REFUSING/);
+    });
+
+    it('stderr message mentions starting a worktree', () => {
+      const { out } = runGuard(tmpDir, { CABLESNAP_PRIMARY_CHECKOUT: tmpDir });
+      expect(out).toMatch(/start a worktree/i);
+    });
+
+    it('exits 3 when the hardcoded /projects/cablesnap path is passed as explicit dir argument', () => {
+      // This tests the hardcoded-path fallback (Method 3). We pass the
+      // primary path explicitly as an argument rather than as cwd so the test
+      // works even when the test runner is NOT inside /projects/cablesnap.
+      const { code } = runGuard(tmpDir, {}, ['/projects/cablesnap']);
+      expect(code).toBe(3);
+    });
+  });
+
+  // ─── AC2 ────────────────────────────────────────────────────────────────────
+
+  describe('AC2: guard passes when directory is NOT the primary checkout', () => {
+    it('exits 0 when CABLESNAP_PRIMARY_CHECKOUT points elsewhere and cwd differs', () => {
+      // Simulate being inside a /tmp/wt-* worktree: override primary to tmpDir
+      // and run from a different temp dir.
+      const otherDir = mkdtempSync(resolve(tmpdir(), 'bld2040-guard-other-'));
+      try {
+        const { code } = runGuard(otherDir, { CABLESNAP_PRIMARY_CHECKOUT: tmpDir });
+        expect(code).toBe(0);
+      } finally {
+        try { rmdirSync(otherDir); } catch { /* ignore */ }
+      }
+    });
+
+    it('prints an OK message on stderr when safe', () => {
+      const otherDir = mkdtempSync(resolve(tmpdir(), 'bld2040-guard-ok-'));
+      try {
+        const { out } = runGuard(otherDir, { CABLESNAP_PRIMARY_CHECKOUT: tmpDir });
+        expect(out).toMatch(/OK/);
+      } finally {
+        try { rmdirSync(otherDir); } catch { /* ignore */ }
+      }
+    });
+
+    it('exits 0 when an explicit safe dir argument is passed', () => {
+      const { code } = runGuard(tmpDir, { CABLESNAP_PRIMARY_CHECKOUT: tmpDir }, [tmpdir()]);
+      expect(code).toBe(0);
+    });
+  });
+
+  // ─── AC3 ────────────────────────────────────────────────────────────────────
+
+  describe('AC3: guard is listed in usage/help', () => {
+    it('usage output includes the guard subcommand', () => {
+      const result = spawnSync('bash', [SCRIPT, 'help'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      const helpText = (result.stderr ?? '') + (result.stdout ?? '');
+      expect(helpText).toMatch(/guard/);
+    });
+
+    it('unknown subcommand still exits 2 (guard does not break unknown-cmd behavior)', () => {
+      const result = spawnSync('bash', [SCRIPT, 'notasubcommand'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      expect(result.status).toBe(2);
+    });
+  });
+
+  // ─── AC6 (partial) ──────────────────────────────────────────────────────────
+
+  describe('AC6: no regressions — existing subcommands and syntax are unchanged', () => {
+    it('bash -n syntax check passes', () => {
+      const result = spawnSync('bash', ['-n', SCRIPT], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      expect(result.status).toBe(0);
+    });
+
+    it('list subcommand exits 0', () => {
+      const result = spawnSync('bash', [SCRIPT, 'list'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      expect(result.status).toBe(0);
+    });
+
+    it('status subcommand exits 0 for an unknown branch (shows missing)', () => {
+      const result = spawnSync('bash', [SCRIPT, 'status', 'bld-9999-nonexistent'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      expect(result.status).toBe(0);
+    });
+
+    it('stop on a nonexistent branch exits 0 (no-op)', () => {
+      const result = spawnSync('bash', [SCRIPT, 'stop', 'bld-9999-nonexistent'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      expect(result.status).toBe(0);
+    });
+
+    it('CABLESNAP_PRIMARY_CHECKOUT env is honored: same dir → exits 3, different dir → exits 0', () => {
+      const dir1 = mkdtempSync(resolve(tmpdir(), 'bld2040-env1-'));
+      const dir2 = mkdtempSync(resolve(tmpdir(), 'bld2040-env2-'));
+      try {
+        const refused = runGuard(dir1, { CABLESNAP_PRIMARY_CHECKOUT: dir1 });
+        expect(refused.code).toBe(3);
+
+        const allowed = runGuard(dir2, { CABLESNAP_PRIMARY_CHECKOUT: dir1 });
+        expect(allowed.code).toBe(0);
+      } finally {
+        try { rmdirSync(dir1); } catch { /* ignore */ }
+        try { rmdirSync(dir2); } catch { /* ignore */ }
+      }
+    });
+  });
+});

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -7,12 +7,23 @@
 # containers. When two agents work in parallel, `git checkout` on one yanks
 # the working tree out from under the other and silently corrupts untracked
 # artefacts (image generation output, build outputs, snapshots, dev-server
-# state). Discovered in BLD-743, tracked in BLD-765.
+# state). Discovered in BLD-743, tracked in BLD-765. Recurrence tracked in
+# BLD-2039 (root cause: conditional rule created a loophole); fixed in BLD-2040.
 #
-# Solution: any agent that does work which (a) generates untracked artefacts
-# OR (b) requires a stable branch checkout while another agent might be
-# active, runs in a per-branch git worktree at /tmp/wt-<branch> instead of
-# the shared /projects/cablesnap working copy.
+# MANDATORY RULE (unconditional as of BLD-2040)
+# ---------------------------------------------
+# For ANY CableSnap implementation work — any git checkout/switch/branch-then-
+# edit, any file edit, any build/test/artefact generation — you MUST work inside
+# a per-ticket worktree under /tmp/wt-<branch> created via `start`.
+#
+# The ONLY operations permitted directly in /projects/cablesnap are read-only
+# inspection of origin/main:
+#   git fetch origin
+#   git log origin/main
+#   reading files (cat, grep, etc.)
+# NEVER run `git checkout <branch>` or `git switch` in /projects/cablesnap.
+#
+# Use `guard` as a preflight check to fail fast if you are in the shared mount.
 #
 # Subcommands
 # -----------
@@ -24,9 +35,13 @@
 #                         with --force).
 #   status [<branch>]     Show status of one or all worktrees.
 #   list                  List all known worktrees.
+#   guard [<dir>]         Preflight: exit 3 (with error) if <dir> (default $PWD)
+#                         is the shared primary checkout. Exit 0 if safe (inside
+#                         a worktree or any other path).
 #
 # Eval-friendly usage (recommended)
 # ---------------------------------
+#   ./scripts/agent-worktree.sh guard            # fail fast if in /projects/cablesnap
 #   eval "$(./scripts/agent-worktree.sh start bld-123-feature)"
 #   cd "$AGENT_WORKTREE_DIR"
 #   ... do work ...
@@ -259,6 +274,76 @@ cmd_list() {
     git -C "$REPO_DIR" worktree list
 }
 
+# cmd_guard [<dir>]
+#
+# Preflight check: refuse if <dir> (default: $PWD) is the shared primary
+# checkout. Intended to be run at the top of any agent implementation task.
+#
+# Exit codes:
+#   0  — safe: the directory is NOT the primary checkout (inside a worktree or
+#              an unrelated path)
+#   2  — usage/argument error
+#   3  — REFUSED: the directory IS the primary checkout
+#
+# Primary checkout detection (belt-and-suspenders):
+#   1. Compare realpath($dir) against realpath of the first entry emitted by
+#      `git worktree list --porcelain` (the main worktree is always first).
+#   2. Also compare against the hardcoded canonical path /projects/cablesnap,
+#      resolved via realpath.
+#   3. Allow override via CABLESNAP_PRIMARY_CHECKOUT env var (for tests).
+#
+# All output goes to stderr to keep stdout eval-clean.
+cmd_guard() {
+    local check_dir="${1:-$PWD}"
+
+    # Resolve the directory to an absolute real path (follow symlinks)
+    if ! check_dir="$(realpath "$check_dir" 2>/dev/null)"; then
+        err "guard: cannot resolve path: ${1:-$PWD}"
+        exit 2
+    fi
+
+    # Determine the primary checkout path using three methods; any match = primary
+
+    # Method 1: env override (for testability)
+    local primary_path=""
+    if [ -n "${CABLESNAP_PRIMARY_CHECKOUT:-}" ]; then
+        primary_path="$(realpath "$CABLESNAP_PRIMARY_CHECKOUT" 2>/dev/null || echo "$CABLESNAP_PRIMARY_CHECKOUT")"
+    fi
+
+    # Method 2: first entry of `git worktree list --porcelain` from REPO_DIR
+    if [ -z "$primary_path" ]; then
+        local wt_first
+        wt_first="$(git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null \
+            | awk 'NR==1 && $1=="worktree" { print $2; exit }' || true)"
+        if [ -n "$wt_first" ]; then
+            primary_path="$(realpath "$wt_first" 2>/dev/null || echo "$wt_first")"
+        fi
+    fi
+
+    # Method 3: fall back to hardcoded canonical path
+    local hardcoded_primary
+    hardcoded_primary="$(realpath "/projects/cablesnap" 2>/dev/null || echo "/projects/cablesnap")"
+
+    # Check: is check_dir the primary checkout?
+    local is_primary=0
+    if [ -n "$primary_path" ] && [ "$check_dir" = "$primary_path" ]; then
+        is_primary=1
+    fi
+    if [ "$check_dir" = "$hardcoded_primary" ]; then
+        is_primary=1
+    fi
+
+    if [ "$is_primary" -eq 1 ]; then
+        err "REFUSING: you are in the shared primary checkout $check_dir — start a worktree first"
+        err "  Run: eval \"\$(./scripts/agent-worktree.sh start bld-<N>-<description>)\" && cd \"\$AGENT_WORKTREE_DIR\""
+        err "  See .agents/CONCURRENT-AGENT-SAFETY.md (BLD-765, BLD-2039, BLD-2040)"
+        exit 3
+    fi
+
+    info "guard: OK — $check_dir is not the primary checkout (safe to work here)"
+    return 0
+}
+
 usage() {
     cat <<'EOF' >&2
 agent-worktree.sh — per-agent git worktree helper for CableSnap
@@ -268,21 +353,31 @@ USAGE:
   scripts/agent-worktree.sh stop  <branch> [--force]
   scripts/agent-worktree.sh status [<branch>]
   scripts/agent-worktree.sh list
+  scripts/agent-worktree.sh guard [<dir>]
+
+MANDATORY RULE (unconditional — BLD-2040):
+  For ANY CableSnap implementation work you MUST be inside a worktree.
+  Use `guard` as a preflight check to fail fast if you are in /projects/cablesnap.
 
 ENVIRONMENT:
-  AGENT_WORKTREE_ROOT   Override worktree parent dir (default: /tmp)
+  AGENT_WORKTREE_ROOT        Override worktree parent dir (default: /tmp)
+  CABLESNAP_PRIMARY_CHECKOUT Override primary checkout path for guard (testing)
 
 EXAMPLES:
+  # Preflight: refuse if in the shared primary checkout
+  ./scripts/agent-worktree.sh guard
+
   # Start an isolated worktree, cd into it, work, then clean up
   eval "$(./scripts/agent-worktree.sh start bld-123-feature)"
   cd "$AGENT_WORKTREE_DIR"
+  ./scripts/agent-worktree.sh guard   # passes — you are in a worktree
   npm test
   eval "$(./scripts/agent-worktree.sh stop bld-123-feature)"
 
   # Inspect everything currently checked out
   ./scripts/agent-worktree.sh list
 
-See BLD-765 and .agents/CONCURRENT-AGENT-SAFETY.md for full context.
+See BLD-765, BLD-2039, BLD-2040 and .agents/CONCURRENT-AGENT-SAFETY.md for full context.
 EOF
 }
 
@@ -294,6 +389,7 @@ main() {
         stop)   cmd_stop "$@" ;;
         status) cmd_status "$@" ;;
         list)   cmd_list ;;
+        guard)  cmd_guard "$@" ;;
         ""|-h|--help|help) usage ;;
         *) err "Unknown subcommand: $sub"; usage; exit 2 ;;
     esac

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -85,6 +85,17 @@ warn() { printf "${YELLOW}[wt]${NC} %s\n" "$*" >&2; }
 err()  { printf "${RED}[wt]${NC} %s\n" "$*" >&2; }
 info() { printf "${CYAN}[wt]${NC} %s\n" "$*" >&2; }
 
+# resolve_lexical <path>
+#
+# Canonicalise a path WITHOUT requiring it to exist on disk (lexical resolution).
+# Uses: realpath -m → readlink -m → raw path (fallback).
+# This ensures guard works on CI runners where /projects/cablesnap is absent.
+resolve_lexical() {
+    realpath -m -- "$1" 2>/dev/null \
+        || readlink -m -- "$1" 2>/dev/null \
+        || printf '%s' "$1"
+}
+
 require_branch_arg() {
     if [ -z "${1:-}" ]; then
         err "Missing required <branch> argument"
@@ -296,18 +307,29 @@ cmd_list() {
 cmd_guard() {
     local check_dir="${1:-$PWD}"
 
-    # Resolve the directory to an absolute real path (follow symlinks)
-    if ! check_dir="$(realpath "$check_dir" 2>/dev/null)"; then
-        err "guard: cannot resolve path: ${1:-$PWD}"
+    # Resolve a path lexically (no filesystem existence required).
+    # Prefers `realpath -m` (GNU coreutils); falls back to `readlink -m`
+    # (also GNU, older); final fallback: return the path as-is.
+    # This ensures guard works on CI runners where /projects/cablesnap is absent.
+    resolve_lexical() {
+        realpath -m -- "$1" 2>/dev/null \
+            || readlink -m -- "$1" 2>/dev/null \
+            || printf '%s' "$1"
+    }
+
+    # Validate the argument: reject empty string only (not non-existent paths).
+    if [ -z "$check_dir" ]; then
+        err "guard: empty directory argument"
         exit 2
     fi
+    check_dir="$(resolve_lexical "$check_dir")"
 
     # Determine the primary checkout path using three methods; any match = primary
 
     # Method 1: env override (for testability)
     local primary_path=""
     if [ -n "${CABLESNAP_PRIMARY_CHECKOUT:-}" ]; then
-        primary_path="$(realpath "$CABLESNAP_PRIMARY_CHECKOUT" 2>/dev/null || echo "$CABLESNAP_PRIMARY_CHECKOUT")"
+        primary_path="$(resolve_lexical "$CABLESNAP_PRIMARY_CHECKOUT")"
     fi
 
     # Method 2: first entry of `git worktree list --porcelain` from REPO_DIR
@@ -316,13 +338,13 @@ cmd_guard() {
         wt_first="$(git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null \
             | awk 'NR==1 && $1=="worktree" { print $2; exit }' || true)"
         if [ -n "$wt_first" ]; then
-            primary_path="$(realpath "$wt_first" 2>/dev/null || echo "$wt_first")"
+            primary_path="$(resolve_lexical "$wt_first")"
         fi
     fi
 
     # Method 3: fall back to hardcoded canonical path
     local hardcoded_primary
-    hardcoded_primary="$(realpath "/projects/cablesnap" 2>/dev/null || echo "/projects/cablesnap")"
+    hardcoded_primary="$(resolve_lexical "/projects/cablesnap")"
 
     # Check: is check_dir the primary checkout?
     local is_primary=0


### PR DESCRIPTION
## Summary

Closes the conditional-language loophole that caused the BLD-2039 race (parallel agent silently wiped uncommitted `Masonry.tsx` + `FlowContainer` edits). The previous rule said *"use a worktree whenever (1) you generate artefacts OR (2) another agent **might** be active"* — an agent doing pure source edits read condition 1 as not applying and gambled on condition 2, losing.

Two-layer fix:
1. **Process (unconditional rule):** all three in-repo docs now state worktrees are mandatory for ANY implementation work, with the only carve-out being read-only `origin/main` inspection.
2. **Technical (`guard` preflight):** new `scripts/agent-worktree.sh guard` subcommand that exits 3 with a clear error if the CWD is the shared primary checkout, exits 0 if safe.

## Changes

- `scripts/agent-worktree.sh` — added `guard [<dir>]` subcommand (AC1, AC2, AC3); updated file header with unconditional rule; added `guard` to `usage()` and `main()`.
- `.agents/CONCURRENT-AGENT-SAFETY.md` — unconditional TL;DR + Rule; `guard` in subcommand table + exit-code table; BLD-2039 recurrence explanation; future hardening note.
- `.claude/CLAUDE.md` — updated Concurrent-Agent Safety section: title, Rule block, bash example with `guard`, subcommand list.
- `.learnings/INDEX.md` — canonical Rule sentence and bash snippet updated with unconditional language and `guard` examples.
- `scripts/__tests__/agent-worktree-guard.test.ts` — NEW: 14 Jest tests covering AC1, AC2, AC3, and AC6 regression (bash -n + existing subcommands).

## Testing

- `bash -n scripts/agent-worktree.sh` — clean
- `npx -p typescript tsc --noEmit` — zero errors
- `npx jest --testPathPattern="scripts/__tests__"` — 112 tests, all pass (10 suites, no regressions)

## Acceptance Criteria

- [x] AC1: `guard` exits 3 + REFUSING message when CWD is primary checkout
- [x] AC2: `guard` exits 0 when CWD is any other path
- [x] AC3: `guard` listed in `help`/`usage`; unknown-subcommand exit 2 unchanged
- [x] AC4: All three docs unconditional; conditional loophole language removed; `guard` documented; BLD-2039 referenced
- [x] AC5: New Jest test passes (14 tests covering AC1+AC2+AC3+AC6)
- [x] AC6: tsc zero errors; 112 existing tests pass; bash -n clean; start/stop/status/list unchanged

## Issue

Resolves BLD-2040
Parent: BLD-2039