### PR TITLE
fix(patch): strip RN a11y props from react-native-svg prepare() (BLD-2349)

### DIFF
--- a/__tests__/patches/react-native-svg-prepare.test.ts
+++ b/__tests__/patches/react-native-svg-prepare.test.ts
@@ -110,3 +110,85 @@ describe('react-native-svg prepare() patch (BLD-1770)', () => {
     });
   });
 });
+
+/**
+ * BLD-2349: Regression test for RN-only accessibility prop stripping.
+ *
+ * react-native-body-highlighter's SvgMaleWrapper/SvgFemaleWrapper hardcodes
+ * `accessible={true}` (and `accessibilityLabel`) on every <Svg>/<Path> element.
+ * The render tree is: MusclesWorkedCard → MuscleMap → <Body> → <Svg>/<Path>.
+ *
+ * `accessible`, `accessibilityElementsHidden`, and `importantForAccessibility`
+ * are RN-only props with no SVG DOM equivalent. When they fall into `...rest`
+ * they reach `createDOMProps` and are emitted raw onto the SVG DOM element,
+ * causing React's "Received `true` for a non-boolean attribute `accessible`"
+ * warning — rendered as a red error toast in dev mode on the bld-480-prefix
+ * audit fixture.
+ *
+ * `accessibilityLabel` is intentionally NOT stripped here — react-native-web
+ * correctly maps it to `aria-label` (it is in createDOMProps's `_excluded`
+ * denylist) so stripping it would remove legitimate a11y labeling.
+ *
+ * Refs: BLD-2349, BLD-1670, BLD-1770.
+ */
+
+const RN_A11Y_PROPS = [
+  'accessible',
+  'accessibilityElementsHidden',
+  'importantForAccessibility',
+] as const;
+
+describe('react-native-svg prepare() patch (BLD-2349)', () => {
+  describe('RN-only accessibility props are stripped', () => {
+    it('does NOT include accessible / accessibilityElementsHidden / importantForAccessibility in the output', () => {
+      const stub = makeStub();
+      const result = prepare(stub as never, {
+        accessible: true,
+        accessibilityElementsHidden: false,
+        importantForAccessibility: 'yes',
+      } as never);
+      for (const prop of RN_A11Y_PROPS) {
+        expect(result).not.toHaveProperty(prop);
+      }
+    });
+
+    it('does NOT include accessible specifically (body-highlighter hardcodes accessible={true})', () => {
+      const stub = makeStub();
+      const onPress = () => (undefined as unknown as (x: unknown) => void)?.(null);
+      const result = prepare(stub as never, {
+        onPress,
+        accessible: true,
+        accessibilityLabel: 'body figure',
+      } as never);
+      expect(result).not.toHaveProperty('accessible');
+    });
+
+    it('preserves accessibilityLabel so react-native-web can map it to aria-label', () => {
+      const stub = makeStub();
+      const result = prepare(stub as never, {
+        accessibilityLabel: 'muscle group diagram',
+        accessible: true,
+      } as never);
+      // accessibilityLabel must NOT be stripped — it is handled by createDOMProps
+      // which maps it to aria-label. Stripping it would remove legitimate a11y.
+      expect(result).toHaveProperty('accessibilityLabel', 'muscle group diagram');
+    });
+
+    it('strips all three RN a11y props together (body-highlighter SvgWrapper pattern)', () => {
+      const stub = makeStub();
+      const onPress = () => (undefined as unknown as (x: unknown) => void)?.(null);
+      const result = prepare(stub as never, {
+        onPress,
+        accessible: true,
+        accessibilityLabel: 'human body diagram',
+        accessibilityElementsHidden: false,
+        importantForAccessibility: 'yes',
+      } as never);
+      for (const prop of RN_A11Y_PROPS) {
+        expect(result).not.toHaveProperty(prop);
+      }
+      // accessibilityLabel must survive
+      expect(result).toHaveProperty('accessibilityLabel', 'human body diagram');
+    });
+  });
+});

