### PR TITLE
feat(audit): add rest-coach to isolation-harness allowlist (BLD-2454)

### DIFF
--- a/scripts/__tests__/audit-isolation-harness-allowlist.test.ts
+++ b/scripts/__tests__/audit-isolation-harness-allowlist.test.ts
@@ -407,6 +407,45 @@ describe('audit-create-finding.sh — BLD-1773 isolation-harness allowlist suppr
     }
   });
 
+  it('AC1: rest-coach scenario (BLD-2454) + near-empty title => SUPPRESSED', async () => {
+    // rest-coach is a dev-only isolation harness that renders ReminderSection
+    // rows in the top ~25% of the viewport, leaving ~75% blank by design.
+    // Without allowlist suppression, the daily audit re-files a near-empty
+    // finding every run (BLD-2454). Adding it to the allowlist stops that.
+    const fp = '113254aabb77';
+    const allowlist = writeAllowlist(['rest-coach']);
+    const desc = path.join(os.tmpdir(), `desc-rc-${process.pid}-${Date.now()}.md`);
+    fs.writeFileSync(
+      desc,
+      `## UX: rest-coach screen renders near-empty\n\n**Fingerprint**: \`${fp}\`\n\nOnly three toggle switches visible in top-right corner — rest of screen is blank.\n`,
+    );
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 870 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: rest-coach screen renders near-empty — only top-right controls visible',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-a1735164',
+          '--run-id', 'run-restcoach-suppression',
+          '--scenario', 'rest-coach',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED rest-coach');
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
   it('allowlist typo / unknown scenario name => inert, issue created normally', async () => {
     // A scenario name in --scenario that does not appear in the allowlist
     // should be treated as non-allowlisted (no suppression).

--- a/scripts/audit-isolation-harness-allowlist.json
+++ b/scripts/audit-isolation-harness-allowlist.json
@@ -35,6 +35,12 @@
       "reason": "Dev-only harness (app/__test__/form-clips.tsx) renders FormLibraryTab in isolation. The component requires a seed object injected via window.__FORM_CLIPS_HARNESS__ by the Playwright spec (page.addInitScript). The audit screenshot is captured without a running Playwright spec, so the seed is absent, window.__FORM_CLIPS_HARNESS__ is undefined, the guard on line 51 of form-clips.tsx returns early, and the component renders null — leaving only the surrounding CTA button visible. The harness intentionally renders sparse during audit; its real regression safety net is the e2e Playwright spec that injects the seed and asserts on FormLibraryTab content. Introduced by BLD-1105/BLD-1123. False-positive audit finding: BLD-2453. Suppression introduced by BLD-2453.",
       "introducedBy": "BLD-1105",
       "suppressionTicket": "BLD-2453"
+    },
+    {
+      "scenario": "rest-coach",
+      "reason": "Dev-only harness (app/__test__/rest-coach.tsx) renders ReminderSection's Smart Rest Coach rows (pre-end cue segmented control + show-next-set toggle) in isolation at /__test__/rest-coach. The component content fills only the top ~25% of the 390×844 viewport; the remaining ~75% is blank by design — there is no footer or scroll content. The three toggle rows and the segmented control are the full content of this harness. Its e2e spec (e2e/scenarios/rest-coach.spec.ts) asserts toggle visibility and AC11 disabled-state text — those assertions are the regression safety net. Introduced by BLD-1137. False-positive audit findings: BLD-2454. Suppression introduced by BLD-2454.",
+      "introducedBy": "BLD-1137",
+      "suppressionTicket": "BLD-2454"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add the `rest-coach` scenario to the isolation-harness allowlist so the daily visual audit stops re-filing false-positive "near-empty" findings on every run.

## Root Cause

`rest-coach` is a dev-only harness (`app/__test__/rest-coach.tsx`) that renders `ReminderSection`'s Smart Rest Coach rows in isolation at `/__test__/rest-coach`. The component content (pre-end cue segmented control, live-countdown toggle, show-next-set toggle) fills only the top ~25% of the 390×844 viewport. The remaining ~75% is intentionally blank — there is no footer, scroll content, or full-page layout.

The daily audit frames captures at the full mobile viewport and classifies any render with 70%+ blank space as "near-empty", triggering a new finding each commit run (fingerprint changes per-commit, evading dedup). This is the same false-positive pattern that led to BLD-1773/BLD-1667 for `stack-marker`.

The `rest-coach` scenario is **not** a production screen — it's a regression harness for the three BLD-1137 settings rows. The Playwright spec (`e2e/scenarios/rest-coach.spec.ts`) asserts toggle visibility and AC11 disabled-state text; those assertions are the real regression safety net.

## Changes

- `scripts/audit-isolation-harness-allowlist.json`: add `rest-coach` entry with explanation
- `scripts/__tests__/audit-isolation-harness-allowlist.test.ts`: add test verifying rest-coach + near-empty title => SUPPRESSED

## Testing

- All 8 allowlist suppression tests pass: `npx jest scripts/__tests__/audit-isolation-harness-allowlist.test.ts`
- New test (AC1 variant) validates rest-coach suppression specifically
- TypeScript: `tsc --noEmit` passes with zero errors
- Existing tests unmodified; non-near-empty findings on rest-coach still flow through normally

## Issue

Resolves BLD-2454