### PR TITLE
feat(infra): reap stale worktrees + count guard to prevent ARG_MAX crash (BLD-2251)

### DIFF
--- a/scripts/__tests__/agent-worktree-reap.test.ts
+++ b/scripts/__tests__/agent-worktree-reap.test.ts
@@ -1,0 +1,119 @@
+/**
+ * BLD-2251 — agent-worktree.sh reap / count / guard-count regression tests
+ *
+ * dispatch heartbeat path-scan crashed with ARG_MAX because 40+ worktrees +
+ * hundreds of /tmp dirs blew past the argv limit. These subcommands census,
+ * reap stale worktrees, and provide a regression guard so the count never
+ * climbs back into the danger zone.
+ *
+ * Pattern mirrors agent-worktree-guard.test.ts: build a throwaway git repo,
+ * add real worktrees, and drive the script via spawnSync with a controlled
+ * REPO_DIR (AGENT_WORKTREE_ROOT) + cwd.
+ *
+ * Acceptance criteria:
+ *   count          → prints number of non-primary worktrees
+ *   guard-count    → exits 1 at/over limit, 0 under
+ *   reap --dry-run → lists stale, removes none
+ *   reap           → removes stale+clean, keeps fresh, keeps package-lock-only,
+ *                    keeps dirty-real-change, keeps unmerged work
+ */
+
+import { spawnSync, execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+
+const SCRIPT = resolve(__dirname, '..', 'agent-worktree.sh');
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function run(repo: string, args: string[], env: Record<string, string> = {}) {
+  const r = spawnSync('bash', [SCRIPT, ...args], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      AGENT_WORKTREE_REPO_DIR: repo,
+      AGENT_WORKTREE_ROOT: env.ROOT ?? '/tmp',
+      ...env,
+    },
+    encoding: 'utf8',
+  });
+  return { code: r.status ?? 1, out: (r.stderr ?? '') + (r.stdout ?? '') };
+}
+
+describe('BLD-2251: agent-worktree.sh reap/count/guard-count', () => {
+  let repo: string;
+  let wtRoot: string;
+
+  beforeAll(() => {
+    repo = mkdtempSync(join(tmpdir(), 'bld2251-repo-'));
+    wtRoot = mkdtempSync(join(tmpdir(), 'bld2251-wt-'));
+    git(repo, 'init', '-q');
+    git(repo, 'config', 'user.email', 't@t.t');
+    git(repo, 'config', 'user.name', 't');
+    git(repo, 'checkout', '-q', '-b', 'main');
+    writeFileSync(join(repo, 'a.txt'), 'x');
+    git(repo, 'add', '.');
+    git(repo, 'commit', '-qm', 'init');
+    // emulate an 'origin/main' remote tracking ref so reap's merge-safety
+    // check (git cherry origin/main HEAD) resolves.
+    git(repo, 'update-ref', 'refs/remotes/origin/main', 'main');
+    // create worktrees: clean (stale), fresh, dirty (real change), unmerged
+    git(repo, 'worktree', 'add', '-q', join(wtRoot, 'wt-clean'), '-b', 'clean', 'main');
+    git(repo, 'worktree', 'add', '-q', join(wtRoot, 'wt-fresh'), '-b', 'fresh', 'main');
+    git(repo, 'worktree', 'add', '-q', join(wtRoot, 'wt-dirty'), '-b', 'dirty', 'main');
+    git(repo, 'worktree', 'add', '-q', join(wtRoot, 'wt-unmerged'), '-b', 'unmerged', 'main');
+    writeFileSync(join(wtRoot, 'wt-dirty', 'real.txt'), 'change');
+    // unmerged: stale + clean but has a commit not in origin/main → must be kept
+    writeFileSync(join(wtRoot, 'wt-unmerged', 'b.txt'), 'extra');
+    git(join(wtRoot, 'wt-unmerged'), 'add', '.');
+    git(join(wtRoot, 'wt-unmerged'), 'commit', '-qm', 'unmerged work');
+    // age wt-clean and wt-unmerged past threshold
+    spawnSync('touch', ['-d', '3 days ago', join(wtRoot, 'wt-clean')]);
+    spawnSync('touch', ['-d', '3 days ago', join(wtRoot, 'wt-unmerged')]);
+  });
+
+  afterAll(() => {
+    try { rmSync(repo, { recursive: true, force: true }); } catch { /* ignore */ }
+    try { rmSync(wtRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('count prints number of non-primary worktrees', () => {
+    const { out } = run(repo, ['count']);
+    expect(parseInt(out.trim(), 10)).toBe(4);
+  });
+
+  it('guard-count exits 1 when over limit', () => {
+    expect(run(repo, ['guard-count', '--limit', '3']).code).toBe(1);
+  });
+
+  it('guard-count exits 0 when under limit', () => {
+    expect(run(repo, ['guard-count', '--limit', '99']).code).toBe(0);
+  });
+
+  it('reap --dry-run removes nothing', () => {
+    run(repo, ['reap', '--dry-run', '--max-age-hours', '48']);
+    expect(existsSync(join(wtRoot, 'wt-clean'))).toBe(true);
+  });
+
+  it('reap removes stale+clean, keeps fresh/dirty/unmerged', () => {
+    run(repo, ['reap', '--max-age-hours', '48']);
+    expect(existsSync(join(wtRoot, 'wt-clean'))).toBe(false);    // stale+clean → reaped
+    expect(existsSync(join(wtRoot, 'wt-fresh'))).toBe(true);     // fresh → kept
+    expect(existsSync(join(wtRoot, 'wt-dirty'))).toBe(true);     // real changes → kept
+    expect(existsSync(join(wtRoot, 'wt-unmerged'))).toBe(true);  // unmerged work → kept
+  });
+
+  it('bash -n syntax check passes', () => {
+    expect(spawnSync('bash', ['-n', SCRIPT]).status).toBe(0);
+  });
+
+  it('usage lists reap/count/guard-count', () => {
+    const help = run(repo, ['help']).out;
+    expect(help).toMatch(/reap/);
+    expect(help).toMatch(/count/);
+    expect(help).toMatch(/guard-count/);
+  });
+});

--- a/scripts/agent-worktree.sh
+++ b/scripts/agent-worktree.sh
@@ -70,7 +70,7 @@ set -euo pipefail
 
 # Resolve the cablesnap repo from the script location (repo/scripts/foo.sh)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="${AGENT_WORKTREE_REPO_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 
 WORKTREE_ROOT="${AGENT_WORKTREE_ROOT:-/tmp}"
 
@@ -366,6 +366,115 @@ cmd_guard() {
     return 0
 }
 
+# ── Worktree census & reaping (BLD-2251) ─────────────────────────────────────
+#
+# Why this exists
+# ---------------
+# Worktrees accrete in /tmp because review/PR worktrees are rarely cleaned up
+# after their PR merges. With 40+ worktrees + hundreds of /tmp dirs, the
+# dispatch heartbeat path-scan blew past ARG_MAX ("argument list too long").
+# `reap` removes stale worktrees and `guard-count` is a regression guard that
+# fails before the count gets dangerous again.
+#
+# DURABLE RULE: never glob all worktree paths into one argv. Enumerate with
+# `git worktree list --porcelain` (bounded, no shell glob) or, for filesystem
+# scans, `find … -print0 | xargs -0` so each path is NUL-delimited and chunked.
+
+PRIMARY_PATH() {
+    git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null \
+        | awk 'NR==1 && $1=="worktree" { print $2; exit }'
+}
+
+# Emit non-primary worktree paths, one per line. Uses porcelain output (no glob).
+list_nonprimary_worktrees() {
+    local primary; primary="$(PRIMARY_PATH)"
+    git -C "$REPO_DIR" worktree list --porcelain 2>/dev/null \
+        | awk -v primary="$primary" '$1=="worktree" && $2!=primary { print $2 }'
+}
+
+# cmd_count — print number of non-primary worktrees
+cmd_count() {
+    list_nonprimary_worktrees | wc -l | tr -d ' '
+}
+
+# cmd_guard_count [--limit N] — regression guard. Exit 1 if count >= limit.
+cmd_guard_count() {
+    local limit=100
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --limit) limit="$2"; shift 2 ;;
+            *) err "Unknown guard-count flag: $1"; return 2 ;;
+        esac
+    done
+    local n; n="$(cmd_count)"
+    if [ "$n" -ge "$limit" ]; then
+        err "worktree count $n >= limit $limit — run 'agent-worktree.sh reap' to stop ARG_MAX risk (BLD-2251)"
+        return 1
+    fi
+    info "guard-count OK — $n worktrees (limit $limit)"
+    return 0
+}
+
+# A worktree is reapable if it is stale (mtime older than max-age) and safe:
+# clean, or only package-lock.json modified (a transient npm-install artefact).
+# Worktrees with real uncommitted changes or a live lockfile are kept + logged.
+reapable() {
+    local d="$1" max_age_h="$2"
+    [ -d "$d" ] || return 1
+    local ts age dirty live_lock
+    ts="$(stat -c %Y "$d" 2>/dev/null || echo 0)"
+    age=$(( ( $(date +%s) - ts ) / 3600 ))
+    [ "$age" -ge "$max_age_h" ] || return 1
+    # Live lock = an agent is using it
+    local lock; lock="$d.lock"
+    if [ -f "$lock" ]; then
+        local pid; pid="$(cat "$lock" 2>/dev/null || echo)"
+        [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && return 1
+    fi
+    dirty="$(git -C "$d" status --porcelain 2>/dev/null | grep -v 'package-lock.json' || true)"
+    [ -z "$dirty" ] || return 1
+    # Final safety: keep worktrees whose HEAD has commits not in origin/main
+    # (unmerged/unpushed work). Reaping these would lose work — refuse unless
+    # caller passes --include-unmerged. cherry shows '+' for unmerged commits.
+    if [ "${REAP_INCLUDE_UNMERGED:-0}" != "1" ]; then
+        local unmerged
+        unmerged="$(git -C "$d" cherry origin/main HEAD 2>/dev/null | grep -c '^+')"
+        [ "${unmerged:-0}" -eq 0 ] || return 1
+    fi
+    return 0
+}
+
+# cmd_reap [--dry-run] [--max-age-hours N]
+cmd_reap() {
+    local dry=0 max_age=48
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --dry-run) dry=1; shift ;;
+            --max-age-hours) max_age="$2"; shift 2 ;;
+            --include-unmerged) export REAP_INCLUDE_UNMERGED=1; shift ;;
+            *) err "Unknown reap flag: $1"; return 2 ;;
+        esac
+    done
+    local reaped=0 kept=0
+    while IFS= read -r d; do
+        [ -n "$d" ] || continue
+        if reapable "$d" "$max_age"; then
+            if [ "$dry" -eq 1 ]; then
+                info "would reap: $d"
+            else
+                git -C "$REPO_DIR" worktree remove --force "$d" >&2 2>/dev/null || rm -rf "$d"
+                rm -f "$d.lock"
+                log "reaped: $d"
+            fi
+            reaped=$((reaped+1))
+        else
+            kept=$((kept+1))
+        fi
+    done < <(list_nonprimary_worktrees)
+    [ "$dry" -eq 1 ] || git -C "$REPO_DIR" worktree prune >&2 2>/dev/null || true
+    info "reap: $reaped reapable, $kept kept (max-age ${max_age}h, dry-run=$dry)"
+}
+
 usage() {
     cat <<'EOF' >&2
 agent-worktree.sh — per-agent git worktree helper for CableSnap
@@ -375,6 +484,9 @@ USAGE:
   scripts/agent-worktree.sh stop  <branch> [--force]
   scripts/agent-worktree.sh status [<branch>]
   scripts/agent-worktree.sh list
+  scripts/agent-worktree.sh count
+  scripts/agent-worktree.sh guard-count [--limit N]
+  scripts/agent-worktree.sh reap [--dry-run] [--max-age-hours N]
   scripts/agent-worktree.sh guard [<dir>]
 
 MANDATORY RULE (unconditional — BLD-2040):
@@ -411,6 +523,9 @@ main() {
         stop)   cmd_stop "$@" ;;
         status) cmd_status "$@" ;;
         list)   cmd_list ;;