--- a/e2e/scenarios/completed-workout-prefix.spec.ts
+++ b/e2e/scenarios/completed-workout-prefix.spec.ts
@@ -55,6 +55,33 @@ test.describe("@scenario bld-480-prefix", () => {
   });
 
   test("captures BLD-480 pre-fix MusclesWorkedCard reproducer", async ({ page }) => {
+    // BLD-2349 regression guard: fail if React DOM prop warnings fire.
+    // react-native-body-highlighter injects accessible={true} / accessibilityElementsHidden
+    // / importantForAccessibility onto every <Svg>/<Path>. Without the
+    // react-native-svg patch these leak onto the SVG DOM and appear as a red
+    // "Received `true` for a non-boolean attribute" error toast in the audit PNG.
+    const domPropErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        const text = msg.text();
+        if (
+          text.includes("does not recognize") ||
+          text.includes("non-boolean attribute") ||
+          text.includes("Invalid prop")
+        ) {
+          domPropErrors.push(text);
+        }
+      }
+    });
+    page.on("pageerror", (err) => {
+      if (
+        err.message.includes("does not recognize") ||
+        err.message.includes("non-boolean attribute")
+      ) {
+        domPropErrors.push(err.message);
+      }
+    });
+
     await page.addInitScript((scenario) => {
       const w = window as unknown as Record<string, unknown>;
       w.__SKIP_ONBOARDING__ = true;
@@ -80,6 +107,17 @@ test.describe("@scenario bld-480-prefix", () => {
       timeout: 10_000,
     });
     await page.waitForTimeout(500);
+
+    // BLD-2349: assert no React DOM prop warnings were emitted on this screen.
+    // If `accessible`, `accessibilityElementsHidden`, or `importantForAccessibility`
+    // leak from react-native-body-highlighter onto the SVG DOM, React emits a
+    // "Received `true` for a non-boolean attribute" warning that shows up as a
+    // persistent red error toast in the audit PNG. This guard catches that exact
+    // regression in the bld-480-prefix render path (identical to the audit pipeline).
+    expect(
+      domPropErrors,
+      "React DOM prop warnings found on bld-480-prefix fixture — RN-only a11y props may be leaking to SVG DOM elements (check react-native-svg patch, BLD-2349)",
+    ).toHaveLength(0);
 
     const viewport = "mobile";
     await captureWithCvd({

--- a/patches/react-native-svg+15.15.3.patch
+++ b/patches/react-native-svg+15.15.3.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js b/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js
-index d57e7c8..0b215d3 100644
+index d57e7c8..094b71c 100644
 --- a/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js
 +++ b/node_modules/react-native-svg/lib/commonjs/web/utils/prepare.js
-@@ -32,6 +32,25 @@ const prepare = (self, props = self.props) => {
+@@ -32,6 +32,41 @@ const prepare = (self, props = self.props) => {
      gradientTransform,
      patternTransform,
      onPress,
@@ -25,10 +25,26 @@ index d57e7c8..0b215d3 100644
 +    delayLongPress,
 +    // eslint-disable-next-line @typescript-eslint/no-unused-vars
 +    disabled,
++    // BLD-2349: strip RN-only accessibility props that are not valid SVG DOM
++    // attributes. `accessible={true}` and `accessibilityElementsHidden={false}`
++    // (and importantForAccessibility) are injected by react-native-body-highlighter's
++    // SvgMaleWrapper/SvgFemaleWrapper onto every <Svg>/<Path>. These fall into
++    // `...rest` and are spread onto the SVG DOM element, causing React's
++    // "Received `true` for a non-boolean attribute `accessible`" warning
++    // (visible as a red error toast in dev mode). Same pattern as BLD-1670
++    // (touch handlers) and BLD-1770 (responder props).
++    // NOTE: accessibilityLabel is intentionally NOT stripped — react-native-web
++    // maps it to aria-label (it is in createDOMProps's _excluded denylist).
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    accessible,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    accessibilityElementsHidden,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    importantForAccessibility,
      ...rest
    } = props;
    const clean = {
-@@ -93,7 +112,16 @@ const prepare = (self, props = self.props) => {
+@@ -93,7 +128,16 @@ const prepare = (self, props = self.props) => {
      var _resolveAssetUri;
      clean.href = (_resolveAssetUri = (0, _resolveAssetUri2.resolveAssetUri)(props.href)) === null || _resolveAssetUri === void 0 ? void 0 : _resolveAssetUri.uri;
    }
@@ -48,10 +64,10 @@ index d57e7c8..0b215d3 100644
  //# sourceMappingURL=prepare.js.map
 \ No newline at end of file
 diff --git a/node_modules/react-native-svg/lib/module/web/utils/prepare.js b/node_modules/react-native-svg/lib/module/web/utils/prepare.js
-index 113eb2b..50428ec 100644
+index 113eb2b..14687f1 100644
 --- a/node_modules/react-native-svg/lib/module/web/utils/prepare.js
 +++ b/node_modules/react-native-svg/lib/module/web/utils/prepare.js
-@@ -26,6 +26,25 @@ export const prepare = (self, props = self.props) => {
+@@ -26,6 +26,41 @@ export const prepare = (self, props = self.props) => {
      gradientTransform,
      patternTransform,
      onPress,
@@ -74,10 +90,26 @@ index 113eb2b..50428ec 100644
 +    delayLongPress,
 +    // eslint-disable-next-line @typescript-eslint/no-unused-vars
 +    disabled,
++    // BLD-2349: strip RN-only accessibility props that are not valid SVG DOM
++    // attributes. `accessible={true}` and `accessibilityElementsHidden={false}`
++    // (and importantForAccessibility) are injected by react-native-body-highlighter's
++    // SvgMaleWrapper/SvgFemaleWrapper onto every <Svg>/<Path>. These fall into
++    // `...rest` and are spread onto the SVG DOM element, causing React's
++    // "Received `true` for a non-boolean attribute `accessible`" warning
++    // (visible as a red error toast in dev mode). Same pattern as BLD-1670
++    // (touch handlers) and BLD-1770 (responder props).
++    // NOTE: accessibilityLabel is intentionally NOT stripped — react-native-web
++    // maps it to aria-label (it is in createDOMProps's _excluded denylist).
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    accessible,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    accessibilityElementsHidden,
++    // eslint-disable-next-line @typescript-eslint/no-unused-vars
++    importantForAccessibility,
      ...rest
    } = props;
    const clean = {
-@@ -87,6 +106,15 @@ export const prepare = (self, props = self.props) => {
+@@ -87,6 +122,15 @@ export const prepare = (self, props = self.props) => {
      var _resolveAssetUri;
      clean.href = (_resolveAssetUri = resolveAssetUri(props.href)) === null || _resolveAssetUri === void 0 ? void 0 : _resolveAssetUri.uri;
    }


### PR DESCRIPTION
## Summary

Extend the existing `react-native-svg` patch to strip three RN-only accessibility props that were leaking onto SVG DOM elements, causing a persistent red React error toast in the `bld-480-prefix` audit fixture.

## Root cause

`react-native-body-highlighter` hardcodes `accessible={true}` (and `accessibilityLabel`) on every `<Svg>/<Path>` element. `accessible` falls into `...rest` → `createDOMProps` → emitted raw onto the DOM `<svg>` element → React warns: "Received `true` for a non-boolean attribute `accessible`" (red error toast in dev/audit builds).

## Changes

- **`patches/react-native-svg+15.15.3.patch`**: extend BLD-1670/BLD-1770 props destructure to also discard `accessible`, `accessibilityElementsHidden`, `importantForAccessibility` from both `commonjs` and `module` builds. Regenerated via `patch-package`. Note: `accessibilityLabel` intentionally NOT stripped — react-native-web maps it to `aria-label` correctly.
- **`__tests__/patches/react-native-svg-prepare.test.ts`**: add BLD-2349 describe block with 4 unit assertions (props absent, `accessibilityLabel` preserved, combined body-highlighter SvgWrapper pattern).
- **`e2e/scenarios/completed-workout-prefix.spec.ts`**: add `domPropErrors` console/pageerror collector + `expect(domPropErrors).toHaveLength(0)` guard before `captureWithCvd` — proves the toast is gone in the exact render path the audit screenshots use.

## Testing

- `tsc --noEmit`: passes with zero errors
- `jest __tests__/patches/react-native-svg-prepare.test.ts`: 9 tests pass (5 existing BLD-1670/BLD-1770 + 4 new BLD-2349)

## Issue

Resolves BLD-2349