### PR TITLE
fix(skia): absolute WASM path + probe guard to prevent LogBox error-overlay (BLD-2125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
+- **Fix: Form clips, session pacing, and stack marker screens no longer show an error overlay in development builds** — tapping "Select clips", tapping the pacing card, or viewing the stack marker pill could trigger a red error overlay that blocked all interaction when testing on sub-path routes. Root cause: the CanvasKit WASM loader was resolving a relative path that Metro dev server returned as an HTML fallback page, causing a WebAssembly compile error. The loader now uses an absolute path and probes WASM availability before loading. (BLD-2125)
 - **Fix: Progress tab no longer crashes with a white error screen on large-screen devices (Fold 7)** — on wide-viewport devices the Progress tab could display a full-screen dev error overlay instead of your progress data. Two root causes were fixed: the CanvasKit chart library is now initialised before the app renders (preventing a crash during chart load), and the body-settings database row is now inserted safely so simultaneous accesses no longer conflict. The Progress tab renders correctly on all screen sizes. (BLD-2078)
 - **Improvement: Integrations and Feedback tiles now match the visual style of all other Settings tiles** — Integrations and Feedback were previously rendered as standalone full-bleed cards without the consistent tile heading and padding that the other 7 Settings sections use. Both are now wrapped in `SettingsTile` so all 9 sections share the same 16 px padding and 18 px/600 heading typography. No functionality changed. (BLD-2090)
 

--- a/__tests__/hooks/useSkiaWebInit-wasm-probe.test.ts
+++ b/__tests__/hooks/useSkiaWebInit-wasm-probe.test.ts
@@ -1,0 +1,210 @@
+/**
+ * BLD-2125 regression-lock: useSkiaWebInit.web.ts must NOT call LoadSkiaWeb()
+ * when /canvaskit.wasm is unavailable or is the SPA HTML fallback.
+ *
+ * Calling LoadSkiaWeb() with an invalid WASM file triggers an internal
+ * WebAssembly.RuntimeError abort that propagates as an unhandled Promise
+ * rejection, surfacing as an Expo LogBox error overlay that blocks all pointer
+ * events in e2e scenario tests (form-clip-compare, session-pacing, stack-marker).
+ *
+ * Root cause: Metro dev server returns the SPA fallback HTML for /canvaskit.wasm,
+ * but the Content-Type header may not be `text/html` (HEAD vs GET discrepancy).
+ * A byte-level magic-number check is the only reliable probe.
+ *
+ * This suite tests:
+ *   1. canvasKitWasmAvailable() — the probe function (unit tests, directly).
+ *   2. useSkiaWebInit integration — confirms ready stays false when probe is false.
+ */
+
+// Mock fetch before any module loads.
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Mock Platform to simulate web environment.
+jest.mock("react-native", () => ({
+  Platform: { OS: "web" },
+}));
+
+import { renderHook, act } from "@testing-library/react-native";
+
+// Import the exported probe function and hook directly.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { canvasKitWasmAvailable, useSkiaWebInit } = require("../../hooks/useSkiaWebInit.web");
+
+// ────────────────────────────────────────────────────────────────────────────
+// WASM magic bytes helper (0x00 0x61 0x73 0x6D = "\0asm")
+// ────────────────────────────────────────────────────────────────────────────
+
+const WASM_MAGIC = new Uint8Array([0x00, 0x61, 0x73, 0x6d]);
+const HTML_START = new Uint8Array([0x3c, 0x21, 0x44, 0x4f]); // "<!DO"
+
+/** Build a mock ReadableStream that yields the given bytes. */
+function mockBodyReader(bytes: Uint8Array) {
+  let done = false;
+  return {
+    getReader: () => ({
+      read: () => {
+        if (done) return Promise.resolve({ value: undefined, done: true });
+        done = true;
+        return Promise.resolve({ value: bytes, done: false });
+      },
+      releaseLock: jest.fn(),
+    }),
+  };
+}
+
+/** Build a minimal fetch Response mock. */
+function mockResponse(
+  status: number,
+  body: Uint8Array,
+  ok = true,
+): object {
+  return {
+    ok,
+    status,
+    body: mockBodyReader(body),
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// 1. canvasKitWasmAvailable() unit tests
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("canvasKitWasmAvailable — BLD-2125 WASM magic-byte probe", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("returns true when the first 4 bytes are the WASM magic number (0x00 0x61 0x73 0x6D)", async () => {
+    mockFetch.mockResolvedValue(mockResponse(206, WASM_MAGIC));
+    expect(await canvasKitWasmAvailable()).toBe(true);
+  });
+
+  it("returns false when the first 4 bytes are HTML (0x3c 0x21 0x44 0x4f = '<!DO')", async () => {
+    // This is the Metro dev server SPA fallback scenario (BLD-2125 root cause).
+    mockFetch.mockResolvedValue(mockResponse(200, HTML_START));
+    expect(await canvasKitWasmAvailable()).toBe(false);
+  });
+
+  it("returns false when the response is not OK and not 206", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      body: mockBodyReader(new Uint8Array()),
+    });
+    expect(await canvasKitWasmAvailable()).toBe(false);
+  });
+
+  it("returns false when the response has no body", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: null,
+    });
+    expect(await canvasKitWasmAvailable()).toBe(false);
+  });
+
+  it("returns false when the fetch throws a network error", async () => {
+    mockFetch.mockRejectedValue(new TypeError("Failed to fetch"));
+    expect(await canvasKitWasmAvailable()).toBe(false);
+  });
+
+  it("returns false when the response body is fewer than 4 bytes", async () => {
+    mockFetch.mockResolvedValue(mockResponse(206, new Uint8Array([0x00, 0x61])));
+    expect(await canvasKitWasmAvailable()).toBe(false);
+  });
+
+  it("accepts a 200 response (Range not honoured) with the WASM magic bytes", async () => {
+    // Some servers respond with 200 + full body instead of 206 + range.
+    mockFetch.mockResolvedValue(mockResponse(200, WASM_MAGIC));
+    expect(await canvasKitWasmAvailable()).toBe(true);
+  });
+
+  it("sends a Range: bytes=0-3 request to avoid downloading the 8 MB file", async () => {
+    mockFetch.mockResolvedValue(mockResponse(206, WASM_MAGIC));
+    await canvasKitWasmAvailable();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/canvaskit.wasm",
+      expect.objectContaining({ headers: { Range: "bytes=0-3" } }),
+    );
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 2. useSkiaWebInit hook integration — safety gate tests (BLD-2125)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("useSkiaWebInit — BLD-2125 safety gate", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    delete (globalThis as Record<string, unknown>).CanvasKit;
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).CanvasKit;
+  });
+
+  it("stays ready=false and probes /canvaskit.wasm when the body starts with HTML bytes", async () => {
+    // BLD-2125 root cause: Metro returns HTML body for /canvaskit.wasm.
+    mockFetch.mockResolvedValue(mockResponse(200, HTML_START));
+
+    const { result } = renderHook(() => useSkiaWebInit());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/canvaskit.wasm",
+      expect.objectContaining({ headers: { Range: "bytes=0-3" } }),
+    );
+    expect(result.current).toBe(false);
+  });
+
+  it("stays ready=false when the WASM probe returns 404", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404, body: mockBodyReader(new Uint8Array()) });
+
+    const { result } = renderHook(() => useSkiaWebInit());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("stays ready=false when the WASM probe fetch throws", async () => {
+    mockFetch.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const { result } = renderHook(() => useSkiaWebInit());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("starts ready=true if CanvasKit is already populated before mount", () => {
+    (globalThis as Record<string, unknown>).CanvasKit = { XYWHRect: jest.fn() };
+
+    const { result } = renderHook(() => useSkiaWebInit());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("becomes ready=true via polling when CanvasKit is set externally", async () => {
+    // Probe says WASM available.
+    mockFetch.mockResolvedValue(mockResponse(206, WASM_MAGIC));
+
+    const { result } = renderHook(() => useSkiaWebInit());
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+      (globalThis as Record<string, unknown>).CanvasKit = { XYWHRect: jest.fn() };
+      await new Promise((r) => setTimeout(r, 200));
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/hooks/useSkiaWebInit.web.ts
+++ b/hooks/useSkiaWebInit.web.ts
@@ -30,15 +30,78 @@ import { Platform } from "react-native";
  * We therefore (a) retry `LoadSkiaWeb()` a few times on transient failure and
  * (b) poll `global.CanvasKit` directly, so we flip to `true` as soon as the
  * global is populated by any path.
+ *
+ * BLD-2125 root cause: CanvasKit builds the WASM URL as `prefix + "canvaskit.wasm"`
+ * where `prefix` defaults to `""` on web. On pages served at a sub-path (e.g.
+ * the `/__test__/stack-marker` harness), the relative URL resolves to
+ * `/__test__/canvaskit.wasm` — a path that does not exist. Metro's SPA handler
+ * returns the fallback HTML for that path. WebAssembly.instantiateStreaming then
+ * tries to compile the HTML bytes, hits the magic-number mismatch, and calls
+ * CanvasKit's internal `abort()`. abort() both rejects an internal module-level
+ * Promise (creating an unhandled rejection) AND throws a WebAssembly.RuntimeError.
+ * The throw is caught by our try/catch, but the internal Promise rejection escapes
+ * to the global `unhandledrejection` handler, which Expo's dev-mode LogBox
+ * captures and displays as a full-screen error overlay — blocking all pointer
+ * events in e2e scenario tests (BLD-2125: form-clip-compare, session-pacing,
+ * stack-marker).
+ *
+ * Fix: pass `locateFile: (f) => '/' + f` to LoadSkiaWeb(). This overrides the
+ * relative path resolution and forces CanvasKit to always fetch `/canvaskit.wasm`
+ * at the absolute root URL, which works correctly from any page sub-path.
+ * The WASM availability probe is a belt-and-suspenders guard: it checks the first
+ * 4 bytes of the WASM (the magic signature 0x00 0x61 0x73 0x6D) before calling
+ * LoadSkiaWeb, so the fatal unhandled rejection never occurs even when the WASM is
+ * genuinely unavailable (e.g. in dev without `public/canvaskit.wasm` present).
  */
 
 const CANVASKIT_POLL_INTERVAL_MS = 100;
 const CANVASKIT_POLL_MAX_MS = 30_000;
 const LOAD_SKIA_MAX_ATTEMPTS = 5;
 const LOAD_SKIA_RETRY_BACKOFF_MS = 250;
+const CANVASKIT_WASM_PATH = "/canvaskit.wasm";
 
 function canvasKitReady(): boolean {
   return typeof (globalThis as { CanvasKit?: unknown }).CanvasKit !== "undefined";
+}
+
+/**
+ * BLD-2125: Probe /canvaskit.wasm availability by fetching the first 4 bytes
+ * and checking for the WebAssembly magic bytes (0x00 0x61 0x73 0x6D = "\0asm").
+ *
+ * A HEAD-then-Content-Type check is unreliable: Metro's dev server can return a
+ * non-HTML content-type for HEAD requests but serve the SPA fallback HTML body
+ * on GET (the streaming WASM compile then fails with "Aborted(CompileError:
+ * WebAssembly.instantiate(): expected magic word 00 61 73 6d, found 3c 21 44
+ * 4f @+0)"). Checking the first 4 bytes via a Range request is the only
+ * reliable way to distinguish WASM from HTML without downloading the 8 MB file.
+ *
+ * We fetch with `Range: bytes=0-3` so only 4 bytes are transferred, verify the
+ * WASM magic signature, and return true only when the response is a real WASM
+ * binary. If the server does not honour Range requests the response falls back
+ * to a 200 with the full body — we still check the first 4 bytes.
+ *
+ * Exported for unit testing.
+ */
+export async function canvasKitWasmAvailable(): Promise<boolean> {
+  try {
+    const res = await fetch(CANVASKIT_WASM_PATH, {
+      // Range: bytes=0-3 — retrieve only the 4-byte WASM magic header.
+      // Servers that don't support Range respond with 200 + full body; we
+      // still check the first 4 bytes, which is sufficient.
+      headers: { Range: "bytes=0-3" },
+    });
+    if (!res.ok && res.status !== 206) return false;
+    // Read the first 4 bytes of the response body.
+    const reader = res.body?.getReader();
+    if (!reader) return false;
+    const { value } = await reader.read();
+    reader.releaseLock();
+    if (!value || value.length < 4) return false;
+    // WebAssembly magic bytes: 0x00 0x61 0x73 0x6D ("\0asm")
+    return value[0] === 0x00 && value[1] === 0x61 && value[2] === 0x73 && value[3] === 0x6d;
+  } catch {
+    return false;
+  }
 }
 
 export function useSkiaWebInit(): boolean {
@@ -73,10 +136,32 @@ export function useSkiaWebInit(): boolean {
       for (let attempt = 1; attempt <= LOAD_SKIA_MAX_ATTEMPTS; attempt++) {
         if (cancelled) return;
         try {
+          // BLD-2125: probe WASM availability before calling LoadSkiaWeb().
+          // If /canvaskit.wasm isn't served as a binary (e.g. Metro dev server
+          // returns the SPA HTML fallback), calling LoadSkiaWeb() triggers an
+          // internal WebAssembly.RuntimeError abort that escapes our try/catch
+          // as an unhandled Promise rejection, surfacing as an Expo LogBox
+          // error overlay that blocks all pointer events in e2e tests.
+          // Skip LoadSkiaWeb() when the WASM isn't available; the retry loop
+          // and polling will succeed once a static server that has the WASM
+          // is used.
+          const wasmAvailable = await canvasKitWasmAvailable();
+          if (!wasmAvailable) {
+            // WASM not ready on this host/server — wait and retry.
+            await new Promise((r) => setTimeout(r, LOAD_SKIA_RETRY_BACKOFF_MS));
+            continue;
+          }
+
           const mod = await import(
             "@shopify/react-native-skia/lib/module/web/LoadSkiaWeb"
           );
-          await mod.LoadSkiaWeb();
+          // BLD-2125: pass locateFile to force the absolute /canvaskit.wasm
+          // path instead of a URL relative to the current page. Without this,
+          // pages served at sub-paths (e.g. /__test__/stack-marker) resolve
+          // the relative "canvaskit.wasm" to "/__test__/canvaskit.wasm" which
+          // doesn't exist → SPA fallback HTML → WebAssembly magic-byte mismatch
+          // → internal abort() unhandled Promise rejection → Expo LogBox overlay.
+          await mod.LoadSkiaWeb({ locateFile: (file: string) => "/" + file });
           if (markReadyIfLoaded()) return;
         } catch {
           // Transient (e.g. "Failed to fetch" on the WASM under a contended


### PR DESCRIPTION
## Problem

In three distinct e2e scenario tests (, , ) the test harness reported `error-overlay intercepts pointer events` (30s timeout). The Expo `@expo/log-box` ErrorOverlay was mounting as a full-screen overlay, blocking all pointer events.

## Root Cause

CanvasKit builds its WASM URL as `prefix + "canvaskit.wasm"` where `prefix` defaults to `""` (empty string) on web. On pages served at sub-paths — such as the dev harness routes `/__test__/stack-marker`, `/__test__/session-pacing`, `/__test__/form-clips` — the relative URL resolves to e.g. `/__test__/canvaskit.wasm`, which doesn't exist.

Metro's SPA handler returns the fallback HTML for any unmatched path. `WebAssembly.instantiateStreaming` then tries to compile the HTML bytes, hits the WASM magic-byte mismatch (`0x3c21444f` ≠ `0x0061736d`), and CanvasKit's internal `abort()` fires. The `abort()` both:
1. Rejects an internal module-level Promise (unhandled rejection)
2. Throws a `WebAssembly.RuntimeError`

The throw is caught by our `try/catch` in `useSkiaWebInit.web.ts`, but the internal Promise rejection escapes to the global `unhandledrejection` handler, which Expo's dev-mode LogBox captures and renders as a full-screen error overlay — blocking all pointer interaction in the three affected e2e test scenarios.

## Fix

Two complementary changes to `hooks/useSkiaWebInit.web.ts`:

1. **Absolute WASM path via `locateFile`**: Pass `{ locateFile: (f) => '/' + f }` to `LoadSkiaWeb()`. This overrides CanvasKit's relative path resolution so it always fetches `/canvaskit.wasm` at the absolute root URL, regardless of the current page sub-path.

2. **Belt-and-suspenders WASM probe (`canvasKitWasmAvailable`)**: Before calling `LoadSkiaWeb()`, fetch the first 4 bytes of `/canvaskit.wasm` via a `Range: bytes=0-3` request and verify the WASM magic signature (`0x00 0x61 0x73 0x6d`). If the probe fails, skip the `LoadSkiaWeb()` call and retry — this prevents the fatal unhandled rejection even when the WASM is genuinely unavailable (e.g. in CI without `public/canvaskit.wasm`).

## Tests

13 new unit tests in `__tests__/hooks/useSkiaWebInit-wasm-probe.test.ts`:
- `canvasKitWasmAvailable()` probe: WASM magic bytes, HTML false-positive, 404, no body, fetch error, short body, Range-not-honoured 200
- `useSkiaWebInit` integration: stays `ready=false` when probe returns HTML/404/throws, starts `ready=true` when CanvasKit already loaded, flips via polling

All 4606 existing tests pass unchanged.

## Acceptance Criteria Verification

The root cause — relative WASM URL resolution at sub-paths triggering an unhandled Promise rejection — is fixed at source. The three failing scenarios (`form-clip-compare.spec.ts:66`, `form-clip-compare.spec.ts:104`, `session-pacing.spec.ts:144`, `stack-marker.spec.ts:49`) should pass once `LoadSkiaWeb()` no longer triggers the LogBox overlay on sub-path harness routes.

Refs: BLD-2125, BLD-2106 (audit origin), BLD-2078 (prior Skia init work)