### PR TITLE
ci: engage KVM accel + job timeout backstop for scheduled-release (BLD-2290)

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -23,6 +23,10 @@ jobs:
   release:
     name: Check, build & release
     runs-on: ubuntu-latest
+    # BLD-2290: hard cap so a wedged QEMU can never burn ~90 min again.
+    # Happy-path is ~30–35 min (build + two emulator attempts); 60 min leaves
+    # headroom while still bounding any hang.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -459,6 +463,31 @@ jobs:
           fi
           echo "Cert fingerprint verified: $ACTUAL_NORM"
 
+      # --- KVM permission enable (BLD-2290) ---
+      #
+      # On some GitHub-hosted runners /dev/kvm exists but the runner user lacks
+      # rw permission, so android-emulator-runner falls back to software TCG
+      # emulation (-accel off), which deadlocks ("detected a hanging thread
+      # 'QEMU2 CPU1 thread'") and never boots (BLD-2289, recurrence of BLD-2137).
+      # Apply the reactivecircus/android-emulator-runner README's mandated udev
+      # rule so /dev/kvm becomes world-rw and real KVM acceleration engages.
+      # Best-effort: || true so the step never hard-fails on the perms tweak.
+      # Gate mirrors the primary smoke test's if: condition so this step runs
+      # iff the emulator would run.
+      - name: Enable KVM acceleration for emulator
+        id: kvm
+        if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
+        run: |
+          if [ -e /dev/kvm ]; then
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+              | sudo tee /etc/udev/rules.d/99-kvm4all.rules >/dev/null || true
+            sudo udevadm control --reload-rules || true
+            sudo udevadm trigger --name-match=kvm || true
+            ls -l /dev/kvm || true
+          else
+            echo "::warning::/dev/kvm absent on this runner — KVM acceleration unavailable. The emulator step will fail loudly if acceleration cannot engage (disable-linux-hw-accel: false)."
+          fi
+
       # --- Emulator smoke test: verify APK launches without crashing ---
       #
       # BLD-2139 (ATOMIC RELEASE): this step now runs BEFORE "Commit and push".
@@ -506,6 +535,14 @@ jobs:
           # avoids GPU init hangs.
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-save -camera-back none
           disable-animations: true
+          # BLD-2290: force real KVM/HW acceleration. The action's default is
+          # `auto`, which can misdetect and silently disable acceleration →
+          # software CPU emulation (the BLD-2289 failure: QEMU2 CPU1 hang,
+          # ~90 min burn). With the 99-kvm4all.rules perms applied in the KVM
+          # step above, `false` makes the emulator hard-require acceleration;
+          # if it genuinely can't accelerate the step fails loudly/fast instead
+          # of crawling in software mode. Mirrors e2e-android-emulator.yml.
+          disable-linux-hw-accel: false
           # cores: 2 reduces QEMU contention on the shared ubuntu-latest runner
           # under post-build load; AVD boot is I/O + CPU bound, not RAM bound.
           cores: 2
@@ -546,6 +583,9 @@ jobs:
           emulator-boot-timeout: 900
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot-save -camera-back none
           disable-animations: true
+          # BLD-2290: force real KVM/HW acceleration on retry as well.
+          # Same rationale as primary smoke test step above.
+          disable-linux-hw-accel: false
           cores: 2
           # force-avd-creation ensures a completely clean AVD for the retry,
           # eliminating any stale state from the failed primary attempt.


### PR DESCRIPTION
## Summary

Fixes the root cause of the BLD-2289 emulator hang (recurrence of BLD-2137): on some GitHub-hosted runners `/dev/kvm` exists but the runner user lacks rw permission, so `android-emulator-runner` silently falls back to software TCG emulation (`-accel off`), which deadlocks on QEMU2's CPU1 thread and never boots. There is also no job-level timeout, so the hang burns the full ~90 min runner budget.

The proven fix already exists in `.github/workflows/e2e-android-emulator.yml` and is ported here.

## Changes

- **`timeout-minutes: 60`** added to the `release` job — hard cap; normal happy-path ~30–35 min, this kills any QEMU hang before burning ~90 min
- **New step: `Enable KVM acceleration for emulator`** (`id: kvm`) — placed after `Set up Android SDK` / `Verify APK signature`, before the primary smoke test. Writes `/etc/udev/rules.d/99-kvm4all.rules` (`MODE="0666"`), reloads udev, triggers the kvm device node. Best-effort (`|| true`); if `/dev/kvm` is absent emits a `::warning::` and does not fail. Gated on `has_new_commits && should_release` (same condition as the smoke test)
- **`disable-linux-hw-accel: false`** added to BOTH emulator steps (primary `smoke_test_primary` + infra-flake retry `smoke_test_retry`) — forces hard-require KVM acceleration; fails loudly/fast if acceleration cannot engage instead of crawling in software mode

## What is NOT changed

- No app code, smoke-test script, or emulator image changes
- No other workflow files touched
- Atomic-release ordering (smoke test BEFORE commit/push) is preserved
- All existing step `if:` conditions and step IDs are unchanged

## Testing

This is a CI-workflow-only change. Headless verification:
- YAML parses without error (no tab indentation, valid structure)
- `99-kvm4all.rules` block matches the proven `e2e-android-emulator.yml` pattern verbatim
- `disable-linux-hw-accel: false` present on both emulator steps (lines 545 + 588)
- `timeout-minutes: 60` present on the `release` job (line 29)
- Step ordering: KVM step (line 477) → primary smoke test (line 518) → retry (line 571) → fail gate (line 600) → commit-and-push (line 626)

Real proof is a green Scheduled Release run on a KVM-flaky runner. CEO to trigger `workflow_dispatch` post-merge as final confirmation.

## Issue

Resolves BLD-2290
Parent incident: BLD-2289 (run #28376063866)
Recurrence of: BLD-2137