+        count)  cmd_count ;;
+        guard-count) cmd_guard_count "$@" ;;
+        reap)   cmd_reap "$@" ;;
         guard)  cmd_guard "$@" ;;
         ""|-h|--help|help) usage ;;
         *) err "Unknown subcommand: $sub"; usage; exit 2 ;;


### PR DESCRIPTION
## BLD-2251 — dispatch-scan ARG_MAX crash

dispatch heartbeat path-scan crashed with `ARG_MAX` ("argument list too long"):
44 live worktrees + 175 `/tmp` dirs overflowed argv. Two-phase fix.

### Phase 1 (operational, done)
Reaped 18 stale worktrees (44 → 26). Each verified merged-PR / 0-unmerged before delete; `bld-1735` (43 unmerged commits) preserved.

### Phase 2 (durable, this PR) — `scripts/agent-worktree.sh`
- **`reap [--dry-run] [--max-age-hours N=48] [--include-unmerged]`** — removes stale worktrees that are clean (or only `package-lock.json` dirty), have no live lock, and **no commits ahead of `origin/main`** (refuses to discard unmerged work unless `--include-unmerged`). Primary checkout never touched.
- **`count`** / **`guard-count [--limit N=100]`** — regression guard, exits 1 at 100+ worktrees.
- **Chunked-scan doctrine**: census via `git worktree list --porcelain`; filesystem scans must use `find … -print0 | xargs -0`. Never glob paths into one argv.

### Tests
`scripts/__tests__/agent-worktree-reap.test.ts` — reap/keep/dirty/unmerged/threshold. 21/21 pass (incl. guard). No user-facing change → no changelog entry; parity check green.

Closes BLD-2251.
