### PR TITLE
fix(form-clips): add minWidth: 44 to selectTogglePressable touch target (BLD-2449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fix: the "Select clips" button in the Form clips header is now reliably tappable on phones** — the header toggle had a 44dp minimum height but no minimum width, so on narrow mobile screens the short "Select" label rendered only ~16px wide, well under the 44dp accessibility touch-target minimum. The button now enforces a 44dp minimum width, giving it a full-size, easy-to-hit tap area regardless of label length. (BLD-2449)
 
 ## v0.26.51 — 2026-07-01
 <!-- versionCode: 121 -->

--- a/__tests__/components/session/FormLibraryTab-touch-target.test.tsx
+++ b/__tests__/components/session/FormLibraryTab-touch-target.test.tsx
@@ -1,11 +1,12 @@
 /**
  * FormLibraryTab-touch-target.test.tsx
  *
- * BLD-1941: "Select" text link in Form clips header must meet 44dp touch target.
+ * BLD-1941 / BLD-2449: "Select" text link in Form clips header must meet 44dp touch target.
  *
  * Tests:
  * - AC1: The "Select clips" Pressable has minHeight ≥ 44 in its resolved style.
- * - AC2: The "Exit select mode" Pressable has minHeight ≥ 44 in its resolved style.
+ * - AC2: The "Select clips" Pressable has minWidth ≥ 44 in its resolved style (BLD-2449).
+ * - AC3: The "Exit select mode" Pressable has paddingHorizontal to ensure horizontal tap area.
  */
 
 import React from "react";
@@ -76,7 +77,18 @@ describe("FormLibraryTab — Select touch target (BLD-1941)", () => {
     expect(flatStyle.minHeight).toBeGreaterThanOrEqual(44);
   });
 
-  it("AC2: Pressable has paddingHorizontal to ensure adequate horizontal tap area", () => {
+  it("AC2: 'Select clips' button meets 44dp minimum touch target width (BLD-2449)", () => {
+    const { getByLabelText } = render(<FormLibraryTab exerciseId="ex-1" />);
+
+    const selectBtn = getByLabelText("Select clips");
+    const flatStyle = StyleSheet.flatten(selectBtn.props.style ?? {});
+
+    // minWidth must be explicitly set to ≥ 44 so the rendered element is always
+    // at least 44dp wide regardless of text content length (BLD-2449 regression).
+    expect(flatStyle.minWidth).toBeGreaterThanOrEqual(44);
+  });
+
+  it("AC3: Pressable has paddingHorizontal to ensure adequate horizontal tap area", () => {
     const { getByLabelText } = render(<FormLibraryTab exerciseId="ex-1" />);
 
     const selectBtn = getByLabelText("Select clips");

--- a/components/session/FormLibraryTab.tsx
+++ b/components/session/FormLibraryTab.tsx
@@ -652,6 +652,7 @@ const styles = StyleSheet.create({
   countBadgeText: { fontSize: fontSizes.xs, fontWeight: "700" },
   selectTogglePressable: {
     minHeight: 44,
+    minWidth: 44,
     paddingHorizontal: 8,
     justifyContent: "center",
     alignItems: "center",


### PR DESCRIPTION
## Summary

Adds `minWidth: 44` to `selectTogglePressable` in `FormLibraryTab.tsx`. The BLD-1941 fix (commit f66fa6ee) added `minHeight: 44` and `paddingHorizontal: 8` but missed `minWidth: 44`. The 'Select' text renders ~16px wide on mobile viewport, failing the Playwright bounding-box assertion added by BLD-1941 itself.

## Changes

- `components/session/FormLibraryTab.tsx`: Add `minWidth: 44` to `selectTogglePressable` style
- `__tests__/components/session/FormLibraryTab-touch-target.test.tsx`: Add AC2 asserting `minWidth >= 44` (previously only `minHeight` was checked)

## Testing

- TypeScript: zero errors (`tsc --noEmit`)
- Jest: 3/3 tests pass (AC1 minHeight, AC2 minWidth, AC3 paddingHorizontal)
- Existing Playwright `form-clips.spec.ts` width assertion (`box!.width >= 44`) will now pass

## Issue

Resolves BLD-2449
Detected in audit BLD-2447 at commit `a1735164`
Root cause of incomplete BLD-1941 fix (commit f66fa6ee)