### PR TITLE
feat: audit-handoff.sh — auth-boundary-safe AUDIT issue create+transition (BLD-2109)

### DIFF
--- a/scripts/__tests__/audit-handoff.test.ts
+++ b/scripts/__tests__/audit-handoff.test.ts
@@ -1,0 +1,505 @@
+/**
+ * BLD-2109 — audit-handoff.sh: Daily AUDIT issue must end each run assigned
+ * to ux-designer with status=in_review (NOT backlog) so the assignment-wake
+ * fires.
+ *
+ * ## Background
+ * BLD-2106 (AUDIT 2026-06-28) was left in backlog assigned to ux-designer.
+ * The Paperclip server's `queueIssueAssignmentWakeup` deliberately skips
+ * backlog issues, so ux-designer was never woken. The root cause was the
+ * status transition being a manual prose step that was silently skipped.
+ *
+ * The fix (this script) bakes the create+transition into a single idempotent
+ * helper so the status-advance is code, not prose.
+ *
+ * ## Auth-boundary ordering asserted here
+ * The clip.sh stub tracks the call sequence so we can assert that:
+ *   1. create-issue was called with assigneeAgentId = CREATING_AGENT (not ux-designer)
+ *   2. update-issue was called in a single PATCH with BOTH status=in_review
+ *      AND assigneeAgentId=ux-designer
+ *
+ * If the test stub received create-issue with assigneeAgentId=ux-designer, a
+ * real Paperclip server would assign the issue to ux-designer first, and the
+ * subsequent PATCH would be denied (403) because claudecoder ≠ ux-designer.
+ *
+ * ## Acceptance Criteria (from BLD-2109)
+ *   AC1: Normal run → end state is assigneeAgentId=ux-designer + status=in_review
+ *   AC2: Partial failure (capture/upload) → NEVER status=backlog
+ *   AC3: PATCH failure → exit non-zero (loud failure, not silent backlog)
+ *   AC4: Issue already in_review or further → no-op, exit 0
+ *   AC5: PATCH call ordering → create with creating-agent; PATCH switches
+ *        BOTH status and assignee in one call
+ *
+ * Refs: BLD-2109, BLD-2107, BLD-2105.
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const AUDIT_HANDOFF = path.join(REPO_ROOT, "scripts", "audit-handoff.sh");
+const STUB_DIR = path.join(__dirname, "fixtures", "audit-handoff-stubs");
+
+// UX designer agent ID used in the script (matches the constant in audit-handoff.sh).
+const UX_DESIGNER_AGENT_ID = "f3ca8bb9-5d5b-45ac-9bd3-f06118059cf4";
+// Creating agent ID (claudecoder default in the script).
+const CREATING_AGENT_ID = "b467dac6-f460-43be-98cf-004496d36b67";
+
+interface ClipIssue {
+  id: string;
+  identifier: string;
+  title: string;
+  description?: string;
+  status: string;
+  assigneeAgentId: string;
+  priority?: string;
+}
+
+interface ClipState {
+  issues: ClipIssue[];
+  nextIdentifier: string;
+  nextId: string;
+}
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  combined: string;
+}
+
+function buildSandbox(opts: {
+  initialState?: Partial<ClipState>;
+  createFail?: boolean;
+  patchFail?: boolean;
+  patchHttpErr?: string;
+  getFail?: boolean;
+  trackCalls?: boolean;
+}): {
+  dir: string;
+  run: (args?: string[], extraEnv?: Record<string, string>) => RunResult;
+  readState: () => ClipState;
+  readCallLog: () => string[];
+  callLogPath: string;
+} {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bld-2109-"));
+  fs.mkdirSync(path.join(dir, "scripts"), { recursive: true });
+
+  // Copy the real script under test.
+  fs.copyFileSync(AUDIT_HANDOFF, path.join(dir, "scripts", "audit-handoff.sh"));
+  fs.chmodSync(path.join(dir, "scripts", "audit-handoff.sh"), 0o755);
+
+  // Copy the stub clip.sh.
+  fs.copyFileSync(
+    path.join(STUB_DIR, "clip.sh"),
+    path.join(dir, "scripts", "clip.sh"),
+  );
+  fs.chmodSync(path.join(dir, "scripts", "clip.sh"), 0o755);
+
+  const statePath = path.join(dir, "state.json");
+  const initialState: ClipState = {
+    issues: [],
+    nextIdentifier: "BLD-9001",
+    nextId: "issue-stub-001",
+    ...opts.initialState,
+  };
+  fs.writeFileSync(statePath, JSON.stringify(initialState, null, 2));
+
+  const callLogPath = path.join(dir, "call-log.txt");
+
+  const run = (
+    args: string[] = ["--title", "AUDIT 2026-06-28 — Visual UX Review"],
+    extraEnv: Record<string, string> = {},
+  ): RunResult => {
+    const env = {
+      ...process.env,
+      STUB_CLIP_STATE: statePath,
+      STUB_CLIP_CREATE_FAIL: opts.createFail ? "1" : "0",
+      STUB_CLIP_PATCH_FAIL: opts.patchFail ? "1" : "0",
+      STUB_CLIP_GET_FAIL: opts.getFail ? "1" : "0",
+      STUB_CLIP_PATCH_HTTP_ERR: opts.patchHttpErr ?? "",
+      STUB_CLIP_TRACK_CALLS: opts.trackCalls ? "1" : "0",
+      STUB_CLIP_CALL_LOG: callLogPath,
+      // Point the script at our stub clip.sh.
+      CLIP: path.join(dir, "scripts", "clip.sh"),
+      // Override agent IDs so tests are deterministic.
+      CREATING_AGENT_ID,
+      UX_DESIGNER_AGENT_ID,
+      ...extraEnv,
+    };
+    const proc = spawnSync(
+      "bash",
+      [path.join(dir, "scripts", "audit-handoff.sh"), ...args],
+      {
+        cwd: dir,
+        env,
+        encoding: "utf8",
+        timeout: 15_000,
+      },
+    );
+    return {
+      status: proc.status,
+      stdout: proc.stdout || "",
+      stderr: proc.stderr || "",
+      combined: (proc.stdout || "") + (proc.stderr || ""),
+    };
+  };
+
+  const readState = (): ClipState =>
+    JSON.parse(fs.readFileSync(statePath, "utf8")) as ClipState;
+
+  const readCallLog = (): string[] => {
+    if (!fs.existsSync(callLogPath)) return [];
+    return fs
+      .readFileSync(callLogPath, "utf8")
+      .split("\n")
+      .filter((l) => l.trim() !== "");
+  };
+
+  return { dir, run, readState, readCallLog, callLogPath };
+}
+
+function cleanup(dir: string) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+}
+
+// Skip the suite if jq is unavailable (the clip.sh stub depends on it).
+const HAS_JQ = (() => {
+  const r = spawnSync("jq", ["--version"], { encoding: "utf8" });
+  return r.status === 0;
+})();
+
+const d = HAS_JQ ? describe : describe.skip;
+
+d("audit-handoff.sh — BLD-2109", () => {
+  it("real script passes bash -n syntax check", () => {
+    expect(() =>
+      execFileSync("bash", ["-n", AUDIT_HANDOFF], { encoding: "utf8" }),
+    ).not.toThrow();
+  });
+
+  it("clip.sh stub passes bash -n syntax check", () => {
+    expect(() =>
+      execFileSync(
+        "bash",
+        ["-n", path.join(STUB_DIR, "clip.sh")],
+        { encoding: "utf8" },
+      ),
+    ).not.toThrow();
+  });
+
+  describe("AC1: happy path — end state is in_review assigned to ux-designer", () => {
+    it("exits 0", () => {
+      const { dir, run } = buildSandbox({});
+      try {
+        const r = run();
+        expect(r.status).toBe(0);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("issue ends with status=in_review", () => {
+      const { dir, run, readState } = buildSandbox({});
+      try {
+        run();
+        const state = readState();
+        expect(state.issues).toHaveLength(1);
+        expect(state.issues[0].status).toBe("in_review");
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("issue ends with assigneeAgentId=ux-designer", () => {
+      const { dir, run, readState } = buildSandbox({});
+      try {
+        run();
+        const state = readState();
+        expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("issue is NEVER left in backlog", () => {
+      const { dir, run, readState } = buildSandbox({});
+      try {
+        run();
+        const state = readState();
+        expect(state.issues[0].status).not.toBe("backlog");
+      } finally {
+        cleanup(dir);
+      }
+    });
+  });
+
+  describe("AC5: auth-boundary ordering — create with creating-agent, single PATCH for both status+assignee", () => {
+    it("create-issue is called with assigneeAgentId=CREATING_AGENT (not ux-designer)", () => {
+      const { dir, run, readCallLog } = buildSandbox({ trackCalls: true });
+      try {
+        run();
+        const calls = readCallLog();
+        const createCall = calls.find((c) => c.startsWith("create-issue"));
+        expect(createCall).toBeDefined();
+        // The create call must include the creating agent's ID, not ux-designer.
+        expect(createCall).toContain(CREATING_AGENT_ID);
+        expect(createCall).not.toContain(UX_DESIGNER_AGENT_ID);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("update-issue PATCH carries BOTH status=in_review AND assigneeAgentId=ux-designer", () => {
+      const { dir, run, readCallLog } = buildSandbox({ trackCalls: true });
+      try {
+        run();
+        const calls = readCallLog();
+        // There should be exactly one update-issue call and it must set both fields.
+        const patchCalls = calls.filter((c) => c.startsWith("update-issue"));
+        expect(patchCalls).toHaveLength(1);
+        expect(patchCalls[0]).toContain("--status");
+        expect(patchCalls[0]).toContain("in_review");
+        expect(patchCalls[0]).toContain("--assignee-agent-id");
+        expect(patchCalls[0]).toContain(UX_DESIGNER_AGENT_ID);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("create-issue call happens BEFORE update-issue call (ordering invariant)", () => {
+      const { dir, run, readCallLog } = buildSandbox({ trackCalls: true });
+      try {
+        run();
+        const calls = readCallLog();
+        const createIdx = calls.findIndex((c) => c.startsWith("create-issue"));
+        const patchIdx = calls.findIndex((c) => c.startsWith("update-issue"));
+        expect(createIdx).toBeGreaterThanOrEqual(0);
+        expect(patchIdx).toBeGreaterThan(createIdx);
+      } finally {
+        cleanup(dir);
+      }
+    });
+  });
+
+  describe("AC2: partial failure — NEVER leaves backlog", () => {
+    it("--capture-failed: issue still ends in_review assigned to ux-designer", () => {
+      const { dir, run, readState } = buildSandbox({});
+      try {
+        const r = run([
+          "--title",
+          "AUDIT 2026-06-28 — Visual UX Review",
+          "--capture-failed",
+        ]);
+        expect(r.status).toBe(0);
+        const state = readState();
+        expect(state.issues[0].status).toBe("in_review");
+        expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+        expect(state.issues[0].status).not.toBe("backlog");
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("--upload-failed: issue still ends in_review assigned to ux-designer", () => {
+      const { dir, run, readState } = buildSandbox({});
+      try {
+        const r = run([
+          "--title",
+          "AUDIT 2026-06-28 — Visual UX Review",
+          "--upload-failed",
+        ]);
+        expect(r.status).toBe(0);
+        const state = readState();
+        expect(state.issues[0].status).toBe("in_review");
+        expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+        expect(state.issues[0].status).not.toBe("backlog");
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("--capture-failed --upload-failed: issue still not in backlog", () => {
+      const { dir, run, readState } = buildSandbox({});
+      try {
+        const r = run([
+          "--title",
+          "AUDIT 2026-06-28 — Visual UX Review",
+          "--capture-failed",
+          "--upload-failed",
+        ]);
+        expect(r.status).toBe(0);
+        const state = readState();
+        expect(state.issues[0].status).not.toBe("backlog");
+        expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+      } finally {
+        cleanup(dir);
+      }
+    });
+  });
+
+  describe("AC3: PATCH failure → exits loudly (non-zero), never silently leaves backlog", () => {
+    it("PATCH fail → exit code 3 (not 0)", () => {
+      const { dir, run } = buildSandbox({ patchFail: true });
+      try {
+        const r = run();
+        expect(r.status).toBe(3);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("PATCH fail → stderr mentions FATAL and ACTION REQUIRED", () => {
+      const { dir, run } = buildSandbox({ patchFail: true });
+      try {
+        const r = run();
+        expect(r.stderr).toMatch(/FATAL/i);
+        expect(r.stderr).toMatch(/ACTION REQUIRED/i);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("PATCH fail → issue status never changed to in_review (still in original state)", () => {
+      const { dir, run, readState } = buildSandbox({ patchFail: true });
+      try {
+        run();
+        const state = readState();
+        // Issue was created but PATCH failed → status should still be 'todo'
+        // (create-issue default), not in_review.
+        expect(state.issues[0].status).not.toBe("in_review");
+        // And the assignee should still be creating-agent, not ux-designer.
+        expect(state.issues[0].assigneeAgentId).toBe(CREATING_AGENT_ID);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("simulated 403 PATCH → exits non-zero and surfaces the HTTP error", () => {
+      const { dir, run } = buildSandbox({
+        patchFail: true,
+        patchHttpErr: "403",
+      });
+      try {
+        const r = run();
+        expect(r.status).not.toBe(0);
+        expect(r.stderr).toContain("403");
+      } finally {
+        cleanup(dir);
+      }
+    });
+  });
+
+  describe("AC4: idempotency — issue already ≥ in_review → no-op", () => {
+    it("--issue-id pointing to an in_review/ux-designer issue → exits 0, no new mutations", () => {
+      const existingIssue: ClipIssue = {
+        id: "issue-preexisting-001",
+        identifier: "BLD-2106",
+        title: "AUDIT 2026-06-27 — Visual UX Review",
+        status: "in_review",
+        assigneeAgentId: UX_DESIGNER_AGENT_ID,
+      };
+      const { dir, run, readState } = buildSandbox({
+        initialState: { issues: [existingIssue], nextIdentifier: "BLD-9001", nextId: "issue-stub-002" },
+        trackCalls: false,
+      });
+      try {
+        const r = run([
+          "--title",
+          "AUDIT 2026-06-27 — Visual UX Review",
+          "--issue-id",
+          "BLD-2106",
+        ]);
+        expect(r.status).toBe(0);
+        // State must be unchanged — no new issues, no status change.
+        const state = readState();
+        expect(state.issues).toHaveLength(1);
+        expect(state.issues[0].status).toBe("in_review");
+        expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("--issue-id pointing to a done issue (ux-designer already finished) → no-op", () => {
+      const existingIssue: ClipIssue = {
+        id: "issue-preexisting-002",
+        identifier: "BLD-2106",
+        title: "AUDIT prior",
+        status: "done",
+        assigneeAgentId: UX_DESIGNER_AGENT_ID,
+      };
+      const { dir, run, readState } = buildSandbox({
+        initialState: { issues: [existingIssue], nextIdentifier: "BLD-9001", nextId: "issue-stub-003" },
+      });
+      try {
+        const r = run([
+          "--title",
+          "AUDIT prior",
+          "--issue-id",
+          "BLD-2106",
+        ]);
+        expect(r.status).toBe(0);
+        // No status regression — must remain done.
+        const state = readState();
+        expect(state.issues[0].status).toBe("done");
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("--issue-id pointing to a backlog/todo issue → still applies the transition", () => {
+      const existingIssue: ClipIssue = {
+        id: "issue-preexisting-003",
+        identifier: "BLD-2106",
+        title: "AUDIT prior",
+        status: "todo",
+        assigneeAgentId: CREATING_AGENT_ID,
+      };
+      const { dir, run, readState } = buildSandbox({
+        initialState: { issues: [existingIssue], nextIdentifier: "BLD-9001", nextId: "issue-stub-004" },
+      });
+      try {
+        const r = run([
+          "--title",
+          "AUDIT prior",
+          "--issue-id",
+          "BLD-2106",
+        ]);
+        expect(r.status).toBe(0);
+        const state = readState();
+        expect(state.issues[0].status).toBe("in_review");
+        expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+      } finally {
+        cleanup(dir);
+      }
+    });
+  });
+
+  describe("usage errors", () => {
+    it("exits 1 when --title is missing", () => {
+      const { dir, run } = buildSandbox({});
+      try {
+        const r = run([]);
+        expect(r.status).toBe(1);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("exits 2 when create-issue fails", () => {
+      const { dir, run } = buildSandbox({ createFail: true });
+      try {
+        const r = run();
+        expect(r.status).toBe(2);
+      } finally {
+        cleanup(dir);
+      }
+    });
+  });
+});

--- a/scripts/__tests__/audit-handoff.test.ts
+++ b/scripts/__tests__/audit-handoff.test.ts
@@ -29,6 +29,11 @@
  *   AC4: Issue already in_review or further → no-op, exit 0
  *   AC5: PATCH call ordering → create with creating-agent; PATCH switches
  *        BOTH status and assignee in one call
+ *   AC6: Post-PATCH verification is strict — the verified end-state must be
+ *        re-read successfully AND status==in_review AND assignee==ux-designer.
+ *        Any unverifiable/wrong end-state exits non-zero (exit 4), because each
+ *        case independently breaks ux-designer's assignment-wake. (QD review of
+ *        PR #660: a "not backlog" check + WARN-only assignee was too weak.)
  *
  * Refs: BLD-2109, BLD-2107, BLD-2105.
  */
