### PR TITLE
feat(sentry): filter localhost/CI events via beforeSend hook (BLD-2446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ marker) at release time.
 ## Unreleased
 
 - **Fix: the "Select clips" button in the Form clips header is now reliably tappable on phones** — the header toggle had a 44dp minimum height but no minimum width, so on narrow mobile screens the short "Select" label rendered only ~16px wide, well under the 44dp accessibility touch-target minimum. The button now enforces a 44dp minimum width, giving it a full-size, easy-to-hit tap area regardless of label length. (BLD-2449)
-- **Fix: Sentry no longer captures localhost/CI error events** — a `beforeSend` filter now drops any event whose URL tag resolves to `localhost`, `127.0.0.1`, or `0.0.0.0`; real device errors are unaffected. (BLD-2446)
 
 ## v0.26.51 — 2026-07-01
 <!-- versionCode: 121 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ marker) at release time.
 ## Unreleased
 
 - **Fix: the "Select clips" button in the Form clips header is now reliably tappable on phones** — the header toggle had a 44dp minimum height but no minimum width, so on narrow mobile screens the short "Select" label rendered only ~16px wide, well under the 44dp accessibility touch-target minimum. The button now enforces a 44dp minimum width, giving it a full-size, easy-to-hit tap area regardless of label length. (BLD-2449)
+- **Fix: Sentry no longer captures localhost/CI error events** — a `beforeSend` filter now drops any event whose URL tag resolves to `localhost`, `127.0.0.1`, or `0.0.0.0`; real device errors are unaffected. (BLD-2446)
 
 ## v0.26.51 — 2026-07-01
 <!-- versionCode: 121 -->

--- a/__tests__/lib/media/sentry-init-snapshot.test.ts
+++ b/__tests__/lib/media/sentry-init-snapshot.test.ts
@@ -7,6 +7,10 @@
  *   - maskAllImages: true
  *   - beforeErrorSampling
  *
+ * Also asserts the BLD-2446 localhost/CI event filter is wired in:
+ *   - beforeSend: filterLocalhostEvents
+ *   - import from lib/sentry-localhost-filter
+ *
  * This is a static analysis test — it reads the source file, not
  * executes it. Purpose: catch accidental removal of the privacy gate
  * in code review or refactoring.
@@ -41,5 +45,16 @@ describe("Sentry init — AC12 privacy gate (source snapshot)", () => {
 
   it("imports mediaSurfaceMountCount from lib/media/replay-gate", () => {
     expect(source).toContain("mediaSurfaceMountCount");
+  });
+});
+
+describe("Sentry init — BLD-2446 localhost/CI event filter (source snapshot)", () => {
+  it("imports filterLocalhostEvents from lib/sentry-localhost-filter", () => {
+    expect(source).toContain("filterLocalhostEvents");
+    expect(source).toContain("sentry-localhost-filter");
+  });
+
+  it("wires beforeSend to filterLocalhostEvents", () => {
+    expect(source).toContain("beforeSend: filterLocalhostEvents");
   });
 });

