### PR TITLE
test(e2e): no-truncation guard for summary stat row (BLD-2140)

### DIFF
--- a/e2e/scenarios/completed-workout.spec.ts
+++ b/e2e/scenarios/completed-workout.spec.ts
@@ -82,6 +82,56 @@ test.describe("@scenario completed-workout", () => {
     });
     await page.waitForTimeout(500);
 
+    const summaryStatValues = [
+      {
+        label: "Duration",
+        locator: page.locator('[aria-label^="Duration:"] [dir="auto"]').first(),
+      },
+      {
+        label: "Sets",
+        locator: page
+          .locator('[aria-label$="sets completed"] [dir="auto"], [aria-label*=" sets:"] [dir="auto"]')
+          .first(),
+      },
+      {
+        label: "Volume",
+        locator: page.locator('[aria-label^="Total volume:"] [dir="auto"]').first(),
+      },
+    ];
+
+    const statMetrics = [];
+    for (const { label, locator } of summaryStatValues) {
+      await expect(locator, `${label} summary stat value should render`).toBeVisible({
+        timeout: 10_000,
+      });
+      statMetrics.push(
+        await locator.evaluate((el, statLabel) => {
+          const textEl = el as HTMLElement;
+          const scrollWidth = textEl.scrollWidth;
+          const clientWidth = textEl.clientWidth;
+
+          return {
+            label: statLabel,
+            text: textEl.textContent?.trim() ?? "",
+            scrollWidth,
+            clientWidth,
+            truncated: scrollWidth > clientWidth + 1,
+          };
+        }, label),
+      );
+    }
+
+    const truncatedStats = statMetrics.filter((stat) => stat.truncated);
+    expect(
+      truncatedStats,
+      `Summary stat values truncated:\n${truncatedStats
+        .map(
+          (stat) =>
+            `  ${stat.label} "${stat.text}" scrollWidth=${stat.scrollWidth} > clientWidth=${stat.clientWidth}`,
+        )
+        .join("\n")}`,
+    ).toHaveLength(0);
+
     // Scroll the inner React Native FlatList (not the document) to the bottom
     // so below-fold content (Estimated pacing card, Sets card, action buttons)
     // is captured. window.scrollTo() does not move RN's scroll container —


### PR DESCRIPTION
Follow-up to BLD-2135 (PR #664, merged). Adds the mandatory Playwright regression guard that was scoped but not delivered with the unit-in-caption fix.

## What
In `e2e/scenarios/completed-workout.spec.ts`, after the summary screen is seeded and ready, assert that the Duration, Sets, and Volume stat **value** text nodes are not visually truncated: each must satisfy `scrollWidth <= clientWidth + 1`. On failure the error lists every truncated stat with its label, text, and measured widths.

## Why
BLD-2135 fixed a truncated Volume stat by moving the unit into the caption, but shipped without a regression guard. This locks that fix in so a future layout/copy change that re-truncates any of the three summary stats fails CI.

## Scope
Pure test addition — **no production code changes**. Pattern mirrors the existing tab-label metric assertion in `e2e/design-quality.spec.ts`.

## Verification
- `npm run typecheck` → clean
- `eslint e2e/scenarios/completed-workout.spec.ts` → no issues
- Targeted `playwright test e2e/scenarios/completed-workout.spec.ts --project=mobile` → PASS (per QD)

Refs: BLD-2140, BLD-2135