### PR TITLE
fix(cvd): pacing bar Other hatch fills full segment, not 18px (BLD-2205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: Pacing bar CVD hatch now covers the full "Other" segment** — the diagonal hatch overlay that makes the grey "Other" segment distinguishable under red-green colour blindness previously only covered the leftmost 18 px of the segment. The hatch now fills the full flex-width segment, so the CVD pattern is visible at any bar width. The legend dot appearance is unchanged. (BLD-2205)
 
 ## v0.26.45 — 2026-06-29
 <!-- versionCode: 115 -->

--- a/__tests__/components/session/summary/PacingCard.cvd.test.tsx
+++ b/__tests__/components/session/summary/PacingCard.cvd.test.tsx
@@ -195,4 +195,47 @@ describe("PacingCard — CVD hatch fix (BLD-1939)", () => {
     const { toJSON } = render(<HatchOverlay width={18} height={0} />);
     expect(toJSON()).toBeNull();
   });
+
+  // ── 13. Bar Other hatch must be full-fill, NOT a fixed px size (BLD-2205) ──
+  //
+  // This test locks the regression: the bar segment is flex-sized (often 100-300px
+  // wide) but the original fix (BLD-1939) rendered the SVG at 18×18px, covering
+  // only the leftmost 18px of the Other segment. Full-fill requires width="100%"
+  // and height="100%" on both the Svg canvas and the Rect fill element.
+  it("bar Other hatch SVG canvas is full-fill (width/height = '100%', not a fixed px number)", () => {
+    const { getByTestId } = render(<PacingCard pacing={makePacing()} />);
+    const hatch = getByTestId("pacing-seg-other-pattern", { includeHiddenElements: true });
+    // The Svg element receives the width/height props directly.
+    expect(hatch.props.width).toBe("100%");
+    expect(hatch.props.height).toBe("100%");
+  });
+
+  it("bar Other hatch Rect fill is full-fill (width/height = '100%', not a fixed px number)", () => {
+    const { getByTestId, UNSAFE_getAllByType } = render(<PacingCard pacing={makePacing()} />);
+    // Verify hatch is present first
+    getByTestId("pacing-seg-other-pattern", { includeHiddenElements: true });
+    // Find all Rect elements (from react-native-svg) and locate the fill rect
+    // inside the bar hatch SVG. The Rect that covers the hatch area uses the
+    // fill url pattern and should have "100%" dimensions.
+    const Rect = require("react-native-svg").Rect;
+    const rects = UNSAFE_getAllByType(Rect);
+    // The bar's fill Rect (pacing-seg-other-pattern's inner rect) uses "100%"
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fillRect = rects.find((r: any) =>
+      r.props.width === "100%" &&
+      typeof r.props.fill === "string" &&
+      r.props.fill.startsWith("url(")
+    );
+    expect(fillRect).toBeTruthy();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((fillRect as any).props.height).toBe("100%");
+  });
+
+  it("legend dot hatch SVG canvas keeps explicit 8×8 dimensions (not full-fill)", () => {
+    const { getByTestId } = render(<PacingCard pacing={makePacing()} />);
+    const dotHatch = getByTestId("pacing-dot-other-pattern", { includeHiddenElements: true });
+    // Legend dot is fixed 8×8 — must NOT use "100%" (that would scale with the dot container)
+    expect(dotHatch.props.width).toBe(8);
+    expect(dotHatch.props.height).toBe(8);
+  });
 });

--- a/components/session/summary/PacingCard.tsx
+++ b/components/session/summary/PacingCard.tsx
@@ -60,24 +60,45 @@ const HATCH_SIZE = 6;          // tile size in px
 const HATCH_STROKE_WIDTH = 1.5;
 const HATCH_STROKE_COLOR = "rgba(255,255,255,0.55)"; // semi-white for theme-agnostic contrast
 