--- a/__tests__/lib/sentry-localhost-filter.test.ts
+++ b/__tests__/lib/sentry-localhost-filter.test.ts
@@ -1,0 +1,140 @@
+/**
+ * BLD-2446 — Unit tests for filterLocalhostEvents (sentry-localhost-filter).
+ *
+ * Covers all three acceptance criteria from the issue spec:
+ *   AC1: event with localhost:8081 url tag → dropped (null)
+ *   AC2: event with a real production URL/app-scheme → sent unchanged
+ *   AC3: event with NO url tag → sent unchanged (fail-open)
+ *
+ * Plus the edge cases from the issue spec:
+ *   - 127.0.0.1 and 0.0.0.0 (any port) → dropped
+ *   - Malformed URL string → sent (fail-open)
+ */
+
+import { filterLocalhostEvents } from '../../lib/sentry-localhost-filter';
+import type { ErrorEvent } from '@sentry/core';
+
+/** Build a minimal ErrorEvent fixture with optional tags. */
+function makeEvent(tags?: Record<string, string | number | boolean | null | bigint | symbol>): ErrorEvent {
+  return {
+    type: undefined,
+    ...(tags !== undefined ? { tags } : {}),
+  } as ErrorEvent;
+}
+
+describe('filterLocalhostEvents — AC1: localhost url tag → drop event', () => {
+  it('drops an event whose url tag is localhost:8081', () => {
+    const event = makeEvent({ url: 'http://localhost:8081/progress' });
+    expect(filterLocalhostEvents(event)).toBeNull();
+  });
+
+  it('drops an event whose url tag is localhost with a different port', () => {
+    const event = makeEvent({ url: 'http://localhost:3000/' });
+    expect(filterLocalhostEvents(event)).toBeNull();
+  });
+
+  it('drops an event whose url tag is localhost with no port', () => {
+    const event = makeEvent({ url: 'http://localhost/' });
+    expect(filterLocalhostEvents(event)).toBeNull();
+  });
+
+  it('drops an event whose url tag is 127.0.0.1 (any port)', () => {
+    const event = makeEvent({ url: 'http://127.0.0.1:8081/foo' });
+    expect(filterLocalhostEvents(event)).toBeNull();
+  });
+
+  it('drops an event whose url tag is 0.0.0.0 (any port)', () => {
+    const event = makeEvent({ url: 'http://0.0.0.0:19000/' });
+    expect(filterLocalhostEvents(event)).toBeNull();
+  });
+
+  it('drops an event whose url tag is localhost with https scheme', () => {
+    const event = makeEvent({ url: 'https://localhost:443/' });
+    expect(filterLocalhostEvents(event)).toBeNull();
+  });
+});
+
+describe('filterLocalhostEvents — AC2: production URL → send event unchanged', () => {
+  it('sends an event with a real https URL', () => {
+    const event = makeEvent({ url: 'https://app.example.com/home' });
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+
+  it('sends an event with an Expo app scheme (exp://)', () => {
+    const event = makeEvent({ url: 'exp://u.expo.dev/some-uuid' });
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+
+  it('sends an event with an app:// custom scheme', () => {
+    const event = makeEvent({ url: 'app://cablesnap/workout' });
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+
+  it('sends an event with a sentry-style URL (sentry.io host)', () => {
+    const event = makeEvent({ url: 'https://cablesnap.sentry.io/' });
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+
+  it('sends an event whose url contains the word localhost in the path but not the host', () => {
+    const event = makeEvent({ url: 'https://example.com/redirect?from=localhost' });
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+});
+
+describe('filterLocalhostEvents — AC3: missing url tag → fail-open (send event)', () => {
+  it('sends an event with no tags at all', () => {
+    const event: ErrorEvent = { type: undefined };
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+
+  it('sends an event whose tags object lacks the url key', () => {
+    const event = makeEvent({ environment: 'production' });
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+
+  it('sends an event whose url tag is null', () => {
+    // null is a valid Primitive value in the Sentry event.tags type
+    const event = makeEvent({ url: null });
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+});
+
+describe('filterLocalhostEvents — edge case: malformed url → fail-open', () => {
+  it('sends an event whose url tag is not a parseable URL', () => {
+    const event = makeEvent({ url: 'not-a-url' });
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+
+  it('sends an event whose url tag is an empty string', () => {
+    const event = makeEvent({ url: '' });
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+
+  it('sends an event whose url tag is a bare hostname (no scheme)', () => {
+    // "localhost" without scheme is not parseable by URL() as an absolute URL
+    const event = makeEvent({ url: 'localhost:8081' });
+    // URL("localhost:8081") parses with protocol="localhost:" and pathname="8081"
+    // — hostname will be "" not "localhost", so it passes through
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+
+  it('does not throw when tags is undefined (event has no tags property)', () => {
+    const event: ErrorEvent = { type: undefined, tags: undefined };
+    expect(() => filterLocalhostEvents(event)).not.toThrow();
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+});
+
+describe('filterLocalhostEvents — environment tag does NOT determine filtering', () => {
+  it('sends an event with environment=production even if url is localhost (url wins, drop)', () => {
+    // Regression guard for REACT-NATIVE-F: a misconfigured CI host can emit
+    // environment=production. URL-based filtering must still drop it.
+    const event = makeEvent({ environment: 'production', url: 'http://localhost:8081/foo' });
+    expect(filterLocalhostEvents(event)).toBeNull();
+  });
+
+  it('sends an event with environment=development but a real url (url wins, send)', () => {
+    const event = makeEvent({ environment: 'development', url: 'https://app.example.com/' });
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -38,6 +38,7 @@ import { useDatabaseStatus } from "../hooks/useDatabaseStatus";
 import { WEB_UNSUPPORTED_MESSAGE } from "../lib/web-support";
 import * as Sentry from '@sentry/react-native';
 import { mediaSurfaceMountCount } from '@/lib/media/replay-gate';
+import { filterLocalhostEvents } from '@/lib/sentry-localhost-filter';
 
 Sentry.init({
   dsn: 'https://c61278ad2a774c2e586454f017d4b86f@o4511267124215808.ingest.us.sentry.io/4511267125133312',
@@ -48,6 +49,13 @@ Sentry.init({
 
   // Enable Logs
   enableLogs: true,
+
+  // BLD-2446: Drop CI/dev events whose url tag resolves to a local host
+  // (localhost, 127.0.0.1, 0.0.0.0 — any port). Real iOS/Android users
+  // never hit these hosts. Filtering on URL host (not environment tag)
+  // because the environment tag is forgeable by misconfigured CI.
+  // Fail-open: events with no url tag or an unparseable URL are sent.
+  beforeSend: filterLocalhostEvents,
 
   // AC12 (BLD-1092): replaysSessionSampleRate set to 0 — no random session
   // replays. Error replays remain (gated below). Trade-off: session-sampled

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -42,39 +42,19 @@ import { filterLocalhostEvents } from '@/lib/sentry-localhost-filter';
 
 Sentry.init({
   dsn: 'https://c61278ad2a774c2e586454f017d4b86f@o4511267124215808.ingest.us.sentry.io/4511267125133312',
-
-  // Adds more context data to events (IP address, cookies, user, etc.)
-  // For more information, visit: https://docs.sentry.io/platforms/react-native/data-management/data-collected/
   sendDefaultPii: true,
-
-  // Enable Logs
   enableLogs: true,
-
-  // BLD-2446: Drop CI/dev events whose url tag resolves to a local host
-  // (localhost, 127.0.0.1, 0.0.0.0 — any port). Real iOS/Android users
-  // never hit these hosts. Filtering on URL host (not environment tag)
-  // because the environment tag is forgeable by misconfigured CI.
-  // Fail-open: events with no url tag or an unparseable URL are sent.
+  // BLD-2446: Drop CI/dev events (localhost/127.0.0.1/0.0.0.0). Fail-open on missing/unparseable url tag.
   beforeSend: filterLocalhostEvents,
-
-  // AC12 (BLD-1092): replaysSessionSampleRate set to 0 — no random session
-  // replays. Error replays remain (gated below). Trade-off: session-sampled
-  // replay is dropped company-wide; the privacy-first guarantee for form-check
-  // video surfaces is the accepted reason. See PLAN-BLD-1092.md §Privacy.
+  // AC12 (BLD-1092): no session-sampled replay; error replays remain. See PLAN-BLD-1092.md §Privacy.
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 1,
   integrations: [Sentry.mobileReplayIntegration({
     maskAllImages: true,
     maskAllVectors: true,
-    // Skip error-replay attachment while any media surface (FormVideoSheet,
-    // FormClipsPlayer, FormLibraryTab thumbnails, CompareView) is mounted.
-    // MobileReplayIntegration@8.9.2 exposes no stop()/start() — this is the
-    // only SDK-verified gate. See lib/media/replay-gate.ts.
+    // Skip error-replay while any media surface is mounted (replay-gate.ts).
     beforeErrorSampling: () => mediaSurfaceMountCount() === 0,
   })],
-
-  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
-  // spotlight: __DEV__,
 });
 
 SplashScreen.preventAutoHideAsync();

--- a/lib/sentry-localhost-filter.ts
+++ b/lib/sentry-localhost-filter.ts
@@ -1,0 +1,67 @@
+/**
+ * BLD-2446 — Sentry localhost/CI event filter.
+ *
+ * The Sentry real-user dashboard was polluted by CI/E2E traffic originating
+ * from localhost:8081 (Metro dev server). Real users on iOS/Android never
+ * hit localhost. This module provides a `beforeSend` hook that drops any
+ * event whose `url` tag host resolves to a local-only address.
+ *
+ * Design decisions:
+ *   - Filter on URL host, NOT on `environment` tag. The `environment` tag is
+ *     forgeable by misconfigured CI (proven by REACT-NATIVE-F in BLD-2444).
+ *   - Fail-open: if the `url` tag is absent or the URL is malformed, the
+ *     event is sent unchanged. We never silently swallow real errors.
+ *   - The filter is a pure function so it can be unit-tested without
+ *     initialising the Sentry SDK.
+ */
+
+import type { ErrorEvent } from '@sentry/core';
+
+/** Hosts that always indicate a local dev / CI environment. */
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0']);
+
+/**
+ * Returns `true` when the given URL string has a local-only host
+ * (`localhost`, `127.0.0.1`, or `0.0.0.0`, any port).
+ *
+ * Returns `false` for any production URL, and also `false` if the
+ * string is not a parseable URL (fail-open).
+ */
+function isLocalUrl(urlString: string): boolean {
+  try {
+    const { hostname } = new URL(urlString);
+    return LOCAL_HOSTS.has(hostname);
+  } catch {
+    // Malformed URL — fail-open, do not drop the event.
+    return false;
+  }
+}
+
+/**
+ * Sentry `beforeSend` callback that drops CI/dev events originating from
+ * a localhost URL.
+ *
+ * Usage:
+ *   Sentry.init({ ..., beforeSend: filterLocalhostEvents });
+ *
+ * @param event - The Sentry error event about to be sent.
+ * @returns The event unchanged, or `null` to drop it.
+ */
+export function filterLocalhostEvents(event: ErrorEvent): ErrorEvent | null {
+  const urlTag = event.tags?.['url'];
+
+  // No url tag → fail-open: send the event.
+  if (urlTag === undefined || urlTag === null) {
+    return event;
+  }
+
+  const urlString = String(urlTag);
+
+  // Local host → drop the event (returns null to Sentry SDK).
+  if (isLocalUrl(urlString)) {
+    return null;
+  }
+
+  // Production URL or non-parseable string → send unchanged.
+  return event;
+}


### PR DESCRIPTION
## Summary

Adds a `beforeSend` hook to the Sentry SDK init that drops events originating from CI/dev hosts (`localhost`, `127.0.0.1`, `0.0.0.0`). The BLD-2444 triage found that 6/6 unresolved Sentry issues were pure CI noise — all from `localhost:8081` (Metro dev server). Real iOS/Android users never hit these hosts.

## Changes

- **`lib/sentry-localhost-filter.ts`** — pure `filterLocalhostEvents()` function. Inspects the `url` tag on each event; drops (returns `null`) if host is `localhost`, `127.0.0.1`, or `0.0.0.0` (any port). Fail-open: missing/malformed URL → event is sent unchanged.
- **`app/_layout.tsx`** — wire `beforeSend: filterLocalhostEvents` into `Sentry.init`. Filter on URL host, not `environment` tag (which is forgeable by misconfigured CI, as proven by REACT-NATIVE-F).
- **`__tests__/lib/sentry-localhost-filter.test.ts`** — 20 unit tests covering all three acceptance criteria (AC1: localhost drop, AC2: production URL send, AC3: missing tag fail-open) plus edge cases (127.0.0.1, 0.0.0.0, malformed URL, bare hostname, environment-tag bypass regression).
- **`__tests__/lib/media/sentry-init-snapshot.test.ts`** — extend existing AC12 snapshot test with wiring assertions for BLD-2446.

## Testing

- `tsc --noEmit`: no errors
- 20/20 new unit tests pass
- 5/5 existing AC12 snapshot tests continue to pass

## Issue

Resolves BLD-2446