### PR TITLE
feat: session set-logging friction reduction — A/B/C/D (BLD-2386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
+- **Improvement: Session set-logging is now faster with less visual noise** — the persistent "+ Add pinned note" empty-state prompt no longer appears on every exercise card; the "Last: …" confirmation dialog is gone (tapping "Last" now prefills the weight immediately without an extra tap); icon buttons got a slightly larger tap target; and the pulley-pin chip is now hidden until you have chosen a cable attachment/mount, so unset cable rows stay cleaner. (BLD-2386)
 - **Fix: "Volume" label in the workout summary stats card no longer truncates with an ellipsis** — the caption `Volume (kg)` was being cut off to `Volume ...` on narrow mobile screens even after the BLD-2197 font-shrink fix. The label now wraps to two lines (`Volume` / `(kg)`) instead of shrinking to fit, ensuring the full text is always visible at any font scale. (BLD-2355)
 - **Fix: Rest Timer Notifications toggle no longer shows ON when the OS permission is denied** — the toggle in Settings now reflects the real system permission state; if the user previously denied notification permission at the OS level, the toggle correctly shows OFF rather than falsely indicating the feature is active. (BLD-2354)
 

--- a/__tests__/components/SetRow-cable-row-density.test.tsx
+++ b/__tests__/components/SetRow-cable-row-density.test.tsx
@@ -189,16 +189,20 @@ describe("SetRow — setup photo thumbnail (BLD-1114)", () => {
 });
 
 describe("SetRow — pulley pin chip (BLD-1114)", () => {
+  // BLD-2386 Item D3: pulley-pin chip is only shown after an attachment or
+  // mount position is chosen. Tests that assert the chip is visible must pass
+  // a set with at least one of those fields populated.
+
   it("shows 'Pin 7' chip when pulleyPin=7", () => {
     const { getByText } = render(
-      <SetRow {...baseProps({ pulleyPin: 7, onOpenPulleyPinPicker: jest.fn() })} />
+      <SetRow {...baseProps({ set: makeSet({ attachment: "handle" }), pulleyPin: 7, onOpenPulleyPinPicker: jest.fn() })} />
     );
     expect(getByText("Pin 7")).toBeTruthy();
   });
 
   it("shows 'Pin —' placeholder when pulleyPin=null", () => {
     const { getByText } = render(
-      <SetRow {...baseProps({ pulleyPin: null, onOpenPulleyPinPicker: jest.fn() })} />
+      <SetRow {...baseProps({ set: makeSet({ attachment: "handle" }), pulleyPin: null, onOpenPulleyPinPicker: jest.fn() })} />
     );
     expect(getByText("Pin —")).toBeTruthy();
   });
@@ -206,7 +210,7 @@ describe("SetRow — pulley pin chip (BLD-1114)", () => {
   it("calls onOpenPulleyPinPicker with set id when chip is tapped", () => {
     const onOpenPulleyPinPicker = jest.fn();
     const { getByLabelText } = render(
-      <SetRow {...baseProps({ pulleyPin: 5, onOpenPulleyPinPicker })} />
+      <SetRow {...baseProps({ set: makeSet({ attachment: "handle" }), pulleyPin: 5, onOpenPulleyPinPicker })} />
     );
     fireEvent.press(getByLabelText("Pulley pin 5, tap to change"));
     expect(onOpenPulleyPinPicker).toHaveBeenCalledWith("s1");

--- a/__tests__/components/session/GroupCardHeader-pinned-note-cta.test.tsx
+++ b/__tests__/components/session/GroupCardHeader-pinned-note-cta.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * BLD-2386 Item A — GroupCardHeader pinned-note empty-state CTA removal.
+ *
+ * AC1: group with no pinned note → no "+ Add pinned note" text CTA;
+ *      pin-outline icon still present and opens the editor on tap.
+ * AC2: group WITH a pinned note → "📌 {note}" read surface unchanged.
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import { GroupCardHeader } from "../../../components/session/GroupCardHeader";
+import type { ExerciseGroup, SetWithMeta } from "../../../components/session/types";
+
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => {
+  const ReactLib = require("react");
+  const { Text } = require("react-native");
+  const Icon = (props: { name: string; size?: number; color?: string; accessibilityLabel?: string; testID?: string }) =>
+    ReactLib.createElement(Text, { ...props, testID: props.testID ?? `icon-${props.name}` }, props.name);
+  return { __esModule: true, default: Icon };
+});
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#6200ee",
+    primaryContainer: "#e8def8",
+    onSurface: "#1c1b1f",
+    onSurfaceVariant: "#49454f",
+    outlineVariant: "#cac4d0",
+    outline: "#79747e",
+    surface: "#fffbfe",
+    surfaceVariant: "#e7e0ec",
+    shadow: "#000000",
+    background: "#fffbfe",
+  }),
+}));
+
+jest.mock("../../../components/session/ExerciseNotesPanel", () => ({
+  __esModule: true,
+  ExerciseNotesPanel: () => null,
+}));
+
+jest.mock("../../../components/session/SuggestionExplainerModal", () => ({
+  SuggestionExplainerModal: () => null,
+}));
+
+function makeGroup(overrides: Partial<ExerciseGroup> = {}): ExerciseGroup {
+  return {
+    exercise_id: "ex-1",
+    name: "Cable Row",
+    is_voltra: false,
+    is_bodyweight: false,
+    trackingMode: "reps",
+    equipment: "cable",
+    exercise_position: 0,
+    link_id: null,
+    sets: [],
+    progressionSuggested: false,
+    ...overrides,
+  } as ExerciseGroup;
+}
+
+const baseProps = {
+  group: makeGroup(),
+  exerciseNotesOpen: false,
+  exerciseNotesDraft: undefined,
+  firstSet: undefined as SetWithMeta | undefined,
+  suggestion: null,
+  step: 2.5,
+  onUpdate: jest.fn(),
+  onModeChange: jest.fn(),
+  onExerciseNotes: jest.fn(),
+  onExerciseNotesDraftChange: jest.fn(),
+  onToggleExerciseNotes: jest.fn(),
+  onShowDetail: jest.fn(),
+  onSwap: jest.fn(),
+  onDeleteExercise: jest.fn(),
+  pinnedNoteDraft: undefined,
+  onPinnedNoteDraftChange: jest.fn(),
+  onPinnedNoteSave: jest.fn(),
+  onBackfillCopy: jest.fn(),
+  onBackfillDismiss: jest.fn(),
+  onLoadBackfill: jest.fn(),
+};
+
+describe("GroupCardHeader — BLD-2386 Item A pinned-note CTA removal", () => {
+  it("AC1: does NOT render '+ Add pinned note' CTA when no pinned note exists", () => {
+    const { queryByText } = render(
+      <GroupCardHeader
+        {...baseProps}
+        group={makeGroup({ pinnedNote: null })}
+      />,
+    );
+    expect(queryByText("+ Add pinned note")).toBeNull();
+    expect(queryByText(/Add pinned note/)).toBeNull();
+  });
+
+  it("AC1: pin-outline icon still present when no pinned note exists", () => {
+    const { UNSAFE_queryAllByProps } = render(
+      <GroupCardHeader
+        {...baseProps}
+        group={makeGroup({ pinnedNote: null })}
+      />,
+    );
+    // The pin-outline Pressable (affordance to open editor) must still exist.
+    const pinOutlineIcons = UNSAFE_queryAllByProps({ name: "pin-outline" });
+    expect(pinOutlineIcons.length).toBeGreaterThan(0);
+  });
+
+  it("AC1: pin-outline icon opens the editor on tap — no crash", () => {
+    // The pin-outline Pressable opens PinnedExerciseNoteEditor.
+    // We verify it's pressable without crashing (editor component is not mocked here).
+    const { UNSAFE_getAllByProps } = render(
+      <GroupCardHeader
+        {...baseProps}
+        group={makeGroup({ pinnedNote: null })}
+        onPinnedNoteSave={jest.fn()}
+      />,
+    );
+    // Find and press the pin-outline icon's Pressable — should not throw.
+    const pinIcon = UNSAFE_getAllByProps({ name: "pin-outline" })[0];
+    // The Pressable wrapping the pin icon has onPress set. Fire it via parent.
+    expect(() => {
+      fireEvent.press(pinIcon);
+    }).not.toThrow();
+  });
+
+  it("AC2: '📌 {note}' read surface is present when a pinned note exists", () => {
+    const { queryByText } = render(
+      <GroupCardHeader
+        {...baseProps}
+        group={makeGroup({ pinnedNote: "Keep elbows close" })}
+      />,
+    );
+    expect(queryByText(/📌 Keep elbows close/)).toBeTruthy();
+  });
+
+  it("AC2: still NO '+ Add pinned note' CTA when a pinned note exists", () => {
+    const { queryByText } = render(
+      <GroupCardHeader
+        {...baseProps}
+        group={makeGroup({ pinnedNote: "Keep elbows close" })}
+      />,
+    );
+    expect(queryByText("+ Add pinned note")).toBeNull();
+  });
+});

--- a/__tests__/components/session/GroupCardHeader-prev-perf-affordance.test.tsx
+++ b/__tests__/components/session/GroupCardHeader-prev-perf-affordance.test.tsx
@@ -120,7 +120,9 @@ describe("GroupCardHeader — previous-performance affordance (BLD-551 / BLD-850
     expect(UNSAFE_queryAllByProps({ name: "refresh" }).length).toBe(0);
   });
 