@@ -75,6 +80,8 @@ function buildSandbox(opts: {
   patchFail?: boolean;
   patchHttpErr?: string;
   getFail?: boolean;
+  getStatusOverride?: string;
+  getAssigneeOverride?: string;
   trackCalls?: boolean;
 }): {
   dir: string;
@@ -119,6 +126,8 @@ function buildSandbox(opts: {
       STUB_CLIP_PATCH_FAIL: opts.patchFail ? "1" : "0",
       STUB_CLIP_GET_FAIL: opts.getFail ? "1" : "0",
       STUB_CLIP_PATCH_HTTP_ERR: opts.patchHttpErr ?? "",
+      STUB_CLIP_GET_STATUS_OVERRIDE: opts.getStatusOverride ?? "",
+      STUB_CLIP_GET_ASSIGNEE_OVERRIDE: opts.getAssigneeOverride ?? "",
       STUB_CLIP_TRACK_CALLS: opts.trackCalls ? "1" : "0",
       STUB_CLIP_CALL_LOG: callLogPath,
       // Point the script at our stub clip.sh.
@@ -475,6 +484,97 @@ d("audit-handoff.sh — BLD-2109", () => {
         const state = readState();
         expect(state.issues[0].status).toBe("in_review");
         expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+      } finally {
+        cleanup(dir);
+      }
+    });
+  });
+
+  describe("AC6: strict post-PATCH verification — unverifiable/wrong end-state is fatal (exit 4)", () => {
+    it("verification re-read failure → exit 4 (must NOT report success)", () => {
+      // PATCH succeeds (patchFail not set) but the post-PATCH get-issue fails.
+      // No --issue-id, so step-0 idempotency read is skipped; the only get-issue
+      // is the verification read. An unverifiable end-state must be fatal.
+      const { dir, run, readState } = buildSandbox({ getFail: true });
+      try {
+        const r = run();
+        expect(r.status).toBe(4);
+        // PATCH did apply to stored state, but the script must not trust that
+        // without a successful re-read.
+        const state = readState();
+        expect(state.issues[0].status).toBe("in_review");
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("verification re-read failure → stderr is FATAL + ACTION REQUIRED (not WARN)", () => {
+      const { dir, run } = buildSandbox({ getFail: true });
+      try {
+        const r = run();
+        expect(r.stderr).toMatch(/FATAL/i);
+        expect(r.stderr).toMatch(/ACTION REQUIRED/i);
+        expect(r.stderr).toMatch(/UNVERIFIABLE/i);
+        // Must NOT claim a successful (even "unverified") done.
+        expect(r.combined).not.toMatch(/DONE \(unverified\)/i);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("verified status != in_review (e.g. reverted to todo) → exit 4", () => {
+      // Simulate PATCH 2xx but a concurrent mutation leaving status=todo.
+      const { dir, run } = buildSandbox({ getStatusOverride: "todo" });
+      try {
+        const r = run();
+        expect(r.status).toBe(4);
+        expect(r.stderr).toMatch(/FATAL/i);
+        expect(r.stderr).toMatch(/expected in_review/i);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("verified status still backlog → exit 4 with explicit 'still in backlog' message", () => {
+      const { dir, run } = buildSandbox({ getStatusOverride: "backlog" });
+      try {
+        const r = run();
+        expect(r.status).toBe(4);
+        expect(r.stderr).toMatch(/STILL in backlog/i);
+        expect(r.stderr).toMatch(/will NOT be woken/i);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("verified status=in_review but assignee != ux-designer → exit 4 (FATAL, not WARN)", () => {
+      // The exact failure this script prevents: status looks fine but the wake
+      // would target the wrong agent. Must be fatal.
+      const wrongAssignee = "00000000-0000-0000-0000-000000000000";
+      const { dir, run } = buildSandbox({
+        getStatusOverride: "in_review",
+        getAssigneeOverride: wrongAssignee,
+      });
+      try {
+        const r = run();
+        expect(r.status).toBe(4);
+        expect(r.stderr).toMatch(/FATAL/i);
+        expect(r.stderr).toMatch(/expected ux-designer/i);
+        expect(r.stderr).toMatch(/will NOT be woken/i);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("fully-correct verified end-state (in_review + ux-designer) → exit 0, VERIFIED", () => {
+      // Control case: with no overrides the re-read matches the PATCH, so the
+      // strict verification passes and the script reports VERIFIED + DONE.
+      const { dir, run } = buildSandbox({});
+      try {
+        const r = run();
+        expect(r.status).toBe(0);
+        expect(r.combined).toMatch(/VERIFIED/);
+        expect(r.combined).toMatch(/DONE: ux-designer will be woken/);
       } finally {
         cleanup(dir);
       }

--- a/scripts/__tests__/fixtures/audit-handoff-stubs/clip.sh
+++ b/scripts/__tests__/fixtures/audit-handoff-stubs/clip.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# State-backed clip.sh stub for BLD-2109 audit-handoff.sh tests.
+#
+# State file: $STUB_CLIP_STATE
+#   JSON: {
+#     "issues": [
+#       {
+#         "id": "uuid",
+#         "identifier": "BLD-NNNN",
+#         "status": "todo",
+#         "assigneeAgentId": "agent-uuid",
+#         "title": "..."
+#       }
+#     ],
+#     "nextIdentifier": "BLD-9001",
+#     "nextId": "issue-uuid-001"
+#   }
+#
+# Failure mode controls (env vars):
+#   STUB_CLIP_CREATE_FAIL    — "1" → create-issue returns exit 1 with error JSON
+#   STUB_CLIP_PATCH_FAIL     — "1" → update-issue returns exit 1 with error JSON
+#   STUB_CLIP_GET_FAIL       — "1" → get-issue returns exit 1
+#   STUB_CLIP_PATCH_HTTP_ERR — HTTP status code to simulate (e.g. "403") for update-issue
+#   STUB_CLIP_TRACK_CALLS    — "1" → append each call to $STUB_CLIP_CALL_LOG
+
+set -u
+
+STATE="${STUB_CLIP_STATE:?STUB_CLIP_STATE not set}"
+CREATE_FAIL="${STUB_CLIP_CREATE_FAIL:-0}"
+PATCH_FAIL="${STUB_CLIP_PATCH_FAIL:-0}"
+GET_FAIL="${STUB_CLIP_GET_FAIL:-0}"
+PATCH_HTTP_ERR="${STUB_CLIP_PATCH_HTTP_ERR:-}"
+TRACK="${STUB_CLIP_TRACK_CALLS:-0}"
+CALL_LOG="${STUB_CLIP_CALL_LOG:-/tmp/audit-handoff-stub-calls.log}"
+
+# Log calls for sequence assertion in tests.
+if [[ "$TRACK" == "1" ]]; then
+  echo "$*" >> "$CALL_LOG"
+fi
+
+CMD="${1:-}"; shift || true
+
+case "$CMD" in
+  create-issue)
+    if [[ "$CREATE_FAIL" == "1" ]]; then
+      echo '{"error":"simulated create-issue failure","code":"STUB_FAIL"}' >&2
+      exit 1
+    fi
+
+    # Parse args to extract title, description, assigneeAgentId.
+    title=""; desc=""; assignee=""; project=""; priority="medium"
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --title)             title="$2"; shift 2;;
+        --description)       desc="$2"; shift 2;;
+        --assignee-agent-id) assignee="$2"; shift 2;;
+        --project-id)        project="$2"; shift 2;;
+        --priority)          priority="$2"; shift 2;;
+        *) shift;;
+      esac
+    done
+
+    # Read nextIdentifier and nextId from state.
+    next_id=$(jq -r '.nextId // "issue-stub-001"' "$STATE")
+    next_ident=$(jq -r '.nextIdentifier // "BLD-9001"' "$STATE")
+
+    # Append new issue to state.
+    tmp=$(mktemp)
+    jq --arg id "$next_id" \
+       --arg ident "$next_ident" \
+       --arg title "$title" \
+       --arg desc "$desc" \
+       --arg assignee "$assignee" \
+       --arg priority "$priority" \
+       --arg status "todo" \
+      '.issues += [{
+         "id": $id,
+         "identifier": $ident,
+         "title": $title,
+         "description": $desc,
+         "status": $status,
+         "assigneeAgentId": $assignee,
+         "priority": $priority
+       }]' "$STATE" > "$tmp" && mv "$tmp" "$STATE"
+
+    # Emit the created issue JSON (mimics real clip.sh create-issue output).
+    jq -n \
+      --arg id "$next_id" \
+      --arg ident "$next_ident" \
+      --arg title "$title" \
+      --arg desc "$desc" \
+      --arg assignee "$assignee" \
+      --arg priority "$priority" \
+      '{
+        "id": $id,
+        "identifier": $ident,
+        "title": $title,
+        "description": $desc,
+        "status": "todo",
+        "assigneeAgentId": $assignee,
+        "priority": $priority
+      }'
+    exit 0
+    ;;
+
+  update-issue)
+    issue_id="${1:-}"; shift || true
+
+    if [[ "$PATCH_FAIL" == "1" ]]; then
+      if [[ -n "$PATCH_HTTP_ERR" ]]; then
+        echo "ERROR $PATCH_HTTP_ERR PATCH /issues/$issue_id" >&2
+        echo "{\"error\":\"simulated HTTP $PATCH_HTTP_ERR\",\"code\":\"STUB_FAIL\"}" >&2
+      else
+        echo '{"error":"simulated update-issue failure","code":"STUB_FAIL"}' >&2
+      fi
+      exit 1
+    fi
+
+    # Parse status and assigneeAgentId from args.
+    new_status=""; new_assignee=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --status)            new_status="$2"; shift 2;;
+        --assignee-agent-id) new_assignee="$2"; shift 2;;
+        *) shift;;
+      esac
+    done
+
+    # Look up the issue (by identifier like BLD-NNN or by UUID).
+    exists=$(jq --arg id "$issue_id" '
+      .issues | map(select(.identifier == $id or .id == $id)) | length
+    ' "$STATE")
+
+    if [[ "$exists" == "0" ]]; then
+      echo "{\"error\":\"issue not found: $issue_id\"}" >&2
+      exit 1
+    fi
+
+    # Apply mutation.
+    tmp=$(mktemp)
+    jq --arg id "$issue_id" \
+       --arg status "$new_status" \
+       --arg assignee "$new_assignee" \
+      '.issues |= map(
+        if (.identifier == $id or .id == $id) then
+          . *
+          (if $status != "" then {"status": $status} else {} end) *
+          (if $assignee != "" then {"assigneeAgentId": $assignee} else {} end)
+        else . end
+      )' "$STATE" > "$tmp" && mv "$tmp" "$STATE"
+
+    # Return the updated issue.
+    jq --arg id "$issue_id" '
+      .issues[] | select(.identifier == $id or .id == $id)
+    ' "$STATE"
+    exit 0
+    ;;
+
+  get-issue)
+    issue_id="${1:-}"
+
+    if [[ "$GET_FAIL" == "1" ]]; then
+      echo '{"error":"simulated get-issue failure","code":"STUB_FAIL"}' >&2
+      exit 1
+    fi
+
+    # Look up the issue.
+    result=$(jq --arg id "$issue_id" '
+      .issues[] | select(.identifier == $id or .id == $id)
+    ' "$STATE" 2>/dev/null || true)
+
+    if [[ -z "$result" ]]; then
+      echo "{\"error\":\"issue not found: $issue_id\"}" >&2
+      exit 1
+    fi
+
+    echo "$result"
+    exit 0
+    ;;
+
+  *)
+    echo "[clip-stub] unsupported command: $CMD" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/__tests__/fixtures/audit-handoff-stubs/clip.sh
+++ b/scripts/__tests__/fixtures/audit-handoff-stubs/clip.sh
@@ -22,6 +22,16 @@
 #   STUB_CLIP_GET_FAIL       — "1" → get-issue returns exit 1
 #   STUB_CLIP_PATCH_HTTP_ERR — HTTP status code to simulate (e.g. "403") for update-issue
 #   STUB_CLIP_TRACK_CALLS    — "1" → append each call to $STUB_CLIP_CALL_LOG
+#
+# Divergent-read controls (simulate PATCH 2xx but server end-state wrong, e.g.
+# a concurrent mutation that reverted the change — the scenario the script's
+# verification block defends against):
+#   STUB_CLIP_GET_STATUS_OVERRIDE   — if set, get-issue reports this status
+#                                      instead of the stored one
+#   STUB_CLIP_GET_ASSIGNEE_OVERRIDE — if set, get-issue reports this assignee
+#                                      instead of the stored one
+# These affect get-issue ONLY (not update-issue), so the stored state still
+# reflects the PATCH while the re-read returns the overridden, divergent values.
 
 set -u
 
@@ -32,6 +42,8 @@ GET_FAIL="${STUB_CLIP_GET_FAIL:-0}"
 PATCH_HTTP_ERR="${STUB_CLIP_PATCH_HTTP_ERR:-}"
 TRACK="${STUB_CLIP_TRACK_CALLS:-0}"
 CALL_LOG="${STUB_CLIP_CALL_LOG:-/tmp/audit-handoff-stub-calls.log}"
+GET_STATUS_OVERRIDE="${STUB_CLIP_GET_STATUS_OVERRIDE:-}"
+GET_ASSIGNEE_OVERRIDE="${STUB_CLIP_GET_ASSIGNEE_OVERRIDE:-}"
 
 # Log calls for sequence assertion in tests.
 if [[ "$TRACK" == "1" ]]; then
@@ -172,6 +184,16 @@ case "$CMD" in
     if [[ -z "$result" ]]; then
       echo "{\"error\":\"issue not found: $issue_id\"}" >&2
       exit 1
+    fi
+
+    # Divergent-read overrides: simulate a server end-state that differs from
+    # what the PATCH stored (e.g. concurrent mutation). Applied to the emitted
+    # JSON only; stored state is untouched.
+    if [[ -n "$GET_STATUS_OVERRIDE" ]]; then
+      result=$(echo "$result" | jq --arg s "$GET_STATUS_OVERRIDE" '.status = $s')
+    fi
+    if [[ -n "$GET_ASSIGNEE_OVERRIDE" ]]; then
+      result=$(echo "$result" | jq --arg a "$GET_ASSIGNEE_OVERRIDE" '.assigneeAgentId = $a')
     fi
 
     echo "$result"

--- a/scripts/audit-handoff.sh
+++ b/scripts/audit-handoff.sh
@@ -46,13 +46,15 @@
 # can compose the right default status comment.
 #
 # ## Exit codes
-#   0  — Issue created-or-reused and successfully advanced to in_review
-#          (or already ≥ in_review; no-op)
+#   0  — Issue created-or-reused and VERIFIED at status=in_review assigned to
+#          ux-designer (or already ≥ in_review assigned to ux-designer; no-op)
 #   1  — Usage error
 #   2  — clip.sh create-issue failed
 #   3  — clip.sh PATCH (status + assignee transition) failed (exits loudly;
 #          never leaves issue in backlog assigned to ux-designer)
-#   4  — verify re-read failed or status still backlog after PATCH
+#   4  — post-PATCH verification failed: re-read errored, OR status != in_review,
+#          OR assignee != ux-designer. Any unverifiable/wrong end-state is fatal
+#          because it means ux-designer's assignment-wake will not fire.
 #
 # Refs: BLD-2109, BLD-2107, BLD-2106, BLD-2105.
 
@@ -104,11 +106,12 @@ The --issue-id flag is for the partial-rerun case (issue already created in a
 prior attempt; skip create and go straight to the transition).
 
 Exit codes:
-  0  success (issue at in_review assigned to ux-designer)
+  0  success (issue VERIFIED at in_review assigned to ux-designer)
   1  usage error
   2  create-issue failed
   3  PATCH (status + assignee transition) failed — NEVER leaves backlog
-  4  post-PATCH verify failed or status still backlog
+  4  post-PATCH verify failed: read errored, status != in_review, or
+     assignee != ux-designer (any unverifiable/wrong end-state is fatal)
 EOF
   exit "${1:-1}"
 }
@@ -298,6 +301,12 @@ echo "[audit-handoff] PATCH succeeded."
 # We never trust the PATCH response alone. A 2xx response with an unexpected
 # body (or a concurrent mutation) could leave the issue in an unexpected state.
 # Re-reading and asserting is the only way to guarantee the downstream wake fires.
+#
+# The verified end-state must satisfy ALL THREE invariants, each FATAL on failure
+# (exit 4) because each independently breaks ux-designer's assignment-wake:
+#   (a) the re-read itself must succeed (else the end-state is unverifiable),
+#   (b) status MUST be exactly in_review (not merely "not backlog"),
+#   (c) assignee MUST be ux-designer (else the wake targets the wrong agent).
 
 echo "[audit-handoff] Verifying end-state for $ISSUE_ID ..."
 
@@ -307,28 +316,43 @@ verify_json=$(run_clip get-issue "$ISSUE_ID" 2>&1)
 verify_rc=$?
 set -e
 
+# (a) Read failure is FATAL. An unverifiable end-state must NOT pass: if we
+# cannot re-read the issue we cannot prove ux-designer's wake will fire, which
+# is the entire purpose of this script (BLD-2109). Exit non-zero so the caller
+# (and CI) surfaces it loudly instead of silently assuming success.
 if [[ $verify_rc -ne 0 ]]; then
-  echo "[audit-handoff] WARN: could not re-read $ISSUE_ID for verification (rc=$verify_rc)." >&2
+  echo "[audit-handoff] FATAL: could not re-read $ISSUE_ID for verification (rc=$verify_rc)." >&2
   echo "[audit-handoff] Output: $verify_json" >&2
-  # Non-fatal warn only — PATCH appeared to succeed; we just can't verify.
-  echo "[audit-handoff] WARN: proceeding despite verify failure. Monitor $ISSUE_ID manually." >&2
-  echo "[audit-handoff] DONE (unverified): $ISSUE_ID → in_review / ux-designer"
-  exit 0
+  echo "[audit-handoff] End-state is UNVERIFIABLE; refusing to report success." >&2
+  echo "[audit-handoff] ACTION REQUIRED: board must confirm $ISSUE_ID is in_review assigned to ux-designer." >&2
+  exit 4
 fi
 
 final_status=$(json_field "$verify_json" "status")
 final_assignee=$(json_field "$verify_json" "assigneeAgentId")
 
-if [[ "$final_status" == "backlog" ]]; then
-  echo "[audit-handoff] FATAL: $ISSUE_ID is STILL in backlog after PATCH. ux-designer will NOT be woken." >&2
-  echo "[audit-handoff] ACTION REQUIRED: board must manually advance $ISSUE_ID." >&2
+# (b) Status must POSITIVELY be in_review. Asserting "not backlog" is too weak —
+# any other status (todo, blocked, an empty/garbled read, a concurrent mutation
+# that reverted the PATCH) also means the verified end-state is wrong. Only
+# in_review proves the assignment-wake will fire, so require it explicitly.
+if [[ "$final_status" != "in_review" ]]; then
+  echo "[audit-handoff] FATAL: $ISSUE_ID status=$final_status after PATCH (expected in_review)." >&2
+  if [[ "$final_status" == "backlog" ]]; then
+    echo "[audit-handoff] Issue is STILL in backlog — ux-designer will NOT be woken." >&2
+  fi
+  echo "[audit-handoff] ACTION REQUIRED: board must manually advance $ISSUE_ID to in_review." >&2
   exit 4
 fi
 
+# (c) Assignee must be ux-designer. A wrong assignee means ux-designer is never
+# woken — the exact failure this script exists to prevent — so this is FATAL,
+# not a warning. (in_review alone is insufficient: the assignment-wake targets
+# the assignee, and only ux-designer should review the audit.)
 if [[ "$final_assignee" != "$UX_DESIGNER_AGENT_ID" ]]; then
-  echo "[audit-handoff] WARN: $ISSUE_ID status=$final_status but assignee=$final_assignee (expected $UX_DESIGNER_AGENT_ID)." >&2
-  # Not a fatal error — status is not backlog, so the wake path is not blocked.
-  # But log loudly so operators can investigate.
+  echo "[audit-handoff] FATAL: $ISSUE_ID status=in_review but assignee=$final_assignee (expected ux-designer $UX_DESIGNER_AGENT_ID)." >&2
+  echo "[audit-handoff] ux-designer will NOT be woken on the audit." >&2
+  echo "[audit-handoff] ACTION REQUIRED: board must reassign $ISSUE_ID to ux-designer." >&2
+  exit 4
 fi
 
 echo "[audit-handoff] VERIFIED: $ISSUE_ID status=$final_status assignee=$final_assignee"

--- a/scripts/audit-handoff.sh
+++ b/scripts/audit-handoff.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# audit-handoff.sh — BLD-2109: create the daily AUDIT issue and reliably
+# advance it to in_review so ux-designer's assignment-wake fires.
+#
+# ## Auth-boundary ordering (CRITICAL — do not reorder without understanding)
+#
+# Paperclip's authorization check (server/src/services/authorization.ts:1266-1295)
+# evaluates the CURRENT (pre-mutation) assignee when deciding if an agent PATCH
+# is allowed:
+#
+#   allowed iff: actor == current.assigneeAgentId  OR  current has no agent assignee
+#
+# The trap that caused BLD-2106 to get stuck in backlog (BLD-2107 forensics):
+#   create-issue assigned to ux-designer
+#   ↓
+#   PATCH status=in_review → denied (actor=claudecoder ≠ assignee=ux-designer)
+#   ↓
+#   Issue left in backlog, ux-designer never woken (server skips backlog for
+#   queueIssueAssignmentWakeup, server/src/services/issue-assignment-wakeup.ts:31)
+#
+# Safe ordering used here:
+#   1. create-issue assigned to CREATING AGENT (claudecoder), status=todo
+#      → issue created with assignee=claudecoder; claudecoder has full mutation authority
+#   2. single PATCH: status=in_review + assigneeAgentId=ux-designer
+#      → pre-mutation assignee is still claudecoder == actor → ALLOWED
+#      → post-mutation assignee is ux-designer; server wakes ux-designer because
+#        status (in_review) is not backlog
+#
+# Do NOT split step 2 into two PATCHes — after the first PATCH switches the
+# assignee to ux-designer, the second PATCH (changing status) would be denied.
+#
+# ## Idempotency
+#
+# If the AUDIT issue already exists for today's date (detected by listing issues
+# with --label "audit" or by the --issue-id override), and its status is already
+# ≥ in_review, the script is a no-op and exits 0. This prevents clobbering
+# ux-designer if she has already advanced the issue further (in_progress / done).
+#
+# ## Partial-failure contract (BLD-2109 requirement)
+#
+# This script is designed to be called AFTER bundle capture and AFTER any
+# comment posting. But callers (daily-audit.sh or its orchestrating run) MUST
+# call this script even when bundle capture or upload fails — the handoff
+# must happen regardless so ux-designer can at minimum record the failure.
+# Callers should pass --capture-failed and/or --upload-failed so this script
+# can compose the right default status comment.
+#
+# ## Exit codes
+#   0  — Issue created-or-reused and successfully advanced to in_review
+#          (or already ≥ in_review; no-op)
+#   1  — Usage error
+#   2  — clip.sh create-issue failed
+#   3  — clip.sh PATCH (status + assignee transition) failed (exits loudly;
+#          never leaves issue in backlog assigned to ux-designer)
+#   4  — verify re-read failed or status still backlog after PATCH
+#
+# Refs: BLD-2109, BLD-2107, BLD-2106, BLD-2105.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ─── Configuration ────────────────────────────────────────────────────
+# UX-designer agent ID (constant — ux-designer is a named company role).
+UX_DESIGNER_AGENT_ID="${UX_DESIGNER_AGENT_ID:-f3ca8bb9-5d5b-45ac-9bd3-f06118059cf4}"
+
+# Creating agent ID (claudecoder by default — override in tests).
+CREATING_AGENT_ID="${CREATING_AGENT_ID:-b467dac6-f460-43be-98cf-004496d36b67}"
+
+# CableSnap project ID (constant).
+PROJECT_ID="${PROJECT_ID:-c3d4e5f6-a7b8-9012-cdef-123456789012}"
+
+# clip.sh path — default is sibling in same scripts/ dir.
+CLIP="${CLIP:-${SCRIPT_DIR}/clip.sh}"
+
+# ─── Argument parsing ─────────────────────────────────────────────────
+TITLE=""
+DESCRIPTION=""
+PRIORITY="high"
+BUNDLE_URL=""
+CAPTURE_FAILED=false
+UPLOAD_FAILED=false
+ISSUE_ID=""  # If set, skip create and operate on this existing issue
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: audit-handoff.sh \
+         --title <issue-title> \
+         [--description <text>] \
+         [--priority <urgent|critical|high|medium|low|none>] \
+         [--bundle-url <url>] \
+         [--capture-failed] \
+         [--upload-failed] \
+         [--issue-id <BLD-NNN or UUID>] \
+         [--clip <path/to/clip.sh>] \
+         [--ux-designer-agent-id <uuid>] \
+         [--creating-agent-id <uuid>]
+
+Creates (or reuses) the daily AUDIT issue and transitions it to in_review
+assigned to ux-designer — all in one run so the creating agent retains
+mutation authority for the PATCH (auth-boundary-safe ordering, BLD-2109).
+
+The --issue-id flag is for the partial-rerun case (issue already created in a
+prior attempt; skip create and go straight to the transition).
+
+Exit codes:
+  0  success (issue at in_review assigned to ux-designer)
+  1  usage error
+  2  create-issue failed
+  3  PATCH (status + assignee transition) failed — NEVER leaves backlog
+  4  post-PATCH verify failed or status still backlog
+EOF
+  exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)                TITLE="$2"; shift 2;;
+    --description)          DESCRIPTION="$2"; shift 2;;
+    --priority)             PRIORITY="$2"; shift 2;;
+    --bundle-url)           BUNDLE_URL="$2"; shift 2;;
+    --capture-failed)       CAPTURE_FAILED=true; shift;;
+    --upload-failed)        UPLOAD_FAILED=true; shift;;
+    --issue-id)             ISSUE_ID="$2"; shift 2;;
+    --clip)                 CLIP="$2"; shift 2;;
+    --ux-designer-agent-id) UX_DESIGNER_AGENT_ID="$2"; shift 2;;
+    --creating-agent-id)    CREATING_AGENT_ID="$2"; shift 2;;
+    -h|--help)              usage 0;;
+    *) echo "audit-handoff: unknown option: $1" >&2; usage 1;;
+  esac
+done
+
+if [[ -z "$TITLE" ]]; then
+  echo "audit-handoff: --title is required" >&2
+  usage 1
+fi
+
+# ─── Helpers ──────────────────────────────────────────────────────────
+
+# Run clip.sh, capturing stdout. On non-zero exit, relay stderr and propagate.
+run_clip() {
+  bash "$CLIP" "$@"
+}
+
+# Extract a JSON field value (no jq dependency — use python3 if available,
+# else basic awk). Falls back gracefully to empty string.
+json_field() {
+  local json="$1" field="$2"
+  if command -v jq >/dev/null 2>&1; then
+    echo "$json" | jq -r ".${field} // empty" 2>/dev/null || true
+  elif command -v python3 >/dev/null 2>&1; then
+    echo "$json" | python3 -c "
+import sys,json
+try:
+  d=json.load(sys.stdin)
+  v=d.get('${field}')
+  print(v if v is not None else '')
+except:
+  print('')
+" 2>/dev/null || true
+  else
+    # Last-resort awk — handles simple string fields only
+    echo "$json" | awk -F'"' -v f="${field}" '
+      $2 == f { print $4; exit }
+    ' || true
+  fi
+}
+
+# ─── Step 0: Check if already at in_review or further (idempotency) ───
+if [[ -n "$ISSUE_ID" ]]; then
+  echo "[audit-handoff] --issue-id provided ($ISSUE_ID); skipping create step."
+  echo "[audit-handoff] Fetching current status to check idempotency..."
+  existing_json=""
+  set +e
+  existing_json=$(run_clip get-issue "$ISSUE_ID" 2>&1)
+  fetch_rc=$?
+  set -e
+
+  if [[ $fetch_rc -ne 0 ]]; then
+    echo "[audit-handoff] WARN: could not fetch issue $ISSUE_ID — proceeding with PATCH attempt." >&2
+  else
+    existing_status=$(json_field "$existing_json" "status")
+    existing_assignee=$(json_field "$existing_json" "assigneeAgentId")
+
+    # If already ≥ in_review and assigned to ux-designer, nothing to do.
+    case "$existing_status" in
+      in_review|in_progress|done|cancelled)
+        if [[ "$existing_assignee" == "$UX_DESIGNER_AGENT_ID" ]]; then
+          echo "[audit-handoff] Issue $ISSUE_ID is already $existing_status assigned to ux-designer — no-op."
+          exit 0
+        fi
+        ;;
+    esac
+  fi
+fi
+
+# ─── Step 1: Create the AUDIT issue (if not provided via --issue-id) ──
+
+if [[ -z "$ISSUE_ID" ]]; then
+  echo "[audit-handoff] Creating AUDIT issue: $TITLE"
+
+  # Build description with optional bundle URL and failure flags.
+  desc="$DESCRIPTION"
+
+  if [[ "$CAPTURE_FAILED" == "true" ]]; then
+    desc="${desc}
+
+## Capture Status
+Bundle capture encountered an error. ux-designer: please see the preceding comment for the capture error. Review what screenshots ARE available before filing findings."
+  fi
+
+  if [[ "$UPLOAD_FAILED" == "true" ]]; then
+    desc="${desc}
+
+## Upload Status
+Bundle upload failed. ux-designer: bundle may be unavailable; check the preceding comment for context."
+  fi
+
+  if [[ -n "$BUNDLE_URL" ]]; then
+    desc="${desc}
+
+## Bundle
+${BUNDLE_URL}"
+  fi
+
+  # AUTH NOTE: Create the issue assigned to CREATING AGENT (claudecoder = self),
+  # NOT to ux-designer. The subsequent PATCH (step 2) switches both status and
+  # assignee atomically while claudecoder still holds the assignee slot.
+  # See the file-header comment for the full auth-boundary rationale.
+  create_json=""
+  set +e
+  create_json=$(run_clip create-issue \
+    --title "$TITLE" \
+    --description "$desc" \
+    --priority "$PRIORITY" \
+    --assignee-agent-id "$CREATING_AGENT_ID" \
+    --project-id "$PROJECT_ID" 2>&1)
+  create_rc=$?
+  set -e
+
+  if [[ $create_rc -ne 0 ]]; then
+    echo "[audit-handoff] ERROR: clip.sh create-issue failed (rc=$create_rc)." >&2
+    echo "[audit-handoff] Output: $create_json" >&2
+    exit 2
+  fi
+
+  # Extract the new issue ID (prefer identifier like BLD-NNN, fall back to UUID id).
+  ISSUE_ID=$(json_field "$create_json" "identifier")
+  if [[ -z "$ISSUE_ID" ]]; then
+    ISSUE_ID=$(json_field "$create_json" "id")
+  fi
+
+  if [[ -z "$ISSUE_ID" ]]; then
+    echo "[audit-handoff] ERROR: create-issue succeeded but could not extract issue ID from response." >&2
+    echo "[audit-handoff] Response: $create_json" >&2
+    exit 2
+  fi
+
+  echo "[audit-handoff] Issue created: $ISSUE_ID"
+fi
+
+# ─── Step 2: Atomic PATCH — status=in_review + assignee=ux-designer ───
+#
+# AUTH BOUNDARY: At this point, the issue's assigneeAgentId == CREATING_AGENT_ID
+# (claudecoder), because either:
+#   (a) we just created it with --assignee-agent-id CREATING_AGENT_ID, or
+#   (b) caller passed --issue-id for a prior partial-create, and step 0 confirmed
+#       the issue is NOT yet at in_review (meaning ux-designer hasn't claimed it yet).
+#
+# The Paperclip auth check evaluates the PRE-MUTATION assignee:
+#   actor (claudecoder) == pre-mutation assignee (claudecoder) → ALLOWED
+#
+# After this PATCH: assignee=ux-designer AND status=in_review → server
+# triggers queueIssueAssignmentWakeup (skips backlog; in_review is fine).
+
+echo "[audit-handoff] PATCH $ISSUE_ID: status=in_review + assigneeAgentId=ux-designer ..."
+
+patch_json=""
+set +e
+patch_json=$(run_clip update-issue "$ISSUE_ID" \
+  --status "in_review" \
+  --assignee-agent-id "$UX_DESIGNER_AGENT_ID" 2>&1)
+patch_rc=$?
+set -e
+
+if [[ $patch_rc -ne 0 ]]; then
+  echo "[audit-handoff] FATAL: PATCH failed (rc=$patch_rc). Issue $ISSUE_ID may still be in backlog." >&2
+  echo "[audit-handoff] PATCH output: $patch_json" >&2
+  echo "[audit-handoff] ACTION REQUIRED: board must manually advance $ISSUE_ID to in_review and assign ux-designer." >&2
+  # Exit 3 — caller should surface this loudly (set -e / CI failure).
+  exit 3
+fi
+
+echo "[audit-handoff] PATCH succeeded."
+
+# ─── Step 3: Verify — re-read the issue and confirm end-state ─────────
+#
+# We never trust the PATCH response alone. A 2xx response with an unexpected
+# body (or a concurrent mutation) could leave the issue in an unexpected state.
+# Re-reading and asserting is the only way to guarantee the downstream wake fires.
+
+echo "[audit-handoff] Verifying end-state for $ISSUE_ID ..."
+
+verify_json=""
+set +e
+verify_json=$(run_clip get-issue "$ISSUE_ID" 2>&1)
+verify_rc=$?
+set -e
+
+if [[ $verify_rc -ne 0 ]]; then
+  echo "[audit-handoff] WARN: could not re-read $ISSUE_ID for verification (rc=$verify_rc)." >&2
+  echo "[audit-handoff] Output: $verify_json" >&2
+  # Non-fatal warn only — PATCH appeared to succeed; we just can't verify.
+  echo "[audit-handoff] WARN: proceeding despite verify failure. Monitor $ISSUE_ID manually." >&2
+  echo "[audit-handoff] DONE (unverified): $ISSUE_ID → in_review / ux-designer"
+  exit 0
+fi
+
+final_status=$(json_field "$verify_json" "status")
+final_assignee=$(json_field "$verify_json" "assigneeAgentId")
+
+if [[ "$final_status" == "backlog" ]]; then
+  echo "[audit-handoff] FATAL: $ISSUE_ID is STILL in backlog after PATCH. ux-designer will NOT be woken." >&2
+  echo "[audit-handoff] ACTION REQUIRED: board must manually advance $ISSUE_ID." >&2
+  exit 4
+fi
+
+if [[ "$final_assignee" != "$UX_DESIGNER_AGENT_ID" ]]; then
+  echo "[audit-handoff] WARN: $ISSUE_ID status=$final_status but assignee=$final_assignee (expected $UX_DESIGNER_AGENT_ID)." >&2
+  # Not a fatal error — status is not backlog, so the wake path is not blocked.
+  # But log loudly so operators can investigate.
+fi
+
+echo "[audit-handoff] VERIFIED: $ISSUE_ID status=$final_status assignee=$final_assignee"
+echo "[audit-handoff] DONE: ux-designer will be woken on $ISSUE_ID."


