### PR TITLE
fix: strip accessible/accessibilityLabel from SVG DOM elements (BLD-2356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ marker) at release time.
 ## Unreleased
 
 - **Improvement: Session set-logging is now faster with less visual noise** — the persistent "+ Add pinned note" empty-state prompt no longer appears on every exercise card; the "Last: …" confirmation dialog is gone (tapping "Last" now prefills the weight immediately without an extra tap); icon buttons got a slightly larger tap target; and the pulley-pin chip is now hidden until you have chosen a cable attachment/mount, so unset cable rows stay cleaner. (BLD-2386)
+- **Fix: Removed a stray red error toast that could appear on body-diagram screens** — the muscle/body highlighter passed React Native accessibility props through to web SVG DOM nodes, producing a "Received `true` for a non-boolean attribute `accessible`" warning that surfaced as a red dev toast. Those props are now stripped before reaching the DOM. (BLD-2356)
 
 ## v0.26.49 — 2026-06-30
 <!-- versionCode: 119 -->


### PR DESCRIPTION
## Summary

Fixes the React prop-type warning toast visible in the `bld-480-prefix` fixture.

## Root Cause

`react-native-body-highlighter`'s `SvgMaleWrapper`/`SvgFemaleWrapper` hardcodes `accessible={true}` and `accessibilityLabel` on the `react-native-svg` `Svg` component. On web, `prepare.js` in `react-native-svg`'s web runtime spreads unknown props via `...rest` onto the DOM SVG element. `accessible={true}` (a boolean) is not a valid SVG/HTML attribute, so React warns:

> Received `true` for a non-boolean attribute `accessible`

In dev mode this warning is captured and rendered as a red error toast, cluttering the bld-480-prefix fixture screen with an unrelated error.

## Fix

Same pattern as BLD-1670 (stripped `onPressIn`/`onPressOut`/etc) and BLD-1770 (stripped `onStartShouldSetResponder`/etc): explicitly destructure `accessible` and `accessibilityLabel` out of `props` before `...rest` in the `prepare()` function in both the ESM and CJS builds of the patch.

Updated `patches/react-native-svg+15.15.3.patch` via `patch-package react-native-svg` from the modified `node_modules` state.