### PR TITLE
fix(release): serialize Scheduled Release + idempotent release-create (BLD-2316)

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -19,6 +19,24 @@ on:
 permissions:
   contents: write
 
+# BLD-2316: serialize Scheduled Release runs so two never publish at once.
+# Without this, the 12h `schedule` cron firing while a `workflow_dispatch` run
+# is mid-flight (or two dispatches) lets both compute the SAME `NEXT` version
+# from the same checkout-time `git tag` snapshot; the loser then dies at
+# "Create GitHub Release" with "a release with the same tag name already
+# exists" (run #28403940771 vs the concurrent run that shipped v0.26.47).
+#
+# `cancel-in-progress: false` is REQUIRED, not a default: a release run that has
+# already built + signed + pushed a version-bump commit must NOT be killed
+# mid-flight — that would leave a bumped CHANGELOG/version on main with no
+# GitHub Release (a "ghost version", the exact failure class BLD-2139 fixed).
+# Queue the second run behind the first instead. The group is a constant
+# (NOT keyed on github.ref or run id) so every dispatch + cron run shares one
+# lane — matching fdroid-release.yml, the repo's other release workflow.
+concurrency:
+  group: scheduled-release
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Check, build & release
@@ -770,6 +788,34 @@ jobs:
           # repo build pulls cablesnap-fdroid.apk per
           # `.github/workflows/fdroid-release.yml`.
           VERSION="${{ steps.next_version.outputs.version }}"
+
+          # BLD-2316 (IDEMPOTENT CREATE): a concurrent Scheduled Release run can
+          # already have published this exact version. The workflow-level
+          # `concurrency: { group: scheduled-release, cancel-in-progress: false }`
+          # serializes runs, but a queued run still wakes with its own
+          # `next_version` output set, so it reaches this step even though the
+          # "Commit and push" step early-exited on "No staged delta after
+          # regenerate — concurrent merge already shipped v$VERSION". Without
+          # this guard the queued run dies on `gh release create` with "a
+          # release with the same tag name already exists" (the BLD-2315 false
+          # failure; run #28403940771 hit it 31 min after v0.26.47 shipped).
+          #
+          # In the normal bump path, an already-existing release means the
+          # concurrent run published identical artifacts from the same commit —
+          # treat it as a successful no-op (do NOT re-upload / duplicate assets).
+          #
+          # Republish mode is DELIBERATELY exempt: it already hard-errors in
+          # "Compute next version" (BLD-1101) when the tag exists, so an
+          # operator-driven republish whose release somehow exists must still
+          # fail loudly here rather than be silently swallowed — keep republish
+          # strictness intact (BLD-2316 edge-case table).
+          if [ "${{ inputs.republish_current }}" != "true" ] && \
+             gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "::notice::Release v$VERSION already exists — a concurrent Scheduled Release run already published it. Treating as a no-op success (no duplicate assets uploaded)."
+            echo "Skipped create: v$VERSION already published by a concurrent run."
+            exit 0
+          fi
+
           gh release create "v$VERSION" \
             cablesnap.apk \
             cablesnap-fdroid.apk \


### PR DESCRIPTION
## What & why

The `Scheduled Release` workflow (`.github/workflows/scheduled-release.yml`) was the **only** workflow in the repo with no `concurrency:` guard. When two runs start close together — the 12h `schedule` cron firing while a `workflow_dispatch` run is mid-flight, or two dispatches — both compute the **same** `NEXT` version from the same checkout-time `git tag --sort` snapshot.

The existing **"Commit and push"** step already handles the git-tag race correctly (resets onto fresh `origin/main`, regenerates the bump, and cleanly early-exits on `No staged delta after regenerate — concurrent merge already shipped v$VERSION`). But the final **"Create GitHub Release with APK"** step ran an unconditional `gh release create` and hard-failed:

```
a release with the same tag name already exists: v0.26.47
##[error]Process completed with exit code 1.
```

### Motivating incident — run #28403940771 (the BLD-2315 trigger)

