### PR TITLE
fix(BLD-1262): rest-complete notification reaches paired watch (OnePlus Watch 3 / Wear OS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Rest-complete now reaches your watch** — the "Rest complete" chime is now mirrored to paired smartwatches (Wear OS, incl. OnePlus Watch 3 via OHealth). Earlier installs created the rest-complete notification channel at low importance, which OEM watch bridges silently skip; it's now a fresh MAX-importance channel sent with MAX priority so the alert bridges to the watch while the phone is in your pocket between sets. (BLD-1262)
 
 ## v0.26.45 — 2026-06-29
 <!-- versionCode: 115 -->

--- a/__tests__/lib/notifications.test.ts
+++ b/__tests__/lib/notifications.test.ts
@@ -19,7 +19,9 @@ jest.mock("expo-notifications", () => {
     dismissNotificationAsync: jest.fn().mockResolvedValue(undefined),
     scheduleNotificationAsync: jest.fn().mockResolvedValue("notif-id"),
     setNotificationChannelAsync: jest.fn().mockResolvedValue(undefined),
-    AndroidImportance: { LOW: 2, HIGH: 4 },
+    deleteNotificationChannelAsync: jest.fn().mockResolvedValue(undefined),
+    AndroidImportance: { LOW: 2, DEFAULT: 3, HIGH: 4, MAX: 5 },
+    AndroidNotificationPriority: { MIN: "min", LOW: "low", DEFAULT: "default", HIGH: "high", MAX: "max" },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setNotificationHandler: jest.fn((h: any) => { handler = h; }),
     addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
@@ -62,7 +64,9 @@ describe("notifications", () => {
         dismissNotificationAsync: jest.fn().mockResolvedValue(undefined),
         scheduleNotificationAsync: jest.fn().mockResolvedValue("notif-id"),
         setNotificationChannelAsync: jest.fn().mockResolvedValue(undefined),
-        AndroidImportance: { LOW: 2, HIGH: 4 },
+        deleteNotificationChannelAsync: jest.fn().mockResolvedValue(undefined),
+        AndroidImportance: { LOW: 2, DEFAULT: 3, HIGH: 4, MAX: 5 },
+        AndroidNotificationPriority: { MIN: "min", LOW: "low", DEFAULT: "default", HIGH: "high", MAX: "max" },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         setNotificationHandler: jest.fn((h: any) => { handler = h; }),
         addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
@@ -621,6 +625,10 @@ describe("notifications", () => {
         await notifications.scheduleRestComplete(60, "sess-ch");
         const call = (Notifications.scheduleNotificationAsync as jest.Mock).mock.calls[0][0];
         expect(call.content.channelId).toBe(notifications.REST_COMPLETE_CHANNEL);
+        // BLD-1262: channel must be the v2 id (immutable channels — v1 stuck LOW)
+        expect(call.content.channelId).toBe("rest-complete-v2");
+        // BLD-1262: MAX priority so the watch bridge mirrors it
+        expect(call.content.priority).toBe("max");
       } finally {
         (Platform as { OS: string }).OS = origOS;
       }
@@ -693,7 +701,7 @@ describe("notifications", () => {
       }
     });
 
-    it("BLD-1208 — registers REST_COMPLETE_CHANNEL (HIGH importance) on Android", async () => {
+    it("BLD-1262 — registers REST_COMPLETE_CHANNEL at MAX importance on Android", async () => {
       const { Platform } = require("react-native");
       const origOS = Platform.OS;
       (Platform as { OS: string }).OS = "android";
@@ -702,9 +710,24 @@ describe("notifications", () => {
         expect(Notifications.setNotificationChannelAsync).toHaveBeenCalledWith(
           notifications.REST_COMPLETE_CHANNEL,
           expect.objectContaining({
-            importance: Notifications.AndroidImportance.HIGH,
+            importance: Notifications.AndroidImportance.MAX,
           }),
         );
+      } finally {
+        (Platform as { OS: string }).OS = origOS;
+      }
+    });
+
+    it("BLD-1262 — deletes the legacy rest-complete channel so old LOW one doesn't linger", async () => {
+      const { Platform } = require("react-native");
+      const origOS = Platform.OS;
+      (Platform as { OS: string }).OS = "android";
+      try {
+        await notifications.ensureRestChannelsRegistered();
+        expect(Notifications.deleteNotificationChannelAsync).toHaveBeenCalledWith(
+          notifications.REST_COMPLETE_CHANNEL_LEGACY,
+        );
+        expect(notifications.REST_COMPLETE_CHANNEL_LEGACY).toBe("rest-complete");
       } finally {
         (Platform as { OS: string }).OS = origOS;
       }

--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -41,9 +41,16 @@ export const REST_CUE_CHANNEL = "rest-cue";
 
 /**
  * Android channel for the rest-complete notification.
- * HIGH importance so Wear OS Companion bridges it to the watch (BLD-1208).
+ * Bumped to v2 (BLD-1262): Android notification channels are IMMUTABLE after
+ * creation, so installs that first created "rest-complete" at LOW importance
+ * (pre-BLD-1208) stay LOW forever — the Wear OS Companion / OnePlus OHealth
+ * bridge skips low-importance channels, so nothing reaches the watch. A new
+ * channel id forces re-creation at MAX importance for those users.
  */
-export const REST_COMPLETE_CHANNEL = "rest-complete";
+export const REST_COMPLETE_CHANNEL = "rest-complete-v2";
+
+/** Legacy rest-complete channel id (pre-BLD-1262). Deleted on cold start. */
+export const REST_COMPLETE_CHANNEL_LEGACY = "rest-complete";
 
 /**
  * Preview of the next set to display on the lock screen.
@@ -125,7 +132,7 @@ function formatBodyWeighted(
 
 /**
  * Register Android notification channels for the Smart Rest Coach (BLD-1137/BLD-1208).
- * Three channels: ongoing (LOW), cue (LOW), complete (HIGH — bridges to Wear OS).
+ * Three channels: ongoing (LOW), cue (LOW), complete (MAX — bridges to Wear OS / OnePlus OHealth).
  * Idempotent — safe to call on every cold start. No-op on iOS.
  */
 export async function ensureRestChannelsRegistered(): Promise<void> {
@@ -149,16 +156,24 @@ export async function ensureRestChannelsRegistered(): Promise<void> {
       vibrationPattern: [],
       showBadge: false,
     });
-    // HIGH importance required so Wear OS Companion bridges this to the watch (BLD-1208).
-    // rest-ongoing stays LOW (unobtrusive ticker — bridging to Wear would be obnoxious).
+    // MAX importance + the immutable v2 channel id (BLD-1262) guarantee the
+    // rest-complete notification bridges to paired watches (Wear OS Companion /
+    // OnePlus OHealth skip LOW/DEFAULT channels). rest-ongoing stays LOW
+    // (unobtrusive ticker — bridging the live countdown would be obnoxious).
+    const maxImportance = AndroidImportance.MAX ?? AndroidImportance.HIGH ?? 5;
     await mod.setNotificationChannelAsync(REST_COMPLETE_CHANNEL, {
       name: "Rest complete",
-      importance: AndroidImportance.HIGH ?? 4,
+      importance: maxImportance,
       sound: "default",
       vibrationPattern: [0, 250, 250, 250],
       showBadge: false,
       enableVibrate: true,
     });
+    // Remove the stale low-importance channel so users don't see a duplicate
+    // (and silent) "Rest complete" entry in system settings. Best-effort.
+    if (typeof mod.deleteNotificationChannelAsync === "function") {
+      try { await mod.deleteNotificationChannelAsync(REST_COMPLETE_CHANNEL_LEGACY); } catch { /* never created */ }
+    }
   } catch {
     // Non-critical — channel registration is best-effort
   }
@@ -488,7 +503,11 @@ export async function scheduleRestComplete(
         body,
         sound: "default",
         data: { sessionId, type: "rest_complete" },
-        ...(Platform.OS === "android" ? { channelId: REST_COMPLETE_CHANNEL } : {}),
+        // MAX priority + HIGH channel so the watch bridge (Wear OS Companion /
+        // OnePlus OHealth) mirrors this to the paired watch (BLD-1262).
+        ...(Platform.OS === "android"
+          ? { channelId: REST_COMPLETE_CHANNEL, priority: mod.AndroidNotificationPriority?.MAX ?? "max" }
+          : {}),
       },
       trigger: {
         type: mod.SchedulableTriggerInputTypes.TIME_INTERVAL,


### PR DESCRIPTION
## Problem
Rest-complete shows only on the phone, never on the OnePlus Watch 3 (Wear OS). Despite BLD-1208 setting the rest-complete channel to HIGH, **Android notification channels are immutable** — installs that first created `rest-complete` at LOW importance stay LOW forever, and OEM watch bridges (Wear OS Companion / OnePlus OHealth) silently skip low-importance channels.

## Fix
- New `rest-complete-v2` channel at **MAX** importance (forces re-creation, escaping stuck-LOW); old channel deleted to avoid a duplicate silent entry.
- `scheduleRestComplete` sends `priority: MAX` so OEM bridges mirror it to the watch.
- Live countdown stays LOW (bridging the per-second ticker would spam the watch).

## Verification
- ESLint clean, tsc clean
- notifications suite 54/54; full suite 4605 pass (13 fails pre-existing infra/env only)
- Android Metro production bundle built; `rest-complete-v2` + `AndroidNotificationPriority` present in artifact
- ⚠️ On-watch bridging needs a physical phone+watch device build (Expo Go won't bridge)

BLD-1262