-  it("fires onPrefill on tap → confirm (no regression on BLD-449)", () => {
+  it("fires onPrefill on tap — direct invocation (BLD-2386: no confirm dialog on Last)", () => {
+    // BLD-2386 Item B: Alert.alert wrapper removed. onPrefill now fires synchronously
+    // on tap — the data-layer computePrefillSets is non-destructive.
     const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     const onPrefill = jest.fn();
     const { getByTestId } = render(
@@ -132,11 +134,9 @@ describe("GroupCardHeader — previous-performance affordance (BLD-551 / BLD-850
     );
 
     fireEvent.press(getByTestId("last-half"));
-    // BLD-850 gates the prefill behind a confirm dialog. Simulate the user
-    // pressing "Refill" — this is the BLD-449 functional contract.
-    const buttons = alertSpy.mock.calls[0][2] as Array<{ text: string; onPress?: () => void }>;
-    buttons.find((b) => b.text === "Refill")?.onPress?.();
+    // BLD-2386: direct tap fires onPrefill immediately, no confirm needed.
     expect(onPrefill).toHaveBeenCalledWith("ex-1");
+    expect(alertSpy).not.toHaveBeenCalled();
     alertSpy.mockRestore();
   });
 });

--- a/__tests__/components/session/GroupCardHeader.memo.test.tsx
+++ b/__tests__/components/session/GroupCardHeader.memo.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * BLD-2386 CORRECTION 3 — GroupCardHeader.memo.test.tsx
+ *
+ * Guards the React.memo wrapper at GroupCardHeader.tsx:390 so that:
+ *   1. Render count stays flat (≤1 re-render) across 10 unrelated
+ *      mode-change cycles (same assertion shape as BLD-560 reference).
+ *   2. Items A and C introduce no always-changing props: Item A is purely
+ *      subtractive (branch removed) and Item C is a static style change —
+ *      neither alters the prop shape, so memo remains effective.
+ *
+ * BLD-560 baseline:
+ *   Before BLD-560: 11 renders per 10 unrelated-mode-change cycles.
+ *   After  BLD-560:  1 render  per 10 unrelated-mode-change cycles.
+ *   This test locks that delta in permanently.
+ */
+import React, { useRef, useState } from "react";
+import { Button } from "react-native";
+import { act, render } from "@testing-library/react-native";
+import { GroupCardHeader } from "../../../components/session/GroupCardHeader";
+import type { ExerciseGroup, SetWithMeta } from "../../../components/session/types";
+import {
+  resetRenderCounts,
+  dumpRenderCounts,
+} from "../../../lib/dev/render-counter";
+import type { TrainingMode } from "../../../lib/types";
+
+// Silence the require inside countRender (__DEV__ is true in jest).
+jest.mock("../../../lib/dev/render-counter", () => {
+  const actual = jest.requireActual("../../../lib/dev/render-counter") as typeof import("../../../lib/dev/render-counter");
+  return actual;
+});
+
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => {
+  const ReactLib = require("react");
+  const { Text } = require("react-native");
+  const Icon = (props: { name: string; size?: number; color?: string }) =>
+    ReactLib.createElement(Text, props, props.name);
+  return { __esModule: true, default: Icon };
+});
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => ({
+    primary: "#6200ee",
+    primaryContainer: "#e8def8",
+    onSurface: "#1c1b1f",
+    onSurfaceVariant: "#49454f",
+    outlineVariant: "#cac4d0",
+    outline: "#79747e",
+    surface: "#fffbfe",
+    surfaceVariant: "#e7e0ec",
+    shadow: "#000000",
+    background: "#fffbfe",
+  }),
+}));
+
+jest.mock("../../../components/session/ExerciseNotesPanel", () => ({
+  __esModule: true,
+  ExerciseNotesPanel: () => null,
+}));
+
+jest.mock("../../../components/session/SuggestionExplainerModal", () => ({
+  SuggestionExplainerModal: () => null,
+}));
+
+function makeGroup(overrides: Partial<ExerciseGroup> = {}): ExerciseGroup {
+  return {
+    exercise_id: "ex-1",
+    name: "Cable Row",
+    is_voltra: false,
+    is_bodyweight: false,
+    trackingMode: "reps",
+    equipment: "cable",
+    exercise_position: 0,
+    link_id: null,
+    sets: [],
+    progressionSuggested: false,
+    ...overrides,
+  } as ExerciseGroup;
+}
+
+/** Stable no-op callbacks to prevent memo busting from changing function refs. */
+const stableCallbacks = {
+  onExerciseNotes: jest.fn(),
+  onExerciseNotesDraftChange: jest.fn(),
+  onToggleExerciseNotes: jest.fn(),
+  onPinnedNoteDraftChange: jest.fn(),
+  onPinnedNoteSave: jest.fn(),
+  onBackfillCopy: jest.fn(),
+  onBackfillDismiss: jest.fn(),
+  onLoadBackfill: jest.fn(),
+  onShowDetail: jest.fn(),
+  onSwap: jest.fn(),
+  onDeleteExercise: jest.fn(),
+  onUpdate: jest.fn(),
+  onModeChange: jest.fn(),
+};
+
+// eslint-disable-next-line max-lines-per-function
+describe("GroupCardHeader — BLD-2386 CORRECTION 3 — memo regression guard", () => {
+  beforeEach(() => {
+    resetRenderCounts();
+  });
+
+  it("renders exactly once on initial mount (baseline)", () => {
+    resetRenderCounts();
+    render(
+      <GroupCardHeader
+        group={makeGroup()}
+        currentMode={"normal" as TrainingMode}
+        exerciseNotesOpen={false}
+        exerciseNotesDraft={undefined}
+        firstSet={undefined as SetWithMeta | undefined}
+        suggestion={null}
+        step={2.5}
+        {...stableCallbacks}
+      />,
+    );
+    const rows = dumpRenderCounts();
+    const row = rows.find((r) => r.name === "GroupCardHeader");
+    // Should be exactly 1 render on mount. Allow ≤2 for strict-mode double-invoke.
+    expect(row?.renders ?? 0).toBeLessThanOrEqual(2);
+    expect(row?.renders ?? 0).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not re-render when unrelated parent state changes (10 cycles)", async () => {
+    const group = makeGroup();
+
+    // A component that re-renders the parent 10 times but passes stable props to GroupCardHeader.
+    function TestWrapper() {
+      const [counter, setCounter] = useState(0);
+      const triggerRef = useRef<() => void>(() => setCounter((n) => n + 1));
+      // Store trigger in a ref so tests can call it outside React.
+      triggerRef.current = () => setCounter((n) => n + 1);
+
+      return (
+        <>
+          <GroupCardHeader
+            group={group}
+            currentMode={"normal" as TrainingMode}
+            exerciseNotesOpen={false}
+            exerciseNotesDraft={undefined}
+            firstSet={undefined as SetWithMeta | undefined}
+            suggestion={null}
+            step={2.5}
+            {...stableCallbacks}
+          />
+          {/* An unrelated counter UI that forces parent to re-render */}
+          <Button
+            testID="bump"
+            onPress={() => setCounter((n) => n + 1)}
+            title={`counter: ${counter}`}
+          />
+        </>
+      );
+    }
+
+    resetRenderCounts();
+    const { getByTestId } = render(<TestWrapper />);
+
+    // Trigger 10 parent re-renders that do NOT change any GroupCardHeader prop.
+    for (let i = 0; i < 10; i++) {
+      await act(async () => {
+        getByTestId("bump").props.onPress?.();
+      });
+    }
+
+    const rows = dumpRenderCounts();
+    const row = rows.find((r) => r.name === "GroupCardHeader");
+    // With React.memo, GroupCardHeader should not re-render after mount.
+    // Allow ≤2 as tolerance for strict-mode double-invoke in dev.
+    expect(row?.renders ?? 0).toBeLessThanOrEqual(2);
+  });
+
+  it("Item A — null pinnedNote renders consistently: no spurious re-render", () => {
+    // Item A removed the '+ Add pinned note' branch. The remaining null branch
+    // renders nothing — no new prop that changes on each cycle.
+    const group = makeGroup({ pinnedNote: null });
+    resetRenderCounts();
+    render(
+      <GroupCardHeader
+        group={group}
+        currentMode={"normal" as TrainingMode}
+        exerciseNotesOpen={false}
+        exerciseNotesDraft={undefined}
+        firstSet={undefined as SetWithMeta | undefined}
+        suggestion={null}
+        step={2.5}
+        {...stableCallbacks}
+      />,
+    );
+    const rows = dumpRenderCounts();
+    const row = rows.find((r) => r.name === "GroupCardHeader");
+    // Exactly 1 render on mount (no spurious re-render from null branch).
+    expect(row?.renders ?? 0).toBeLessThanOrEqual(2);
+    expect(row?.renders ?? 0).toBeGreaterThanOrEqual(1);
+  });
+
+  it("Item C — static style change (padding 8→10) does not introduce dynamic props", () => {
+    // Item C only changed iconBtn: { padding: 10 } — a static StyleSheet entry.
+    // No dynamic value derived from props, so memo is unaffected.
+    const group = makeGroup();
+    resetRenderCounts();
+    render(
+      <GroupCardHeader
+        group={group}
+        currentMode={"normal" as TrainingMode}
+        exerciseNotesOpen={false}
+        exerciseNotesDraft={undefined}
+        firstSet={undefined as SetWithMeta | undefined}
+        suggestion={null}
+        step={2.5}
+        {...stableCallbacks}
+      />,
+    );
+    const rows = dumpRenderCounts();
+    const row = rows.find((r) => r.name === "GroupCardHeader");
+    expect(row?.renders ?? 0).toBeLessThanOrEqual(2);
+    expect(row?.renders ?? 0).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/__tests__/components/session/LastNextRow.test.tsx
+++ b/__tests__/components/session/LastNextRow.test.tsx
@@ -125,6 +125,7 @@ function pressAlertButton(spy: jest.SpyInstance, name: string): void {
   btn!.onPress?.();
 }
 
+// eslint-disable-next-line max-lines-per-function
 describe("LastNextRow (BLD-850)", () => {
   let alertSpy: jest.SpyInstance;
 
@@ -271,8 +272,10 @@ describe("LastNextRow (BLD-850)", () => {
     });
   });
 
-  describe("Last — refill confirm flow", () => {
-    it("opens the 'Refill from last session?' Alert on tap", () => {
+  describe("Last — refill (BLD-2386 Item B: no confirm dialog)", () => {
+    it("fires onPrefillLast synchronously on tap — no Alert.alert call", () => {
+      // BLD-2386: Alert.alert wrapper removed from Last half. onPrefillLast fires
+      // directly on tap — the data layer (computePrefillSets) is non-destructive.
       const onPrefillLast = jest.fn();
       const { getByTestId } = render(
         <LastNextRow
@@ -288,14 +291,12 @@ describe("LastNextRow (BLD-850)", () => {
         />,
       );
       fireEvent.press(getByTestId("last-half"));
-      expect(alertSpy).toHaveBeenCalledTimes(1);
-      const [title] = alertSpy.mock.calls[0];
-      expect(title).toBe("Refill from last session?");
-      // Without confirm, the prefill must not fire.
-      expect(onPrefillLast).not.toHaveBeenCalled();
+      // Must fire synchronously — no confirm dialog.
+      expect(onPrefillLast).toHaveBeenCalledTimes(1);
+      expect(alertSpy).not.toHaveBeenCalled();
     });
 
-    it("fires onPrefillLast when the user presses Refill", () => {
+    it("fires onPrefillLast on tap (direct invocation — replaces old 'Refill' button flow)", () => {
       const onPrefillLast = jest.fn();
       const { getByTestId } = render(
         <LastNextRow
@@ -311,11 +312,12 @@ describe("LastNextRow (BLD-850)", () => {
         />,
       );
       fireEvent.press(getByTestId("last-half"));
-      pressAlertButton(alertSpy, "Refill");
       expect(onPrefillLast).toHaveBeenCalledTimes(1);
     });
 
-    it("does NOT fire onPrefillLast when the user cancels", () => {
+    it("does NOT invoke Alert.alert for Last tap (no cancel path exists anymore)", () => {
+      // BLD-2386: the Cancel path is intentionally removed — the data layer is safe
+      // (non-destructive). No alert should be called on Last tap.
       const onPrefillLast = jest.fn();
       const { getByTestId } = render(
         <LastNextRow
@@ -331,8 +333,8 @@ describe("LastNextRow (BLD-850)", () => {
         />,
       );
       fireEvent.press(getByTestId("last-half"));
-      pressAlertButton(alertSpy, "Cancel");
-      expect(onPrefillLast).not.toHaveBeenCalled();
+      expect(alertSpy).not.toHaveBeenCalled();
+      expect(onPrefillLast).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/components/session/SetRow-d3-pulley-pin-gate.test.tsx
+++ b/__tests__/components/session/SetRow-d3-pulley-pin-gate.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * BLD-2386 Item D3 — Pulley-pin chip gating behind variant selection.
+ *
+ * AC6: pending cable set with no variant → footer shows a compact, visually-light,
+ *      still-VISIBLE affordance (not removed, not hidden); the "Pin —" pulley chip
+ *      is NOT shown while variant is unset. Variant set → existing chips render.
+ * AC7: composite accessibilityLabel + clear-on-long-press preserved.
+ *
+ * The unset-footer Pressable MUST stay mounted (ref focus-restore contract:
+ * useVariantPickerSheet.ts:63-74 uses variantFooterRef, no fallback exists).
+ */
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+jest.mock("@expo/vector-icons/MaterialCommunityIcons", () => {
+  const { Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ name }: { name: string }) => <Text>{name}</Text>,
+  };
+});
+
+jest.mock("expo-haptics", () => ({
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  notificationAsync: jest.fn(),
+  selectionAsync: jest.fn().mockResolvedValue(undefined),
+  ImpactFeedbackStyle: { Light: "light", Medium: "medium", Heavy: "heavy" },
+  NotificationFeedbackType: { Success: "success" },
+}));
+
+jest.mock("@/lib/audio", () => ({
+  play: jest.fn().mockResolvedValue(undefined),
+  setEnabled: jest.fn(),
+  preload: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/lib/db", () => ({
+  getAppSetting: jest.fn().mockResolvedValue(null),
+  setAppSetting: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/hooks/useThemeColors", () => {
+  const { lightMockColors } = require("../../helpers/theme");
+  return { useThemeColors: () => lightMockColors };
+});
+
+jest.mock("../../../components/WeightPicker", () => {
+  const { Text } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ value, accessibilityLabel }: { value: number; accessibilityLabel: string }) => (
+      <Text accessibilityLabel={accessibilityLabel}>{value}</Text>
+    ),
+  };
+});
+
+jest.mock("../../../components/session/PlateHint", () => ({ PlateHint: () => null }));
+
+jest.mock("../../../components/SwipeRowAction", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+import { SetRow, type SetRowProps } from "../../../components/session/SetRow";
+import type { SetWithMeta } from "../../../components/session/types";
+import type { Equipment } from "../../../lib/types";
+
+function makeSet(over: Partial<SetWithMeta> = {}): SetWithMeta {
+  return {
+    id: "s1",
+    session_id: "sess",
+    exercise_id: "ex1",
+    set_number: 1,
+    round: null,
+    weight: null,
+    reps: 10,
+    rpe: null,
+    notes: "",
+    completed: false,
+    completed_at: null,
+    set_type: "normal",
+    duration_seconds: null,
+    link_id: null,
+    training_mode: null,
+    tempo: null,
+    swapped_from_exercise_id: null,
+    exercise_position: 0,
+    previous: "",
+    is_pr: false,
+    ...over,
+  } as unknown as SetWithMeta;
+}
+
+function cableProps(over: Partial<SetRowProps> = {}): SetRowProps {
+  const noop = jest.fn();
+  return {
+    set: makeSet(),
+    step: 2.5,
+    unit: "kg",
+    trackingMode: "reps",
+    equipment: "cable" as Equipment,
+    onUpdate: jest.fn(),
+    onCheck: jest.fn(),
+    onDelete: jest.fn(),
+    onCycleSetType: noop,
+    onLongPressSetType: noop,
+    isBodyweight: false,
+    exerciseName: "Cable Pulldown",
+    onOpenBodyweightGripPicker: jest.fn(),
+    onClearBodyweightGrip: jest.fn(),
+    onOpenBodyweightModifier: jest.fn(),
+    onClearBodyweightModifier: jest.fn(),
+    onOpenVariantPicker: jest.fn(),
+    onClearVariant: jest.fn(),
+    ...over,
+  };
+}
+
+describe("SetRow — BLD-2386 Item D3: pulley-pin chip gated behind variant selection", () => {
+  it("AC6: does NOT render pulley-pin chip when variant is unset (attachment=null, mount_position=null)", () => {
+    const set = makeSet({ attachment: null, mount_position: null });
+    const { queryByLabelText } = render(
+      <SetRow
+        {...cableProps({ set, pulleyPin: 5, showPulleyPin: true })}
+      />,
+    );
+    // Pulley chip must not appear when no variant is set
+    expect(queryByLabelText("Pulley pin 5, tap to change")).toBeNull();
+    expect(queryByLabelText("Pulley pin not set, tap to set")).toBeNull();
+  });
+
+  it("AC6: unset-footer Pressable IS still mounted when variant is unset (ref focus-restore)", () => {
+    const set = makeSet({ attachment: null, mount_position: null });
+    const { queryByLabelText } = render(
+      <SetRow {...cableProps({ set })} />,
+    );
+    // The composite label Pressable must remain mounted (ref focus-restore invariant).
+    // It renders the "not set. Double-tap to choose." label.
+    expect(queryByLabelText(/cable variant: not set/)).toBeTruthy();
+  });
+
+  it("AC6: renders pulley-pin chip when attachment is set", () => {
+    const set = makeSet({ attachment: "rope", mount_position: null });
+    const { queryByLabelText } = render(
+      <SetRow
+        {...cableProps({ set, pulleyPin: 7, showPulleyPin: true })}
+      />,
+    );
+    expect(queryByLabelText("Pulley pin 7, tap to change")).toBeTruthy();
+  });
+
+  it("AC6: renders pulley-pin chip when mount_position is set", () => {
+    const set = makeSet({ attachment: null, mount_position: "low" });
+    const { queryByLabelText } = render(
+      <SetRow
+        {...cableProps({ set, pulleyPin: 3, showPulleyPin: true })}
+      />,
+    );
+    expect(queryByLabelText("Pulley pin 3, tap to change")).toBeTruthy();
+  });
+
+  it("AC6: renders pulley-pin chip when both attachment and mount_position are set", () => {
+    const set = makeSet({ attachment: "rope", mount_position: "high" });
+    const { queryByLabelText } = render(
+      <SetRow
+        {...cableProps({ set, pulleyPin: 2, showPulleyPin: true })}
+      />,
+    );
+    expect(queryByLabelText("Pulley pin 2, tap to change")).toBeTruthy();
+  });
+
+  it("AC7: composite accessibilityLabel preserved on unset footer", () => {
+    const set = makeSet({ attachment: null, mount_position: null });
+    const { getByLabelText } = render(<SetRow {...cableProps({ set })} />);
+    // Composite label + Double-tap hint preserved
+    expect(getByLabelText("Set 1 cable variant: not set. Double-tap to choose.")).toBeTruthy();
+  });
+
+  it("AC7: long-press clear-on-long-press preserved (fires onClearVariant)", () => {
+    const onClearVariant = jest.fn();
+    const set = makeSet({ attachment: "rope", mount_position: "low" });
+    const { getByLabelText } = render(
+      <SetRow {...cableProps({ set, onClearVariant })} />,
+    );
+    fireEvent(
+      getByLabelText("Set 1 cable variant: Rope, Low. Double-tap to edit."),
+      "longPress",
+    );
+    expect(onClearVariant).toHaveBeenCalledWith("s1");
+  });
+
+  describe("partial variant states (QD edge-case coverage)", () => {
+    it("attachment set, mount_position null → shows attachment chip; pulley chip visible", () => {
+      const set = makeSet({ attachment: "rope", mount_position: null });
+      const { queryByLabelText } = render(
+        <SetRow {...cableProps({ set, pulleyPin: 4, showPulleyPin: true })} />,
+      );
+      expect(queryByLabelText(/attachment not set/)).toBeNull();
+      expect(queryByLabelText(/position not set/)).toBeTruthy();
+      expect(queryByLabelText("Pulley pin 4, tap to change")).toBeTruthy();
+    });
+
+    it("mount_position set, attachment null → shows mount chip; pulley chip visible", () => {
+      const set = makeSet({ attachment: null, mount_position: "mid" });
+      const { queryByLabelText } = render(
+        <SetRow {...cableProps({ set, pulleyPin: 6, showPulleyPin: true })} />,
+      );
+      expect(queryByLabelText(/attachment not set/)).toBeTruthy();
+      expect(queryByLabelText("Pulley pin 6, tap to change")).toBeTruthy();
+    });
+  });
+});
+
+describe("SetRow — BLD-2386 Item D3: grip footer visual weight (AC6 symmetric)", () => {
+  function bwProps(over: Partial<SetRowProps> = {}): SetRowProps {
+    const noop = jest.fn();
+    return {
+      set: makeSet(),
+      step: 2.5,
+      unit: "kg",
+      trackingMode: "reps",
+      equipment: "bodyweight" as Equipment,
+      onUpdate: jest.fn(),
+      onCheck: jest.fn(),
+      onDelete: jest.fn(),
+      onCycleSetType: noop,
+      onLongPressSetType: noop,
+      isBodyweight: true,
+      exerciseName: "Pull-Up",
+      onOpenBodyweightGripPicker: jest.fn(),
+      onClearBodyweightGrip: jest.fn(),
+      onOpenBodyweightModifier: jest.fn(),
+      onClearBodyweightModifier: jest.fn(),
+      onOpenVariantPicker: jest.fn(),
+      onClearVariant: jest.fn(),
+      ...over,
+    };
+  }
+
+  it("AC7: composite a11y label preserved on unset grip footer", () => {
+    const set = makeSet({ grip_type: null, grip_width: null });
+    const { getByLabelText } = render(<SetRow {...bwProps({ set })} />);
+    expect(getByLabelText("Set 1 grip variant: not set. Double-tap to choose.")).toBeTruthy();
+  });
+
+  it("AC7: long-press clear preserved on grip footer (fires onClearBodyweightGrip)", () => {
+    const onClearBodyweightGrip = jest.fn();
+    const set = makeSet({ grip_type: "overhand", grip_width: "narrow" });
+    const { getByLabelText } = render(
+      <SetRow {...bwProps({ set, onClearBodyweightGrip })} />,
+    );
+    fireEvent(
+      getByLabelText("Set 1 grip variant: Overhand, Narrow. Double-tap to edit."),
+      "longPress",
+    );
+    expect(onClearBodyweightGrip).toHaveBeenCalledWith("s1");
+  });
+});

--- a/components/session/GroupCardHeader.tsx
+++ b/components/session/GroupCardHeader.tsx
@@ -278,6 +278,9 @@ function GroupCardHeaderInner({
           />
         )}
         {/* BLD-1028: pinned note read surface — always visible when a note exists */}
+        {/* BLD-2386 Item A: removed persistent "+ Add pinned note" empty-state CTA.
+            The pin-outline icon (above) is the sole affordance when no note exists.
+            No tooltip/instructional chrome reintroduced. */}
         {!pinnedNoteOpen && group.pinnedNote ? (
           <Pressable
             onPress={() => setPinnedNoteOpen(true)}
@@ -286,16 +289,6 @@ function GroupCardHeaderInner({
           >
             <Text style={[styles.pinnedNotePreview, { color: colors.onSurfaceVariant, borderColor: colors.outlineVariant }]}>
               📌 {group.pinnedNote}
-            </Text>
-          </Pressable>
-        ) : !pinnedNoteOpen && !group.pinnedNote ? (
-          <Pressable
-            onPress={() => setPinnedNoteOpen(true)}
-            accessibilityLabel={`Add pinned note for ${group.name}`}
-            accessibilityRole="button"
-          >
-            <Text style={[styles.pinnedNoteEmpty, { color: colors.primary }]}>
-              + Add pinned note
             </Text>
           </Pressable>
         ) : null}
@@ -358,7 +351,9 @@ const styles = StyleSheet.create({
   },
   detailsBtn: { marginLeft: -24 },
   controlsCluster: { flexDirection: "row", alignItems: "center" },
-  iconBtn: { padding: 8 },
+  // BLD-2386 Item C: padding 8→10 gives a visible 44×44dp box (24dp icon + 2×10 padding = 44dp).
+  // hitSlop is unchanged at 8 so effective hit target is 60dp (≥WCAG 2.5.5).
+  iconBtn: { padding: 10 },
   moveBtn: { width: 56, height: 56, alignItems: "center", justifyContent: "center" },
   moveBtnDisabled: { opacity: 0.4 },
   // BLD-1028: pinned note
@@ -370,7 +365,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     paddingVertical: 4,
   },
-  pinnedNoteEmpty: { fontSize: 13, fontWeight: "600", paddingVertical: 2 },
 });
 
 /**

--- a/components/session/LastNextRow.tsx
+++ b/components/session/LastNextRow.tsx
@@ -146,15 +146,11 @@ export function LastNextRow({
   const hasNext = suggestion != null;
   if (!hasLast && !hasNext) return null;
 
+  // BLD-2386 Item B: removed Alert.alert wrapper — call onPrefillLast() directly.
+  // Safety is proven at the data layer: computePrefillSets (lib/format.ts:228)
+  // skips completed sets (:251) and any already-filled set (:259). Non-destructive.
   const confirmAndPrefillLast = () => {
-    alertFn(
-      "Refill from last session?",
-      "Empty sets will be filled with values from your previous session. Existing values won't be overwritten.",
-      [
-        { text: "Cancel", style: "cancel" },
-        { text: "Refill", onPress: () => onPrefillLast() },
-      ],
-    );
+    onPrefillLast();
   };
 
   const confirmAndApplyNext = () => {

--- a/components/session/SetRow.tsx
+++ b/components/session/SetRow.tsx
@@ -673,16 +673,21 @@ export const SetRow = memo(function SetRow({
                 <View
                   style={[
                     styles.variantPlaceholder,
-                    { borderColor: colors.outline },
+                    // BLD-2386 Item D3: lighter visual weight on unset placeholder.
+                    // Still mounted + visible for a11y (ref focus-restore contract).
+                    // accessibilityState={{ expanded }} is N/A under D3 — no collapse/expand.
+                    styles.variantPlaceholderLight,
+                    { borderColor: colors.outlineVariant },
                   ]}
                 >
                   <Text
                     style={[
                       styles.variantPlaceholderLabel,
-                      { color: colors.onSurfaceVariant },
+                      styles.variantPlaceholderLabelLight,
+                      { color: colors.outlineVariant },
                     ]}
                   >
-                    Tap to set variant
+                    + variant
                   </Text>
                 </View>
               ) : (
@@ -692,7 +697,10 @@ export const SetRow = memo(function SetRow({
                 </>
               )}
             </Pressable>
-            {(showPulleyPin !== false) && pulleyPin !== undefined ? (
+            {/* BLD-2386 Item D3: gate pulley-pin chip behind variant selection.
+                Show only after an attachment/mount is chosen — reduces chrome
+                on unset rows. Keep symmetric with grip footer (BLD-822/823). */}
+            {(showPulleyPin !== false) && pulleyPin !== undefined && (set.attachment != null || set.mount_position != null) ? (
               <Pressable
                 onPress={() => onOpenPulleyPinPicker?.(set.id)}
                 hitSlop={8}
@@ -773,16 +781,21 @@ export const SetRow = memo(function SetRow({
                 <View
                   style={[
                     styles.variantPlaceholder,
-                    { borderColor: colors.outline },
+                    // BLD-2386 Item D3: lighter visual weight — symmetric with cable footer.
+                    // Stays mounted for a11y ref focus-restore (bodyweightGripFooterRef).
+                    // accessibilityState={{ expanded }} N/A under D3 — no collapse/expand.
+                    styles.variantPlaceholderLight,
+                    { borderColor: colors.outlineVariant },
                   ]}
                 >
                   <Text
                     style={[
                       styles.variantPlaceholderLabel,
-                      { color: colors.onSurfaceVariant },
+                      styles.variantPlaceholderLabelLight,
+                      { color: colors.outlineVariant },
                     ]}
                   >
-                    Tap to set grip
+                    + grip
                   </Text>
                 </View>
               ) : (
@@ -943,6 +956,18 @@ const styles = StyleSheet.create({
     fontSize: fontSizes.xs,
     lineHeight: 16,
     fontWeight: "500",
+  },
+  // BLD-2386 Item D3: lighter variant for the unset-state pill (both null).
+  // Reduces visual weight vs. the partial-state placeholders (which remain
+  // at full weight because they signal a missing axis for a partially-set row).
+  variantPlaceholderLight: {
+    paddingVertical: 2,
+    paddingHorizontal: 6,
+    borderWidth: 1,
+  },
+  variantPlaceholderLabelLight: {
+    fontSize: fontSizes.xs,
+    fontWeight: "400",
   },
   colSet: {
     width: 36,


### PR DESCRIPTION
## Summary

Four independently-shippable subtractive edits on the in-session set-logging screen, reducing cognitive load on the primary training path. No schema/migration, no new deps.

## Changes

**Item A — Remove persistent `+ Add pinned note` empty-state CTA**
- Removed the `!pinnedNoteOpen && !group.pinnedNote` branch that rendered a text CTA
- Pin-outline icon affordance preserved (`GroupCardHeader.tsx:230–241`)
- `📌 {note}` read surface preserved (`GroupCardHeader.tsx:281–290`)
- Removed unused `pinnedNoteEmpty` style

**Item B — One-tap `Last:` prefill (drop the confirm)**
- `confirmAndPrefillLast` now calls `onPrefillLast()` directly
- Alert.alert wrapper removed — safe because `computePrefillSets` (lib/format.ts:228) skips completed sets and already-filled sets
- `Next:` confirm dialog unchanged (still gated)

**Item C — Header icon touch targets (visible box 44×44dp)**
- `iconBtn` padding: `8 → 10` → visible box = 24dp icon + 2×10 = 44dp
- `hitSlop` unchanged at 8 → effective target = 60dp (passes WCAG 2.5.5)
- Static style change only, memo-safe

**Item D3 — Variant footer declutter + pulley-pin chip gate**
- Unset cable/grip placeholder pill: lighter visual weight (`+ variant` / `+ grip` copy, reduced padding, `outlineVariant` color)
- Unset footer Pressable stays MOUNTED (ref focus-restore invariant for `variantFooterRef` / `bodyweightGripFooterRef`)
- `SetPulleyPinChip` gated: only shown when `attachment != null || mount_position != null`
- Applied symmetrically to the bodyweight grip footer (BLD-822/823 keep-in-sync invariant)
- Note re: accessibilityState={{ expanded }}: N/A under D3 — no collapse/expand exists, noted in code

**CORRECTION 1 (REQUIRED)** — Rewrote 3 `LastNextRow.test.tsx` tests to assert synchronous `onPrefillLast` with NO `Alert.alert` call. Updated `GroupCardHeader-prev-perf-affordance.test.tsx:134` for direct-invoke.

**CORRECTION 3 (REQUIRED)** — Created `GroupCardHeader.memo.test.tsx`: asserts render count ≤2 across 10 parent re-render cycles (memo regression guard for Items A + C).

**CORRECTION 4 (REQUIRED)** — `SetRow-cable-footer-a11y.test.tsx` and `SetRow-grip-footer.test.tsx` composite label assertions pass unchanged (Pressable is still mounted, composite label is unchanged).

## New test files
- `__tests__/components/session/GroupCardHeader-pinned-note-cta.test.tsx` — AC1+AC2
- `__tests__/components/session/GroupCardHeader.memo.test.tsx` — CORRECTION 3 memo guard
- `__tests__/components/session/SetRow-d3-pulley-pin-gate.test.tsx` — AC6+AC7, QD edge cases

## Testing

- `npm install --legacy-peer-deps` ✅
- `tsc --noEmit` ✅ (0 errors)
- ESLint ✅ (no warnings/errors on changed files)
- Existing tests: LastNextRow, GroupCardHeader-prev-perf-affordance, SetRow-cable-footer-a11y, SetRow-grip-footer all pass

## @ux-designer note on Item D copy

Current placeholder copy: `+ variant` / `+ grip` (compact, hints at action without being a full CTA). Open to alternatives — please comment if you'd prefer different copy/visual treatment.

## Issue

Resolves BLD-2386