### PR TITLE
feat(settings): wrap Integrations + Feedback in SettingsTile for tile visual consistency (BLD-2090)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ marker) at release time.
 ## Unreleased
 
 - **Fix: Progress tab no longer crashes with a white error screen on large-screen devices (Fold 7)** — on wide-viewport devices the Progress tab could display a full-screen dev error overlay instead of your progress data. Two root causes were fixed: the CanvasKit chart library is now initialised before the app renders (preventing a crash during chart load), and the body-settings database row is now inserted safely so simultaneous accesses no longer conflict. The Progress tab renders correctly on all screen sizes. (BLD-2078)
+- **Improvement: Integrations and Feedback tiles now match the visual style of all other Settings tiles** — Integrations and Feedback were previously rendered as standalone full-bleed cards without the consistent tile heading and padding that the other 7 Settings sections use. Both are now wrapped in `SettingsTile` so all 9 sections share the same 16 px padding and 18 px/600 heading typography. No functionality changed. (BLD-2090)
 
 ## v0.26.43 — 2026-06-28
 <!-- versionCode: 113 -->

--- a/__tests__/acceptance/settings.test.tsx
+++ b/__tests__/acceptance/settings.test.tsx
@@ -166,6 +166,27 @@ describe('Settings Screen Acceptance', () => {
     expect(await findByText(/Free & open-source workout tracker/)).toBeTruthy()
   })
 
+  // ── BLD-2090: All 9 tiles use SettingsTile (visual consistency) ──────────────────────────────────
+
+  it('renders all 9 SettingsTile testIDs — Integrations and Feedback wrapped as peers (BLD-2090)', async () => {
+    const { findByTestId } = renderScreen(<Settings />)
+    // Verify all 9 tiles render via SettingsTile (consistent padding/heading)
+    expect(await findByTestId('settings-tile-profile')).toBeTruthy()
+    expect(await findByTestId('settings-tile-units-appearance')).toBeTruthy()
+    expect(await findByTestId('settings-tile-training')).toBeTruthy()
+    expect(await findByTestId('settings-tile-notifications')).toBeTruthy()
+    expect(await findByTestId('settings-tile-coaching')).toBeTruthy()
+    expect(await findByTestId('settings-tile-integrations')).toBeTruthy()
+    expect(await findByTestId('settings-tile-data-backup')).toBeTruthy()
+    expect(await findByTestId('settings-tile-feedback')).toBeTruthy()
+    expect(await findByTestId('settings-tile-about')).toBeTruthy()
+  })
+
+  it('Integrations tile renders its title heading via SettingsTile (BLD-2090)', async () => {
+    const { findByText } = renderScreen(<Settings />)
+    expect(await findByText('Integrations')).toBeTruthy()
+  })
+
   // ── Unit Toggles (Weight kg/lb) ──────────────────────────────────
 
   it('shows weight unit toggle defaulting to kg with both options visible', async () => {

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -278,14 +278,17 @@ export default function Settings() {
         </SettingsTile>
 
         {/* ── 6. Integrations ── */}
-        <IntegrationsCard
-          colors={colors}
-          toast={toast}
-          stravaAthlete={stravaAthlete}
-          setStravaAthlete={setStravaAthlete}
-          stravaLoading={stravaLoading}
-          setStravaLoading={setStravaLoading}
-        />
+        <SettingsTile colors={colors} title="Integrations" testID="settings-tile-integrations">
+          <IntegrationsCard
+            colors={colors}
+            toast={toast}
+            stravaAthlete={stravaAthlete}
+            setStravaAthlete={setStravaAthlete}
+            stravaLoading={stravaLoading}
+            setStravaLoading={setStravaLoading}
+            bareContent
+          />
+        </SettingsTile>
 
         {/* ── 7. Data & Backup ── */}
         <SettingsTile colors={colors} title="Data & Backup" testID="settings-tile-data-backup">
@@ -306,13 +309,16 @@ export default function Settings() {
         </SettingsTile>
 
         {/* ── 8. Feedback ── */}
-        <FeedbackCard
-          colors={colors}
-          count={count}
-          onBug={() => router.push({ pathname: '/feedback', params: { type: 'bug' } })}
-          onFeature={() => router.push({ pathname: '/feedback', params: { type: 'feature' } })}
-          onErrors={() => router.push('/errors')}
-        />
+        <SettingsTile colors={colors} title="Feedback & Reports" testID="settings-tile-feedback">
+          <FeedbackCard
+            colors={colors}
+            count={count}
+            onBug={() => router.push({ pathname: '/feedback', params: { type: 'bug' } })}
+            onFeature={() => router.push({ pathname: '/feedback', params: { type: 'feature' } })}
+            onErrors={() => router.push('/errors')}
+            bareContent
+          />
+        </SettingsTile>
 
         {/* ── 9. About ── */}
         <SettingsTile colors={colors} title="About" testID="settings-tile-about">

--- a/components/settings/FeedbackCard.tsx
+++ b/components/settings/FeedbackCard.tsx
@@ -22,12 +22,14 @@ type Props = {
 export default function FeedbackCard({ colors, count, onBug, onFeature, onErrors, bareContent = false }: Props) {
   const content = (
     <>
-      <Text
-        variant="body"
-        style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}
-      >
-        Feedback &amp; Reports
-      </Text>
+      {!bareContent && (
+        <Text
+          variant="body"
+          style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}
+        >
+          Feedback &amp; Reports
+        </Text>
+      )}
       <View style={styles.buttonFlow}>
         <Button variant="default" size="sm" icon={Bug} onPress={onBug} accessibilityLabel="Report a bug">
           Report Bug

--- a/components/settings/IntegrationsCard.tsx
+++ b/components/settings/IntegrationsCard.tsx
@@ -32,7 +32,9 @@ export default function IntegrationsCard({
 
   const content = (
     <>
-      <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Integrations</Text>
+      {!bareContent && (
+        <Text variant="body" style={{ color: colors.onSurface, fontWeight: '600', fontSize: fontSizes.sm, marginBottom: 8 }}>Integrations</Text>
+      )}
 
       {stravaAthlete ? (
         <View>


### PR DESCRIPTION
## Summary

Wraps the Integrations and Feedback tiles in `SettingsTile` so all 9 masonry tiles on the Settings screen use consistent padding (16px) and heading typography (18px/600).

## Changes

- `app/(tabs)/settings.tsx`: Wrap `IntegrationsCard` in `<SettingsTile title="Integrations" testID="settings-tile-integrations">` with `bareContent`
- `app/(tabs)/settings.tsx`: Wrap `FeedbackCard` in `<SettingsTile title="Feedback & Reports" testID="settings-tile-feedback">` with `bareContent`
- `components/settings/IntegrationsCard.tsx`: Suppress duplicate in-card heading when `bareContent=true` (heading now provided by `SettingsTile`)
- `components/settings/FeedbackCard.tsx`: Suppress duplicate in-card heading when `bareContent=true`
- `__tests__/acceptance/settings.test.tsx`: Add tests verifying all 9 SettingsTile testIDs render; verify Integrations title from tile heading

## Testing

- TypeScript: `tsc --noEmit` — zero errors
- Jest: `npm test -- --testPathPattern="acceptance/settings"` — 28/28 tests pass
- ErrorBoundary isolation on IntegrationsCard preserved (bareContent branch wraps in `ErrorBoundary`)

## Issue

Resolves BLD-2090 — follow-up from PR #655 techlead review FU-1