### PR TITLE
feat: progress + nutrition regression-guard specs + de-noise coverage report (BLD-2357)

### DIFF
--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -72,8 +72,9 @@ export default function Nutrition() {
   }, [load]);
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <View testID="nutrition-screen-container" style={[styles.container, { backgroundColor: colors.background }]}>
       <SectionList
+        testID="nutrition-scroll-view"
         sections={sections}
         keyExtractor={(item) => item.id}
         style={styles.scroll}

--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -13,7 +13,7 @@ export default function Progress() {
   const [segment, setSegment] = useState("workouts");
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <View testID="progress-screen-container" style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={styles.tabsContainer}>
         {/* ScrollableTabs handles its own edge padding via contentContainerStyle —
             do NOT wrap with horizontal padding or the trailing fade gets clipped. */}

--- a/e2e/scenarios/nutrition-tab.spec.ts
+++ b/e2e/scenarios/nutrition-tab.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * Scenario spec: nutrition-tab.
+ *
+ * Regression-guard for the Nutrition tab (/nutrition). Navigates to the route,
+ * captures top + bottom scroll positions across all four store viewports, and
+ * asserts the nutrition screen's primary container testID and scroll-view are
+ * mounted. Includes a hard crash guard: the test FAILS if a `pageerror` fires
+ * or a React error-boundary / crash-overlay testID is attached.
+ *
+ * Does NOT require a seeded scenario — the nutrition screen renders a
+ * self-contained default state (empty food log for today) when no data exists,
+ * exactly like settings.spec.ts which needs no seed. If a test-seed hook for
+ * nutrition exists in the future, it can be added here; for now, the empty
+ * state is the authoritative capture.
+ *
+ * NOTE: The nutrition screen renders "No food logged yet." when empty.
+ * The spec asserts the SectionList container is mounted (not the items),
+ * so the empty-state is a valid structural baseline.
+ *
+ * Both a "top" and "bottom" scroll-position shot are captured per viewport
+ * (mirroring settings.spec.ts BLD-1124 pattern).
+ *
+ * Three CVD-emulated variants (deuteranopia / protanopia / tritanopia) are
+ * also captured for the "bottom" shot via `captureWithCvd`.
+ *
+ * Structural assertions:
+ *   - "nutrition-screen-container" testID is attached after page load.
+ *   - "nutrition-scroll-view" (SectionList) testID is attached.
+ *   - Crash guard: any `pageerror` or `data-testid="react-crash-overlay"`
+ *     element causes an immediate test failure.
+ *
+ * Refs: BLD-1819, BLD-2357
+ */
+import { test, expect } from "@playwright/test";
+import * as path from "path";
+import { captureWithCvd } from "./capture-with-cvd";
+
+const SCENARIO = "nutrition-tab";
+const OUT_DIR = path.resolve(
+  __dirname,
+  "../../.pixelslop/screenshots/scenarios",
+  SCENARIO,
+);
+
+test.describe("@scenario nutrition-tab", () => {
+  // Same 4 viewports as settings.spec.ts (BLD-1124 AC1):
+  //   mobile        (390×844)  ≈ iPhone 14
+  //   mobile-narrow (320×640)  ≈ iPhone SE 3rd gen
+  //   store-pixel9  (412×924)  ≈ Pixel 6a
+  //   store-fold7   (712×853)  ≈ Z Fold6 inner screen
+  const ALLOWED_PROJECTS = new Set([
+    "mobile",
+    "mobile-narrow",
+    "store-pixel9",
+    "store-fold7",
+  ]);
+  // eslint-disable-next-line no-empty-pattern -- Playwright 1.59 requires destructured fixtures arg
+  test.beforeAll(({}, testInfo) => {
+    test.skip(
+      !ALLOWED_PROJECTS.has(testInfo.project.name),
+      "BLD-2357: only run on SE3 / iPhone 14 / Pixel 6a / Fold6 viewports",
+    );
+  });
+
+  test("captures nutrition top (header + macro ring)", async ({ page }, testInfo) => {
+    // Crash guard: any unhandled JS error fails the test immediately.
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(err.message);
+    });
+
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.addInitScript(() => {
+      const w = window as unknown as Record<string, unknown>;
+      w.__SKIP_ONBOARDING__ = true;
+    });
+
+    await page.goto("/nutrition");
+
+    // Wait for the primary container to mount.
+    await expect(page.getByTestId("nutrition-screen-container")).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Double rAF to guarantee compositor commit before screenshot.
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          void document.documentElement.offsetHeight;
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }),
+    );
+    await page.waitForTimeout(300);
+
+    // Crash guard assertion.
+    expect(
+      pageErrors,
+      `pageerror(s) detected on /nutrition — crash guard tripped (Refs: BLD-1819):\n${pageErrors.join("\n")}`,
+    ).toHaveLength(0);
+
+    await expect(
+      page.getByTestId("react-crash-overlay"),
+      "React crash overlay testID is attached — nutrition screen crashed (Refs: BLD-1819)",
+    ).not.toBeAttached();
+
+    const viewport = testInfo.project.name;
+    const screenshotPath = path.join(
+      OUT_DIR,
+      `nutrition-top-${viewport}.png`,
+    );
+    await page.screenshot({ path: screenshotPath, fullPage: false });
+    expect(screenshotPath).toBeTruthy();
+  });
+
+  test("captures nutrition bottom (empty-state / food log list + CVD variants)", async ({ page }, testInfo) => {
+    // Capture the empty default state at the bottom of the SectionList.
+    // No seed needed: nutrition renders a self-contained default state.
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(err.message);
+    });
+
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.addInitScript(() => {
+      const w = window as unknown as Record<string, unknown>;
+      w.__SKIP_ONBOARDING__ = true;
+    });
+
+    await page.goto("/nutrition");
+
+    await expect(page.getByTestId("nutrition-screen-container")).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.waitForTimeout(500);
+
+    // Pre-scroll crash guard.
+    expect(
+      pageErrors,
+      `pageerror(s) on /nutrition before scroll:\n${pageErrors.join("\n")}`,
+    ).toHaveLength(0);
+    await expect(
+      page.getByTestId("react-crash-overlay"),
+      "React crash overlay attached before scroll on nutrition screen",
+    ).not.toBeAttached();
+
+    // Scroll the SectionList container (not the document).
+    const scrollEl = page.getByTestId("nutrition-scroll-view");
+    await expect(scrollEl).toBeVisible({ timeout: 10_000 });
+    await scrollEl.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
+    await page.waitForTimeout(300);
+
+    // Post-scroll crash guard.
+    expect(
+      pageErrors,
+      `pageerror(s) on /nutrition after scroll:\n${pageErrors.join("\n")}`,
+    ).toHaveLength(0);
+    await expect(
+      page.getByTestId("react-crash-overlay"),
+      "React crash overlay appeared after scroll on nutrition screen (Refs: BLD-1819)",
+    ).not.toBeAttached();
+
+    const viewport = testInfo.project.name;
+    await captureWithCvd({
+      page,
+      outDir: OUT_DIR,
+      viewport,
+      meta: {
+        scenario: SCENARIO,
+        viewport,
+        capturedAt: new Date().toISOString(),
+        note: "Bottom of nutrition tab — default empty state capture; no seed required (mirrors settings.spec.ts). Refs: BLD-1819",
+      },
+    });
+  });
+
+  test("nutrition-screen-container and nutrition-scroll-view testIDs are mounted (BLD-2357)", async ({ page }) => {
+    // Structural IA assertion + crash guard on all allowed viewports.
+    // Fails if the nutrition screen crashes or its root containers are removed.
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(err.message);
+    });
+
+    await page.addInitScript(() => {
+      const w = window as unknown as Record<string, unknown>;
+      w.__SKIP_ONBOARDING__ = true;
+    });
+
+    await page.goto("/nutrition");
+
+    // Wait for the primary container.
+    await expect(page.getByTestId("nutrition-screen-container")).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Structural assertions: both containers attached.
+    await expect(
+      page.getByTestId("nutrition-screen-container"),
+      "nutrition-screen-container testID must be attached after page load",
+    ).toBeAttached({ timeout: 5_000 });
+
+    await expect(
+      page.getByTestId("nutrition-scroll-view"),
+      "nutrition-scroll-view (SectionList) testID must be attached after page load",
+    ).toBeAttached({ timeout: 5_000 });
+
+    // Hard crash guard.
+    expect(
+      pageErrors,
+      `pageerror(s) detected on /nutrition — crash guard tripped (Refs: BLD-1819):\n${pageErrors.join("\n")}`,
+    ).toHaveLength(0);
+
+    await expect(
+      page.getByTestId("react-crash-overlay"),
+      "React crash overlay must not be attached on nutrition screen (Refs: BLD-1819)",
+    ).not.toBeAttached({ timeout: 3_000 });
+  });
+});

