### PR TITLE
fix(settings): Rest Timer Notifications toggle shows OFF when permission denied (BLD-2354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: Rest Timer Notifications toggle no longer shows ON when the OS permission is denied** — the toggle in Settings now reflects the real system permission state; if the user previously denied notification permission at the OS level, the toggle correctly shows OFF rather than falsely indicating the feature is active. (BLD-2354)
 
 ## v0.26.48 — 2026-06-29
 <!-- versionCode: 118 -->

--- a/__tests__/acceptance/settings.test.tsx
+++ b/__tests__/acceptance/settings.test.tsx
@@ -140,7 +140,7 @@ import { FLOATING_TAB_BAR_HEIGHT } from '../../components/FloatingTabBar'
 import { spacing } from '../../constants/design-tokens'
 
 const { setEnabled: mockSetAudioEnabled } = require('../../lib/audio')
-const { requestPermission, scheduleReminders, cancelAll } = require('../../lib/notifications')
+const { requestPermission, scheduleReminders, cancelAll, getPermissionStatus } = require('../../lib/notifications')
 
 describe('Settings Screen Acceptance', () => {
   beforeEach(() => {
@@ -367,6 +367,46 @@ describe('Settings Screen Acceptance', () => {
       expect(requestPermission).toHaveBeenCalled()
     })
     expect(await findByText(/Notifications blocked/)).toBeTruthy()
+  })
+
+  // ── Rest Timer Notifications toggle (BLD-2354) ──────────────────────────────────
+
+  it('Rest Timer Notifications toggle renders OFF when permission is denied (BLD-2354)', async () => {
+    // Simulate: restNotifications preference is saved as "true" but perm is denied
+    getPermissionStatus.mockResolvedValue('denied')
+
+    mockGetAppSetting.mockImplementation((key: string) => {
+      if (key === 'rest_notification_enabled') return Promise.resolve('true')
+      if (key === 'reminders_enabled') return Promise.resolve('false')
+      if (key === 'timer_sound_enabled') return Promise.resolve('true')
+      return Promise.resolve(null)
+    })
+
+    const { findByLabelText } = renderScreen(<Settings />)
+    const toggle = await findByLabelText('Rest Timer Notifications')
+
+    // Toggle value must be false when permission is denied — even if preference is saved as true
+    await waitFor(() => {
+      expect(toggle.props.value).toBe(false)
+    })
+  })
+
+  it('Rest Timer Notifications toggle renders ON when permission is granted and preference is true (BLD-2354)', async () => {
+    getPermissionStatus.mockResolvedValue('granted')
+
+    mockGetAppSetting.mockImplementation((key: string) => {
+      if (key === 'rest_notification_enabled') return Promise.resolve('true')
+      if (key === 'reminders_enabled') return Promise.resolve('false')
+      if (key === 'timer_sound_enabled') return Promise.resolve('true')
+      return Promise.resolve(null)
+    })
+
+    const { findByLabelText } = renderScreen(<Settings />)
+    const toggle = await findByLabelText('Rest Timer Notifications')
+
+    await waitFor(() => {
+      expect(toggle.props.value).toBe(true)
+    })
   })
 
   // ── Export/Import & CSV ──────────────────────────────────

--- a/components/settings/ReminderSection.tsx
+++ b/components/settings/ReminderSection.tsx
@@ -223,7 +223,7 @@ export default function ReminderSection({
           </View>
         </Pressable>
         <Switch
-          value={restNotifications}
+          value={restNotifications && !permDenied}
           onValueChange={async (val) => {
             if (val) {
               try {


### PR DESCRIPTION
## Summary

When the system notification permission is denied, the "Rest Timer Notifications" toggle was showing as visually ON (green/teal) while simultaneously displaying "Notifications are blocked in Android Settings." This conflicting state misled users into believing their rest-timer reminders were active.

## Changes

- `components/settings/ReminderSection.tsx`: Changed toggle `value` from `restNotifications` to `restNotifications && !permDenied`, so the visual state reflects the effective (blocked) state when permission is denied
- `__tests__/acceptance/settings.test.tsx`: Added 2 acceptance tests covering the perm-denied → toggle OFF scenario and the granted → toggle ON scenario

## Behaviour

- **Before**: Toggle shows ON + error banner visible simultaneously → confusing contradictory UI
- **After**: Toggle shows OFF when permission is denied → consistent, accurate state
- **Preservation**: The stored DB preference is unchanged — once the user grants permission, the toggle restores its saved value without re-configuration

## Testing

- TypeScript: `tsc --noEmit` passes with 0 errors
- All 23 settings acceptance tests pass including 2 new BLD-2354 regression tests

## Issue

Closes BLD-2354