### PR TITLE
chore(deps): ignore react-test-renderer minor/patch in dependabot (BLD-75 lockstep)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,9 @@ updates:
       # Ignore major updates as most major updates will need manual intervention
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
+      # react-test-renderer must stay version-locked to the Expo-SDK-pinned react
+      # version (see .learnings BLD-75). Dependabot must not bump it independently —
+      # it only moves during a manual Expo SDK upgrade. Closed PR #674 was a failing
+      # patch bump that slipped past the major-only ignore.
+      - dependency-name: "react-test-renderer"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]


### PR DESCRIPTION
## Summary

Add a Dependabot ignore rule for `react-test-renderer` minor and patch updates. This prevents recurring broken bump PRs (like the now-closed #674) caused by the BLD-75 invariant: `react-test-renderer` must stay version-locked to the Expo-SDK-pinned `react` version and can only be bumped manually during an Expo SDK upgrade.

## Changes

- `.github/dependabot.yml`: Add ignore entry for `react-test-renderer` covering `semver-minor` and `semver-patch` update types alongside the existing `*` major-ignore rule

## Testing

- YAML validated via js-yaml parse (js-yaml in node_modules): valid, 2 ignore entries confirmed
- Existing `*` major-ignore rule is untouched
- No other dependabot rules are altered or removed

## Issue

Resolves BLD-2275