--- a/e2e/scenarios/progress-tab.spec.ts
+++ b/e2e/scenarios/progress-tab.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * Scenario spec: progress-tab.
+ *
+ * Regression-guard for the Progress tab (/progress). Navigates to the route,
+ * captures top + bottom scroll positions across all four store viewports, and
+ * asserts the progress screen's primary container testID is mounted. Includes
+ * a hard crash guard: the test FAILS if a `pageerror` fires or a React
+ * error-boundary / crash-overlay testID is attached.
+ *
+ * The store-fold7 (712×853) viewport is the CRITICAL regression surface for
+ * this spec — BLD-2074 and BLD-2078 both manifested as a crash overlay on the
+ * Progress tab exclusively on the Z Fold6 inner screen (712px wide). That
+ * crash was undetected until a store screenshot revealed it.
+ *
+ * Does NOT require a seeded scenario — the progress screen renders an
+ * empty-state when no workout data exists. Skips onboarding via
+ * window.__SKIP_ONBOARDING__.
+ *
+ * Both a "top" and "bottom" scroll-position shot are captured per viewport
+ * (mirroring settings.spec.ts BLD-1124 pattern).
+ *
+ * Three CVD-emulated variants (deuteranopia / protanopia / tritanopia) are
+ * also captured for the "bottom" shot via `captureWithCvd`.
+ *
+ * Structural assertion:
+ *   - "progress-screen-container" testID is attached after page load (guards
+ *     the primary container introduced in BLD-2357).
+ *   - Crash guard: any `pageerror` or `data-testid="react-crash-overlay"`
+ *     element causes an immediate test failure.
+ *
+ * Refs: BLD-2074, BLD-2078, BLD-2357
+ */
+import { test, expect } from "@playwright/test";
+import * as path from "path";
+import { captureWithCvd } from "./capture-with-cvd";
+
+const SCENARIO = "progress-tab";
+const OUT_DIR = path.resolve(
+  __dirname,
+  "../../.pixelslop/screenshots/scenarios",
+  SCENARIO,
+);
+
+test.describe("@scenario progress-tab", () => {
+  // BLD-2357 requires the same 4 viewports as settings.spec.ts (BLD-1124 AC1):
+  //   mobile        (390×844)  ≈ iPhone 14
+  //   mobile-narrow (320×640)  ≈ iPhone SE 3rd gen
+  //   store-pixel9  (412×924)  ≈ Pixel 6a
+  //   store-fold7   (712×853)  ≈ Z Fold6 inner screen  ← BLD-2074/2078 crash surface
+  const ALLOWED_PROJECTS = new Set([
+    "mobile",
+    "mobile-narrow",
+    "store-pixel9",
+    "store-fold7",
+  ]);
+  // eslint-disable-next-line no-empty-pattern -- Playwright 1.59 requires destructured fixtures arg
+  test.beforeAll(({}, testInfo) => {
+    test.skip(
+      !ALLOWED_PROJECTS.has(testInfo.project.name),
+      "BLD-2357: only run on SE3 / iPhone 14 / Pixel 6a / Fold6 viewports",
+    );
+  });
+
+  test("captures progress top (tabs + initial segment)", async ({ page }, testInfo) => {
+    // Crash guard: any unhandled JS error fails the test immediately.
+    // This is the guard BLD-2074/2078 would have tripped had it existed.
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(err.message);
+    });
+
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.addInitScript(() => {
+      const w = window as unknown as Record<string, unknown>;
+      w.__SKIP_ONBOARDING__ = true;
+    });
+
+    await page.goto("/progress");
+
+    // Wait for the primary container to mount — this also guards empty-state
+    // render so we don't capture a blank frame.
+    await expect(page.getByTestId("progress-screen-container")).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Double rAF to guarantee the compositor has committed a frame.
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          void document.documentElement.offsetHeight;
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }),
+    );
+    await page.waitForTimeout(300);
+
+    // Crash guard assertion: if any pageerror fired during load, fail now.
+    expect(
+      pageErrors,
+      `pageerror(s) detected on /progress — crash guard tripped (Refs: BLD-2074, BLD-2078):\n${pageErrors.join("\n")}`,
+    ).toHaveLength(0);
+
+    // Structural assertion: confirm no crash overlay is attached.
+    await expect(
+      page.getByTestId("react-crash-overlay"),
+      "React crash overlay testID is attached — progress screen crashed (Refs: BLD-2074, BLD-2078)",
+    ).not.toBeAttached();
+
+    const viewport = testInfo.project.name;
+    const screenshotPath = path.join(
+      OUT_DIR,
+      `progress-top-${viewport}.png`,
+    );
+    await page.screenshot({ path: screenshotPath, fullPage: false });
+    expect(screenshotPath).toBeTruthy();
+  });
+
+  test("captures progress bottom (below-fold segment content + CVD variants)", async ({ page }, testInfo) => {
+    // Crash guard (same pattern as top test — independent page context).
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(err.message);
+    });
+
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.addInitScript(() => {
+      const w = window as unknown as Record<string, unknown>;
+      w.__SKIP_ONBOARDING__ = true;
+    });
+
+    await page.goto("/progress");
+
+    await expect(page.getByTestId("progress-screen-container")).toBeVisible({
+      timeout: 20_000,
+    });
+    await page.waitForTimeout(500);
+
+    // Crash guard assertion before scrolling.
+    expect(
+      pageErrors,
+      `pageerror(s) on /progress before scroll:\n${pageErrors.join("\n")}`,
+    ).toHaveLength(0);
+    await expect(
+      page.getByTestId("react-crash-overlay"),
+      "React crash overlay attached before scroll on progress screen",
+    ).not.toBeAttached();
+
+    // Scroll the inner React Native container (not the document).
+    // The progress screen uses a ScrollableTabs + segment composition;
+    // try the scrollable tabs container first, fall back to the screen root.
+    const container = page.getByTestId("progress-screen-container");
+    await container.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
+    await page.waitForTimeout(300);
+
+    // Crash guard: post-scroll — the BLD-2074/2078 crash manifested specifically
+    // at this viewport width after the component tree fully rendered.
+    expect(
+      pageErrors,
+      `pageerror(s) on /progress after scroll — crash guard tripped (Refs: BLD-2074, BLD-2078):\n${pageErrors.join("\n")}`,
+    ).toHaveLength(0);
+    await expect(
+      page.getByTestId("react-crash-overlay"),
+      "React crash overlay appeared after scroll on progress screen (Refs: BLD-2074, BLD-2078)",
+    ).not.toBeAttached();
+
+    const viewport = testInfo.project.name;
+    await captureWithCvd({
+      page,
+      outDir: OUT_DIR,
+      viewport,
+      meta: {
+        scenario: SCENARIO,
+        viewport,
+        capturedAt: new Date().toISOString(),
+        note: "Bottom of progress tab — regression surface for BLD-2074/BLD-2078 wide-viewport crash on store-fold7",
+      },
+    });
+  });
+
+  test("progress-screen-container testID is mounted and no crash overlay (BLD-2357)", async ({ page }) => {
+    // Structural IA assertion + crash guard on all allowed viewports.
+    // This test is the durable regression-lock: if the progress screen crashes
+    // or its root container is removed, this fails immediately.
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => {
+      pageErrors.push(err.message);
+    });
+
+    await page.addInitScript(() => {
+      const w = window as unknown as Record<string, unknown>;
+      w.__SKIP_ONBOARDING__ = true;
+    });
+
+    await page.goto("/progress");
+
+    // Wait for the progress container to mount.
+    await expect(page.getByTestId("progress-screen-container")).toBeVisible({
+      timeout: 20_000,
+    });
+
+    // Structural assertion: container is attached (not just visible).
+    await expect(
+      page.getByTestId("progress-screen-container"),
+      "progress-screen-container testID must be attached after page load",
+    ).toBeAttached({ timeout: 5_000 });
+
+    // Hard crash guard.
+    expect(
+      pageErrors,
+      `pageerror(s) detected on /progress — crash guard tripped (Refs: BLD-2074, BLD-2078):\n${pageErrors.join("\n")}`,
+    ).toHaveLength(0);
+
+    await expect(
+      page.getByTestId("react-crash-overlay"),
+      "React crash overlay must not be attached on progress screen (Refs: BLD-2074, BLD-2078)",
+    ).not.toBeAttached({ timeout: 3_000 });
+  });
+});

