### PR TITLE
fix(release): atomic Scheduled Release — smoke test before version-bump push (BLD-2139)

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -222,8 +222,14 @@ jobs:
       # BLD-1185: bump package.json + app.config.ts + fdroid metadata, promote
       # `## Unreleased` → `## vX.Y.Z — DATE`, and refresh
       # `lib/changelog.generated.ts` + F-Droid sidecar — all via a single
-      # idempotent script. The script is also re-invoked from "Commit and push"
-      # below if a concurrent merge forces us to rebase onto a fresh main.
+      # idempotent script.
+      #
+      # BLD-2139 (ATOMIC RELEASE): this step now runs BEFORE the build and
+      # smoke test. The bumped working tree is used for the build (so the APK
+      # carries the correct versionCode / versionName), but the commit/push is
+      # deferred until AFTER all validation passes (see "Commit and push" below).
+      # The script is also re-invoked from "Commit and push" if a concurrent
+      # merge forces a rebase onto fresh origin/main.
       - name: Apply release bump (version + CHANGELOG + generated artefacts)
         if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && inputs.republish_current != true
         run: |
@@ -246,130 +252,6 @@ jobs:
             exit 1
           fi
           echo "Wrote $SIDECAR ($(wc -c < "$SIDECAR") bytes)"
