### PR TITLE
fix: Volume caption adjustsFontSizeToFit to prevent truncation (BLD-2199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ marker) at release time.
 ## Unreleased
 
 - **Rest-complete now reaches your watch** — the "Rest complete" chime is now mirrored to paired smartwatches (Wear OS, incl. OnePlus Watch 3 via OHealth). Earlier installs created the rest-complete notification channel at low importance, which OEM watch bridges silently skip; it's now a fresh MAX-importance channel sent with MAX priority so the alert bridges to the watch while the phone is in your pocket between sets. (BLD-1262)
+- **Fix: Volume label in post-workout summary now shows fully without truncation** — the caption `Volume (kg)` was being cut off to `Volume ...` on narrow mobile screens. The label now auto-shrinks to fit the tile width, matching the behaviour of the value text above it. (BLD-2197)
 
 ## v0.26.45 — 2026-06-29
 <!-- versionCode: 115 -->

--- a/__tests__/acceptance/summary-stat-tile-single-line.acceptance.test.tsx
+++ b/__tests__/acceptance/summary-stat-tile-single-line.acceptance.test.tsx
@@ -170,8 +170,10 @@ describe('Summary stat tile captions — single-line constraint (BLD-1993)', () 
     // Caption is now "Volume (kg)" or "Volume (lb)" — NOT bare "Volume".
     const volumeCaption = await screen.findByText(/^Volume \((kg|lb)\)$/i)
     expect(volumeCaption.props.numberOfLines).toBe(1)
-    // Caption remains a static label — no need for adjustsFontSizeToFit
-    expect(volumeCaption.props.adjustsFontSizeToFit).toBeFalsy()
+    // BLD-2197: "Volume (kg)" still truncated to "Volume ..." in the narrow 3-tile
+    // row, so the caption now shrinks to fit (mirrors the value Text). Must keep
+    // adjustsFontSizeToFit so it never ellipsizes.
+    expect(volumeCaption.props.adjustsFontSizeToFit).toBe(true)
   })
 
   it('Volume VALUE text is a bare number (no unit suffix) with adjustsFontSizeToFit (BLD-2135)', async () => {
@@ -283,6 +285,8 @@ describe('Summary stat tile captions — single-line constraint (BLD-1993)', () 
     // Verify the caption carries the unit instead (BLD-2135)
     const volumeCaption = await screen.findByText(/^Volume \((kg|lb)\)$/i)
     expect(volumeCaption.props.numberOfLines).toBe(1)
-    expect(volumeCaption.props.adjustsFontSizeToFit).toBeFalsy()
+    // BLD-2197: caption "Volume (kg)" shrinks to fit (was truncating to "Volume ..."),
+    // matching the value Text treatment.
+    expect(volumeCaption.props.adjustsFontSizeToFit).toBe(true)
   })
 })

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -285,7 +285,7 @@ function SummaryHeader({ colors, session, duration, durationSpokenText, complete
         <Card style={StyleSheet.flatten([styles.stat, { backgroundColor: colors.surface }])} accessibilityLabel={`Total volume: ${volumeDisplay.toLocaleString()} ${unit}`}>
           <CardContent style={styles.statInner}>
             <Text variant="heading" style={{ color: colors.primary }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>{volumeDisplay.toLocaleString()}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1}>Volume ({unit})</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>Volume ({unit})</Text>
           </CardContent>
         </Card>
       </View>


### PR DESCRIPTION
## Summary

The Volume caption in the completed-workout summary stat tile was displaying as `Volume ...` on narrow 390px viewports because `Volume (kg)` (11 chars) doesn't fit at caption font size in the 3-tile row.

## Changes

- : add `adjustsFontSizeToFit minimumFontScale={0.7}` to the Volume caption `<Text>`, mirroring the same props already on the heading Text (line 287) and on Duration/Sets headings (lines 275, 281).

## Testing

- TypeScript: `tsc --noEmit` — no errors
- Change is minimal and targeted: one prop addition to one `<Text>` element
- Mirrors existing pattern used on heading texts in the same component

## Issue

Resolves BLD-2199 (child of BLD-2197)