### PR TITLE
feat(settings): staggered tile entrance + reduced-motion (BLD-2036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Improvement: Settings tiles fade in with a subtle staggered entrance** — when the Settings screen opens, its themed tiles now ease in with a brief fade/slide-up cascade instead of appearing all at once, giving the redesigned screen a more polished first paint. The effect is intentionally short and is fully disabled when the device's "Reduce Motion" accessibility setting is on (tiles appear instantly). Tile content is never hidden behind the animation. (BLD-2036)
 
 ## v0.26.44 — 2026-06-28
 <!-- versionCode: 114 -->

--- a/__mocks__/react-native-reanimated.js
+++ b/__mocks__/react-native-reanimated.js
@@ -6,11 +6,12 @@ const React = require('react');
 const noop = () => {};
 const noopValue = (v) => ({ value: v });
 
-// Chainable layout animation mock — supports .delay().duration() and .duration().delay()
+// Chainable layout animation mock — supports .delay().duration().easing() in any order
 const makeLayoutAnim = () => {
   const anim = {};
   anim.duration = () => anim;
   anim.delay = () => anim;
+  anim.easing = () => anim;
   anim.springify = () => anim;
   anim.damping = () => anim;
   anim.stiffness = () => anim;

--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -57,6 +57,7 @@ jest.mock('react-native-reanimated', () => {
     },
     FadeIn: chainable(),
     FadeInDown: chainable(),
+    FadeInUp: chainable(),
     useAnimatedStyle: () => ({}),
     useAnimatedProps: (fn: () => unknown) => fn(),
     useSharedValue: <T,>(v: T) => ({ value: v }),

--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -47,6 +47,7 @@ jest.mock('react-native-reanimated', () => {
     const obj: Record<string, unknown> = {}
     obj.delay = () => obj
     obj.duration = () => obj
+    obj.easing = () => obj
     return obj
   }
   return {

--- a/__tests__/components/settings/SettingsTile.test.tsx
+++ b/__tests__/components/settings/SettingsTile.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * __tests__/components/settings/SettingsTile.test.tsx
+ *
+ * BLD-2036 (P2-8, epic BLD-2028) — Motion: Settings tile entrance + reduced
+ * motion.
+ *
+ * Coverage:
+ *  - Headless-safe contract: tile title + children render regardless of motion
+ *    state (content is NEVER gated on the entrance animation).
+ *  - Reduced motion → instant: `tileEntering` resolves to `undefined`, and the
+ *    rendered wrapper receives `entering === undefined` (no animation).
+ *  - Motion ON → a defined `entering` animation is applied.
+ *  - Stagger math: `staggerDelayMs` is order-proportional, clamped at
+ *    MAX_STAGGER_STEPS, and safe for index 0 / negative / non-finite input.
+ *
+ * The reanimated layout builders are opaque under the global mock
+ * (__mocks__/react-native-reanimated.js), so motion-on assertions are made on
+ * the *decision* (defined vs. undefined `entering`) and the pure stagger helper,
+ * not on the builder's internal delay/duration values.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+// Mutable reduced-motion state, flipped per test. Mirrors the established
+// per-test hook-mock pattern (e.g. RpeChipStrip.test.tsx).
+let mockReduceMotion = false;
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => mockReduceMotion,
+}));
+
+import {
+  SettingsTile,
+  tileEntering,
+  staggerDelayMs,
+  STAGGER_STEP_MS,
+  MAX_STAGGER_STEPS,
+} from '@/components/settings/SettingsTile';
+import { Text } from '@/components/ui/text';
+import { lightMockColors } from '../../helpers/theme';
+
+const TID = 'settings-tile-test';
+
+function renderTile(extra: Partial<React.ComponentProps<typeof SettingsTile>> = {}) {
+  return render(
+    <SettingsTile colors={lightMockColors as never} title="Profile" testID={TID} {...extra}>
+      <Text>child-content</Text>
+    </SettingsTile>,
+  );
+}
+
+describe('staggerDelayMs (BLD-2036)', () => {
+  it('is zero for the first tile', () => {
+    expect(staggerDelayMs(0)).toBe(0);
+  });
+
+  it('is order-proportional below the cap', () => {
+    expect(staggerDelayMs(1)).toBe(STAGGER_STEP_MS);
+    expect(staggerDelayMs(3)).toBe(3 * STAGGER_STEP_MS);
+  });
+
+  it('clamps at MAX_STAGGER_STEPS so the last tile is never perceptibly slow', () => {
+    const capped = MAX_STAGGER_STEPS * STAGGER_STEP_MS;
+    expect(staggerDelayMs(MAX_STAGGER_STEPS)).toBe(capped);
+    expect(staggerDelayMs(MAX_STAGGER_STEPS + 5)).toBe(capped);
+    expect(staggerDelayMs(999)).toBe(capped);
+  });
+
+  it('is safe (0) for negative or non-finite index', () => {
+    expect(staggerDelayMs(-3)).toBe(0);
+    expect(staggerDelayMs(Number.NaN)).toBe(0);
+    // Non-finite (Infinity) is treated as "no stagger" rather than the cap —
+    // `Number.isFinite(Infinity)` is false, so the guard returns 0. Safe either
+    // way: the tile still mounts, just without an added delay.
+    expect(staggerDelayMs(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+});
+
+describe('tileEntering (BLD-2036)', () => {
+  it('returns undefined under reduced motion (instant, no animation)', () => {
+    expect(tileEntering(0, true)).toBeUndefined();
+    expect(tileEntering(5, true)).toBeUndefined();
+  });
+
+  it('returns a defined entering animation when motion is enabled', () => {
+    expect(tileEntering(0, false)).toBeDefined();
+    expect(tileEntering(3, false)).toBeDefined();
+  });
+});
+
+describe('SettingsTile — headless-safe render (BLD-2036)', () => {
+  afterEach(() => {
+    mockReduceMotion = false;
+  });
+
+  it('renders title + children with motion ENABLED (content not gated on animation)', () => {
+    mockReduceMotion = false;
+    const { getByText, getByTestId } = renderTile({ index: 2 });
+    expect(getByText('Profile')).toBeTruthy();
+    expect(getByText('child-content')).toBeTruthy();
+    expect(getByTestId(TID)).toBeTruthy();
+  });
+
+  it('renders title + children under REDUCED motion (content still present, instant)', () => {
+    mockReduceMotion = true;
+    const { getByText, getByTestId } = renderTile({ index: 2 });
+    expect(getByText('Profile')).toBeTruthy();
+    expect(getByText('child-content')).toBeTruthy();
+    expect(getByTestId(TID)).toBeTruthy();
+  });
+
+  it('passes entering === undefined to the wrapper under reduced motion', () => {
+    mockReduceMotion = true;
+    const { getByTestId } = renderTile({ index: 4 });
+    // The Animated.View wrapper exposes its own `${testID}-entrance` testID.
+    const wrapper = getByTestId(`${TID}-entrance`);
+    expect(wrapper.props.entering).toBeUndefined();
+  });
+
+  it('passes a defined entering to the wrapper when motion is enabled', () => {
+    mockReduceMotion = false;
+    const { getByTestId } = renderTile({ index: 4 });
+    const wrapper = getByTestId(`${TID}-entrance`);
+    expect(wrapper.props.entering).toBeDefined();
+  });
+
+  it('renders without a title when omitted (child component supplies its own heading)', () => {
+    mockReduceMotion = false;
+    const { queryByText, getByText } = renderTile({ title: undefined });
+    expect(queryByText('Profile')).toBeNull();
+    expect(getByText('child-content')).toBeTruthy();
+  });
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -179,7 +179,7 @@ export default function Settings() {
       <Masonry gap={spacing.base} testID="settings-masonry">
 
         {/* ── 1. Profile ── */}
-        <SettingsTile colors={colors} title="Profile" testID="settings-tile-profile">
+        <SettingsTile colors={colors} title="Profile" testID="settings-tile-profile" index={0}>
           <BodyProfileCard
             weightUnit={weightUnit}
             heightUnit={measureUnit}
@@ -195,7 +195,7 @@ export default function Settings() {
         </SettingsTile>
 
         {/* ── 2. Units & Appearance ── */}
-        <SettingsTile colors={colors} title="Units & Appearance" testID="settings-tile-units-appearance">
+        <SettingsTile colors={colors} title="Units & Appearance" testID="settings-tile-units-appearance" index={1}>
           <UnitsCard
             colors={colors}
             toast={toast}
@@ -212,7 +212,7 @@ export default function Settings() {
         </SettingsTile>
 
         {/* ── 3. Training ── */}
-        <SettingsTile colors={colors} title="Training" testID="settings-tile-training">
+        <SettingsTile colors={colors} title="Training" testID="settings-tile-training" index={2}>
           <SettingsLinkRow
             colors={colors}
             title="Gym Profiles"
@@ -230,7 +230,7 @@ export default function Settings() {
         </SettingsTile>
 
         {/* ── 4. Notifications ── */}
-        <SettingsTile colors={colors} title="Notifications" testID="settings-tile-notifications">
+        <SettingsTile colors={colors} title="Notifications" testID="settings-tile-notifications" index={3}>
           <PreferencesCard
             colors={colors}
             toast={toast}
@@ -261,7 +261,7 @@ export default function Settings() {
         </SettingsTile>
 
         {/* ── 5. Coaching ── */}
-        <SettingsTile colors={colors} title="Coaching" testID="settings-tile-coaching">
+        <SettingsTile colors={colors} title="Coaching" testID="settings-tile-coaching" index={4}>
           <SettingsLinkRow
             colors={colors}
             title="Adaptive Macro Coach"
@@ -280,7 +280,7 @@ export default function Settings() {
         </SettingsTile>
 
         {/* ── 6. Integrations ── */}
-        <SettingsTile colors={colors} title="Integrations" testID="settings-tile-integrations">
+        <SettingsTile colors={colors} title="Integrations" testID="settings-tile-integrations" index={5}>
           <IntegrationsCard
             colors={colors}
             toast={toast}
@@ -293,7 +293,7 @@ export default function Settings() {
         </SettingsTile>
 
         {/* ── 7. Data & Backup ── */}
-        <SettingsTile colors={colors} title="Data & Backup" testID="settings-tile-data-backup">
+        <SettingsTile colors={colors} title="Data & Backup" testID="settings-tile-data-backup" index={6}>
           <AutoBackupSection colors={colors} toast={toast} bareContent />
           <Separator style={styles.tileDivider} />
           <FormClipsStorageRow onClipsChanged={() => {}} />
@@ -311,7 +311,7 @@ export default function Settings() {
         </SettingsTile>
 
         {/* ── 8. Feedback ── */}
-        <SettingsTile colors={colors} title="Feedback & Reports" testID="settings-tile-feedback">
+        <SettingsTile colors={colors} title="Feedback & Reports" testID="settings-tile-feedback" index={7}>
           <FeedbackCard
             colors={colors}
             count={count}
@@ -323,7 +323,7 @@ export default function Settings() {
         </SettingsTile>
 
         {/* ── 9. About ── */}
-        <SettingsTile colors={colors} title="About" testID="settings-tile-about">
+        <SettingsTile colors={colors} title="About" testID="settings-tile-about" index={8}>
           <Pressable
             onPress={() => setReleaseNotesVisible(true)}
             accessibilityRole="button"

--- a/components/settings/SettingsTile.tsx
+++ b/components/settings/SettingsTile.tsx
@@ -1,10 +1,58 @@
 import { StyleSheet } from 'react-native';
 import type { ReactNode } from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
+import Animated, {
+  FadeInUp,
+  type EntryExitAnimationFunction,
+} from 'react-native-reanimated';
 import { Card } from '@/components/ui/card';
 import { Text } from '@/components/ui/text';
-import { spacing } from '@/constants/design-tokens';
+import { duration, easing, spacing } from '@/constants/design-tokens';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import type { ThemeColors } from '@/hooks/useThemeColors';
+
+/**
+ * Per-tile stagger step (ms). Each tile's entrance is delayed by
+ * `min(index, MAX_STAGGER_STEPS) * STAGGER_STEP_MS` so the stack reveals as a
+ * gentle cascade rather than all at once.
+ */
+export const STAGGER_STEP_MS = 40;
+
+/**
+ * Cap the number of staggered steps so the *last* tile is never perceptibly
+ * slow and the screenshot/e2e settle window stays bounded
+ * (`MAX_STAGGER_STEPS * STAGGER_STEP_MS` = 320ms added delay at most).
+ */
+export const MAX_STAGGER_STEPS = 8;
+
+/** Staggered entrance delay (ms) for the tile at `index` (clamped, never negative). */
+export function staggerDelayMs(index: number): number {
+  const safe = Number.isFinite(index) && index > 0 ? Math.floor(index) : 0;
+  return Math.min(safe, MAX_STAGGER_STEPS) * STAGGER_STEP_MS;
+}
+
+/**
+ * Resolve the `entering` animation for a tile.
+ *
+ * - Under reduced motion → `undefined` (the tile mounts at its final state
+ *   instantly; **no** animation). This is the key accessibility contract.
+ * - Otherwise → a short fade/slide-up (`duration.fast`, decelerate) staggered by
+ *   tile order. Built inline from `FadeInUp` + design tokens (rather than the
+ *   `lib/animations/layout` barrel) so the tile owns exactly the entrance it
+ *   uses and pulls in no unrelated exit/slide animators.
+ *
+ * Extracted as a pure function so the reduced-motion + stagger decision is unit
+ * testable without inspecting reanimated's opaque builder internals.
+ */
+export function tileEntering(
+  index: number,
+  reduceMotion: boolean,
+): EntryExitAnimationFunction | undefined {
+  if (reduceMotion) return undefined;
+  return FadeInUp.duration(duration.fast)
+    .easing(easing.decelerate)
+    .delay(staggerDelayMs(index)) as unknown as EntryExitAnimationFunction;
+}
 
 type Props = {
   /**
@@ -17,6 +65,12 @@ type Props = {
   /** Extra style merged onto the underlying Card (e.g. masonry cell sizing). */
   style?: StyleProp<ViewStyle>;
   testID?: string;
+  /**
+   * Position of this tile in the Settings stack (0-based). Drives the staggered
+   * entrance delay. Defaults to `0` (no stagger). Has no visible effect under
+   * reduced motion.
+   */
+  index?: number;
 };
 
 /**
@@ -31,29 +85,52 @@ type Props = {
  * Settings stack reads as a calm list rather than a column of floating cards,
  * matching the declutter treatment applied to every other Settings card in
  * BLD-2030.
+ *
+ * Motion (BLD-2036, P2-8): the Card is wrapped in an `Animated.View` that plays
+ * a short, staggered fade/slide-up on first paint, and is **instant under
+ * reduced motion**. The entrance uses reanimated's declarative `entering` (the
+ * element is mounted and laid out immediately) — tile content is NEVER gated on
+ * the animation, so the headless-safe contract of `Masonry` is preserved: tiles
+ * render fully even where worklets don't run (SSR/Playwright/jest) or the
+ * animation short-circuits. The wrapper is layout-transparent (`width: 100%`,
+ * no padding/margin) so masonry cell sizing is unaffected.
  */
-export function SettingsTile({ title, children, colors, style, testID }: Props) {
+export function SettingsTile({ title, children, colors, style, testID, index = 0 }: Props) {
+  const reduceMotion = useReducedMotion();
+  const entering = tileEntering(index, reduceMotion);
+
   return (
-    <Card
-      variant="outline"
-      testID={testID}
-      style={StyleSheet.flatten([
-        styles.tile,
-        { backgroundColor: colors.surface },
-        style,
-      ])}
+    <Animated.View
+      entering={entering}
+      style={styles.entrance}
+      testID={testID ? `${testID}-entrance` : undefined}
     >
-      {title ? (
-        <Text variant="subtitle" style={[styles.title, { color: colors.onSurface }]}>
-          {title}
-        </Text>
-      ) : null}
-      {children}
-    </Card>
+      <Card
+        variant="outline"
+        testID={testID}
+        style={StyleSheet.flatten([
+          styles.tile,
+          { backgroundColor: colors.surface },
+          style,
+        ])}
+      >
+        {title ? (
+          <Text variant="subtitle" style={[styles.title, { color: colors.onSurface }]}>
+            {title}
+          </Text>
+        ) : null}
+        {children}
+      </Card>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
+  // Layout-transparent wrapper: full-width so the Card fills the masonry cell
+  // exactly as it did before, with no padding/margin of its own.
+  entrance: {
+    width: '100%',
+  },
   tile: {
     padding: spacing.base,
   },

--- a/e2e/scenarios/settings.spec.ts
+++ b/e2e/scenarios/settings.spec.ts
@@ -58,6 +58,11 @@ test.describe("@scenario settings", () => {
   });
 
   test("captures settings top (title + first cards)", async ({ page }, testInfo) => {
+    // Reduce motion so the BLD-2036 tile entrance animation is inert on capture
+    // (instant final state) — keeps the daily UX-audit screenshots deterministic
+    // and immune to mid-animation/blank-tile frames. The SettingsTile entrance
+    // honors reduced motion via useReducedMotion → no `entering` animation.
+    await page.emulateMedia({ reducedMotion: "reduce" });
     await page.addInitScript(() => {
       const w = window as unknown as Record<string, unknown>;
       w.__SKIP_ONBOARDING__ = true;
@@ -95,6 +100,8 @@ test.describe("@scenario settings", () => {
   });
 
   test("captures settings bottom — BMC/About cards above floating tab bar", async ({ page }, testInfo) => {
+    // Reduce motion so the BLD-2036 tile entrance is inert on capture (see "top").
+    await page.emulateMedia({ reducedMotion: "reduce" });
     await page.addInitScript(() => {
       const w = window as unknown as Record<string, unknown>;
       w.__SKIP_ONBOARDING__ = true;


### PR DESCRIPTION
## P2-8 — Motion: Settings tile entrance + reduced-motion (BLD-2036)

Final polish slice of the Settings masonry redesign (epic **BLD-2028**, Phase 3). Settings tiles now ease in with a short, **staggered** fade/slide-up on first paint, and appear **instantly** when "Reduce Motion" is on.

### What changed
- **`SettingsTile`** wraps its `Card` in an `Animated.View` with a declarative `entering` (`FadeInUp`, `duration.fast` = 200ms, `easing.decelerate`), staggered by a new `index` prop: `delay = min(index, 8) * 40ms` (≤320ms total so the last tile never feels slow).
- **Reduced motion** via `@/hooks/useReducedMotion` → `entering = undefined` (instant final state, no animation).
- **`settings.tsx`** — passes `index={0..8}` to the 9 `SettingsTile` sections in source order. (Only change to the screen; logging path untouched.)
- **e2e** `settings` scenario — `page.emulateMedia({ reducedMotion: "reduce" })` before each capture so the daily UX-audit screenshots stay deterministic (no mid-animation / blank-tile frames).
- **jest reanimated mock** — added a chainable `.easing()` to the layout-anim builder (it was missing) so token-tuned animators are testable.
- **`accessibility.acceptance.test.tsx`** — added `FadeInUp: chainable()` to its local reanimated mock (this suite renders the Settings screen, which now imports `FadeInUp`).
- **CHANGELOG** — user-facing bullet, matching the epic's sibling entries.

### Headless-safe (critical constraint)
The entrance uses **declarative `entering` only** — the element is mounted and laid out immediately; tile content is **never** gated behind the animation. This preserves `Masonry`'s first-paint/SSR/Playwright contract (`Masonry.tsx` renders fully without `onLayout`). `testID` stays on the inner `Card` (so the BLD-2037 a11y/responsive tests and the Masonry structure tests are unaffected); the wrapper exposes `${testID}-entrance`.

### Notable bug fixed during implementation
`tileEntering` builds from the **static** `FadeInUp` each call (a fresh builder instance) rather than reusing the shared `enteringFadeUp` singleton. Reanimated's *instance* `.duration()/.delay()` mutate in place — reusing a shared instance would make the **last** tile's delay win for **every** tile (stagger broken) and corrupt the shared helper for other consumers. The jest mock hid this (opaque builders), so it would have shipped silently.

### Testing
- `npx tsc --noEmit` — clean.
- New `__tests__/components/settings/SettingsTile.test.tsx` — 11 tests: headless-safe render (motion on/off), reduced-motion → `entering` undefined, motion-on → defined, and `staggerDelayMs` math (zero/proportional/clamped/safe for negative+non-finite).
- Regression-checked the at-risk suites green: `Masonry.test.tsx`, `settings-responsive-a11y.test.tsx` (BLD-2037), `settings.test.tsx`, `accessibility.acceptance.test.tsx`, plus animation/masonry-adjacent suites (`RpeChipStrip`, `RecentWorkoutsList`, progress masonry).
- Changed files introduce **no new lint errors** (repo has pre-existing eslint baseline in untouched files).

> **Note (pre-existing, not from this PR):** the heavy acceptance suites intermittently emit "worker process failed to exit gracefully" (async-effect/timer leak in `Settings`/`HydrationCard`/`CSVExportCard` effects). Reproduced identically on `main` with this branch stashed. Out of scope here; can file a tech-debt ticket if useful.

### Reviewer
**@ux-designer** — mandatory design review of the entrance feel (duration/stagger/easing) before merge, per the epic.

Closes BLD-2036.