- The concurrent run #28402259323 (started 20:58Z) successfully shipped **v0.26.47** at 21:35:28Z with all three APKs attached.
- This run #28403940771 (started 21:30Z) reached "Create GitHub Release" at 22:06:57Z — **31 min after the release already existed** — and failed with "release already exists".
- Tag `v0.26.47` → `eb09ad21…` == current `origin/main` HEAD. **No data loss; the release shipped fine.** This was a pure false-alarm failure that generated noise issue **BLD-2315**. Recurring pattern: also BLD-2137 (#28322396584).

## Changes (single file, additive only — 46 insertions, 0 deletions)

### 1. Workflow-level `concurrency:` block
```yaml
concurrency:
  group: scheduled-release
  cancel-in-progress: false
```
- **`cancel-in-progress: false` is required, not a default.** A run that has already built + signed + **pushed a version-bump commit** must NOT be killed mid-flight — that would leave a bumped CHANGELOG/version on `main` with no GitHub Release (a *ghost version*, the exact failure class **BLD-2139** fixed). The second run queues behind the first instead.
- The `group` is a **constant** (not keyed on `github.ref` or run id), so every cron + dispatch run shares one lane. This matches `fdroid-release.yml`, the repo's other release workflow.

### 2. Idempotent "Create GitHub Release with APK"
Guarded with `gh release view "v$VERSION"` before `gh release create`:
- **Bump mode + release already exists** → `::notice::` + `exit 0`, no duplicate assets (the concurrent run published identical artifacts).
- **Bump mode + no release (happy path)** → create with all 3 APKs, **unchanged**.
- **Republish mode (BLD-1101)** is **deliberately exempt**: that path already hard-errors in "Compute next version" when the tag exists, so an operator-driven republish whose release somehow exists still fails loudly here rather than being silently masked. Republish strictness preserved.

## Verification (headless — this is a CI YAML change, no on-device AC)

| Check | Result |
|---|---|
| YAML parses | ✅ `js-yaml` — top-level keys `name, on, permissions, concurrency, jobs`; `concurrency = {group: scheduled-release, cancel-in-progress: false}` |
| Bash syntax of release-create block (`bash -n`) | ✅ both bump and republish modes |
| Guard logic simulated (stub `gh`) across all 4 edge cases | ✅ see table below |
| Diff scope | ✅ 1 file, 46 insertions, **0 deletions** → happy path byte-for-byte unchanged |

Guard-logic simulation:

| # | Mode | Release exists? | Behavior |
|---|------|-----------------|----------|
| 1 | bump | yes (concurrent shipped) | **NO-OP** (`::notice::` + exit 0) — kills the false failure |
| 2 | bump | no (happy path) | **CREATE** with 3 APKs (unchanged) |
| 3 | republish | yes | **CREATE attempted** — no silent mask, republish strictness intact |
| 4 | republish | no | **CREATE** (unchanged) |

> A real concurrency collision cannot be deterministically forced in CI (GitHub guarantees the `concurrency` semantics; the race is timing-dependent). Primary proof is static review of the guard + the simulation above, per the issue's Headless Verification Path.

## Acceptance criteria

- [x] `scheduled-release.yml` has a workflow-level `concurrency:` group with `cancel-in-progress: false`.
- [x] "Create GitHub Release with APK" no longer hard-fails when `vX.Y.Z` already exists; exits 0 with a clear `::notice::`, does not overwrite/duplicate assets.
- [x] Happy path (no pre-existing release) still creates the release with all 3 APKs, identical title/notes/target.
- [x] No change to version-bump, smoke-test ordering, or push-recovery logic (BLD-2139/BLD-1185 preserved).
- [x] YAML is valid (verified with `js-yaml` + `bash -n`; actionlint segfaulted in the sandbox — environment limitation, not a workflow defect).
- [ ] PR passes all CI checks with no regressions. *(pending CI)*

## Out of scope
Cron cadence, `workflow_dispatch` removal, version-computation/push-recovery rework, emulator/KVM path (BLD-2290), APK/build/signing changes.

Parent: **BLD-2315**. Closes the recurring false-failure class.