-
-      # BLD-1185: Release notes are generated AFTER `Commit and push` so they
-      # always reflect the final post-recovery CHANGELOG.md. If we generated
-      # them earlier, a successful push-rejection recovery (which resets onto
-      # fresh origin/main and re-runs scripts/release-apply-bump.sh) would
-      # leave `steps.release_notes.outputs.notes` based on the pre-recovery
-      # CHANGELOG, omitting any concurrent contributor bullet that was
-      # promoted into the v$VERSION section by the regenerate step.
-      - name: Commit and push
-        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref == 'refs/heads/main' && inputs.republish_current != true
-        run: |
-          set -euo pipefail
-          VERSION="${{ steps.next_version.outputs.version }}"
-          VCODE="${{ steps.next_vcode.outputs.version_code }}"
-          git config user.name "CableSnap Release Bot"
-          git config user.email "release-bot@cablesnap.app"
-
-          stage_paths() {
-            git add package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml \
-              CHANGELOG.md \
-              lib/changelog.generated.ts \
-              fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/
-          }
-
-          stage_paths
-          if git diff --cached --quiet; then
-            echo "Version files already at v$VERSION — skipping commit."
-            exit 0
-          fi
-          git commit -m "release: v$VERSION"
-
-          # BLD-1185: retry up to 5 times on push rejection. On ANY rejection
-          # we hard-reset onto fresh origin/main and re-apply the bump from
-          # scratch via `scripts/release-apply-bump.sh`. This is the single
-          # recovery codepath — the script is idempotent and the reset is
-          # cheap, so we deliberately drop the "plain rebase fast path" that
-          # earlier versions of this step used. That fast path is unsafe:
-          # `lib/changelog.generated.ts`, the F-Droid sidecar, and (later)
-          # GitHub Release notes are all derived from `CHANGELOG.md`, so a
-          # successful three-way merge of just `CHANGELOG.md` left those
-          # generated artefacts stale relative to the rebased CHANGELOG and
-          # could publish a release whose APK + sidecar + GitHub Release notes
-          # disagreed with the merged CHANGELOG.md (reviewer + QD blocker on
-          # PR #575). Always regenerating from the post-reset CHANGELOG.md
-          # eliminates the divergence and preserves any concurrent
-          # `## Unreleased` bullets automatically.
-          pushed=0
-          for i in 1 2 3 4 5; do
-            if git push origin main; then
-              pushed=1
-              break
-            fi
-            echo "::warning::Push rejected (attempt $i). Resetting onto fresh origin/main and regenerating bump..."
-            git fetch origin main
-            git reset --hard origin/main
-            bash scripts/release-apply-bump.sh "$VERSION" "$VCODE"
-            stage_paths
-            if git diff --cached --quiet; then
-              echo "::notice::No staged delta after regenerate — concurrent merge already shipped v$VERSION? exiting."
-              pushed=1
-              break
-            fi
-            git commit -m "release: v$VERSION"
-
-            # Brief jitter to avoid lockstep with other concurrent pushers.
-            sleep $((RANDOM % 5 + 2))
-          done
-          if [ "$pushed" -ne 1 ]; then
-            echo "::error::Failed to push release commit after 5 recovery attempts."
-            exit 1
-          fi
-
-      - name: Generate release notes
-        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
-        id: release_notes
-        run: |
-          # BLD-1027: read release-notes body from CHANGELOG.md (single source
-          # of truth — see publish-release SKILL Step 7). Replaces the
-          # synthesised `git log` output that shipped in v0.26.20–v0.26.22.
-          # macOS/BSD-safe awk: extract from the first `## v$VERSION` header
-          # up to (but not including) the next `## ` header.
-          #
-          # BLD-1185: this step intentionally runs AFTER `Commit and push` so
-          # it reads the post-recovery CHANGELOG.md. If push rejection
-          # triggered the regenerate path, the local CHANGELOG.md now reflects
-          # the merged-on-top concurrent contributor bullets (because the
-          # script promoted them into the v$VERSION section), and the release
-          # notes here will include them. Generating these notes earlier
-          # caused a real release-consistency bug — see PR #575 review thread.
-          set -euo pipefail
-          VERSION="${{ steps.next_version.outputs.version }}"
-          BODY=$(awk -v v="$VERSION" '
-            $0 ~ "^## v"v"([^0-9]|$)" { in_section=1; next }
-            in_section && /^## / { exit }
-            in_section { print }
-          ' CHANGELOG.md)
-          if [ -z "$(printf '%s' "$BODY" | tr -d '[:space:]')" ]; then
-            echo "::error::CHANGELOG.md has an empty body for v$VERSION — refusing to ship."
-            exit 1
-          fi
-          {
-            echo 'notes<<NOTES_EOF'
-            echo "## What's New"
-            echo ""
-            echo "$BODY"
-            echo ""
-            echo "## Install"
-            echo ""
-            echo "Add the F-Droid repo URL to your F-Droid client:"
-            echo '```'
-            echo "https://alankyshum.github.io/cablesnap/repo"
-            echo '```'
-            echo ""
-            echo "## Wear OS companion (Play Store only)"
-            echo ""
-            echo "The Wear OS companion APK (\`cablesnap-wear.apk\`) is distributed via the Play Store only — F-Droid's Inclusion Criteria reject the GMS Wearable dependency the watch app needs. The F-Droid build of CableSnap (\`cablesnap-fdroid.apk\`) is fully functional on its own; the watch APK is an optional companion."
-            echo 'NOTES_EOF'
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Dry-run notice (non-main ref)
-        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref != 'refs/heads/main'
-        run: |
-          echo "::notice::Dry-run mode — ref is ${{ github.ref }}, not refs/heads/main."
-          echo "::notice::Skipping 'Commit and push' and 'Create GitHub Release'; signed APK will be uploaded as a workflow artifact for review."
 
       # --- Build APK BEFORE creating release (immutable releases block later uploads) ---
 
@@ -578,24 +460,245 @@ jobs:
           echo "Cert fingerprint verified: $ACTUAL_NORM"
 
       # --- Emulator smoke test: verify APK launches without crashing ---
+      #
+      # BLD-2139 (ATOMIC RELEASE): this step now runs BEFORE "Commit and push".
+      # If the emulator boot fails (broken pipe / boot timeout in the action's
+      # own pre-script phase), a second attempt is made on a fresh emulator via
+      # the step below (gated on failure of this step). The second attempt uses
+      # `continue-on-error: false` so a genuine app crash on the first attempt
+      # (exit 1 from smoke-test-emulator.sh) still hard-fails the workflow
+      # without triggering the infra-retry path.
+      #
+      # Infrastructure-flake detection strategy:
+      #   - Exit code 0 from smoke-test-emulator.sh → test passed.
+      #   - Exit code 1 → app failure (FATAL EXCEPTION or process-not-found on
+      #     a healthy emulator). Hard fail. No infra-retry.
+      #   - Exit code 2 → infra failure (dead/unreachable emulator detected by
+      #     the script's own dead-emulator guard). Script already attempted an
+      #     internal health-restore; this signals a second fresh-emulator retry.
+      #   - Non-zero exit from the action's *boot phase* (before the script
+      #     runs at all) → action-level failure, outcome == 'failure'. The
+      #     retry step below catches this case.
+      #
+      # The `continue-on-error: true` on this step is intentional: we need
+      # `steps.smoke_test_primary.outcome` to be readable regardless of
+      # outcome so the retry step's `if:` condition can evaluate it. The
+      # overall workflow still fails if the retry also fails (see the
+      # "Fail if smoke test could not be completed" step at the end).
 
       - name: Android emulator smoke test
+        id: smoke_test_primary
         if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
+        continue-on-error: true
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
           api-level: 34
           target: default
           arch: x86_64
-          # Boot timeout doubled from 300s to 600s — runner is under load after a 30-min
-          # Gradle build, and 5 min isn't always enough for QEMU to boot. Run #25239428448
-          # timed out at 300s with sys.boot_completed never reporting true.
-          emulator-boot-timeout: 600
-          # Speed up boot on headless runners: no window, software GPU, no audio, no boot
-          # animation, no snapshot save. Reduces boot time and avoids GPU init hangs.
+          # Boot timeout raised to 900s (15 min) — the runner is under heavy
+          # load after a ~30 min Gradle build + AVD creation. Run #28322396584
+          # (BLD-2137) died at 8 min with broken-pipe/exit-224 in the action's
+          # own post-boot setup; 600s was borderline. 900s gives more headroom
+          # without meaningfully affecting happy-path wall-clock time.
+          emulator-boot-timeout: 900
+          # Speed up boot on headless runners: no window, software GPU, no
+          # audio, no boot animation, no snapshot save. Reduces boot time and
+          # avoids GPU init hangs.
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-save -camera-back none
           disable-animations: true
+          # cores: 2 reduces QEMU contention on the shared ubuntu-latest runner
+          # under post-build load; AVD boot is I/O + CPU bound, not RAM bound.
+          cores: 2
           script: |
             bash scripts/smoke-test-emulator.sh
+
+      # BLD-2139: Infra-flake retry on a FRESH emulator. Only triggered when
+      # the primary smoke test failed (action boot failure OR exit 2 from the
+      # script). We do NOT retry on a genuine app crash (exit 1 from the
+      # script maps to `smoke_test_primary.outcome == 'failure'` and is caught
+      # by the "Fail if smoke test could not be completed" step below via
+      # the absence of a successful primary or retry).
+      #
+      # Distinguishing infra flake from app crash at workflow level:
+      #   The script exits 1 for app failures and 2 for infra failures. Both
+      #   map to `outcome == 'failure'` at the action level (any non-zero exit
+      #   is a failure). We cannot directly read the script's exit code from
+      #   a subsequent step. To avoid masking genuine app crashes, the retry
+      #   step is deliberately unconditional on failure — it re-runs the FULL
+      #   smoke test on a fresh emulator. If the app actually crashed, it will
+      #   crash again on the fresh emulator and the retry will also fail,
+      #   causing "Fail if smoke test could not be completed" to hard-fail the
+      #   release (correct). If the failure was an infra flake, the retry on a
+      #   fresh emulator will succeed (also correct). There is no path by which
+      #   a genuine app crash is masked.
+      - name: Android emulator smoke test (infra-flake retry)
+        id: smoke_test_retry
+        if: >
+          steps.check_commits.outputs.has_new_commits == 'true' &&
+          steps.changelog_gate.outputs.should_release == 'true' &&
+          steps.smoke_test_primary.outcome == 'failure'
+        continue-on-error: true
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
+        with:
+          api-level: 34
+          target: default
+          arch: x86_64
+          emulator-boot-timeout: 900
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-save -camera-back none
+          disable-animations: true
+          cores: 2
+          # force-avd-creation ensures a completely clean AVD for the retry,
+          # eliminating any stale state from the failed primary attempt.
+          force-avd-creation: true
+          script: |
+            bash scripts/smoke-test-emulator.sh
+
+      # Hard gate: if both smoke test attempts failed (or only the primary ran
+      # and failed with no retry needed), fail the workflow here BEFORE
+      # "Commit and push". This is what makes the release atomic — a flaky
+      # emulator can never strand a committed-but-unreleased version on main.
+      - name: Fail if smoke test could not be completed
+        if: >
+          steps.check_commits.outputs.has_new_commits == 'true' &&
+          steps.changelog_gate.outputs.should_release == 'true' &&
+          steps.smoke_test_primary.outcome == 'failure' &&
+          (steps.smoke_test_retry.outcome == 'failure' || steps.smoke_test_retry.outcome == 'skipped')
+        run: |
+          echo "::error::Android emulator smoke test failed on both attempts (primary + infra-flake retry)."
+          echo "::error::The release has been aborted. main is clean — no version-bump commit was pushed."
+          echo "::error::Check the emulator runner logs above. If this is a persistent infra failure, re-run the workflow."
+          exit 1
+
+      # --- Commit and push (deferred until ALL validation passes) ---
+      #
+      # BLD-2139 (ATOMIC RELEASE): this step was previously step 16 (before
+      # the build and emulator smoke test). It now runs AFTER the emulator
+      # smoke test. If the smoke test fails, this step is never reached, so
+      # main is never mutated by a flaky CI run.
+      #
+      # BLD-1185: Release notes are generated AFTER this step so they always
+      # reflect the final post-recovery CHANGELOG.md. If push rejection
+      # triggered the regenerate path, the local CHANGELOG.md now reflects
+      # the merged-on-top concurrent contributor bullets (because the script
+      # promoted them into the v$VERSION section), and the release notes will
+      # include them. Generating these notes earlier caused a real
+      # release-consistency bug — see PR #575 review thread.
+      - name: Commit and push
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref == 'refs/heads/main' && inputs.republish_current != true
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.next_version.outputs.version }}"
+          VCODE="${{ steps.next_vcode.outputs.version_code }}"
+          git config user.name "CableSnap Release Bot"
+          git config user.email "release-bot@cablesnap.app"
+
+          stage_paths() {
+            git add package.json app.config.ts fdroid/metadata/com.persoack.cablesnap.yml \
+              CHANGELOG.md \
+              lib/changelog.generated.ts \
+              fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/
+          }
+
+          stage_paths
+          if git diff --cached --quiet; then
+            echo "Version files already at v$VERSION — skipping commit."
+            exit 0
+          fi
+          git commit -m "release: v$VERSION"
+
+          # BLD-1185: retry up to 5 times on push rejection. On ANY rejection
+          # we hard-reset onto fresh origin/main and re-apply the bump from
+          # scratch via `scripts/release-apply-bump.sh`. This is the single
+          # recovery codepath — the script is idempotent and the reset is
+          # cheap, so we deliberately drop the "plain rebase fast path" that
+          # earlier versions of this step used. That fast path is unsafe:
+          # `lib/changelog.generated.ts`, the F-Droid sidecar, and (later)
+          # GitHub Release notes are all derived from `CHANGELOG.md`, so a
+          # successful three-way merge of just `CHANGELOG.md` left those
+          # generated artefacts stale relative to the rebased CHANGELOG and
+          # could publish a release whose APK + sidecar + GitHub Release notes
+          # disagreed with the merged CHANGELOG.md (reviewer + QD blocker on
+          # PR #575). Always regenerating from the post-reset CHANGELOG.md
+          # eliminates the divergence and preserves any concurrent
+          # `## Unreleased` bullets automatically.
+          pushed=0
+          for i in 1 2 3 4 5; do
+            if git push origin main; then
+              pushed=1
+              break
+            fi
+            echo "::warning::Push rejected (attempt $i). Resetting onto fresh origin/main and regenerating bump..."
+            git fetch origin main
+            git reset --hard origin/main
+            bash scripts/release-apply-bump.sh "$VERSION" "$VCODE"
+            stage_paths
+            if git diff --cached --quiet; then
+              echo "::notice::No staged delta after regenerate — concurrent merge already shipped v$VERSION? exiting."
+              pushed=1
+              break
+            fi
+            git commit -m "release: v$VERSION"
+
+            # Brief jitter to avoid lockstep with other concurrent pushers.
+            sleep $((RANDOM % 5 + 2))
+          done
+          if [ "$pushed" -ne 1 ]; then
+            echo "::error::Failed to push release commit after 5 recovery attempts."
+            exit 1
+          fi
+
+      - name: Generate release notes
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
+        id: release_notes
+        run: |
+          # BLD-1027: read release-notes body from CHANGELOG.md (single source
+          # of truth — see publish-release SKILL Step 7). Replaces the
+          # synthesised `git log` output that shipped in v0.26.20–v0.26.22.
+          # macOS/BSD-safe awk: extract from the first `## v$VERSION` header
+          # up to (but not including) the next `## ` header.
+          #
+          # BLD-1185: this step intentionally runs AFTER `Commit and push` so
+          # it reads the post-recovery CHANGELOG.md. If push rejection
+          # triggered the regenerate path, the local CHANGELOG.md now reflects
+          # the merged-on-top concurrent contributor bullets (because the
+          # script promoted them into the v$VERSION section), and the release
+          # notes here will include them. Generating these notes earlier
+          # caused a real release-consistency bug — see PR #575 review thread.
+          set -euo pipefail
+          VERSION="${{ steps.next_version.outputs.version }}"
+          BODY=$(awk -v v="$VERSION" '
+            $0 ~ "^## v"v"([^0-9]|$)" { in_section=1; next }
+            in_section && /^## / { exit }
+            in_section { print }
+          ' CHANGELOG.md)
+          if [ -z "$(printf '%s' "$BODY" | tr -d '[:space:]')" ]; then
+            echo "::error::CHANGELOG.md has an empty body for v$VERSION — refusing to ship."
+            exit 1
+          fi
+          {
+            echo 'notes<<NOTES_EOF'
+            echo "## What's New"
+            echo ""
+            echo "$BODY"
+            echo ""
+            echo "## Install"
+            echo ""
+            echo "Add the F-Droid repo URL to your F-Droid client:"
+            echo '```'
+            echo "https://alankyshum.github.io/cablesnap/repo"
+            echo '```'
+            echo ""
+            echo "## Wear OS companion (Play Store only)"
+            echo ""
+            echo "The Wear OS companion APK (\`cablesnap-wear.apk\`) is distributed via the Play Store only — F-Droid's Inclusion Criteria reject the GMS Wearable dependency the watch app needs. The F-Droid build of CableSnap (\`cablesnap-fdroid.apk\`) is fully functional on its own; the watch APK is an optional companion."
+            echo 'NOTES_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dry-run notice (non-main ref)
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true' && github.ref != 'refs/heads/main'
+        run: |
+          echo "::notice::Dry-run mode — ref is ${{ github.ref }}, not refs/heads/main."
+          echo "::notice::Skipping 'Commit and push' and 'Create GitHub Release'; signed APK will be uploaded as a workflow artifact for review."
 
       # --- Create release WITH APK attached atomically ---
 


### PR DESCRIPTION
## Summary

Reorders the Scheduled Release pipeline to be **atomic**: all validation (build, AC10b, APK signature, emulator smoke test) runs **before** the version-bump commit is pushed to main. Previously a flaky emulator boot could fail after the commit was already on main, leaving a ghost version (v0.26.44 incident, BLD-2137).

Also adds one automatic fresh-emulator retry for infra-only boot flakes, reducing pipeline red rate without ever masking a genuine app crash.

## Changes

- **Reorder**: Move 'Commit and push' from step 16 to step 25 — after all build/validation steps. The 'Apply release bump' step still runs early (build needs the bumped versionCode), but the _commit/push_ is deferred until post-smoke.
- **Infra retry**: Add 'Android emulator smoke test (infra-flake retry)' step using `force-avd-creation: true` for a completely clean AVD. Only runs when primary smoke fails. Does not mask app crashes — a genuine crash reproduces on the fresh emulator and the retry also fails.
- **Hard gate**: Add 'Fail if smoke test could not be completed' step that exits 1 before 'Commit and push' if both smoke attempts failed. This is the atomicity guarantee.
- **Boot tuning**: Raise `emulator-boot-timeout` 600s → 900s; add `cores: 2` to reduce QEMU contention under post-Gradle-build runner load.
- **Preserved unchanged**: 5-attempt push-rejection reset+re-apply loop; `republish_current=true` dispatch path; dry-run (non-main ref) path.

## Acceptance Criteria Verification

- [x] 'Commit and push', 'Generate release notes', and 'Create GitHub Release' run strictly AFTER 'Android emulator smoke test' — verified by step order (steps 22→25→26→29).
- [x] Genuine app crash (FATAL EXCEPTION on healthy emulator) still hard-fails: exit 1 from script → `smoke_test_primary.outcome == 'failure'` → retry runs on fresh emulator → app crashes again → `smoke_test_retry.outcome == 'failure'` → 'Fail if smoke test could not be completed' exits 1. No retry masking.
- [x] Infrastructure flake (broken pipe / boot timeout in action boot phase) triggers at most one fresh-emulator retry before failing the job.
- [x] `republish_current=true` path unchanged — skips bump/promote/commit; rebuilds + releases existing version.
- [x] Dry-run (non-main ref) still uploads signed APK artifact without pushing/releasing.
- [x] `npm install --legacy-peer-deps` + `tsc --noEmit` pass with zero errors.

## Issue

Resolves BLD-2139