### PR TITLE
feat(settings): consolidate ~18 cards into ~8 themed masonry tiles (BLD-2031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ marker) at release time.
 - Settings: tidied up text hierarchy so titles, labels, and helper text use consistent sizes and weights for a cleaner, less cluttered look.
 - **Improvement: Settings tiles are lighter and less cluttered** — the Settings screen previously rendered as a vertical stack of drop-shadowed boxes. Each tile now uses a subtle 1px outline instead of a shadow, with slightly tighter padding, so the screen reads as a clean, calm list rather than a column of floating cards. (BLD-2030)
 - **Improvement: Settings link rows are more legible and easier to tap** — the Gym Profiles, Advanced Set Types, and Adaptive Macro Coach entries now use a larger, consistent title size and a guaranteed 48 dp minimum touch target, and Settings tiles share a single, consistent density (padding and heading size). No functionality changed — the links open the same screens as before. (BLD-2032)
+- **Improvement: Settings screen is reorganised into themed sections** — the previously long list of ~18 individual setting cards is now grouped into 9 clearly-labelled tiles (Profile, Units & Appearance, Training, Notifications, Coaching, Integrations, Data & Backup, Feedback, About) using a tidy masonry layout on wider screens. Related settings now sit together under a named heading, and the screen reads as a clean, scannable list instead of a tall stack of cards. All settings open the same screens as before. (BLD-2031)
 
 ## v0.26.42 — 2026-06-27
 <!-- versionCode: 112 -->

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -7,9 +7,10 @@ import {
   View,
 } from 'react-native';
 import { Text } from '@/components/ui/text';
+import { Separator } from '@/components/ui/separator';
 import { useLayout } from '../../lib/layout';
 import { useFloatingTabBarHeight } from '../../components/FloatingTabBar';
-import FlowContainer from '../../components/ui/FlowContainer';
+import Masonry from '../../components/ui/Masonry';
 import BodyProfileCard from '../../components/BodyProfileCard';
 import Constants from 'expo-constants';
 import { useRouter } from 'expo-router';
@@ -48,18 +49,15 @@ import { useQueryClient } from '@tanstack/react-query';
 
 /**
  * Extra bottom clearance beyond the floating tab bar zone.
- * On wide/foldable screens the FlowContainer produces a multi-column layout
- * that reduces total content height; this extra padding ensures the About
- * card (with badge images) is always comfortably scrollable into view.
  *
  * On Android with gesture navigation, `insets.bottom` is often 0, so the
  * floating tab bar (which is `position: absolute`) can overlay the bottom
  * cards and block interaction unless we add generous extra clearance here.
  *
- * Set to 160px (was 96px) to guarantee the last interactive card sits
- * comfortably above the floating tab bar on Android phones with gesture
- * navigation, foldables, and other form factors where safe-area-inset
- * reporting may understate the actual visual clearance needed.
+ * Set to 160px to guarantee the last interactive card sits comfortably above
+ * the floating tab bar on Android phones with gesture navigation, foldables,
+ * and other form factors where safe-area-inset reporting may understate the
+ * actual visual clearance needed.
  */
 export const SETTINGS_SCROLL_EXTRA_BOTTOM = 160;
 
