### PR TITLE
fix: prevent Volume label truncation in workout summary stats card (BLD-2355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
+- **Fix: "Volume" label in the workout summary stats card no longer truncates with an ellipsis** — the caption `Volume (kg)` was being cut off to `Volume ...` on narrow mobile screens even after the BLD-2197 font-shrink fix. The label now wraps to two lines (`Volume` / `(kg)`) instead of shrinking to fit, ensuring the full text is always visible at any font scale. (BLD-2355)
 - **Fix: Rest Timer Notifications toggle no longer shows ON when the OS permission is denied** — the toggle in Settings now reflects the real system permission state; if the user previously denied notification permission at the OS level, the toggle correctly shows OFF rather than falsely indicating the feature is active. (BLD-2354)
 
 ## v0.26.48 — 2026-06-29

--- a/__tests__/acceptance/summary-stat-tile-single-line.acceptance.test.tsx
+++ b/__tests__/acceptance/summary-stat-tile-single-line.acceptance.test.tsx
@@ -14,9 +14,13 @@
  *  - Volume label:   "Volume (kg)" (unit shown in caption instead)
  *  - accessibilityLabel on the card: "Total volume: 3,720 kg" (unchanged — a11y preserved)
  *
+ * BLD-2355 fixes the Volume caption still truncating even with adjustsFontSizeToFit:
+ *  - Volume label uses numberOfLines=2 (wraps to two lines) instead of numberOfLines=1
+ *  - adjustsFontSizeToFit is removed from the caption (no longer needed with wrapping)
+ *
  * Verifies:
  *  - Duration / Sets captions render exact static text with numberOfLines=1
- *  - Volume caption renders "Volume (kg)" or "Volume (lb)" with numberOfLines=1
+ *  - Volume caption renders "Volume (kg)" or "Volume (lb)" with numberOfLines=2 (BLD-2355)
  *  - Volume VALUE text is a bare number (no unit suffix)
  *  - Volume VALUE text has numberOfLines=1 and adjustsFontSizeToFit
  *  - The Volume Card accessibilityLabel still includes the unit (a11y not regressed)
@@ -158,7 +162,7 @@ describe('Summary stat tile captions — single-line constraint (BLD-1993)', () 
     expect(statCaption!.props.minimumFontScale).toBeFalsy()
   })
 
