### PR TITLE
fix(strava): repoint OAuth callback proxy to current workers.dev subdomain (#648)

### DIFF
--- a/.claude/skills/cablesnap--strava-oauth/SKILL.md
+++ b/.claude/skills/cablesnap--strava-oauth/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: cablesnap--strava-oauth
-description: "CableSnap Strava OAuth ops: app config (id 227474), Cloudflare Worker proxy at strava-proxy.alan200994.workers.dev, redirect URI architecture. Use when debugging 'Connect Strava' failures, 'invalid redirect URI' errors, or modifying the Strava connect/token/refresh flow."
+description: "CableSnap Strava OAuth ops: app config (id 227474), Cloudflare Worker proxy at strava-proxy.alankyshum.workers.dev, redirect URI architecture. Use when debugging 'Connect Strava' failures, 'invalid redirect URI' errors, or modifying the Strava connect/token/refresh flow."
 ---
 
 # Critical Rules
 
 - **NEVER** use a custom URI scheme (`cablesnap://...`) as `redirect_uri` to Strava — Strava's `/oauth/authorize` and `/oauth/mobile/authorize` both reject it with `{"field":"redirect_uri","code":"invalid"}`. Only `http(s)://` URLs whose host matches the registered Authorization Callback Domain are accepted.
-- **MUST** route Strava → app via the worker bounce: Strava → `https://strava-proxy.alan200994.workers.dev/callback?code=...` → 302 → `cablesnap://strava-callback?code=...` → app.
+- **MUST** route Strava → app via the worker bounce: Strava → `https://strava-proxy.alankyshum.workers.dev/callback?code=...` → 302 → `cablesnap://strava-callback?code=...` → app.
 - **MUST** keep app's `state` param matching between authorize URL and callback (CSRF). Generated via `lib/uuid.ts`.
 - **NEVER** commit `STRAVA_CLIENT_SECRET` (lives in Cloudflare Worker via `wrangler secret put`) or the Strava session cookie / CSRF token (lives in `.env.local`).
 
@@ -16,7 +16,7 @@ description: "CableSnap Strava OAuth ops: app config (id 227474), Cloudflare Wor
 [App] WebBrowser.openAuthSessionAsync(authorizeUrl, "cablesnap://strava-callback")
   └─ authorizeUrl: https://www.strava.com/oauth/authorize
        ?client_id=227474
-       &redirect_uri=https://strava-proxy.alan200994.workers.dev/callback
+       &redirect_uri=https://strava-proxy.alankyshum.workers.dev/callback
        &response_type=code&scope=activity:write&state=<uuid>
 [Strava] consent → 302 → worker /callback?code=...&state=...
 [Worker] GET /callback → 302 → cablesnap://strava-callback?<all-params>
@@ -39,7 +39,8 @@ description: "CableSnap Strava OAuth ops: app config (id 227474), Cloudflare Wor
 
 - Strava member id: `22254762`
 - Strava app id: `227474`
-- Cloudflare account: `alan200994` (worker subdomain `*.alan200994.workers.dev`)
+- Cloudflare account: `alan200994@gmail.com` (id `fbe46925529a77537b36114bed4e1ae1`)
+- Worker subdomain (account-wide, ONE per account): `alankyshum.workers.dev` — verify the live value with `curl -s https://api.cloudflare.com/client/v4/accounts/<id>/workers/subdomain -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"`. If the account handle is ever renamed, every `*.workers.dev` URL changes and the old one returns NXDOMAIN.
 
 # Credentials Setup (one-time)
 
@@ -79,7 +80,7 @@ Strava login automation is blocked by anti-bot — user must log in manually fir
 
 1. `open -a "Google Chrome" "https://www.strava.com/login"` → ask user to log in.
 2. Attach via tool--chrome (CDP port 9222), navigate to authorize URL with `&approval_prompt=force&state=verify-test`.
-3. Capture real `code` via CDP `Network.requestWillBeSent` listener on `strava-proxy.alan200994.workers.dev/callback` (the `cablesnap://` final hop fails in Chrome — that's correct).
+3. Capture real `code` via CDP `Network.requestWillBeSent` listener on `strava-proxy.alankyshum.workers.dev/callback` (the `cablesnap://` final hop fails in Chrome — that's correct).
 4. POST code to worker `/token` → verify `access_token`, `refresh_token`, `expires_at`, `athlete{id,firstname,lastname}`.
 5. Cleanup: `curl -X POST https://www.strava.com/oauth/deauthorize -H "Authorization: Bearer <token>"` → 200.
 
@@ -87,7 +88,8 @@ Strava login automation is blocked by anti-bot — user must log in manually fir
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| `{"errors":[{"resource":"Application","field":"redirect_uri","code":"invalid"}]}` | `redirect_uri` host doesn't match registered `domain`, OR is a custom scheme | Run `get-app.sh`; ensure `domain` is `alan200994.workers.dev` and `redirect_uri` is `https://strava-proxy.alan200994.workers.dev/callback` |
+| Callback page shows `DNS_PROBE_FINISHED_NXDOMAIN` / host won't resolve after Strava authorizes | Cloudflare account `workers.dev` subdomain was renamed, so `strava-proxy.<old>.workers.dev` no longer exists | Get the current subdomain (see Identifiers), then update `app.config.ts` extra.stravaProxyUrl, `lib/strava.ts`, the Strava app `domain` (run `update-app.sh`), and all skill scripts to the new host |
+| `{"errors":[{"resource":"Application","field":"redirect_uri","code":"invalid"}]}` | `redirect_uri` host doesn't match registered `domain`, OR is a custom scheme | Run `get-app.sh`; ensure `domain` is `alankyshum.workers.dev` and `redirect_uri` is `https://strava-proxy.alankyshum.workers.dev/callback` |
 | Auth completes but app never gets callback | Native binary built before `scheme: "cablesnap"` was added to `app.config.ts` | `npx expo prebuild --clean` + rebuild |
 | Worker `/token` returns 401 from Strava | Wrong `STRAVA_CLIENT_SECRET` in worker | `cd workers/strava-proxy && npx wrangler secret put STRAVA_CLIENT_SECRET` |
 | Test mock missing | `expo-web-browser.openAuthSessionAsync` not stubbed | `__mocks__/expo-web-browser.js` needs `openAuthSessionAsync: jest.fn()` |
@@ -97,5 +99,5 @@ Strava login automation is blocked by anti-bot — user must log in manually fir
 # Notes
 
 - **Use `/usr/bin/curl` directly** in scripts — environment wrappers may truncate response bodies.
-- `domain` field in Strava app config MUST be `alan200994.workers.dev` (NOT `cablesnap` — that has no public DNS).
+- `domain` field in Strava app config MUST be `alankyshum.workers.dev` (NOT `cablesnap` — that has no public DNS).
 - Strava accepts the registered domain AND its subdomains as redirect_uri hosts.

--- a/.claude/skills/cablesnap--strava-oauth/scripts/_lib.sh
+++ b/.claude/skills/cablesnap--strava-oauth/scripts/_lib.sh
@@ -24,7 +24,7 @@ require_var() {
 # Constants — public, OK to hardcode.
 STRAVA_APP_ID="227474"
 STRAVA_OWNER_ID="22254762"
-WORKER_BASE="https://strava-proxy.alan200994.workers.dev"
+WORKER_BASE="https://strava-proxy.alankyshum.workers.dev"
 DASHBOARD_BASE="https://www.strava.com/api/next/data/athlete-applications"
 
 # Wrap real curl to bypass any shell wrappers that truncate output.

--- a/.claude/skills/cablesnap--strava-oauth/scripts/update-app.sh
+++ b/.claude/skills/cablesnap--strava-oauth/scripts/update-app.sh
@@ -12,7 +12,7 @@ BODY=$(cat <<EOF
   "category": "Training",
   "userSupportUrl": "https://github.com/alankyshum/cablesnap",
   "description": "Free, open-source workout & macro tracker. A lightweight, responsive alternative to commercial fitness apps — no subscriptions, no ads, no paywalls.",
-  "domain": "alan200994.workers.dev"
+  "domain": "alankyshum.workers.dev"
 }
 EOF
 )

--- a/.claude/skills/cablesnap--strava-oauth/scripts/verify-redirect.sh
+++ b/.claude/skills/cablesnap--strava-oauth/scripts/verify-redirect.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"
 
-URL="https://www.strava.com/oauth/authorize?response_type=code&client_id=$STRAVA_APP_ID&redirect_uri=https%3A%2F%2Fstrava-proxy.alan200994.workers.dev%2Fcallback&scope=activity%3Awrite&approval_prompt=auto"
+URL="https://www.strava.com/oauth/authorize?response_type=code&client_id=$STRAVA_APP_ID&redirect_uri=https%3A%2F%2Fstrava-proxy.alankyshum.workers.dev%2Fcallback&scope=activity%3Awrite&approval_prompt=auto"
 
 echo "GET $URL"
 CODE=$("$CURL" -s -o /dev/null -w '%{http_code}' "$URL")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ marker) at release time.
 ## Unreleased
 
 - **Rest-complete now plays a satisfying "ca-ching" chime** — when a rest timer finishes, the phone notification now plays a custom ascending "ca-ching" completion sound instead of the generic system tone, so finishing a rest feels like ticking off a win. The sound is a procedurally-generated, public-domain (CC0) bell — no third-party samples. (Note: paired smartwatches still play their own notification tone/vibration for bridged alerts; the custom sound applies to the phone.) (BLD-1263)
+- **Fix: "Connect Strava" no longer fails with a DNS error after authorization** — the OAuth callback proxy moved to its current Cloudflare Workers subdomain (`strava-proxy.alankyshum.workers.dev`); the old hostname stopped resolving (`DNS_PROBE_FINISHED_NXDOMAIN`). (#648)
 
 ## v0.26.46 — 2026-06-29
 <!-- versionCode: 116 -->

--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -197,7 +197,7 @@ describe("Strava Integration — Config", () => {
   it("has stravaClientId, stravaProxyUrl, and required plugins in app.config.ts", () => {
     expect(configSrc).toContain("stravaClientId");
     expect(configSrc).toContain("stravaProxyUrl");
-    expect(configSrc).toContain("strava-proxy.alan200994.workers.dev");
+    expect(configSrc).toContain("strava-proxy.alankyshum.workers.dev");
     expect(configSrc).toContain("expo-web-browser");
     expect(configSrc).toContain("expo-secure-store");
     // No client_secret in app config

--- a/app.config.ts
+++ b/app.config.ts
@@ -104,6 +104,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       projectId: "24dc5f10-9a21-4336-bac0-6334a5f6b82b",
     },
     stravaClientId: "227474",
-    stravaProxyUrl: "https://strava-proxy.alan200994.workers.dev",
+    stravaProxyUrl: "https://strava-proxy.alankyshum.workers.dev",
   },
 });

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -6,7 +6,7 @@
  * It only accepts http(s):// URLs whose host matches the registered
  * "Authorization Callback Domain".
  *
- * Fix: We send redirect_uri=https://strava-proxy.alan200994.workers.dev/callback
+ * Fix: We send redirect_uri=https://strava-proxy.alankyshum.workers.dev/callback
  * (accepted by Strava). The worker's GET /callback handler reads the code/scope/
  * state query params and 302-redirects to cablesnap://strava-callback?<params>.
  * WebBrowser.openAuthSessionAsync intercepts that cablesnap:// redirect (matches
@@ -78,7 +78,7 @@ function getProxyUrl(): string {
 // OAuth redirect constants
 // redirect_uri sent to Strava — must be an https:// URL matching the registered domain.
 // The worker's GET /callback bounces this to the cablesnap:// deep link below.
-const REDIRECT_URI_FOR_STRAVA = `${Constants.expoConfig?.extra?.stravaProxyUrl ?? "https://strava-proxy.alan200994.workers.dev"}/callback`;
+const REDIRECT_URI_FOR_STRAVA = `${Constants.expoConfig?.extra?.stravaProxyUrl ?? "https://strava-proxy.alankyshum.workers.dev"}/callback`;
 // Deep link that WebBrowser.openAuthSessionAsync watches for to close the browser.
 const APP_DEEP_LINK = "cablesnap://strava-callback";
 // On bare Android, Custom Tabs may dismiss and report `cancel`/`dismiss` one


### PR DESCRIPTION
## Problem
Closes #648. After authorizing Strava, the callback page failed with `DNS_PROBE_FINISHED_NXDOMAIN`.

**Root cause:** the Cloudflare account's `workers.dev` subdomain was renamed `alan200994` → `alankyshum`, so `strava-proxy.alan200994.workers.dev` no longer resolves. A Cloudflare account has exactly one `workers.dev` subdomain, so the old host can't be restored without losing the new one. The worker itself is healthy at `strava-proxy.alankyshum.workers.dev` (verified: `/callback` 302s to `cablesnap://strava-callback`, `/token` forwards to Strava).

## Change
Repoint every reference to `strava-proxy.alankyshum.workers.dev`:
- `app.config.ts` → `extra.stravaProxyUrl` (the value baked into release builds)
- `lib/strava.ts` → fallback redirect URI + header comment
- `__tests__/lib/strava.test.ts` → assertion
- `cablesnap--strava-oauth` skill docs + scripts (`_lib.sh`, `update-app.sh`, `verify-redirect.sh`) + a new troubleshooting row for this exact NXDOMAIN/rename failure mode

## Out-of-band
- Strava app **Authorization Callback Domain** updated to `alankyshum.workers.dev`.
- A new app release is required for the fix to reach devices (the old URL is baked into installed 0.26.4x builds and cannot be fixed remotely).