@@ -81,6 +79,7 @@ export default function Settings() {
   useEffect(() => {
     getMacroCoachEnabled().then(setMacroCoachEnabled).catch(() => setMacroCoachEnabled(false));
   }, []);
+
   const {
     toast,
     loading, setLoading,
@@ -165,19 +164,53 @@ export default function Settings() {
         paddingBottom: tabBarHeight + SETTINGS_SCROLL_EXTRA_BOTTOM,
       }}
     >
-      <FlowContainer gap={16}>
-        <UnitsCard
-          colors={colors}
-          toast={toast}
-          weightUnit={weightUnit}
-          setWeightUnit={setWeightUnit}
-          measureUnit={measureUnit}
-          setMeasureUnit={setMeasureUnit}
-          weightGoal={weightGoal}
-          fatGoal={fatGoal}
-        />
-        <AppearanceCard colors={colors} />
-        <SettingsTile colors={colors}>
+      {/*
+       * P0-3: Settings IA — ~18 individual cards consolidated into ~8 themed
+       * masonry tiles (BLD-2031). FlowContainer replaced with Masonry so tiles
+       * pack shortest-column-first on wide screens instead of flex-wrap rows.
+       *
+       * Watch-outs (from BLD-2028 plan):
+       *   - No card-in-card nesting: child components use bareContent={true}
+       *   - Keep logging path untouched (session screen not affected here)
+       *   - Do not gate tile visibility on reveal transitions (headless-safe)
+       */}
+      <Masonry gap={16} testID="settings-masonry">
+
+        {/* ── 1. Profile ── */}
+        <SettingsTile colors={colors} title="Profile" testID="settings-tile-profile">
+          <BodyProfileCard
+            weightUnit={weightUnit}
+            heightUnit={measureUnit}
+            bareContent
+          />
+          <Separator style={styles.tileDivider} />
+          <FrequencyGoalPicker
+            colors={colors}
+            value={weeklyGoal}
+            onChange={handleWeeklyGoalChange}
+            bareContent
+          />
+        </SettingsTile>
+
+        {/* ── 2. Units & Appearance ── */}
+        <SettingsTile colors={colors} title="Units & Appearance" testID="settings-tile-units-appearance">
+          <UnitsCard
+            colors={colors}
+            toast={toast}
+            weightUnit={weightUnit}
+            setWeightUnit={setWeightUnit}
+            measureUnit={measureUnit}
+            setMeasureUnit={setMeasureUnit}
+            weightGoal={weightGoal}
+            fatGoal={fatGoal}
+            bareContent
+          />
+          <Separator style={styles.tileDivider} />
+          <AppearanceCard colors={colors} bareContent />
+        </SettingsTile>
+
+        {/* ── 3. Training ── */}
+        <SettingsTile colors={colors} title="Training" testID="settings-tile-training">
           <SettingsLinkRow
             colors={colors}
             title="Gym Profiles"
@@ -185,8 +218,6 @@ export default function Settings() {
             accessibilityLabel="Open gym profiles settings"
             onPress={() => router.push('/settings/gym-profiles')}
           />
-        </SettingsTile>
-        <SettingsTile colors={colors}>
           <SettingsLinkRow
             colors={colors}
             title="Advanced Set Types"
@@ -195,7 +226,40 @@ export default function Settings() {
             onPress={() => router.push('/settings/advanced-sets')}
           />
         </SettingsTile>
-        <SettingsTile colors={colors}>
+
+        {/* ── 4. Notifications ── */}
+        <SettingsTile colors={colors} title="Notifications" testID="settings-tile-notifications">
+          <PreferencesCard
+            colors={colors}
+            toast={toast}
+            soundEnabled={soundEnabled}
+            setSoundEnabled={setSoundEnabled}
+            bareContent
+          >
+            <ReminderSection
+              colors={colors}
+              toast={toast}
+              reminders={reminders}
+              setReminders={setReminders}
+              reminderTime={reminderTime}
+              setReminderTime={setReminderTime}
+              permDenied={permDenied}
+              setPermDenied={setPermDenied}
+              scheduleCount={scheduleCount}
+              restNotifications={restNotifications}
+              setRestNotifications={setRestNotifications}
+              restPreEndCueSeconds={restPreEndCueSeconds}
+              setRestPreEndCueSeconds={setRestPreEndCueSeconds}
+              restLiveCountdown={restLiveCountdown}
+              setRestLiveCountdown={setRestLiveCountdown}
+              restShowNextSet={restShowNextSet}
+              setRestShowNextSet={setRestShowNextSet}
+            />
+          </PreferencesCard>
+        </SettingsTile>
+
+        {/* ── 5. Coaching ── */}
+        <SettingsTile colors={colors} title="Coaching" testID="settings-tile-coaching">
           <SettingsLinkRow
             colors={colors}
             title="Adaptive Macro Coach"
@@ -209,40 +273,11 @@ export default function Settings() {
             accessibilityLabel="Open Adaptive Macro Coach settings"
             onPress={() => router.push('/settings/macro-coach')}
           />
+          <Separator style={styles.tileDivider} />
+          <HydrationCard colors={colors} toast={toast} bareContent />
         </SettingsTile>
-        <BodyProfileCard weightUnit={weightUnit} heightUnit={measureUnit} />
-        <FrequencyGoalPicker
-          colors={colors}
-          value={weeklyGoal}
-          onChange={handleWeeklyGoalChange}
-        />
-        <PreferencesCard
-          colors={colors}
-          toast={toast}
-          soundEnabled={soundEnabled}
-          setSoundEnabled={setSoundEnabled}
-        >
-          <ReminderSection
-            colors={colors}
-            toast={toast}
-            reminders={reminders}
-            setReminders={setReminders}
-            reminderTime={reminderTime}
-            setReminderTime={setReminderTime}
-            permDenied={permDenied}
-            setPermDenied={setPermDenied}
-            scheduleCount={scheduleCount}
-            restNotifications={restNotifications}
-            setRestNotifications={setRestNotifications}
-            restPreEndCueSeconds={restPreEndCueSeconds}
-            setRestPreEndCueSeconds={setRestPreEndCueSeconds}
-            restLiveCountdown={restLiveCountdown}
-            setRestLiveCountdown={setRestLiveCountdown}
-            restShowNextSet={restShowNextSet}
-            setRestShowNextSet={setRestShowNextSet}
-          />
-        </PreferencesCard>
-        <HydrationCard colors={colors} toast={toast} />
+
+        {/* ── 6. Integrations ── */}
         <IntegrationsCard
           colors={colors}
           toast={toast}
@@ -251,16 +286,26 @@ export default function Settings() {
           stravaLoading={stravaLoading}
           setStravaLoading={setStravaLoading}
         />
-        <AutoBackupSection colors={colors} toast={toast} />
-        <FormClipsStorageRow onClipsChanged={() => {}} />
-        <DataManagementCard
-          colors={colors}
-          loading={loading}
-          exportProgress={exportProgress}
-          onExport={() => setExportSheetVisible(true)}
-          onImport={openImportSheet}
-        />
-        <CSVExportCard colors={colors} />
+
+        {/* ── 7. Data & Backup ── */}
+        <SettingsTile colors={colors} title="Data & Backup" testID="settings-tile-data-backup">
+          <AutoBackupSection colors={colors} toast={toast} bareContent />
+          <Separator style={styles.tileDivider} />
+          <FormClipsStorageRow onClipsChanged={() => {}} />
+          <Separator style={styles.tileDivider} />
+          <DataManagementCard
+            colors={colors}
+            loading={loading}
+            exportProgress={exportProgress}
+            onExport={() => setExportSheetVisible(true)}
+            onImport={openImportSheet}
+            bareContent
+          />
+          <Separator style={styles.tileDivider} />
+          <CSVExportCard colors={colors} bareContent />
+        </SettingsTile>
+
+        {/* ── 8. Feedback ── */}
         <FeedbackCard
           colors={colors}
           count={count}
@@ -268,7 +313,9 @@ export default function Settings() {
           onFeature={() => router.push({ pathname: '/feedback', params: { type: 'feature' } })}
           onErrors={() => router.push('/errors')}
         />
-        <SettingsTile colors={colors} title="About">
+
+        {/* ── 9. About ── */}
+        <SettingsTile colors={colors} title="About" testID="settings-tile-about">
           <Pressable
             onPress={() => setReleaseNotesVisible(true)}
             accessibilityRole="button"
@@ -330,7 +377,8 @@ export default function Settings() {
             </Pressable>
           </View>
         </SettingsTile>
-      </FlowContainer>
+
+      </Masonry>
       <ReleaseNotesModal
         visible={releaseNotesVisible}
         onClose={() => setReleaseNotesVisible(false)}
@@ -363,20 +411,12 @@ export default function Settings() {
 
 const styles = StyleSheet.create({
   container: { flex: 1 },
-  settingsRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.sm,
-    minHeight: 44,
-  },
   versionRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingVertical: spacing.sm,
-    minHeight: 44,
+    minHeight: 48,
   },
   versionRowRight: {
     flexDirection: 'row',
@@ -384,5 +424,9 @@ const styles = StyleSheet.create({
   },
   aboutBlock: {
     marginTop: 4,
+  },
+  /** Vertical margin around the hairline Separator between sub-sections within a tile. */
+  tileDivider: {
+    marginVertical: spacing.sm,
   },
 });

--- a/components/BodyProfileCard.tsx
+++ b/components/BodyProfileCard.tsx
@@ -13,43 +13,60 @@ import { useBodyProfile } from "@/hooks/useBodyProfile";
 type BodyProfileCardProps = {
   weightUnit?: "kg" | "lb";
   heightUnit?: "cm" | "in";
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
-export default function BodyProfileCard({ weightUnit, heightUnit }: BodyProfileCardProps = {}) {
+export default function BodyProfileCard({ weightUnit, heightUnit, bareContent = false }: BodyProfileCardProps = {}) {
   const colors = useThemeColors();
   const profile = useBodyProfile(weightUnit, heightUnit);
   const cardStyle = StyleSheet.flatten([styles.card, { backgroundColor: colors.surface }]);
 
   if (profile.cardState === "loading") {
+    const loadingContent = (
+      <View style={styles.loadingContainer}>
+        <Spinner size="sm" />
+        <Text variant="body" style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}>Loading profile…</Text>
+      </View>
+    );
+    if (bareContent) return loadingContent;
     return (
       <Card variant="outline" style={cardStyle}>
-        <CardContent>
-          <View style={styles.loadingContainer}>
-            <Spinner size="sm" />
-            <Text variant="body" style={{ color: colors.onSurfaceVariant, marginLeft: 8 }}>Loading profile…</Text>
-          </View>
-        </CardContent>
+        <CardContent>{loadingContent}</CardContent>
       </Card>
     );
   }
 
   if (profile.cardState === "error") {
+    const errorContent = (
+      <>
+        <Text variant="body" style={{ color: colors.error, marginBottom: 8 }}>Could not load profile</Text>
+        <Button variant="outline" onPress={profile.loadProfile} accessibilityLabel="Retry loading profile">Retry</Button>
+      </>
+    );
+    if (bareContent) return <View>{errorContent}</View>;
     return (
       <Card variant="outline" style={cardStyle}>
-        <CardContent>
-          <Text variant="body" style={{ color: colors.error, marginBottom: 8 }}>Could not load profile</Text>
-          <Button variant="outline" onPress={profile.loadProfile} accessibilityLabel="Retry loading profile">Retry</Button>
-        </CardContent>
+        <CardContent>{errorContent}</CardContent>
       </Card>
     );
   }
 
+  const mainContent = (
+    <>
+      <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Body Profile</Text>
+      <BodyProfileForm colors={colors} {...profile} />
+    </>
+  );
+
+  if (bareContent) return <View>{mainContent}</View>;
+
   return (
     <Card variant="outline" style={cardStyle}>
-      <CardContent>
-        <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Body Profile</Text>
-        <BodyProfileForm colors={colors} {...profile} />
-      </CardContent>
+      <CardContent>{mainContent}</CardContent>
     </Card>
   );
 }

--- a/components/settings/AppearanceCard.tsx
+++ b/components/settings/AppearanceCard.tsx
@@ -8,33 +8,44 @@ import type { ThemeColors } from "@/hooks/useThemeColors";
 
 type Props = {
   colors: ThemeColors;
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
-export default function AppearanceCard({ colors }: Props) {
+export default function AppearanceCard({ colors, bareContent = false }: Props) {
   const { themeMode, setThemeMode } = useThemeMode();
+
+  const content = (
+    <>
+      <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Appearance</Text>
+      <View style={styles.row}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>Theme</Text>
+        <View style={styles.themeToggle}>
+          <SegmentedControl
+            value={themeMode}
+            onValueChange={(val) => setThemeMode(val as ThemeMode)}
+            buttons={[
+              { value: "system", label: "Auto" },
+              { value: "light", label: "Light" },
+              { value: "dark", label: "Dark" },
+            ]}
+          />
+        </View>
+      </View>
+      <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
+        Auto follows your device system setting.
+      </Text>
+    </>
+  );
+
+  if (bareContent) return <View>{content}</View>;
 
   return (
     <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-      <CardContent>
-        <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Appearance</Text>
-        <View style={styles.row}>
-          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>Theme</Text>
-          <View style={styles.themeToggle}>
-            <SegmentedControl
-              value={themeMode}
-              onValueChange={(val) => setThemeMode(val as ThemeMode)}
-              buttons={[
-                { value: "system", label: "Auto" },
-                { value: "light", label: "Light" },
-                { value: "dark", label: "Dark" },
-              ]}
-            />
-          </View>
-        </View>
-        <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>
-          Auto follows your device system setting.
-        </Text>
-      </CardContent>
+      <CardContent>{content}</CardContent>
     </Card>
   );
 }

--- a/components/settings/AutoBackupSection.tsx
+++ b/components/settings/AutoBackupSection.tsx
@@ -16,6 +16,11 @@ const STEP_BUTTON_SIZE = 32;
 type Props = {
   colors: ThemeColors;
   toast: ReturnType<typeof useToast>;
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
 function formatLastBackup(iso: string | null): string {
@@ -41,7 +46,7 @@ function formatLastBackup(iso: string | null): string {
   return `Last backup: ${date.toLocaleDateString()} at ${time}`;
 }
 
-export default function AutoBackupSection({ colors, toast }: Props) {
+export default function AutoBackupSection({ colors, toast, bareContent = false }: Props) {
   const router = useRouter();
   const [enabled, setEnabled] = useState(true);
   const [retention, setRetention] = useState(5);
@@ -115,110 +120,116 @@ export default function AutoBackupSection({ colors, toast }: Props) {
 
   if (!ready) return null;
 
-  return (
-    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-      <CardContent>
-        <Text
-          variant="body"
-          style={{ color: colors.onSurface, fontWeight: "600", fontSize: fontSizes.sm, marginBottom: 8 }}
+  const content = (
+    <>
+      <Text
+        variant="body"
+        style={{ color: colors.onSurface, fontWeight: "600", fontSize: fontSizes.sm, marginBottom: 8 }}
+      >
+        Auto-Backup
+      </Text>
+
+      <View style={styles.row}>
+        <Pressable
+          onPress={() => setTooltipVisible(!tooltipVisible)}
+          accessibilityRole="button"
+          accessibilityLabel="Auto-Backup. Tap for more info"
+          style={{ flex: 1 }}
         >
-          Auto-Backup
-        </Text>
+          <View style={styles.labelWithIcon}>
+            <Text variant="body" style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>
+              Auto-Backup
+            </Text>
+            <Text variant="caption" style={{ color: colors.primary, fontSize: fontSizes.xs, marginLeft: 4 }}>ⓘ</Text>
+          </View>
+        </Pressable>
+        <Switch
+          value={enabled}
+          onValueChange={handleToggle}
+          accessibilityRole="switch"
+          accessibilityLabel="Toggle auto-backup after workouts"
+        />
+      </View>
 
-        <View style={styles.row}>
-          <Pressable
-            onPress={() => setTooltipVisible(!tooltipVisible)}
-            accessibilityRole="button"
-            accessibilityLabel="Auto-Backup. Tap for more info"
-            style={{ flex: 1 }}
-          >
-            <View style={styles.labelWithIcon}>
-              <Text variant="body" style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>
-                Auto-Backup
-              </Text>
-              <Text variant="caption" style={{ color: colors.primary, fontSize: fontSizes.xs, marginLeft: 4 }}>ⓘ</Text>
-            </View>
-          </Pressable>
-          <Switch
-            value={enabled}
-            onValueChange={handleToggle}
-            accessibilityRole="switch"
-            accessibilityLabel="Toggle auto-backup after workouts"
-          />
-        </View>
-
-        {tooltipVisible && (
-          <Text
-            variant="caption"
-            style={[styles.tooltipText, { color: colors.onSurfaceVariant, backgroundColor: colors.surfaceVariant }]}
-          >
-            Automatically saves your data after each workout.
-          </Text>
-        )}
-
+      {tooltipVisible && (
         <Text
           variant="caption"
-          style={{ color: colors.onSurfaceVariant, marginBottom: 12 }}
-          accessibilityLabel={formatLastBackup(lastBackup)}
+          style={[styles.tooltipText, { color: colors.onSurfaceVariant, backgroundColor: colors.surfaceVariant }]}
         >
-          {formatLastBackup(lastBackup)}
+          Automatically saves your data after each workout.
         </Text>
+      )}
 
-        {enabled && (
-          <View style={styles.retentionRow} accessibilityLabel={`Keep last ${retention} backups`}>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm }}>
-              Keep last
-            </Text>
-            <Pressable
-              onPress={() => retention > MIN_RETENTION && handleRetentionChange(retention - 1)}
-              disabled={retention <= MIN_RETENTION}
-              accessibilityRole="button"
-              accessibilityLabel="Decrease backup retention"
-              style={[styles.stepButton, { backgroundColor: colors.surfaceVariant, opacity: retention > MIN_RETENTION ? 1 : 0.35 }]}
-            >
-              <MaterialCommunityIcons name="minus" size={16} color={colors.onSurface} />
-            </Pressable>
-            <Text variant="body" style={[styles.retentionValue, { color: colors.onSurface }]}>
-              {retention}
-            </Text>
-            <Pressable
-              onPress={() => retention < MAX_RETENTION && handleRetentionChange(retention + 1)}
-              disabled={retention >= MAX_RETENTION}
-              accessibilityRole="button"
-              accessibilityLabel="Increase backup retention"
-              style={[styles.stepButton, { backgroundColor: colors.surfaceVariant, opacity: retention < MAX_RETENTION ? 1 : 0.35 }]}
-            >
-              <MaterialCommunityIcons name="plus" size={16} color={colors.onSurface} />
-            </Pressable>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm }}>
-              backups
-            </Text>
-          </View>
-        )}
+      <Text
+        variant="caption"
+        style={{ color: colors.onSurfaceVariant, marginBottom: 12 }}
+        accessibilityLabel={formatLastBackup(lastBackup)}
+      >
+        {formatLastBackup(lastBackup)}
+      </Text>
 
-        <View style={styles.buttonRow}>
-          <Button
-            variant="outline"
-            size="sm"
-            onPress={handleBackupNow}
-            loading={loading}
-            disabled={loading}
-            accessibilityLabel="Create a backup now"
+      {enabled && (
+        <View style={styles.retentionRow} accessibilityLabel={`Keep last ${retention} backups`}>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm }}>
+            Keep last
+          </Text>
+          <Pressable
+            onPress={() => retention > MIN_RETENTION && handleRetentionChange(retention - 1)}
+            disabled={retention <= MIN_RETENTION}
             accessibilityRole="button"
+            accessibilityLabel="Decrease backup retention"
+            style={[styles.stepButton, { backgroundColor: colors.surfaceVariant, opacity: retention > MIN_RETENTION ? 1 : 0.35 }]}
           >
-            Backup Now
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onPress={() => router.push("/settings/backups")}
-            accessibilityLabel="View all backups"
+            <MaterialCommunityIcons name="minus" size={16} color={colors.onSurface} />
+          </Pressable>
+          <Text variant="body" style={[styles.retentionValue, { color: colors.onSurface }]}>
+            {retention}
+          </Text>
+          <Pressable
+            onPress={() => retention < MAX_RETENTION && handleRetentionChange(retention + 1)}
+            disabled={retention >= MAX_RETENTION}
             accessibilityRole="button"
+            accessibilityLabel="Increase backup retention"
+            style={[styles.stepButton, { backgroundColor: colors.surfaceVariant, opacity: retention < MAX_RETENTION ? 1 : 0.35 }]}
           >
-            View Backups
-          </Button>
+            <MaterialCommunityIcons name="plus" size={16} color={colors.onSurface} />
+          </Pressable>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.sm }}>
+            backups
+          </Text>
         </View>
-      </CardContent>
+      )}
+
+      <View style={styles.buttonRow}>
+        <Button
+          variant="outline"
+          size="sm"
+          onPress={handleBackupNow}
+          loading={loading}
+          disabled={loading}
+          accessibilityLabel="Create a backup now"
+          accessibilityRole="button"
+        >
+          Backup Now
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onPress={() => router.push("/settings/backups")}
+          accessibilityLabel="View all backups"
+          accessibilityRole="button"
+        >
+          View Backups
+        </Button>
+      </View>
+    </>
+  );
+
+  if (bareContent) return <View>{content}</View>;
+
+  return (
+    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+      <CardContent>{content}</CardContent>
     </Card>
   );
 }

--- a/components/settings/CSVExportCard.tsx
+++ b/components/settings/CSVExportCard.tsx
@@ -19,9 +19,14 @@ const RANGE_BUTTONS = [
 
 type Props = {
   colors: ThemeColors;
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
-export default function CSVExportCard({ colors }: Props) {
+export default function CSVExportCard({ colors, bareContent = false }: Props) {
   const [range, setRange] = useState("30");
   const [counts, setCounts] = useState({ sessions: 0, entries: 0 });
   const { loading, exportCSV } = useCSVExport();
@@ -30,25 +35,31 @@ export default function CSVExportCard({ colors }: Props) {
     getCSVCounts(sinceForRange(range)).then(setCounts);
   }, [range]);
 
+  const content = (
+    <>
+      <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>CSV Export</Text>
+      <SegmentedControl value={range} onValueChange={setRange} buttons={RANGE_BUTTONS} style={styles.segment} />
+      <Text
+        variant="caption"
+        style={{ color: colors.onSurfaceVariant, marginBottom: 12, marginTop: 8 }}
+        accessibilityLabel={`${counts.sessions} workout sessions, ${counts.entries} nutrition entries`}
+      >
+        {counts.sessions} session{counts.sessions !== 1 ? "s" : ""}, {counts.entries} entr{counts.entries !== 1 ? "ies" : "y"}
+      </Text>
+      <View style={styles.buttonFlow}>
+        <Button variant="outline" size="sm" icon={FileOutput} onPress={() => exportCSV("workouts", range)} loading={loading} disabled={loading} accessibilityLabel="Export workouts as CSV">Workouts</Button>
+        <Button variant="outline" size="sm" icon={Apple} onPress={() => exportCSV("nutrition", range)} loading={loading} disabled={loading} accessibilityLabel="Export nutrition as CSV">Nutrition</Button>
+        <Button variant="outline" size="sm" icon={Scale} onPress={() => exportCSV("bodyWeight", range)} loading={loading} disabled={loading} accessibilityLabel="Export body weight as CSV">Body Weight</Button>
+        <Button variant="outline" size="sm" icon={User} onPress={() => exportCSV("bodyMeasurements", range)} loading={loading} disabled={loading} accessibilityLabel="Export body measurements as CSV">Measurements</Button>
+      </View>
+    </>
+  );
+
+  if (bareContent) return <View>{content}</View>;
+
   return (
     <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-      <CardContent>
-        <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>CSV Export</Text>
-        <SegmentedControl value={range} onValueChange={setRange} buttons={RANGE_BUTTONS} style={styles.segment} />
-        <Text
-          variant="caption"
-          style={{ color: colors.onSurfaceVariant, marginBottom: 12, marginTop: 8 }}
-          accessibilityLabel={`${counts.sessions} workout sessions, ${counts.entries} nutrition entries`}
-        >
-          {counts.sessions} session{counts.sessions !== 1 ? "s" : ""}, {counts.entries} entr{counts.entries !== 1 ? "ies" : "y"}
-        </Text>
-        <View style={styles.buttonFlow}>
-          <Button variant="outline" size="sm" icon={FileOutput} onPress={() => exportCSV("workouts", range)} loading={loading} disabled={loading} accessibilityLabel="Export workouts as CSV">Workouts</Button>
-          <Button variant="outline" size="sm" icon={Apple} onPress={() => exportCSV("nutrition", range)} loading={loading} disabled={loading} accessibilityLabel="Export nutrition as CSV">Nutrition</Button>
-          <Button variant="outline" size="sm" icon={Scale} onPress={() => exportCSV("bodyWeight", range)} loading={loading} disabled={loading} accessibilityLabel="Export body weight as CSV">Body Weight</Button>
-          <Button variant="outline" size="sm" icon={User} onPress={() => exportCSV("bodyMeasurements", range)} loading={loading} disabled={loading} accessibilityLabel="Export body measurements as CSV">Measurements</Button>
-        </View>
-      </CardContent>
+      <CardContent>{content}</CardContent>
     </Card>
   );
 }

--- a/components/settings/DataManagementCard.tsx
+++ b/components/settings/DataManagementCard.tsx
@@ -12,6 +12,11 @@ type Props = {
   exportProgress: string | null;
   onExport: () => void;
   onImport: () => void;
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
 export default function DataManagementCard({
@@ -20,7 +25,64 @@ export default function DataManagementCard({
   exportProgress,
   onExport,
   onImport,
+  bareContent = false,
 }: Props) {
+  const content = (
+    <>
+      <Text
+        variant="body"
+        style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}
+      >
+        Data Management
+      </Text>
+      <View style={styles.buttonFlow}>
+        <Button
+          variant="default"
+          size="sm"
+          icon={Download}
+          onPress={onExport}
+          loading={loading}
+          disabled={loading}
+          accessibilityLabel="Export all data as JSON"
+          accessibilityRole="button"
+        >
+          Export All Data
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          icon={Upload}
+          onPress={onImport}
+          loading={loading}
+          disabled={loading}
+          accessibilityLabel="Import data"
+          accessibilityRole="button"
+        >
+          Import CableSnap Backup
+        </Button>
+      </View>
+      {exportProgress && (
+        <Text
+          variant="caption"
+          style={{ color: colors.primary, marginTop: 8 }}
+          accessibilityLiveRegion="polite"
+          accessibilityLabel={exportProgress}
+        >
+          {exportProgress}
+        </Text>
+      )}
+      <Text
+        variant="caption"
+        style={{ color: colors.onSurfaceVariant, marginTop: 8, marginBottom: 16 }}
+      >
+        Export your complete CableSnap data as a JSON backup file, or restore from a previous
+        backup. Duplicates are skipped.
+      </Text>
+    </>
+  );
+
+  if (bareContent) return <View>{content}</View>;
+
   return (
     <Card
       variant="outline"
@@ -30,57 +92,7 @@ export default function DataManagementCard({
         { backgroundColor: colors.surface },
       ])}
     >
-      <CardContent>
-        <Text
-          variant="body"
-          style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}
-        >
-          Data Management
-        </Text>
-        <View style={styles.buttonFlow}>
-          <Button
-            variant="default"
-            size="sm"
-            icon={Download}
-            onPress={onExport}
-            loading={loading}
-            disabled={loading}
-            accessibilityLabel="Export all data as JSON"
-            accessibilityRole="button"
-          >
-            Export All Data
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            icon={Upload}
-            onPress={onImport}
-            loading={loading}
-            disabled={loading}
-            accessibilityLabel="Import data"
-            accessibilityRole="button"
-          >
-            Import CableSnap Backup
-          </Button>
-        </View>
-        {exportProgress && (
-          <Text
-            variant="caption"
-            style={{ color: colors.primary, marginTop: 8 }}
-            accessibilityLiveRegion="polite"
-            accessibilityLabel={exportProgress}
-          >
-            {exportProgress}
-          </Text>
-        )}
-        <Text
-          variant="caption"
-          style={{ color: colors.onSurfaceVariant, marginTop: 8, marginBottom: 16 }}
-        >
-          Export your complete CableSnap data as a JSON backup file, or restore from a previous
-          backup. Duplicates are skipped.
-        </Text>
-      </CardContent>
+      <CardContent>{content}</CardContent>
     </Card>
   );
 }

--- a/components/settings/FeedbackCard.tsx
+++ b/components/settings/FeedbackCard.tsx
@@ -12,40 +12,51 @@ type Props = {
   onBug: () => void;
   onFeature: () => void;
   onErrors: () => void;
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
-export default function FeedbackCard({ colors, count, onBug, onFeature, onErrors }: Props) {
+export default function FeedbackCard({ colors, count, onBug, onFeature, onErrors, bareContent = false }: Props) {
+  const content = (
+    <>
+      <Text
+        variant="body"
+        style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}
+      >
+        Feedback &amp; Reports
+      </Text>
+      <View style={styles.buttonFlow}>
+        <Button variant="default" size="sm" icon={Bug} onPress={onBug} accessibilityLabel="Report a bug">
+          Report Bug
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          icon={Lightbulb}
+          onPress={onFeature}
+          accessibilityLabel="Request a feature"
+        >
+          Feature Request
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          icon={List}
+          onPress={onErrors}
+          accessibilityLabel={`View error log, ${count} ${count === 1 ? 'error' : 'errors'}`}
+        >{`Errors (${count})`}</Button>
+      </View>
+    </>
+  );
+
+  if (bareContent) return <View>{content}</View>;
+
   return (
     <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-      <CardContent>
-        <Text
-          variant="body"
-          style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}
-        >
-          Feedback &amp; Reports
-        </Text>
-        <View style={styles.buttonFlow}>
-          <Button variant="default" size="sm" icon={Bug} onPress={onBug} accessibilityLabel="Report a bug">
-            Report Bug
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            icon={Lightbulb}
-            onPress={onFeature}
-            accessibilityLabel="Request a feature"
-          >
-            Feature Request
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            icon={List}
-            onPress={onErrors}
-            accessibilityLabel={`View error log, ${count} ${count === 1 ? 'error' : 'errors'}`}
-          >{`Errors (${count})`}</Button>
-        </View>
-      </CardContent>
+      <CardContent>{content}</CardContent>
     </Card>
   );
 }

--- a/components/settings/FrequencyGoalPicker.tsx
+++ b/components/settings/FrequencyGoalPicker.tsx
@@ -9,74 +9,85 @@ type Props = {
   colors: ThemeColors;
   value: number | null;
   onChange: (goal: number | null) => void;
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
 const MIN_DAYS = 1;
 const MAX_DAYS = 7;
 const BUTTON_SIZE = 36;
 
-export default function FrequencyGoalPicker({ colors, value, onChange }: Props) {
+export default function FrequencyGoalPicker({ colors, value, onChange, bareContent = false }: Props) {
   const canDecrement = value != null && value > MIN_DAYS;
   const canIncrement = value != null && value < MAX_DAYS;
 
-  return (
-    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-      <CardContent>
-        <Text variant="body" style={{ color: colors.onSurface, fontWeight: "600", fontSize: fontSizes.sm, marginBottom: 4 }}>
-          Weekly Training Goal
-        </Text>
-        <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginBottom: 12 }}>
-          Shown on the home screen to track workouts completed vs. your target each week.
-        </Text>
-        {value == null ? (
-          <Pressable
-            onPress={() => onChange(3)}
-            accessibilityRole="button"
-            accessibilityLabel="Set weekly training goal"
-            style={[styles.setButton, { borderColor: colors.primary }]}
-          >
-            <Text variant="body" style={{ color: colors.primary, fontWeight: "600", fontSize: fontSizes.sm }}>
-              Set a goal
-            </Text>
-          </Pressable>
-        ) : (
-          <View style={styles.stepperRow}>
-            <View style={styles.stepper} accessibilityLabel={`Weekly training goal: ${value} days`}>
-              <Pressable
-                onPress={() => canDecrement && onChange(value - 1)}
-                disabled={!canDecrement}
-                accessibilityRole="button"
-                accessibilityLabel="Decrease training days"
-                style={[styles.stepButton, { backgroundColor: colors.surfaceVariant, opacity: canDecrement ? 1 : 0.35 }]}
-              >
-                <MaterialCommunityIcons name="minus" size={20} color={colors.onSurface} />
-              </Pressable>
-              <Text variant="body" style={[styles.stepValue, { color: colors.onSurface }]}>
-                {value} {value === 1 ? "day" : "days"} / week
-              </Text>
-              <Pressable
-                onPress={() => canIncrement && onChange(value + 1)}
-                disabled={!canIncrement}
-                accessibilityRole="button"
-                accessibilityLabel="Increase training days"
-                style={[styles.stepButton, { backgroundColor: colors.surfaceVariant, opacity: canIncrement ? 1 : 0.35 }]}
-              >
-                <MaterialCommunityIcons name="plus" size={20} color={colors.onSurface} />
-              </Pressable>
-            </View>
+  const content = (
+    <>
+      <Text variant="body" style={{ color: colors.onSurface, fontWeight: "600", fontSize: fontSizes.sm, marginBottom: 4 }}>
+        Weekly Training Goal
+      </Text>
+      <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginBottom: 12 }}>
+        Shown on the home screen to track workouts completed vs. your target each week.
+      </Text>
+      {value == null ? (
+        <Pressable
+          onPress={() => onChange(3)}
+          accessibilityRole="button"
+          accessibilityLabel="Set weekly training goal"
+          style={[styles.setButton, { borderColor: colors.primary }]}
+        >
+          <Text variant="body" style={{ color: colors.primary, fontWeight: "600", fontSize: fontSizes.sm }}>
+            Set a goal
+          </Text>
+        </Pressable>
+      ) : (
+        <View style={styles.stepperRow}>
+          <View style={styles.stepper} accessibilityLabel={`Weekly training goal: ${value} days`}>
             <Pressable
-              onPress={() => onChange(null)}
+              onPress={() => canDecrement && onChange(value - 1)}
+              disabled={!canDecrement}
               accessibilityRole="button"
-              accessibilityLabel="Clear weekly training goal"
-              style={styles.clearButton}
+              accessibilityLabel="Decrease training days"
+              style={[styles.stepButton, { backgroundColor: colors.surfaceVariant, opacity: canDecrement ? 1 : 0.35 }]}
             >
-              <Text variant="caption" style={{ color: colors.primary }}>
-                Clear
-              </Text>
+              <MaterialCommunityIcons name="minus" size={20} color={colors.onSurface} />
+            </Pressable>
+            <Text variant="body" style={[styles.stepValue, { color: colors.onSurface }]}>
+              {value} {value === 1 ? "day" : "days"} / week
+            </Text>
+            <Pressable
+              onPress={() => canIncrement && onChange(value + 1)}
+              disabled={!canIncrement}
+              accessibilityRole="button"
+              accessibilityLabel="Increase training days"
+              style={[styles.stepButton, { backgroundColor: colors.surfaceVariant, opacity: canIncrement ? 1 : 0.35 }]}
+            >
+              <MaterialCommunityIcons name="plus" size={20} color={colors.onSurface} />
             </Pressable>
           </View>
-        )}
-      </CardContent>
+          <Pressable
+            onPress={() => onChange(null)}
+            accessibilityRole="button"
+            accessibilityLabel="Clear weekly training goal"
+            style={styles.clearButton}
+          >
+            <Text variant="caption" style={{ color: colors.primary }}>
+              Clear
+            </Text>
+          </Pressable>
+        </View>
+      )}
+    </>
+  );
+
+  if (bareContent) return <View>{content}</View>;
+
+  return (
+    <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
+      <CardContent>{content}</CardContent>
     </Card>
   );
 }

--- a/components/settings/HydrationCard.tsx
+++ b/components/settings/HydrationCard.tsx
@@ -17,6 +17,11 @@ import { mlToOz, ozToMl, type HydrationUnit } from "@/lib/hydration-units";
 type Props = {
   colors: ThemeColors;
   toast: ReturnType<typeof useToast>;
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
 const DEFAULT_GOAL_ML = 2000;
@@ -35,7 +40,7 @@ function fromDisplay(text: string, unit: HydrationUnit): number | null {
   return Math.round(unit === "ml" ? n : ozToMl(n));
 }
 
-export default function HydrationCard({ colors, toast }: Props) {
+export default function HydrationCard({ colors, toast, bareContent = false }: Props) {
   const [unit, setUnit] = useState<HydrationUnit>("ml");
   const [goalText, setGoalText] = useState(String(DEFAULT_GOAL_ML));
   const [presetText, setPresetText] = useState<[string, string, string]>(["250", "500", "750"]);
@@ -126,89 +131,97 @@ export default function HydrationCard({ colors, toast }: Props) {
     } catch { toast.error("Failed to reset hydration settings"); }
   };
 
-  return (
-    <Card variant="outline" style={StyleSheet.flatten([styles.card, { backgroundColor: colors.surface }])}>
-      <CardContent>
-        <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>
-          Hydration
-        </Text>
+  const hydrationContent = (
+    <>
+      <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>
+        Hydration
+      </Text>
 
-        {/* Unit toggle */}
-        <View style={styles.row}>
-          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>Unit</Text>
-          <View style={styles.toggleRow}>
-            {(["ml", "fl_oz"] as HydrationUnit[]).map((u) => (
-              <Pressable
-                key={u}
-                onPress={() => handleUnitChange(u)}
-                accessibilityLabel={u === "ml" ? "Use milliliters" : "Use fluid ounces"}
-                accessibilityRole="button"
-                accessibilityState={{ selected: unit === u }}
-                style={({ pressed }) => [
-                  styles.toggleBtn,
-                  { borderColor: colors.primary },
-                  unit === u && { backgroundColor: colors.primary },
-                  pressed && { opacity: 0.7 },
-                ]}
-              >
-                <Text variant="caption" style={{ color: unit === u ? "#fff" : colors.primary }}>
-                  {u === "ml" ? "ml" : "fl oz"}
-                </Text>
-              </Pressable>
-            ))}
-          </View>
+      {/* Unit toggle */}
+      <View style={styles.row}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>Unit</Text>
+        <View style={styles.toggleRow}>
+          {(["ml", "fl_oz"] as HydrationUnit[]).map((u) => (
+            <Pressable
+              key={u}
+              onPress={() => handleUnitChange(u)}
+              accessibilityLabel={u === "ml" ? "Use milliliters" : "Use fluid ounces"}
+              accessibilityRole="button"
+              accessibilityState={{ selected: unit === u }}
+              style={({ pressed }) => [
+                styles.toggleBtn,
+                { borderColor: colors.primary },
+                unit === u && { backgroundColor: colors.primary },
+                pressed && { opacity: 0.7 },
+              ]}
+            >
+              <Text variant="caption" style={{ color: unit === u ? "#fff" : colors.primary }}>
+                {u === "ml" ? "ml" : "fl oz"}
+              </Text>
+            </Pressable>
+          ))}
         </View>
+      </View>
 
-        {/* Daily goal */}
-        <View style={styles.row}>
+      {/* Daily goal */}
+      <View style={styles.row}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+          Daily goal ({unit === "ml" ? "ml" : "fl oz"})
+        </Text>
+        <TextInput
+          accessibilityLabel="Daily hydration goal"
+          value={goalText}
+          onChangeText={setGoalText}
+          onBlur={commitGoal}
+          keyboardType="numeric"
+          editable={hydrated}
+          style={[styles.input, { color: colors.onSurface, borderColor: colors.onSurfaceVariant }]}
+        />
+      </View>
+
+      {/* Presets */}
+      {[0, 1, 2].map((i) => (
+        <View key={`preset-${i}`} style={styles.row}>
           <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
-            Daily goal ({unit === "ml" ? "ml" : "fl oz"})
+            Preset {i + 1} ({unit === "ml" ? "ml" : "fl oz"})
           </Text>
           <TextInput
-            accessibilityLabel="Daily hydration goal"
-            value={goalText}
-            onChangeText={setGoalText}
-            onBlur={commitGoal}
+            accessibilityLabel={`Preset ${i + 1}`}
+            value={presetText[i]}
+            onChangeText={(t) => setPresetText((p) => {
+              const next = [...p] as [string, string, string];
+              next[i] = t;
+              return next;
+            })}
+            onBlur={() => commitPreset(i as 0 | 1 | 2)}
             keyboardType="numeric"
             editable={hydrated}
             style={[styles.input, { color: colors.onSurface, borderColor: colors.onSurfaceVariant }]}
           />
         </View>
+      ))}
 
-        {/* Presets */}
-        {[0, 1, 2].map((i) => (
-          <View key={`preset-${i}`} style={styles.row}>
-            <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
-              Preset {i + 1} ({unit === "ml" ? "ml" : "fl oz"})
-            </Text>
-            <TextInput
-              accessibilityLabel={`Preset ${i + 1}`}
-              value={presetText[i]}
-              onChangeText={(t) => setPresetText((p) => {
-                const next = [...p] as [string, string, string];
-                next[i] = t;
-                return next;
-              })}
-              onBlur={() => commitPreset(i as 0 | 1 | 2)}
-              keyboardType="numeric"
-              editable={hydrated}
-              style={[styles.input, { color: colors.onSurface, borderColor: colors.onSurfaceVariant }]}
-            />
-          </View>
-        ))}
+      <Pressable
+        onPress={handleReset}
+        accessibilityLabel="Reset hydration settings to defaults"
+        accessibilityRole="button"
+        style={({ pressed }) => [
+          { marginTop: 12, alignSelf: "flex-start", minHeight: 44, justifyContent: "center", paddingHorizontal: 4 },
+          pressed && { opacity: 0.6 },
+        ]}
+        hitSlop={8}
+      >
+        <Text variant="caption" style={{ color: colors.primary }}>Reset to defaults</Text>
+      </Pressable>
+    </>
+  );
 
-        <Pressable
-          onPress={handleReset}
-          accessibilityLabel="Reset hydration settings to defaults"
-          accessibilityRole="button"
-          style={({ pressed }) => [
-            { marginTop: 12, alignSelf: "flex-start", minHeight: 44, justifyContent: "center", paddingHorizontal: 4 },
-            pressed && { opacity: 0.6 },
-          ]}
-          hitSlop={8}
-        >
-          <Text variant="caption" style={{ color: colors.primary }}>Reset to defaults</Text>
-        </Pressable>
+  if (bareContent) return <View>{hydrationContent}</View>;
+
+  return (
+    <Card variant="outline" style={StyleSheet.flatten([styles.card, { backgroundColor: colors.surface }])}>
+      <CardContent>
+        {hydrationContent}
       </CardContent>
     </Card>
   );

--- a/components/settings/IntegrationsCard.tsx
+++ b/components/settings/IntegrationsCard.tsx
@@ -16,75 +16,87 @@ type Props = {
   setStravaAthlete: (v: string | null) => void;
   stravaLoading: boolean;
   setStravaLoading: (v: boolean) => void;
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
 export default function IntegrationsCard({
   colors, toast,
   stravaAthlete, setStravaAthlete, stravaLoading, setStravaLoading,
+  bareContent = false,
 }: Props) {
   if (Platform.OS === "web") return null;
+
+  const content = (
+    <>
+      <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Integrations</Text>
+
+      {stravaAthlete ? (
+        <View>
+          <View style={styles.row}>
+            <View style={{ flex: 1 }}>
+              <Text variant="body" style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>Strava</Text>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Connected as {stravaAthlete}</Text>
+            </View>
+            <Button
+              variant="outline"
+              size="sm"
+              onPress={async () => {
+                setStravaLoading(true);
+                try { await disconnectStrava(); setStravaAthlete(null); toast.success("Strava disconnected"); }
+                catch { toast.error("Failed to disconnect Strava"); }
+                finally { setStravaLoading(false); }
+              }}
+              loading={stravaLoading}
+              disabled={stravaLoading}
+              accessibilityRole="button"
+              accessibilityLabel={`Disconnect Strava account (${stravaAthlete})`}
+            >
+              Disconnect
+            </Button>
+          </View>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>Completed workouts are automatically uploaded to Strava.</Text>
+        </View>
+      ) : (
+        <View>
+          <Button
+            variant="default"
+            size="sm"
+            icon={Activity}
+            onPress={async () => {
+              setStravaLoading(true);
+              try {
+                const result = await connectStrava();
+                if (result) { setStravaAthlete(result.athleteName); toast.success("Connected to Strava!"); }
+              } catch (err) {
+                if (__DEV__) {
+                  console.warn("Strava connect failed:", err);
+                }
+                toast.error(getStravaUserMessage(err), { action: getStravaSupportAction(err) });
+              } finally { setStravaLoading(false); }
+            }}
+            loading={stravaLoading}
+            disabled={stravaLoading}
+            accessibilityRole="button"
+            accessibilityLabel="Connect your Strava account"
+          >
+            Connect Strava
+          </Button>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 8 }}>Automatically upload completed workouts to your Strava account.</Text>
+        </View>
+      )}
+    </>
+  );
+
+  if (bareContent) return <ErrorBoundary><View>{content}</View></ErrorBoundary>;
 
   return (
     <ErrorBoundary>
       <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-        <CardContent>
-          <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Integrations</Text>
-
-          {stravaAthlete ? (
-            <View>
-              <View style={styles.row}>
-                <View style={{ flex: 1 }}>
-                  <Text variant="body" style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>Strava</Text>
-                  <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Connected as {stravaAthlete}</Text>
-                </View>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onPress={async () => {
-                    setStravaLoading(true);
-                    try { await disconnectStrava(); setStravaAthlete(null); toast.success("Strava disconnected"); }
-                    catch { toast.error("Failed to disconnect Strava"); }
-                    finally { setStravaLoading(false); }
-                  }}
-                  loading={stravaLoading}
-                  disabled={stravaLoading}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Disconnect Strava account (${stravaAthlete})`}
-                >
-                  Disconnect
-                </Button>
-              </View>
-              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 4 }}>Completed workouts are automatically uploaded to Strava.</Text>
-            </View>
-          ) : (
-            <View>
-              <Button
-                variant="default"
-                size="sm"
-                icon={Activity}
-                onPress={async () => {
-                  setStravaLoading(true);
-                  try {
-                    const result = await connectStrava();
-                    if (result) { setStravaAthlete(result.athleteName); toast.success("Connected to Strava!"); }
-                  } catch (err) {
-                    if (__DEV__) {
-                      console.warn("Strava connect failed:", err);
-                    }
-                    toast.error(getStravaUserMessage(err), { action: getStravaSupportAction(err) });
-                  } finally { setStravaLoading(false); }
-                }}
-                loading={stravaLoading}
-                disabled={stravaLoading}
-                accessibilityRole="button"
-                accessibilityLabel="Connect your Strava account"
-              >
-                Connect Strava
-              </Button>
-              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 8 }}>Automatically upload completed workouts to your Strava account.</Text>
-            </View>
-          )}
-        </CardContent>
+        <CardContent>{content}</CardContent>
       </Card>
     </ErrorBoundary>
   );

--- a/components/settings/PreferencesCard.tsx
+++ b/components/settings/PreferencesCard.tsx
@@ -23,12 +23,18 @@ type Props = {
   soundEnabled: boolean;
   setSoundEnabled: (v: boolean) => void;
   children?: React.ReactNode;
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
 export default function PreferencesCard({
   colors, toast,
   soundEnabled, setSoundEnabled,
   children,
+  bareContent = false,
 }: Props) {
   const [soundTooltipVisible, setSoundTooltipVisible] = useState(false);
 
@@ -140,176 +146,184 @@ export default function PreferencesCard({
     catch { toast.error("Failed to save Tempo Coach setting"); }
   };
 
+  const preferencesContent = (
+    <>
+      <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Preferences</Text>
+
+      {children}
+
+      <View style={[styles.row, { marginTop: 16 }]}>
+        <Pressable
+          onPress={() => setSoundTooltipVisible(!soundTooltipVisible)}
+          accessibilityRole="button"
+          accessibilityLabel="Timer Sound. Tap for more info"
+          style={{ flex: 1 }}
+        >
+          <View style={styles.labelWithIcon}>
+            <Text variant="body" style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>Timer Sound</Text>
+            <Text variant="caption" style={{ color: colors.primary, fontSize: fontSizes.xs, marginLeft: 4 }}>ⓘ</Text>
+          </View>
+        </Pressable>
+        <Switch
+          value={soundEnabled}
+          onValueChange={async (val) => {
+            setSoundEnabled(val);
+            setAudioCategoryEnabled("timer", val);
+            try { await setAppSetting("timer_sound_enabled", val ? "true" : "false"); }
+            catch { toast.error("Failed to save timer sound setting"); }
+          }}
+          accessibilityLabel="Timer Sound"
+          accessibilityRole="switch"
+          accessibilityHint="Enable or disable audio cues for workout timers"
+        />
+      </View>
+      {soundTooltipVisible && (
+        <Text variant="caption" style={[styles.tooltipText, { color: colors.onSurfaceVariant, backgroundColor: colors.surfaceVariant }]}>
+          Audio cues for interval timers and rest countdowns.
+        </Text>
+      )}
+
+      {/* Intelligent Rest Timer (BLD-531) */}
+      <View style={styles.row}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+          Adaptive rest timer
+        </Text>
+        <Switch
+          value={adaptiveRest}
+          onValueChange={updateAdaptive}
+          accessibilityLabel="Adaptive rest timer"
+          accessibilityRole="switch"
+          accessibilityHint="Adjust rest duration automatically by set type, RPE, and equipment"
+        />
+      </View>
+      <View style={styles.row}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+          Show adaptive reason chip
+        </Text>
+        <Switch
+          value={showBreakdown}
+          onValueChange={updateShowBreakdown}
+          accessibilityLabel="Show adaptive reason chip"
+          accessibilityRole="switch"
+          accessibilityHint="Show why the timer picked this rest duration"
+          disabled={!adaptiveRest}
+        />
+      </View>
+      <View style={styles.row}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+          Rest after warmup sets
+        </Text>
+        <Switch
+          value={restAfterWarmup}
+          onValueChange={updateRestAfterWarmup}
+          accessibilityLabel="Rest after warmup sets"
+          accessibilityRole="switch"
+          accessibilityHint="Start a short rest timer after warmup sets"
+        />
+      </View>
+
+      {/* BLD-559: Set-completion confirmation feedback */}
+      <View style={styles.row}>
+        <View style={{ flex: 1 }}>
+          <Text variant="body" style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>
+            Capture set RPE during workouts
+          </Text>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.xs, marginTop: 2, lineHeight: 16 }}>
+            Tap a chip after each set to log how it felt. Powers the smart rest timer and progression suggestions.
+          </Text>
+        </View>
+        <Switch
+          testID="pref-capture-rpe-switch"
+          value={captureRpe}
+          onValueChange={updateCaptureRpe}
+          accessibilityLabel="Capture set RPE during workouts"
+          accessibilityRole="switch"
+          accessibilityHint="Shows effort chips after each set you complete"
+        />
+      </View>
+
+      {/* BLD-1114: Pulley pin tracking */}
+      <View style={styles.row}>
+        <View style={{ flex: 1 }}>
+          <Text variant="body" style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>
+            Track pulley pin position
+          </Text>
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.xs, marginTop: 2, lineHeight: 16 }}>
+            Show a pin-number chip on cable sets to log which pulley pin you used.
+          </Text>
+        </View>
+        <Switch
+          value={pulleyPinTracking}
+          onValueChange={updatePulleyPinTracking}
+          accessibilityLabel="Track pulley pin position"
+          accessibilityRole="switch"
+          accessibilityHint="Show or hide the pulley pin chip on cable exercise sets"
+        />
+      </View>
+
+      {/* BLD-1158b: Tempo Coach */}
+      <View style={styles.row}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+          Tempo Coach (haptic)
+        </Text>
+        <Switch
+          value={tempoCoachEnabled}
+          onValueChange={updateTempoCoachEnabled}
+          accessibilityLabel="Tempo Coach"
+          accessibilityRole="switch"
+          accessibilityHint="Enable haptic rep guide to coach your tempo on each set"
+          testID="pref-tempo-coach-switch"
+        />
+      </View>
+
+      {/* BLD-559: Set-completion confirmation feedback */}
+      <View style={styles.row}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+          Haptic on set complete
+        </Text>
+        <Switch
+          value={setCompleteHaptic}
+          onValueChange={updateSetCompleteHaptic}
+          accessibilityLabel="Haptic on set complete"
+          accessibilityRole="switch"
+          accessibilityHint="Vibrate briefly when you tap to complete a set"
+        />
+      </View>
+      <View style={styles.row}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+          Sound on set complete
+        </Text>
+        <Switch
+          value={setCompleteAudio}
+          onValueChange={updateSetCompleteAudio}
+          accessibilityLabel="Sound on set complete"
+          accessibilityRole="switch"
+          accessibilityHint="Play a short confirmation tone when you tap to complete a set"
+        />
+      </View>
+      {/* BLD-580 discoverability helper row. Non-pressable (pure <Text>),
+          rendered ONLY while the user has never interacted with the audio
+          toggle. Auto-dismisses silently on first interaction. Locked
+          copy — DO NOT edit without updating AC-2 snapshot test. */}
+      {!audioEverInteracted && (
+        <Text
+          variant="caption"
+          accessibilityRole="text"
+          style={[styles.helperRow, { color: colors.onSurfaceVariant, fontSize: fontSizes.xs }]}
+          testID="set-complete-audio-helper"
+        >
+          Plays a short confirmation cue when you complete a set.
+        </Text>
+      )}
+    </>
+  );
+
+  if (bareContent) return <View>{preferencesContent}</View>;
+
   return (
     <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
       <CardContent>
-        <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Preferences</Text>
-
-        {children}
-
-        <View style={[styles.row, { marginTop: 16 }]}>
-          <Pressable
-            onPress={() => setSoundTooltipVisible(!soundTooltipVisible)}
-            accessibilityRole="button"
-            accessibilityLabel="Timer Sound. Tap for more info"
-            style={{ flex: 1 }}
-          >
-            <View style={styles.labelWithIcon}>
-              <Text variant="body" style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>Timer Sound</Text>
-              <Text variant="caption" style={{ color: colors.primary, fontSize: fontSizes.xs, marginLeft: 4 }}>ⓘ</Text>
-            </View>
-          </Pressable>
-          <Switch
-            value={soundEnabled}
-            onValueChange={async (val) => {
-              setSoundEnabled(val);
-              setAudioCategoryEnabled("timer", val);
-              try { await setAppSetting("timer_sound_enabled", val ? "true" : "false"); }
-              catch { toast.error("Failed to save timer sound setting"); }
-            }}
-            accessibilityLabel="Timer Sound"
-            accessibilityRole="switch"
-            accessibilityHint="Enable or disable audio cues for workout timers"
-          />
-        </View>
-        {soundTooltipVisible && (
-          <Text variant="caption" style={[styles.tooltipText, { color: colors.onSurfaceVariant, backgroundColor: colors.surfaceVariant }]}>
-            Audio cues for interval timers and rest countdowns.
-          </Text>
-        )}
-
-        {/* Intelligent Rest Timer (BLD-531) */}
-        <View style={styles.row}>
-          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
-            Adaptive rest timer
-          </Text>
-          <Switch
-            value={adaptiveRest}
-            onValueChange={updateAdaptive}
-            accessibilityLabel="Adaptive rest timer"
-            accessibilityRole="switch"
-            accessibilityHint="Adjust rest duration automatically by set type, RPE, and equipment"
-          />
-        </View>
-        <View style={styles.row}>
-          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
-            Show adaptive reason chip
-          </Text>
-          <Switch
-            value={showBreakdown}
-            onValueChange={updateShowBreakdown}
-            accessibilityLabel="Show adaptive reason chip"
-            accessibilityRole="switch"
-            accessibilityHint="Show why the timer picked this rest duration"
-            disabled={!adaptiveRest}
-          />
-        </View>
-        <View style={styles.row}>
-          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
-            Rest after warmup sets
-          </Text>
-          <Switch
-            value={restAfterWarmup}
-            onValueChange={updateRestAfterWarmup}
-            accessibilityLabel="Rest after warmup sets"
-            accessibilityRole="switch"
-            accessibilityHint="Start a short rest timer after warmup sets"
-          />
-        </View>
-
-        {/* BLD-559: Set-completion confirmation feedback */}
-        <View style={styles.row}>
-          <View style={{ flex: 1 }}>
-            <Text variant="body" style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>
-              Capture set RPE during workouts
-            </Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.xs, marginTop: 2, lineHeight: 16 }}>
-              Tap a chip after each set to log how it felt. Powers the smart rest timer and progression suggestions.
-            </Text>
-          </View>
-          <Switch
-            testID="pref-capture-rpe-switch"
-            value={captureRpe}
-            onValueChange={updateCaptureRpe}
-            accessibilityLabel="Capture set RPE during workouts"
-            accessibilityRole="switch"
-            accessibilityHint="Shows effort chips after each set you complete"
-          />
-        </View>
-
-        {/* BLD-1114: Pulley pin tracking */}
-        <View style={styles.row}>
-          <View style={{ flex: 1 }}>
-            <Text variant="body" style={{ color: colors.onSurface, fontSize: fontSizes.sm }}>
-              Track pulley pin position
-            </Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant, fontSize: fontSizes.xs, marginTop: 2, lineHeight: 16 }}>
-              Show a pin-number chip on cable sets to log which pulley pin you used.
-            </Text>
-          </View>
-          <Switch
-            value={pulleyPinTracking}
-            onValueChange={updatePulleyPinTracking}
-            accessibilityLabel="Track pulley pin position"
-            accessibilityRole="switch"
-            accessibilityHint="Show or hide the pulley pin chip on cable exercise sets"
-          />
-        </View>
-
-        {/* BLD-1158b: Tempo Coach */}
-        <View style={styles.row}>
-          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
-            Tempo Coach (haptic)
-          </Text>
-          <Switch
-            value={tempoCoachEnabled}
-            onValueChange={updateTempoCoachEnabled}
-            accessibilityLabel="Tempo Coach"
-            accessibilityRole="switch"
-            accessibilityHint="Enable haptic rep guide to coach your tempo on each set"
-            testID="pref-tempo-coach-switch"
-          />
-        </View>
-
-        {/* BLD-559: Set-completion confirmation feedback */}
-        <View style={styles.row}>
-          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
-            Haptic on set complete
-          </Text>
-          <Switch
-            value={setCompleteHaptic}
-            onValueChange={updateSetCompleteHaptic}
-            accessibilityLabel="Haptic on set complete"
-            accessibilityRole="switch"
-            accessibilityHint="Vibrate briefly when you tap to complete a set"
-          />
-        </View>
-        <View style={styles.row}>
-          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
-            Sound on set complete
-          </Text>
-          <Switch
-            value={setCompleteAudio}
-            onValueChange={updateSetCompleteAudio}
-            accessibilityLabel="Sound on set complete"
-            accessibilityRole="switch"
-            accessibilityHint="Play a short confirmation tone when you tap to complete a set"
-          />
-        </View>
-        {/* BLD-580 discoverability helper row. Non-pressable (pure <Text>),
-            rendered ONLY while the user has never interacted with the audio
-            toggle. Auto-dismisses silently on first interaction. Locked
-            copy — DO NOT edit without updating AC-2 snapshot test. */}
-        {!audioEverInteracted && (
-          <Text
-            variant="caption"
-            accessibilityRole="text"
-            style={[styles.helperRow, { color: colors.onSurfaceVariant, fontSize: fontSizes.xs }]}
-            testID="set-complete-audio-helper"
-          >
-            Plays a short confirmation cue when you complete a set.
-          </Text>
-        )}
+        {preferencesContent}
       </CardContent>
     </Card>
   );

--- a/components/settings/UnitsCard.tsx
+++ b/components/settings/UnitsCard.tsx
@@ -16,6 +16,11 @@ type Props = {
   setMeasureUnit: (v: 'cm' | 'in') => void;
   weightGoal: number | null;
   fatGoal: number | null;
+  /**
+   * When `true`, omit the outer Card wrapper so this component can be
+   * composed inside a parent SettingsTile without nesting cards (BLD-2031).
+   */
+  bareContent?: boolean;
 };
 
 export default function UnitsCard({
@@ -27,63 +32,70 @@ export default function UnitsCard({
   setMeasureUnit,
   weightGoal,
   fatGoal,
+  bareContent = false,
 }: Props) {
+  const content = (
+    <>
+      <Text
+        variant="body"
+        style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}
+      >
+        Units
+      </Text>
+      <View style={styles.row}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+          Weight
+        </Text>
+        <View style={styles.unitToggle}>
+          <SegmentedControl
+            value={weightUnit}
+            onValueChange={async (val) => {
+              const u = val as 'kg' | 'lb';
+              setWeightUnit(u);
+              try {
+                await updateBodySettings(u, measureUnit, weightGoal, fatGoal);
+              } catch {
+                toast.error('Could not save unit');
+              }
+            }}
+            buttons={[
+              { value: 'kg', label: 'kg' },
+              { value: 'lb', label: 'lb' },
+            ]}
+          />
+        </View>
+      </View>
+      <View style={[styles.row, { marginTop: 12 }]}>
+        <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
+          Measurements
+        </Text>
+        <View style={styles.unitToggle}>
+          <SegmentedControl
+            value={measureUnit}
+            onValueChange={async (val) => {
+              const m = val as 'cm' | 'in';
+              setMeasureUnit(m);
+              try {
+                await updateBodySettings(weightUnit, m, weightGoal, fatGoal);
+              } catch {
+                toast.error('Could not save unit');
+              }
+            }}
+            buttons={[
+              { value: 'cm', label: 'cm' },
+              { value: 'in', label: 'in' },
+            ]}
+          />
+        </View>
+      </View>
+    </>
+  );
+
+  if (bareContent) return <View>{content}</View>;
+
   return (
     <Card variant="outline" style={StyleSheet.flatten([styles.flowCard, { backgroundColor: colors.surface }])}>
-      <CardContent>
-        <Text
-          variant="body"
-          style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}
-        >
-          Units
-        </Text>
-        <View style={styles.row}>
-          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
-            Weight
-          </Text>
-          <View style={styles.unitToggle}>
-            <SegmentedControl
-              value={weightUnit}
-              onValueChange={async (val) => {
-                const u = val as 'kg' | 'lb';
-                setWeightUnit(u);
-                try {
-                  await updateBodySettings(u, measureUnit, weightGoal, fatGoal);
-                } catch {
-                  toast.error('Could not save unit');
-                }
-              }}
-              buttons={[
-                { value: 'kg', label: 'kg' },
-                { value: 'lb', label: 'lb' },
-              ]}
-            />
-          </View>
-        </View>
-        <View style={[styles.row, { marginTop: 12 }]}>
-          <Text variant="body" style={{ color: colors.onSurface, flex: 1, fontSize: fontSizes.sm }}>
-            Measurements
-          </Text>
-          <View style={styles.unitToggle}>
-            <SegmentedControl
-              value={measureUnit}
-              onValueChange={async (val) => {
-                const m = val as 'cm' | 'in';
-                setMeasureUnit(m);
-                try {
-                  await updateBodySettings(weightUnit, m, weightGoal, fatGoal);
-                } catch {
-                  toast.error('Could not save unit');
-                }
-              }}
-              buttons={[
-                { value: 'cm', label: 'cm' },
-                { value: 'in', label: 'in' },
-              ]}
-            />
-          </View>
-        </View>
-      </CardContent>
+      <CardContent>{content}</CardContent>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

Consolidate the Settings screen from ~18 individual stacked cards into 9 themed masonry tiles, as specified in the P0-3 task of the declutter epic (BLD-2028).

## Changes

**settings.tsx** (main screen):
- Replace `FlowContainer` with `Masonry` — shortest-column-first layout on wide screens
- Group components into 9 `SettingsTile` sections: **Profile** / **Units & Appearance** / **Training** / **Notifications** / **Coaching** / **Integrations** / **Data & Backup** / **Feedback** / **About**
- `Separator` hairlines between sub-sections within a tile

**Card components** (add `bareContent` prop):
- `BodyProfileCard`, `AppearanceCard`, `AutoBackupSection`, `CSVExportCard`, `DataManagementCard`, `FeedbackCard`, `FrequencyGoalPicker`, `HydrationCard`, `IntegrationsCard`, `PreferencesCard`, `UnitsCard`
- `bareContent={true}` skips the outer Card wrapper for card-in-card-free composition inside a parent `SettingsTile`
- All existing usages remain unchanged (default `bareContent={false}`)

## Acceptance criteria

- Tile count: 9 (within the ~8–10 target)
- Related settings co-located under a named tile heading
- No card-in-card nesting (enforced by `bareContent` pattern)
- Logging path untouched (session screen unaffected)
- Do not gate tile content on reveal transitions (headless-safe — no changes to Masonry rendering model)

## Testing

- `tsc --noEmit`: 0 errors
- `npm test`: 4536/4536 passed (380 suites)

## Issue

Resolves BLD-2031