--- a/scripts/daily-audit.sh
+++ b/scripts/daily-audit.sh
@@ -164,9 +164,34 @@ echo "[daily-audit] building rolling coverage report (past ${ROLLING_WINDOW_DAYS
       plan_cell="—"
       [ -f "$plan" ] && plan_cell="\`$(basename "$plan")\`"
 
+      # UI-relevance heuristic (BLD-2350): a ticket is eligible for the
+      # MISSING flag only if its merge commit(s) in the rolling window touched
+      # files under app/, components/, or theme/. Infra/CI/bugfix tickets that
+      # never touch those paths (e.g. BLD-1631 playwright-install, BLD-1710
+      # dependabot, BLD-1796 test-flake, BLD-1976 emulator-smoke, BLD-2040
+      # worktree-guard) will NEVER have a visual scenario and used to inflate
+      # the MISSING count forever, burying real gaps. Any commit touching at
+      # least one app/, components/, or theme/ file counts as UI-relevant.
+      ui_files=$(git log --since="${ROLLING_WINDOW_DAYS} days ago" \
+        --pretty=format:'' --name-only --diff-filter=ACDMRT -- . \
+        2>/dev/null \
+        | grep -E '^(app|components|theme)/' | head -1 || true)
+      # Narrow to commits that mention this ticket in the subject line.
+      ticket_ui_files=$(git log --since="${ROLLING_WINDOW_DAYS} days ago" \
+        --pretty=format:'%s' --name-only --diff-filter=ACDMRT -- . \
+        2>/dev/null \
+        | awk -v t="$ticket" '
+          /^BLD-/ || /^(feat|fix|chore|test|refactor|docs|perf|ci)/ { in_commit=0 }
+          $0 ~ t { in_commit=1 }
+          in_commit && /^(app|components|theme)\// { print; exit }
+        ' || true)
       vis="❌ MISSING"
       if grep -rl "$ticket" e2e/scenarios/ 2>/dev/null | head -1 | grep -q .; then
         vis="✅"
+      elif [ -z "$ticket_ui_files" ]; then
+        # No app/components/theme files touched by this ticket's commits —
+        # it is an infra/CI/test/bugfix-only ticket; never flag as MISSING.
+        vis="— n/a (non-UI)"
       fi
 
       ac_cell="—"


### PR DESCRIPTION
## Summary

Adds visual regression-guard scenario specs for the Progress and Nutrition tabs (both previously had zero dedicated e2e coverage), and de-noises the rolling-coverage report to stop flagging infra/CI tickets as `❌ MISSING`.

## Changes

### Part A — New scenario specs
- `e2e/scenarios/progress-tab.spec.ts`: Navigate to `/progress`, capture top + bottom across 4 viewports (mobile 390×844, mobile-narrow 320×640, store-pixel9 412×924, store-fold7 712×853). Hard crash guard on `pageerror` / `react-crash-overlay` testID. Structural assertion on `progress-screen-container`. CVD variants on bottom shot. Refs BLD-2074, BLD-2078.
- `e2e/scenarios/nutrition-tab.spec.ts`: Same pattern for `/nutrition`. No seed required — captures self-contained default empty state (mirrors settings.spec.ts). Structural assertions on `nutrition-screen-container` + `nutrition-scroll-view`. Refs BLD-1819.
- `app/(tabs)/progress.tsx`: Added `testID="progress-screen-container"` to root View.
- `app/(tabs)/nutrition.tsx`: Added `testID="nutrition-screen-container"` to root View; `testID="nutrition-scroll-view"` to SectionList.

### Part B — De-noise rolling-coverage report
- `scripts/daily-audit.sh`: Added UI-relevance heuristic. A ticket is eligible for `❌ MISSING` only if its commits touched files under `app/`, `components/`, or `theme/`. Infra/CI tickets (BLD-1631, BLD-1710, BLD-1796, BLD-1976, BLD-2040) now render as `— n/a (non-UI)`.

## Testing

- `tsc --noEmit`: **TypeScript: No errors found**
- Specs model exactly the house style of `settings.spec.ts` + `completed-workout.spec.ts`
- Playwright: `npx playwright test e2e/scenarios/progress-tab.spec.ts e2e/scenarios/nutrition-tab.spec.ts`

## Issue

Resolves BLD-2357 (Parent: BLD-2350)