### PR TITLE
fix(home): flow Workouts cards into a real grid on tablets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: Workouts home cards now flow into a proper grid on tablets** — on wider screens the Templates, Programs, and Recent Workouts lists were each trapped in a single half-width column, so their cards stacked one-per-row instead of filling the available space. These lists now use the same column-distributing grid as the rest of the app, so cards fan out into 2 columns (or 3 on the widest screens) while phones keep the single-column layout.
 
 ## v0.26.50 — 2026-06-30
 <!-- versionCode: 120 -->

--- a/__tests__/components/home/RecentWorkoutsList.test.tsx
+++ b/__tests__/components/home/RecentWorkoutsList.test.tsx
@@ -1,9 +1,11 @@
 /**
- * BLD-1033: Recent Workout cards cropped on tablet rows
+ * BLD-1033: Recent Workout cards cropped on tablet rows.
  *
- * Regression test: Animated.View wrapper must have alignSelf:'flex-start' so
- * each card sizes to its own content rather than stretching to the tallest
- * sibling in the flex-wrap row.
+ * Superseded by the Masonry migration: the list now renders inside a
+ * column-distributing <Masonry> instead of a flex-wrap row, so each card
+ * lives in its own independent column and must STRETCH to fill that column
+ * width (alignSelf:'stretch'). The old flex-wrap crop (which required
+ * alignSelf:'flex-start') can no longer occur.
  */
 
 jest.mock("expo-router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
@@ -78,7 +80,7 @@ describe("RecentWorkoutsList", () => {
     expect(getByText(/No workouts yet/)).toBeTruthy();
   });
 
-  it("animatedCard wrapper has alignSelf flex-start to prevent tablet row crop (BLD-1033)", () => {
+  it("animatedCard wrapper stretches to fill its Masonry column (BLD-1033, superseded by Masonry migration)", () => {
     const { StyleSheet } = require("react-native");
     const { toJSON } = render(
       <RecentWorkoutsList
@@ -89,20 +91,24 @@ describe("RecentWorkoutsList", () => {
       />,
     );
 
-    // Walk the JSON tree looking for a node with alignSelf: 'flex-start'
+    // Walk the JSON tree looking for a card wrapper that stretches to its
+    // column. The card must NOT pin to flex-start (that would leave it at its
+    // 280px intrinsic width instead of filling the Masonry column).
     type JsonNode = { props?: { style?: unknown }; children?: JsonNode[] | string[] | null };
-    function hasAlignSelfFlexStart(node: JsonNode | string | null): boolean {
+    function findAlignSelf(node: JsonNode | string | null, value: string): boolean {
       if (!node || typeof node === "string") return false;
       if (node.props?.style) {
         const flat = StyleSheet.flatten(node.props.style);
-        if (flat?.alignSelf === "flex-start") return true;
+        if (flat?.alignSelf === value) return true;
       }
       if (Array.isArray(node.children)) {
-        return (node.children as Array<JsonNode | string>).some((child) => hasAlignSelfFlexStart(child));
+        return (node.children as Array<JsonNode | string>).some((child) => findAlignSelf(child, value));
       }
       return false;
     }
 
-    expect(hasAlignSelfFlexStart(toJSON() as JsonNode | string | null)).toBe(true);
+    const tree = toJSON() as JsonNode | string | null;
+    expect(findAlignSelf(tree, "stretch")).toBe(true);
+    expect(findAlignSelf(tree, "flex-start")).toBe(false);
   });
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -95,10 +95,12 @@ export default function Workouts() {
     router.push(`/session/${s.id}?templateId=${todaySchedule.template_id}`);
   }, [todaySchedule, router]);
 
-  // On wide screens the info tiles (summary, GTG, recovery heatmap, templates/programs,
-  // recent workouts) flow into 2-3 Masonry columns. Quick Start and the page header
-  // (stats, banners, adherence bar) always stay full-width.
-  const masonryTiles = (
+  // On wide screens the small info tiles (weekly summary, GTG, recovery heatmap)
+  // flow into 2-3 Masonry columns. The Templates/Programs and Recent Workouts
+  // lists render full-width below so their OWN internal Masonry grids can fan
+  // cards across the whole screen. Quick Start and the page header (stats,
+  // banners, adherence bar) always stay full-width.
+  const infoTiles = (
     <>
       <WeeklySummaryCard
         colors={colors}
@@ -117,6 +119,11 @@ export default function Workouts() {
         />
       )}
       <RecoveryHeatmap recoveryStatus={data?.recoveryStatus ?? []} colors={colors} />
+    </>
+  );
+
+  const mainLists = (
+    <>
       <View>
         <SegmentedControl
           value={segment}
@@ -191,14 +198,18 @@ export default function Workouts() {
           </Button>
         </View>
 
-        {/* Info tiles: Masonry on wide screens, linear stack on compact */}
+        {/* Small info tiles: Masonry on wide screens, linear stack on compact */}
         {layout.atLeastMedium ? (
           <Masonry gap={16} testID="home-masonry">
-            {masonryTiles}
+            {infoTiles}
           </Masonry>
         ) : (
-          masonryTiles
+          infoTiles
         )}
+        {/* Templates/Programs + Recent Workouts: always full-width so their own
+            internal Masonry grids flow across the entire screen (2 cols on
+            tablet / 3 on expanded) instead of being trapped in one outer column. */}
+        {mainLists}
       </ScrollView>
 
       {/* BLD-1089: Quick Add FAB — AC1 */}

--- a/components/home/ProgramsList.tsx
+++ b/components/home/ProgramsList.tsx
@@ -9,6 +9,7 @@ import type { Program } from "../../lib/types";
 import { FlowCard, difficultyBadge, type MetaBadge, type FlowCardMenuItem } from "../FlowCard";
 import type { useThemeColors } from "@/hooks/useThemeColors";
 import { fontSizes } from "@/constants/design-tokens";
+import Masonry from "@/components/ui/Masonry";
 
 type Props = {
   colors: ReturnType<typeof useThemeColors>;
@@ -116,7 +117,7 @@ export function ProgramsList({ colors, programs, dayCounts, onPress, onDelete, o
           )}
         </View>
       ) : (
-        <View style={styles.flowList}>
+        <Masonry gap={12}>
           {filtered.map((item) => {
             const badges: { label: string; type: "active" | "starter" | "recommended" }[] = [];
             if (item.is_active) badges.push({ label: "ACTIVE", type: "active" });
@@ -144,14 +145,13 @@ export function ProgramsList({ colors, programs, dayCounts, onPress, onDelete, o
                 menuItems={menuItems} />
             );
           })}
-        </View>
+        </Masonry>
       )}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  flowList: { flexDirection: "row", flexWrap: "wrap", gap: 12, alignItems: "flex-start" },
   section: { marginBottom: 20 },
   sectionHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginBottom: 8 },
   empty: { alignItems: "center", paddingVertical: 16 },

--- a/components/home/RecentWorkoutsList.tsx
+++ b/components/home/RecentWorkoutsList.tsx
@@ -4,7 +4,7 @@ import { Text } from "@/components/ui/text";
 import { useRouter } from "expo-router";
 import { rpeColor, rpeText } from "@/lib/rpe";
 import { formatDuration, formatDateShort } from "@/lib/format";
-import { flowCardStyle } from "@/components/ui/FlowContainer";
+import Masonry from "@/components/ui/Masonry";
 import { Button } from "@/components/ui/button";
 import type { WorkoutSession } from "@/lib/types";
 import type { ThemeColors } from "@/hooks/useThemeColors";
@@ -32,7 +32,7 @@ export default function RecentWorkoutsList({ colors, sessions, setCounts, avgRPE
           <Text style={{ color: colors.onSurfaceVariant }}>No workouts yet. Start one above!</Text>
         </View>
       ) : (
-        <View style={styles.flowList}>
+        <Masonry gap={12}>
           {sessions.map((item, index) => {
             const rpe = avgRPEs[item.id];
             const rpeStr = rpe != null ? ` · RPE ${Math.round(rpe * 10) / 10}` : "";
@@ -59,7 +59,7 @@ export default function RecentWorkoutsList({ colors, sessions, setCounts, avgRPE
               </Animated.View>
             );
           })}
-        </View>
+        </Masonry>
       )}
     </View>
   );
@@ -68,8 +68,7 @@ export default function RecentWorkoutsList({ colors, sessions, setCounts, avgRPE
 const styles = StyleSheet.create({
   section: { marginBottom: 20 },
   sectionHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginBottom: 8 },
-  flowList: { flexDirection: "row", flexWrap: "wrap", gap: 12 },
-  animatedCard: { ...flowCardStyle, alignSelf: "flex-start" },
+  animatedCard: { alignSelf: "stretch" },
   flowCard: { marginBottom: 8 },
   empty: { alignItems: "center", paddingVertical: 16 },
   recentRow: { flexDirection: "row", alignItems: "center" },

--- a/components/home/TemplatesList.tsx
+++ b/components/home/TemplatesList.tsx
@@ -10,6 +10,7 @@ import { FlowCard, difficultyBadge, type MetaBadge, type FlowCardMenuItem } from
 import type { TemplateReadiness } from "../../lib/recovery-readiness";
 import type { useThemeColors } from "@/hooks/useThemeColors";
 import { fontSizes } from "@/constants/design-tokens";
+import Masonry from "@/components/ui/Masonry";
 
 import { formatDurationEstimate, formatSpokenDuration } from "../../lib/format";
 
@@ -90,7 +91,7 @@ export function TemplatesList({ colors, templates, counts, durationEstimates, st
           <Button variant="outline" onPress={() => router.push("/template/create")} style={styles.emptyBtn} accessibilityLabel="Create your first template" label="Create Template" />
         </View>
       ) : (
-        <View style={styles.flowList}>
+        <Masonry gap={12}>
           {templates.map((item) => {
             const meta = starterMeta(item.id);
             const isStarter = !!meta || !!item.is_starter;
@@ -110,14 +111,13 @@ export function TemplatesList({ colors, templates, counts, durationEstimates, st
                 menuItems={menuItems} />
             );
           })}
-        </View>
+        </Masonry>
       )}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  flowList: { flexDirection: "row", flexWrap: "wrap", gap: 12, alignItems: "flex-start" },
   section: { marginBottom: 20 },
   sectionHeader: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginBottom: 8 },
   headerActions: { flexDirection: "row", alignItems: "center", gap: 4 },


### PR DESCRIPTION
## What
Applies the same **Masonry grid** fix used for Settings/Progress to the **Workouts home screen** so cards auto-flow into multiple columns on tablets.

User report: *"the cards/items are not auto flown correctly even when there're 2 cols in the tablet view."*

## Why it was broken
The Templates, Programs, and Recent Workouts lists still used the deprecated flex `row + wrap` layout **and** each whole list sat as a single tile inside the outer home `Masonry`. So on tablet each list was trapped in one ~half-width column and its cards could never flow into 2/3 columns.

## The fix
- **`TemplatesList`, `ProgramsList`, `RecentWorkoutsList`** — replaced the `<View style={flowList}>` wrapper with `<Masonry gap={12}>` (the real column-distributing primitive) and deleted the dead `flowList` style. In `RecentWorkoutsList`, the card wrapper changed from `{...flowCardStyle, alignSelf:"flex-start"}` (pinned to 280px, blocked stretch) to `{ alignSelf:"stretch" }` so cards fill their column.
- **`app/(tabs)/index.tsx`** — split the single `masonryTiles` fragment into `infoTiles` (WeeklySummary / Today's GTG / RecoveryHeatmap → stay in the outer `home-masonry`) and `mainLists` (Templates/Programs segment + Recent Workouts), which now render **full-width below** the outer masonry so their internal grids get the full screen width.

Result: cards fan into **2 columns (medium) / 3 (expanded)**; phones keep the single-column stack. Outer `home-masonry` testID and phone ordering unchanged.

## Verification
- `tsc --noEmit`: clean
- `eslint` (4 files): clean
- Jest: `masonry-wide-screen`, `masonry-wide-home`, `dashboard`, `templates-list-helpers` → **36/36 pass**