### PR TITLE
chore(audit): allowlist form-clips isolation harness for near-empty suppression (BLD-2453)

### DIFF
--- a/scripts/audit-isolation-harness-allowlist.json
+++ b/scripts/audit-isolation-harness-allowlist.json
@@ -29,6 +29,12 @@
       "reason": "Dev-only harness (app/__test__/stack-marker.tsx) renders a single StackMarkerPill (~44px) on a blank padded <View>. The harness intentionally renders sparse to test the pill in isolation without the live MarkerPickerSheet. Its e2e spec (e2e/scenarios/stack-marker.spec.ts) asserts pill visibility and exact text — those assertions are the real regression safety net. Introduced by BLD-1126. False-positive audit findings: BLD-1667, BLD-1766. Suppression introduced by BLD-1773.",
       "introducedBy": "BLD-1126",
       "suppressionTicket": "BLD-1773"
+    },
+    {
+      "scenario": "form-clips",
+      "reason": "Dev-only harness (app/__test__/form-clips.tsx) renders FormLibraryTab in isolation. The component requires a seed object injected via window.__FORM_CLIPS_HARNESS__ by the Playwright spec (page.addInitScript). The audit screenshot is captured without a running Playwright spec, so the seed is absent, window.__FORM_CLIPS_HARNESS__ is undefined, the guard on line 51 of form-clips.tsx returns early, and the component renders null — leaving only the surrounding CTA button visible. The harness intentionally renders sparse during audit; its real regression safety net is the e2e Playwright spec that injects the seed and asserts on FormLibraryTab content. Introduced by BLD-1105/BLD-1123. False-positive audit finding: BLD-2453. Suppression introduced by BLD-2453.",
+      "introducedBy": "BLD-1105",
+      "suppressionTicket": "BLD-2453"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The `form-clips` test route (`/__test__/form-clips`) is a dev-only isolation harness for `FormLibraryTab`. It requires a seed object injected via `window.__FORM_CLIPS_HARNESS__` by its Playwright spec. During the daily audit screenshot capture no spec runs, so the seed is absent, the component guard returns early, and the screen renders null — only the CTA button remains visible.

This is the same pattern as `stack-marker` (suppressed via BLD-1773). This PR adds `form-clips` to the isolation harness allowlist so the recurring false-positive near-empty finding is suppressed going forward.

## Changes

- `scripts/audit-isolation-harness-allowlist.json`: adds `form-clips` entry with full explanation of the seed-injection mechanism and why audit captures render sparse

## Testing

- JSON validated via Python `json.load()`
- `tsc --noEmit` passes with zero errors
- No runtime code changed — config-only update

## Issue

Resolves BLD-2453