-type HatchOverlayProps = {
-  /** Width and height of the area to cover. Pass explicit values for the bar
-   *  segment (determined by flex at runtime) or the legend dot (8×8). */
-  width: number;
-  height: number;
-  testID?: string;
-};
+type HatchOverlayProps =
+  | {
+      /** Fill mode: SVG and Rect use "100%" to cover the full flex-sized parent.
+       *  Use for the bar Other segment where width is determined by flex at runtime. */
+      fill: true;
+      width?: never;
+      height?: never;
+      testID?: string;
+    }
+  | {
+      /** Explicit-size mode: pass exact pixel dimensions for fixed-size elements
+       *  such as the legend dot (8×8). */
+      fill?: false;
+      width: number;
+      height: number;
+      testID?: string;
+    };
 
 /**
  * HatchOverlay — decorative diagonal stripe fill.
  * Caller is responsible for positioning (absoluteFill or explicit dimensions).
+ *
+ * Two modes:
+ *   fill=true  — SVG canvas is "100%×100%" so it fills any flex-sized parent
+ *                without needing runtime width measurement. Use for the bar
+ *                Other segment (BLD-2205 fix: prevents 18px-only coverage).
+ *   fill=false — Pass explicit width/height for fixed-size elements (legend dot).
  */
-export function HatchOverlay({ width, height, testID }: HatchOverlayProps) {
-  if (width <= 0 || height <= 0) return null;
+export function HatchOverlay({ fill, width, height, testID }: HatchOverlayProps) {
+  // In explicit-size mode, guard against non-positive dimensions.
+  if (!fill && (width <= 0 || height <= 0)) return null;
+
+  const svgWidth = fill ? "100%" : width;
+  const svgHeight = fill ? "100%" : height;
+
   return (
     <Svg
-      width={width}
-      height={height}
+      width={svgWidth}
+      height={svgHeight}
       style={StyleSheet.absoluteFillObject}
       // Decorative overlay — must NOT be announced by screen readers.
       // RN-only a11y props are gated to native: react-native-svg's WebShape
@@ -114,8 +135,8 @@ export function HatchOverlay({ width, height, testID }: HatchOverlayProps) {
       <Rect
         x="0"
         y="0"
-        width={width}
-        height={height}
+        width={svgWidth}
+        height={svgHeight}
         fill={`url(#${HATCH_PATTERN_ID})`}
       />
     </Svg>
@@ -227,8 +248,7 @@ export default function PacingCard({ pacing, exerciseNames = {} }: Props) {
                 >
                   {otherFrac > 0 && (
                     <HatchOverlay
-                      width={BAR_HEIGHT}
-                      height={BAR_HEIGHT}
+                      fill
                       testID="pacing-seg-other-pattern"
                     />
                   )}


### PR DESCRIPTION
## Summary

The pacing bar's "Other" segment hatch overlay (added in BLD-1939 for CVD accessibility) only covered the first 18px of the segment. The flex-sized bar segment can be 100–300px wide, so under deuteranopia the rest of the segment was solid grey — indistinguishable from "Working". This is a CVD regression recurrence (BLD-2201).

## Root Cause

`HatchOverlay` was called with `width={BAR_HEIGHT}` / `height={BAR_HEIGHT}` (18×18px). The `<Svg>` canvas + `<Rect>` only tiled a fixed 18×18 square at the segment's left edge; flex-sized width was never covered.

## Changes

- **`HatchOverlay` gets a `fill` prop** (discriminated union): when `fill=true`, the `<Svg>` and `<Rect>` both use `"100%"` dimensions — filling the full absoluteFill parent. `patternUnits="userSpaceOnUse"` is preserved so the tile size stays constant (6px stripes) regardless of canvas size.
- **Bar Other segment** now uses `<HatchOverlay fill />` — fills full flex-width.
- **Legend dot** is unchanged — still passes explicit `width={8} height={8}`.
- **3 new regression-locking tests** added to `PacingCard.cvd.test.tsx`:
  - bar SVG canvas is `"100%"` width/height (not a fixed number)
  - bar Rect fill is `"100%"` width/height
  - legend dot stays 8×8 (regression guard in both directions)

## Testing

- All 20 CVD tests pass (`PacingCard.cvd.test.tsx`)
- TypeScript: zero errors
- Full suite: 4618/4620 pass — 2 pre-existing failures in `summary-stat-tile-single-line` (unrelated, present on main)

## Issue

Resolves BLD-2205