### PR TITLE
test(e2e): assert settings-masonry + settings-tile-* IDs are mounted (BLD-2091)

### DIFF
--- a/e2e/scenarios/settings.spec.ts
+++ b/e2e/scenarios/settings.spec.ts
@@ -18,7 +18,13 @@
  * Three CVD-emulated variants (deuteranopia / protanopia / tritanopia) are
  * also captured for the "bottom" shot via `captureWithCvd`.
  *
- * Refs: BLD-1106, BLD-1124
+ * Structural IA assertions (BLD-2091):
+ *   - "settings-masonry container and all 7 settings-tile-* IDs are mounted"
+ *     asserts the masonry container and all 7 tile testIDs from PR #655 are
+ *     attached to the DOM. Uses toBeAttached() (not toBeVisible()) because tiles
+ *     lower in the scroll list may be off-screen on short viewports.
+ *
+ * Refs: BLD-1106, BLD-1124, BLD-2031, BLD-2091
  */
 import { test, expect } from "@playwright/test";
 import * as path from "path";
@@ -128,5 +134,50 @@ test.describe("@scenario settings", () => {
         note: "Bottom of settings — BMC/About section above floating tab bar (BLD-1124 regression surface)",
       },
     });
+  });
+
+  test("settings-masonry container and all 7 settings-tile-* IDs are mounted (BLD-2091)", async ({ page }) => {
+    // BLD-2091: regression-lock the Settings IA structure introduced in PR #655.
+    // Assert that the masonry container and every named tile testID are attached
+    // to the DOM after page load. We use toBeAttached() rather than toBeVisible()
+    // because tiles toward the bottom of the scroll list may be off-screen on
+    // short-viewport devices (iPhone SE 3rd gen, etc.) and would fail a
+    // toBeVisible() check without scrolling — but structural presence is the
+    // invariant we want to protect, not viewport position.
+    await page.addInitScript(() => {
+      const w = window as unknown as Record<string, unknown>;
+      w.__SKIP_ONBOARDING__ = true;
+    });
+
+    await page.goto("/settings");
+
+    // Wait for the scroll view to mount — indicates the settings tree is rendered.
+    await expect(page.getByTestId("settings-scroll-view")).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Assert the masonry container is attached.
+    await expect(page.getByTestId("settings-masonry")).toBeAttached({
+      timeout: 5_000,
+    });
+
+    // Assert all 7 settings-tile-* IDs introduced in PR #655 are attached.
+    // If a tile is removed or its testID is renamed, this test will catch it.
+    const expectedTileIds = [
+      "settings-tile-profile",
+      "settings-tile-units-appearance",
+      "settings-tile-training",
+      "settings-tile-notifications",
+      "settings-tile-coaching",
+      "settings-tile-data-backup",
+      "settings-tile-about",
+    ] as const;
+
+    for (const tileId of expectedTileIds) {
+      await expect(
+        page.getByTestId(tileId),
+        `Expected tile "${tileId}" to be attached to the DOM`,
+      ).toBeAttached({ timeout: 5_000 });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Adds a structural assertion test to `e2e/scenarios/settings.spec.ts` that regression-locks the Settings IA layout introduced in PR #655 (BLD-2031). The new test asserts that the masonry container and all 7 tile testIDs are attached to the DOM after the settings page loads.

## Changes

- **e2e/scenarios/settings.spec.ts**: Added new test `"settings-masonry container and all 7 settings-tile-* IDs are mounted (BLD-2091)"` that:
  - Navigates to `/settings` and waits for `settings-scroll-view` to mount
  - Asserts `settings-masonry` container is attached
  - Asserts all 7 `settings-tile-*` IDs are attached: `profile`, `units-appearance`, `training`, `notifications`, `coaching`, `data-backup`, `about`
- Updated file-level JSDoc to reference BLD-2091 and explain the `toBeAttached()` vs `toBeVisible()` choice

## Design Decision: `toBeAttached()` vs `toBeVisible()`

Uses `toBeAttached()` rather than `toBeVisible()` because:
- Tiles near the bottom of the scroll list may be off-screen on short-viewport devices (iPhone SE 3rd gen, 320×640)
- The structural invariant we're protecting is DOM presence, not viewport position
- Existing screenshot tests already cover visual layout across all viewports

## Testing

- `tsc --noEmit`: 0 errors
- `eslint e2e/scenarios/settings.spec.ts`: 0 warnings
- The new test runs under the existing `ALLOWED_PROJECTS` filter (mobile/mobile-narrow/store-pixel9/store-fold7)

## Issue

Closes BLD-2091 (follow-up from BLD-2031 / PR #655 techlead review)