### PR DESCRIPTION
## Summary

Fixes the Daily UX Audit routine leaving AUDIT issues in `backlog` assigned to ux-designer — preventing ux-designer from ever being woken (Paperclip skips backlog for assignment-wakeup).

## Root Cause (BLD-2106 / BLD-2107)

The routine created issues assigned to ux-designer, then tried to PATCH `status=in_review` as claudecoder. Paperclip's auth check evaluates the **pre-mutation assignee** — since `assignee=ux-designer ≠ actor=claudecoder`, the PATCH returned 403 and was silently dropped. Result: issue stuck in backlog forever.

## Changes

- **`scripts/audit-handoff.sh`** — new idempotent helper that creates the AUDIT issue and reliably transitions it to `in_review` assigned to ux-designer in a single run
  - Auth-boundary-safe ordering: create with `assigneeAgentId=claudecoder`, then single PATCH setting `status=in_review` + `assigneeAgentId=ux-designer` (evaluated while claudecoder is still the pre-mutation assignee → allowed)
  - Partial-failure contract: `--capture-failed` / `--upload-failed` flags — handoff happens regardless
  - Idempotent: if issue already ≥ in_review assigned to ux-designer, no-op
  - Fail-loud: PATCH failure → exit 3 with explicit FATAL + ACTION REQUIRED message; never silently leaves backlog
  - Post-PATCH verification: re-reads the issue and asserts status ≠ backlog
  - Auth-boundary rationale documented inline so it is not accidentally regressed

- **`scripts/__tests__/audit-handoff.test.ts`** — 21 unit tests covering all acceptance criteria

- **`scripts/__tests__/fixtures/audit-handoff-stubs/clip.sh`** — state-backed clip.sh stub supporting create-issue / update-issue / get-issue with configurable failure modes

## Testing

All 21 tests pass:
- AC1: happy path → `in_review` assigned to ux-designer
- AC2: partial failure (`--capture-failed` / `--upload-failed`) → never `backlog`
- AC3: PATCH failure → exit 3, FATAL stderr, no silent backlog
- AC4: idempotency — issue already `in_review` → no-op (no status regression)
- AC5: call sequence — create with creating-agent first; single PATCH carries both `status` and `assigneeAgentId`

`tsc --noEmit`: 0 errors

## Issue

Resolves BLD-2109