### PR TITLE
chore(release): ship Strava callback proxy fix in next build (#648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: "Connect Strava" really does use the working callback proxy now** — v0.26.47's release notes listed this fix, but that APK was compiled moments before the fix landed, so the old, dead hostname was still baked into the binary. This build ships the corrected `strava-proxy.alankyshum.workers.dev` OAuth callback proxy for real, so authorizing Strava no longer dead-ends on a DNS error. (#648)
 
 ## v0.26.47 — 2026-06-29
 <!-- versionCode: 117 -->


### PR DESCRIPTION
## Why

v0.26.47's APK was built moments before the Strava callback-proxy fix (#684, a742ab69) merged. Due to the scheduled-release atomic-bump flow rebasing the CHANGELOG onto fresh `main` *after* the APK was already built, **the published v0.26.47 binary still has the dead `strava-proxy.alan200994.workers.dev` hostname baked in** even though its release notes list the fix. Verified by `strings`-grepping the published `cablesnap.apk`.

## What

The corrected `alankyshum.workers.dev` proxy URL is already in `main`'s source. This PR just adds a `## Unreleased` CHANGELOG entry so the next scheduled-release build (v0.26.48 / versionCode 118) actually ships the working binary that all users will update to.

## Note

The app-side fix is complete, but Strava OAuth will still fail until the Strava app's **Authorization Callback Domain** is set to exactly `alankyshum.workers.dev` (currently it matches neither host — `/oauth/authorize` returns 400 `redirect_uri invalid`).

Refs #648