### PR TITLE
fix(skia): locate root-staged canvaskit.wasm so LoadSkiaWeb stops mounting LogBox (BLD-2125)

### DIFF
--- a/__tests__/hooks/canvaskitLocateFile.test.ts
+++ b/__tests__/hooks/canvaskitLocateFile.test.ts
@@ -1,0 +1,80 @@
+/**
+ * BLD-2125 regression-lock for `canvaskitLocateFile`.
+ *
+ * Root cause recap: `LoadSkiaWeb()` was called with NO `locateFile`, so
+ * emscripten/CanvasKit resolved `canvaskit.wasm` relative to its own JS chunk
+ * (`/_expo/static/js/web/canvaskit.wasm`) — a path that 404s under a SPA static
+ * host and is rewritten to `index.html`. CanvasKit then tried to compile HTML
+ * as WASM and aborted with an UNCAUGHT `pageerror`, which mounted the Expo
+ * LogBox `#error-overlay` on every web route and blocked all pointer events
+ * (form-clip-compare / session-pacing / stack-marker scenario failures).
+ *
+ * The fix points CanvasKit at the root-staged `/canvaskit.wasm` (placed there by
+ * `scripts/skia-setup.js` → `public/canvaskit.wasm` → bundle root). These tests
+ * lock that mapping so a future refactor cannot silently reintroduce the
+ * relative-resolution bug.
+ */
+import { canvaskitLocateFile } from "../../hooks/canvaskitLocateFile";
+
+describe("canvaskitLocateFile (BLD-2125)", () => {
+  const originalLocation = (globalThis as { location?: unknown }).location;
+
+  function setOrigin(origin: string | undefined): void {
+    if (origin === undefined) {
+      // Simulate a non-browser global (e.g. SSR/prerender) with no location.
+      delete (globalThis as { location?: unknown }).location;
+      return;
+    }
+    Object.defineProperty(globalThis, "location", {
+      configurable: true,
+      value: { origin },
+    });
+  }
+
+  afterEach(() => {
+    if (originalLocation === undefined) {
+      delete (globalThis as { location?: unknown }).location;
+    } else {
+      Object.defineProperty(globalThis, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
+  it("maps the CanvasKit WASM to the origin-rooted staged path", () => {
+    setOrigin("http://localhost:8081");
+    expect(canvaskitLocateFile("canvaskit.wasm")).toBe(
+      "http://localhost:8081/canvaskit.wasm",
+    );
+  });
+
+  it("roots ANY .wasm file at origin (not just canvaskit.wasm)", () => {
+    setOrigin("https://example.com");
+    expect(canvaskitLocateFile("some-other.wasm")).toBe(
+      "https://example.com/some-other.wasm",
+    );
+  });
+
+  it("never returns the JS-chunk-relative path that 404s on a SPA host", () => {
+    setOrigin("https://example.com");
+    const resolved = canvaskitLocateFile("canvaskit.wasm");
+    // The pre-fix bug fetched a path under the JS bundle dir.
+    expect(resolved).not.toContain("_expo/static/js");
+    // Must be an absolute, origin-anchored URL so it resolves to the bundle root.
+    expect(resolved.startsWith("https://example.com/")).toBe(true);
+  });
+
+  it("falls back to a leading-slash absolute path when origin is unavailable", () => {
+    setOrigin(undefined);
+    // With no origin we still emit an absolute (root-anchored) URL — never a
+    // bare relative filename that would resolve next to the JS chunk.
+    expect(canvaskitLocateFile("canvaskit.wasm")).toBe("/canvaskit.wasm");
+  });
+
+  it("passes non-WASM asset names through unchanged", () => {
+    setOrigin("http://localhost:8081");
+    expect(canvaskitLocateFile("canvaskit.js")).toBe("canvaskit.js");
+    expect(canvaskitLocateFile("anything-else")).toBe("anything-else");
+  });
+});

--- a/e2e/scenarios/skia-no-error-overlay.spec.ts
+++ b/e2e/scenarios/skia-no-error-overlay.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Scenario spec: skia-no-error-overlay (BLD-2125 regression guard).
+ *
+ * Locks the root-cause fix: on the static `--dev` web bundle, `LoadSkiaWeb()`
+ * must locate the root-staged `/canvaskit.wasm` (via `canvaskitLocateFile`) so
+ * CanvasKit initialises WITHOUT throwing an uncaught `pageerror`. Before the
+ * fix, CanvasKit fetched a non-existent `/_expo/static/js/web/canvaskit.wasm`,
+ * received the SPA `index.html` fallback, aborted with
+ * `WebAssembly.instantiate(): expected magic word …`, and the Expo LogBox
+ * mounted `#error-overlay` on EVERY web route — intercepting all pointer events
+ * and breaking form-clip-compare / session-pacing / stack-marker.
+ *
+ * This guard is intentionally route-agnostic: the overlay was global (the Skia
+ * init runs in the root `app/_layout.tsx`), so a single representative harness
+ * route is sufficient to detect a regression. We assert:
+ *   1. No `#error-overlay` host ever mounts.
+ *   2. No uncaught `pageerror` mentioning the WASM magic-word / CanvasKit abort.
+ *
+ * Refs: BLD-2125. Reproduction recipe matches scripts/daily-audit.sh
+ * (expo export -p web --dev + E2E_USE_STATIC=1 playwright … --project=mobile).
+ */
+import { test, expect } from "@playwright/test";
+
+const SAMPLE_PACING = {
+  working: 1122,
+  rest: 2470,
+  other: 428,
+  gross: 4020,
+  isEmpty: false,
+  perExercise: [{ exercise_id: "ex1", working: 252, rest: 585, other: 150 }],
+};
+
+test.describe("@scenario skia-no-error-overlay", () => {
+  // eslint-disable-next-line no-empty-pattern -- Playwright requires destructured fixtures arg
+  test.beforeAll(({}, testInfo) => {
+    test.skip(
+      !["mobile"].includes(testInfo.project.name),
+      "skia-no-error-overlay: mobile viewport only",
+    );
+  });
+
+  test("no LogBox error-overlay / CanvasKit WASM pageerror on web routes (BLD-2125)", async ({
+    page,
+  }) => {
+    const wasmAbortErrors: string[] = [];
+    page.on("pageerror", (err) => {
+      const msg = `${err.name}: ${err.message}`;
+      if (
+        msg.includes("expected magic word") ||
+        msg.includes("WebAssembly.instantiate") ||
+        msg.toLowerCase().includes("canvaskit") ||
+        msg.includes("Aborted(")
+      ) {
+        wasmAbortErrors.push(msg);
+      }
+    });
+
+    // Any harness route mounts the root layout (and thus useSkiaWebInit).
+    await page.addInitScript((pacing) => {
+      const w = window as unknown as Record<string, unknown>;
+      w.__SKIP_ONBOARDING__ = true;
+      w.__SESSION_PACING_HARNESS__ = {
+        harnessActive: true,
+        pacing,
+        exerciseNames: { ex1: "Cable Row" },
+      };
+    }, SAMPLE_PACING);
+
+    await page.goto("/__test__/session-pacing");
+    await expect(page.locator("body[data-test-ready='true']")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Give the Skia init retry/poll loop time to run and (pre-fix) throw.
+    await page.waitForTimeout(2000);
+
+    // 1. The blocking LogBox overlay must never mount.
+    await expect(page.locator("#error-overlay")).toHaveCount(0);
+
+    // 2. No uncaught CanvasKit/WASM abort escaped LoadSkiaWeb().
+    expect(
+      wasmAbortErrors,
+      "CanvasKit WASM failed to load — locateFile likely not pointing at the " +
+        "root-staged /canvaskit.wasm (see hooks/canvaskitLocateFile.ts).",
+    ).toHaveLength(0);
+
+    // 3. Sanity: the seeded card is interactable (overlay would block this).
+    const cardBody = page.getByRole("button", { name: /Estimated pacing/i });
+    await expect(cardBody).toBeVisible({ timeout: 5000 });
+    await cardBody.click();
+    await expect(page.getByText("Pacing by exercise")).toBeVisible({
+      timeout: 5000,
+    });
+  });
+});

--- a/hooks/canvaskitLocateFile.ts
+++ b/hooks/canvaskitLocateFile.ts
@@ -1,0 +1,39 @@
+/**
+ * Resolve where emscripten/CanvasKit should fetch the staged Skia WASM on web.
+ *
+ * Extracted as a standalone, platform-agnostic, side-effect-free module so it
+ * can be unit-tested without importing `useSkiaWebInit.web.ts` (which lazily
+ * `import()`s `@shopify/react-native-skia` → `canvaskit-wasm`, a web-only dep
+ * that must never enter a native/jest module graph). See BLD-2125.
+ *
+ * Background: `CanvasKitInit` (invoked by `LoadSkiaWeb`) resolves
+ * `canvaskit.wasm` relative to the location of its OWN JS chunk by default —
+ * under Expo's web output that is `/_expo/static/js/web/canvaskit.wasm`, which
+ * does not exist. On a SPA static host (`npx serve -s dist`, our screenshot/e2e
+ * pipeline and the deployed site) that 404 is rewritten to `index.html`, so
+ * CanvasKit receives `<!DOCTYPE …>` instead of a WASM binary and aborts with
+ * `WebAssembly.instantiate(): expected magic word 00 61 73 6d, found 3c 21 44 4f`.
+ * That abort is rethrown OUTSIDE the awaited `LoadSkiaWeb()` promise chain, so
+ * it surfaces as an uncaught `pageerror`, which mounts the Expo LogBox
+ * `#error-overlay` on EVERY web route (the loader runs in the root
+ * `app/_layout.tsx`) and intercepts all pointer events.
+ *
+ * `scripts/skia-setup.js` stages the binary at `public/canvaskit.wasm`, which
+ * Expo copies to the bundle ROOT (`/canvaskit.wasm`). Returning an origin-rooted
+ * absolute URL for any `.wasm` file points CanvasKit at that staged copy
+ * regardless of where its JS chunk lives, so the fetch returns
+ * `application/wasm` and CanvasKit initialises cleanly.
+ */
+export function canvaskitLocateFile(file: string): string {
+  if (!file.endsWith(".wasm")) {
+    // Non-WASM assets (CanvasKit ships none under our setup, but be defensive)
+    // fall through to emscripten's default relative resolution.
+    return file;
+  }
+  const origin =
+    typeof globalThis !== "undefined" &&
+    (globalThis as { location?: { origin?: string } }).location?.origin
+      ? (globalThis as unknown as { location: { origin: string } }).location.origin
+      : "";
+  return `${origin}/${file}`;
+}

--- a/hooks/useSkiaWebInit.web.ts
+++ b/hooks/useSkiaWebInit.web.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Platform } from "react-native";
+import { canvaskitLocateFile } from "./canvaskitLocateFile";
 
 /**
  * Web implementation of the CanvasKit readiness signal. The native (default)
@@ -76,7 +77,10 @@ export function useSkiaWebInit(): boolean {
           const mod = await import(
             "@shopify/react-native-skia/lib/module/web/LoadSkiaWeb"
           );
-          await mod.LoadSkiaWeb();
+          // Pass `locateFile` so CanvasKit fetches the root-staged
+          // `/canvaskit.wasm` (see `canvaskitLocateFile`) instead of the
+          // non-existent path next to its JS chunk (BLD-2125).
+          await mod.LoadSkiaWeb({ locateFile: canvaskitLocateFile });
           if (markReadyIfLoaded()) return;
         } catch {
           // Transient (e.g. "Failed to fetch" on the WASM under a contended


### PR DESCRIPTION
## Summary

Fixes **BLD-2125**: the Expo LogBox `#error-overlay` was mounting on every web route and intercepting all pointer events, breaking three scenarios flagged by the 2026-06-28 daily UX audit (audit HEAD `35de8735`):

- `form-clip-compare.spec.ts:66` — two clips selected → Compare CTA enabled
- `form-clip-compare.spec.ts:104` — one clip selected → Compare CTA absent/disabled
- `session-pacing.spec.ts:144` — tap PacingCard body → breakdown sheet opens
- `stack-marker.spec.ts:49` — pristine pill renders 'Pick marker'

## Root cause (what error, why)

`hooks/useSkiaWebInit.web.ts` called `LoadSkiaWeb()` with **no `locateFile`**. emscripten/CanvasKit (via `CanvasKitInit`) therefore resolved `canvaskit.wasm` **relative to its own JS chunk** — under Expo's web output that is `/_expo/static/js/web/canvaskit.wasm`, which does not exist.

On the static `--dev` bundle the audit uses (`npx serve -s dist`), that 404 is rewritten to the SPA `index.html`. CanvasKit received `<!DOCTYPE …>` and tried to compile HTML as WASM:

```
RuntimeError: Aborted(CompileError: WebAssembly.instantiate():
  expected magic word 00 61 73 6d, found 3c 21 44 4f @+0)   // 3c 21 44 4f = "<!DO"
    at async Object.LoadSkiaWeb (...)
    at async driveLoad (hooks/useSkiaWebInit.web.ts)
```

The emscripten `abort()` is rethrown **outside** the awaited `LoadSkiaWeb()` promise chain, so the existing `try { … } catch {}` never caught it — it surfaced as an **uncaught `pageerror`**. Because `useSkiaWebInit()` runs in the **root** `app/_layout.tsx:114`, the LogBox overlay mounted on **every** web route and blocked all interaction.

Definitive probe under `npx serve -s dist`:

| URL requested | Result |
|---|---|
| `/canvaskit.wasm` (root — where BLD-2078 staged it) | `200 application/wasm 8076553 bytes` ✓ |
| `/_expo/static/js/web/canvaskit.wasm` (what emscripten actually fetched) | `200 text/html 2363 bytes` ✗ SPA fallback |

BLD-2078 staged the WASM at the bundle root (`public/canvaskit.wasm` → `/canvaskit.wasm`) but never told CanvasKit to look there — so the staging silently had no effect on the static host.

## The fix

Pass `locateFile` to `LoadSkiaWeb({ locateFile })`, returning the origin-rooted `/canvaskit.wasm`. CanvasKit now fetches the correctly-staged binary regardless of where its JS chunk lives. This:

1. Removes the uncaught `pageerror` → LogBox `#error-overlay` no longer mounts → all three scenarios are interactable again.
2. Finally lets the Progress-tab charts render on the static web bundle (the original BLD-2078 goal).

The pure path-mapping is extracted to `hooks/canvaskitLocateFile.ts` (side-effect-free, no Skia import) so it is unit-testable without dragging `canvaskit-wasm` into the jest/native module graph.

## Files

- `hooks/useSkiaWebInit.web.ts` — wire `locateFile: canvaskitLocateFile` into `LoadSkiaWeb()` (+5 −1).
- `hooks/canvaskitLocateFile.ts` — new pure helper mapping `.wasm` → origin-rooted URL.
- `__tests__/hooks/canvaskitLocateFile.test.ts` — locks the root-anchored mapping (never JS-chunk-relative).
- `e2e/scenarios/skia-no-error-overlay.spec.ts` — scenario regression guard: asserts no `#error-overlay` and no CanvasKit WASM `pageerror` on a representative harness route.

## Verification (headless, matches `scripts/daily-audit.sh`)

```
npx expo export -p web --dev --no-minify
E2E_USE_STATIC=1 npx playwright test \
  e2e/scenarios/form-clip-compare.spec.ts \
  e2e/scenarios/session-pacing.spec.ts \
  e2e/scenarios/stack-marker.spec.ts \
  e2e/scenarios/skia-no-error-overlay.spec.ts \
  --project=mobile
```

**Before:** 4 failed (`<div id="error-overlay"></div> intercepts pointer events`), 3 passed.
**After:** **8/8 passed.**

Also green: `tsc --noEmit`, `eslint` on changed files, `jest __tests__/hooks/canvaskitLocateFile.test.ts __tests__/app/fta-decomposition.test.ts`.

## Acceptance criteria

- [x] form-clip-compare (1 or 2 clips): no overlay, Compare CTA interactable.
- [x] session-pacing: tapping PacingCard opens the breakdown sheet (no interception).
- [x] stack-marker: pristine pill shows 'Pick marker' and is interactable.
- [x] Root cause documented (above).
- [x] All tests pass, no new lint warnings.

## Out of scope (per issue)

- The 7 adaptive-rest snapshot pixel-diffs and the advanced-sets / completed-workout timeouts (tracked separately).

Refs: BLD-2125, BLD-2078, BLD-2106.