-  it('Volume caption renders "Volume (kg)" or "Volume (lb)" with numberOfLines=1 (BLD-2135)', async () => {
+  it('Volume caption renders "Volume (kg)" or "Volume (lb)" with numberOfLines=2 (BLD-2355)', async () => {
     const { session, exercises, sets } = createCompletedWorkoutFixture()
     mockDb.getSessionById.mockResolvedValue(session)
     mockDb.getSessionSets.mockResolvedValue(sets)
@@ -169,11 +173,11 @@ describe('Summary stat tile captions — single-line constraint (BLD-1993)', () 
     // BLD-2135: unit moved from value line to caption to prevent large-value truncation.
     // Caption is now "Volume (kg)" or "Volume (lb)" — NOT bare "Volume".
     const volumeCaption = await screen.findByText(/^Volume \((kg|lb)\)$/i)
-    expect(volumeCaption.props.numberOfLines).toBe(1)
-    // BLD-2197: "Volume (kg)" still truncated to "Volume ..." in the narrow 3-tile
-    // row, so the caption now shrinks to fit (mirrors the value Text). Must keep
-    // adjustsFontSizeToFit so it never ellipsizes.
-    expect(volumeCaption.props.adjustsFontSizeToFit).toBe(true)
+    // BLD-2355: caption wraps to two lines instead of truncating with ellipsis.
+    // numberOfLines=2 replaces the old numberOfLines=1 + adjustsFontSizeToFit approach.
+    expect(volumeCaption.props.numberOfLines).toBe(2)
+    // BLD-2355: adjustsFontSizeToFit is removed — wrapping is the correct fix.
+    expect(volumeCaption.props.adjustsFontSizeToFit).not.toBe(true)
   })
 
   it('Volume VALUE text is a bare number (no unit suffix) with adjustsFontSizeToFit (BLD-2135)', async () => {
@@ -194,7 +198,8 @@ describe('Summary stat tile captions — single-line constraint (BLD-1993)', () 
     // The value text node inside the card's heading is a bare number — no " kg"/" lb" suffix
     // The caption "Volume (kg)" carries the unit instead.
     const volumeCaption = await screen.findByText(/^Volume \((kg|lb)\)$/i)
-    expect(volumeCaption.props.numberOfLines).toBe(1)
+    // BLD-2355: caption now wraps to two lines instead of truncating
+    expect(volumeCaption.props.numberOfLines).toBe(2)
   })
 
   it('Sets tile accessibilityLabel still exposes full breakdown text (a11y not regressed)', async () => {
@@ -284,9 +289,9 @@ describe('Summary stat tile captions — single-line constraint (BLD-1993)', () 
     // The accessibilityLabel confirms the card is the right one.
     // Verify the caption carries the unit instead (BLD-2135)
     const volumeCaption = await screen.findByText(/^Volume \((kg|lb)\)$/i)
-    expect(volumeCaption.props.numberOfLines).toBe(1)
-    // BLD-2197: caption "Volume (kg)" shrinks to fit (was truncating to "Volume ..."),
-    // matching the value Text treatment.
-    expect(volumeCaption.props.adjustsFontSizeToFit).toBe(true)
+    // BLD-2355: caption wraps to two lines instead of ellipsizing
+    expect(volumeCaption.props.numberOfLines).toBe(2)
+    // BLD-2355: adjustsFontSizeToFit removed — wrapping is the correct fix.
+    expect(volumeCaption.props.adjustsFontSizeToFit).not.toBe(true)
   })
 })

--- a/__tests__/components/session/summary/VolumeLabel.truncation.test.tsx
+++ b/__tests__/components/session/summary/VolumeLabel.truncation.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * BLD-2355: Volume label in workout summary stats card must not truncate.
+ *
+ * Before the fix: `Volume ({unit})` used `numberOfLines={1}` with
+ * `adjustsFontSizeToFit minimumFontScale={0.7}`, which still showed
+ * "Volume …" at 390×844 because even 70% of the caption font is too wide
+ * for the equal-flex column.
+ *
+ * After the fix: the label uses `numberOfLines={2}` (no `adjustsFontSizeToFit`)
+ * so it wraps to two lines ("Volume" + "(kg)") instead of truncating.
+ *
+ * This test renders the full Summary route with a fully-resolved data mock
+ * and asserts:
+ *   1. The Volume label text node is present in the tree.
+ *   2. Its closest `numberOfLines` prop is 2, not 1.
+ *   3. It has no `adjustsFontSizeToFit` prop set to true (the broken prior fix).
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react-native'
+
+// ── Minimal router mock ────────────────────────────────────────────────────
+jest.mock('expo-router', () => {
+  const RealReact = require('react')
+  return {
+    Stack: { Screen: () => null },
+    useRouter: () => ({ push: jest.fn(), replace: jest.fn(), back: jest.fn() }),
+    useLocalSearchParams: () => ({ id: 'session-1' }),
+    usePathname: () => '/session/summary/session-1',
+    useFocusEffect: (cb: () => (() => void) | void) => {
+      RealReact.useEffect(() => {
+        const cleanup = cb()
+        return typeof cleanup === 'function' ? cleanup : undefined
+      }, [])
+    },
+  }
+})
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => 'Icon')
+jest.mock('lucide-react-native', () => {
+  const dummy = () => null
+  return new Proxy({}, { get: () => dummy })
+})
+
+jest.mock('../../../../lib/layout', () => ({
+  useLayout: () => ({ wide: false, width: 390, scale: 1.0, horizontalPadding: 16 }),
+}))
+jest.mock('../../../../lib/interactions', () => ({
+  log: jest.fn(),
+  recent: jest.fn().mockResolvedValue([]),
+}))
+jest.mock('expo-file-system', () => ({ File: jest.fn(), Paths: { cache: '/cache' } }))
+jest.mock('expo-sharing', () => ({ shareAsync: jest.fn() }))
+jest.mock('../../../../lib/errors', () => ({
+  logError: jest.fn(),
+  generateReport: jest.fn().mockResolvedValue('{}'),
+  getRecentErrors: jest.fn().mockResolvedValue([]),
+  generateGitHubURL: jest.fn().mockReturnValue('https://github.com'),
+}))
+
+// ── Data hook mocks — provide a completed session so the stats card renders ─
+jest.mock('../../../../hooks/useSummaryData', () => ({
+  useSummaryData: () => ({
+    session: {
+      id: 'session-1',
+      name: 'Test Workout',
+      completed_at: 1700000000,
+      started_at: 1700000000,
+      duration_seconds: 3600,
+      rating: null,
+      notes: null,
+      edited_at: null,
+    },
+    grouped: [],
+    prs: [],
+    repPrs: [],
+    increases: [],
+    comparison: null,
+    unit: 'kg' as const,
+    volume: 3720,
+    setsBreakdown: '',
+    newAchievements: [],
+    completedSetCount: 12,
+    primaryMuscles: [],
+    secondaryMuscles: [],
+    error: null,
+  }),
+}))
+
+jest.mock('../../../../hooks/useSummaryActions', () => ({
+  useSummaryActions: () => ({
+    rating: null,
+    handleRatingChange: jest.fn(),
+    notesExpanded: false,
+    setNotesExpanded: jest.fn(),
+    notesText: '',
+    setNotesText: jest.fn(),
+    handleNotesSave: jest.fn(),
+    templateModalVisible: false,
+    setTemplateModalVisible: jest.fn(),
+    templateName: '',
+    setTemplateName: jest.fn(),
+    saving: false,
+    handleSaveAsTemplate: jest.fn(),
+    handleShareButtonPress: jest.fn(),
+    previewVisible: false,
+    setPreviewVisible: jest.fn(),
+    imageLoading: false,
+    setImageLoading: jest.fn(),
+    shareCardRef: { current: null },
+    handleCaptureAndShare: jest.fn(),
+    handleShareImage: jest.fn(),
+    shareSheetRef: { current: null },
+  }),
+}))
+
+jest.mock('../../../../hooks/useSessionPacing', () => ({
+  useSessionPacing: () => ({ pacing: null }),
+}))
+
+jest.mock('../../../../components/RatingWidget', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('../../../../components/ShareSheet', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('../../../../components/session/summary/SummaryFooter', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+import SummaryRoute from '../../../../app/session/summary/[id]'
+
+describe('BLD-2355 — Volume stat label truncation fix', () => {
+  it('renders the Volume label without truncation (numberOfLines === 2)', () => {
+    const { getAllByText } = render(<SummaryRoute />)
+
+    // The label rendered is "Volume (kg)" with the mocked unit='kg'.
+    const nodes = getAllByText(/Volume \(kg\)/)
+    expect(nodes.length).toBeGreaterThan(0)
+
+    // Walk up the tree from the text node to find the closest numberOfLines prop.
+    const textNode = nodes[0]
+    let cursor: typeof textNode | null = textNode
+    let resolvedNumberOfLines: number | undefined
+    while (cursor) {
+      const n = cursor.props?.numberOfLines as number | undefined
+      if (typeof n === 'number') {
+        resolvedNumberOfLines = n
+        break
+      }
+      cursor = cursor.parent ?? null
+    }
+
+    // Must be 2 (wraps) — NOT 1 (truncates)
+    expect(resolvedNumberOfLines).toBe(2)
+  })
+
+  it('Volume label does not use adjustsFontSizeToFit (previous broken workaround)', () => {
+    const { getAllByText } = render(<SummaryRoute />)
+
+    const nodes = getAllByText(/Volume \(kg\)/)
+    expect(nodes.length).toBeGreaterThan(0)
+
+    const textNode = nodes[0]
+    // The fix removes adjustsFontSizeToFit from the label entirely.
+    // Walk up to find the enclosing Text node and confirm the prop is absent/false.
+    let cursor: typeof textNode | null = textNode
+    let foundAdjusts: boolean | undefined
+    while (cursor) {
+      if (cursor.props && 'adjustsFontSizeToFit' in cursor.props) {
+        foundAdjusts = cursor.props.adjustsFontSizeToFit as boolean
+        break
+      }
+      cursor = cursor.parent ?? null
+    }
+    // Should not be true (either absent or explicitly false)
+    expect(foundAdjusts).not.toBe(true)
+  })
+})

--- a/app/session/summary/[id].tsx
+++ b/app/session/summary/[id].tsx
@@ -285,7 +285,7 @@ function SummaryHeader({ colors, session, duration, durationSpokenText, complete
         <Card style={StyleSheet.flatten([styles.stat, { backgroundColor: colors.surface }])} accessibilityLabel={`Total volume: ${volumeDisplay.toLocaleString()} ${unit}`}>
           <CardContent style={styles.statInner}>
             <Text variant="heading" style={{ color: colors.primary }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>{volumeDisplay.toLocaleString()}</Text>
-            <Text variant="caption" style={{ color: colors.onSurfaceVariant }} numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}>Volume ({unit})</Text>
+            <Text variant="caption" style={{ color: colors.onSurfaceVariant, textAlign: "center" }} numberOfLines={2}>Volume ({unit})</Text>
           </CardContent>
         </Card>
       </View>


### PR DESCRIPTION
## Summary

The "Volume" stat label in the workout summary stats card was shown as "Volume …" with a trailing ellipsis at 390×844 mobile viewport. The three stat cards share equal `flex: 1` width, but "Volume (kg)" is the longest label and overflowed the single-line budget even with the previous `adjustsFontSizeToFit minimumFontScale={0.7}` workaround.

## Changes

- `app/session/summary/[id].tsx`: Replace `numberOfLines={1} adjustsFontSizeToFit minimumFontScale={0.7}` on the Volume label with `numberOfLines={2} textAlign="center"`, allowing the label to wrap to two lines ("Volume" / "(kg)") instead of truncating to an ellipsis
- `__tests__/components/session/summary/VolumeLabel.truncation.test.tsx`: Add style-contract test locking `numberOfLines={2}` and confirming `adjustsFontSizeToFit` is not set on the Volume label

## Testing

- TypeScript: `tsc --noEmit` — zero errors
- New test: 2/2 passing
  - `renders the Volume label without truncation (numberOfLines === 2)`
  - `Volume label does not use adjustsFontSizeToFit (previous broken workaround)`

## Issue

Resolves BLD-2355

**Audit context**: completed-workout scenario, mobile 390×844, commit e128b60f, fingerprint 78b4c52976e0