### PR TITLE
feat: suppress bld-480-prefix expected-defect audit findings at intake (BLD-2460)

### DIFF
--- a/scripts/__tests__/audit-isolation-harness-allowlist.test.ts
+++ b/scripts/__tests__/audit-isolation-harness-allowlist.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  *
- * BLD-1773 — Tests for the isolation-harness suppression feature in
+ * BLD-1773 + BLD-2460 — Tests for the isolation-harness suppression feature in
  * `scripts/audit-create-finding.sh`.
  *
  * Problem: dev-only isolation harnesses (e.g. stack-marker) intentionally
@@ -11,10 +11,18 @@
  * the QD#3 dedup fingerprint changes per-commit, the same benign finding evades
  * dedup and re-files every audit run.
  *
+ * BLD-2460 extends this to 'expected-defect' anchor fixtures: bld-480-prefix
+ * deliberately re-imposes the BLD-480 maxHeight crop so regression-smoke.sh
+ * (QD#2) can assert the vision pipeline still detects it. The crop finding on
+ * bld-480-prefix is NOT a real defect; suppressing it at intake does not weaken
+ * the QD#2 trust anchor (regression-smoke.sh asserts directly against the
+ * vision API, never via audit-create-finding.sh).
+ *
  * Fix: audit-create-finding.sh accepts --scenario and --allowlist flags. When
  * the scenario is in the isolation-harness allowlist AND the finding matches
- * near-empty/content-missing keywords, the script exits SUPPRESSED with exit
- * code 0 and makes no Paperclip API calls.
+ * near-empty/content-missing keywords (BLD-1773) OR the entry's
+ * expectedDefectRegex (BLD-2460), the script exits SUPPRESSED with exit code 0
+ * and makes no Paperclip API calls.
  *
  * Acceptance criteria (BLD-1773):
  *   AC1. Allowlisted scenario + near-empty finding => SUPPRESSED (no issue, no comment).
@@ -23,6 +31,13 @@
  *   Edge. Missing allowlist file => silently inert (no crash, normal create path).
  *   Edge. No --scenario flag => suppression check skipped (backward-compat).
  *   Edge. Allowlist typo / unknown scenario name => inert (normal create path).
+ *
+ * Acceptance criteria (BLD-2460):
+ *   AC-B1. bld-480-prefix + crop finding (matches expectedDefectRegex) => SUPPRESSED.
+ *   AC-B2. bld-480-prefix + near-empty finding => SUPPRESSED (near-empty branch still fires).
+ *   AC-B3. stack-marker + crop finding (no expectedDefectRegex on entry) => NOT suppressed.
+ *   AC-B4. completed-workout (real, non-allowlisted) + crop finding => NOT suppressed.
+ *   Regression. stack-marker + near-empty finding => still SUPPRESSED (BLD-1773 unchanged).
  */
 import { spawn } from 'child_process';
 import * as http from 'http';
@@ -159,6 +174,39 @@ function writeAllowlist(scenarios: string[]): string {
   return file;
 }
 
+/**
+ * Write an allowlist with a bld-480-prefix entry that includes the
+ * QD#2 crop expectedDefectRegex, matching the production entry in
+ * audit-isolation-harness-allowlist.json (BLD-2460).
+ * Optionally also includes stack-marker (without expectedDefectRegex).
+ */
+function writeAllowlistWithExpectedDefect(
+  includeStackMarker = true,
+): string {
+  const file = path.join(
+    os.tmpdir(),
+    `allowlist-edr-${process.pid}-${Date.now()}.json`,
+  );
+  const entries: object[] = [];
+  if (includeStackMarker) {
+    entries.push({
+      scenario: 'stack-marker',
+      reason: 'Test harness — near-empty only (no expectedDefectRegex)',
+      introducedBy: 'BLD-1126',
+      suppressionTicket: 'BLD-1773',
+    });
+  }
+  entries.push({
+    scenario: 'bld-480-prefix',
+    reason: 'Expected-defect anchor for BLD-480 trust anchor — crop is intentional.',
+    introducedBy: 'BLD-951',
+    suppressionTicket: 'BLD-2460',
+    expectedDefectRegex: 'crop|truncat|clip|maxHeight|cut off|MusclesWorkedCard|body-figure',
+  });
+  fs.writeFileSync(file, JSON.stringify({ isolationHarnesses: entries }, null, 2));
+  return file;
+}
+
 /** Write a description file whose body contains a near-empty phrase. */
 function writeNearEmptyDesc(fp: string, phrase: string): string {
   const file = path.join(os.tmpdir(), `desc-near-empty-${process.pid}-${Date.now()}.md`);
@@ -175,6 +223,16 @@ function writeRegularDesc(fp: string): string {
   fs.writeFileSync(
     file,
     `## UX: touch target too small\n\n**Fingerprint**: \`${fp}\`\n\nThe pill tap target is 32dp, below the 44dp minimum.\n`,
+  );
+  return file;
+}
+
+/** Write a description file whose body contains a crop-defect phrase (QD#2 regex). */
+function writeCropDesc(fp: string, phrase: string): string {
+  const file = path.join(os.tmpdir(), `desc-crop-${process.pid}-${Date.now()}.md`);
+  fs.writeFileSync(
+    file,
+    `## UX: ${phrase}\n\n**Fingerprint**: \`${fp}\`\n\nThe MusclesWorkedCard body-figure is cropped by maxHeight clamp.\n`,
   );
   return file;
 }
@@ -478,6 +536,45 @@ describe('audit-create-finding.sh — BLD-1773 isolation-harness allowlist suppr
       await server.close();
     }
   });
+
+  it('AC1: rest-coach scenario (BLD-2454) + near-empty title => SUPPRESSED', async () => {
+    // rest-coach is a dev-only isolation harness that renders ReminderSection
+    // rows in the top ~25% of the viewport, leaving ~75% blank by design.
+    // Without allowlist suppression, the daily audit re-files a near-empty
+    // finding every run (BLD-2454). Adding it to the allowlist stops that.
+    const fp = '113254aabb77';
+    const allowlist = writeAllowlist(['rest-coach']);
+    const desc = path.join(os.tmpdir(), `desc-rc-${process.pid}-${Date.now()}.md`);
+    fs.writeFileSync(
+      desc,
+      `## UX: rest-coach screen renders near-empty\n\n**Fingerprint**: \`${fp}\`\n\nOnly three toggle switches visible in top-right corner — rest of screen is blank.\n`,
+    );
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 870 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: rest-coach screen renders near-empty — only top-right controls visible',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-a1735164',
+          '--run-id', 'run-restcoach-suppression',
+          '--scenario', 'rest-coach',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED rest-coach');
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
 });
 
 /**
@@ -732,6 +829,245 @@ describe('audit-create-finding.sh — BLD-2464 CVD hue-shift suppression', () =>
       expect(r.status).toBe(0);
       expect(r.stdout.trim()).toBe('SUPPRESSED-CVD');
       expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+});
+
+describe('audit-create-finding.sh — BLD-2460 expected-defect suppression (bld-480-prefix)', () => {
+  it('AC-B1: bld-480-prefix + crop finding matching expectedDefectRegex => SUPPRESSED', async () => {
+    // The ux-designer runs vision on bld-480-prefix and gets back a crop finding.
+    // That crop is the EXPECTED defect for the QD#2 trust anchor — suppress it.
+    const fp = '111222333444';
+    const allowlist = writeAllowlistWithExpectedDefect();
+    const desc = writeCropDesc(fp, 'MusclesWorkedCard body-figure cropped by maxHeight clamp');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 900 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: MusclesWorkedCard body-figure cropped by maxHeight clamp (bld-480-prefix)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-aabbcc',
+          '--run-id', 'run-bld2460-test',
+          '--scenario', 'bld-480-prefix',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED bld-480-prefix');
+      // Critical: NO issue should be created and NO comment posted.
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('AC-B1: bld-480-prefix + "maxHeight" in description body => SUPPRESSED', async () => {
+    const fp = '222333444555';
+    const allowlist = writeAllowlistWithExpectedDefect();
+    const desc = path.join(os.tmpdir(), `desc-maxh-${process.pid}-${Date.now()}.md`);
+    fs.writeFileSync(
+      desc,
+      `## UX: card cropped\n\n**Fingerprint**: \`${fp}\`\n\nThe card height is limited by a maxHeight constraint that truncates the body-figure.\n`,
+    );
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 910 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: card cropped (bld-480-prefix)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-aabbcc',
+          '--run-id', 'run-bld2460-test',
+          '--scenario', 'bld-480-prefix',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED bld-480-prefix');
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('AC-B2: bld-480-prefix + near-empty finding (broken fixture render) => SUPPRESSED via NEAR_EMPTY_RE branch', async () => {
+    // If the fixture itself fails to render and produces a near-empty capture,
+    // that should also be suppressed (caught by regression-smoke.sh FAIL, not
+    // by a filed audit issue — per edge-case table in BLD-2460 description).
+    const fp = '333444555666';
+    const allowlist = writeAllowlistWithExpectedDefect();
+    const desc = writeNearEmptyDesc(fp, 'blank screen — fixture failed to render');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 920 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: blank screen — fixture failed (bld-480-prefix)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-aabbcc',
+          '--run-id', 'run-bld2460-test',
+          '--scenario', 'bld-480-prefix',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED bld-480-prefix');
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('AC-B3 (regression): stack-marker + crop finding => NOT suppressed (no expectedDefectRegex on entry)', async () => {
+    // stack-marker has no expectedDefectRegex — only near-empty suppression applies.
+    // A crop finding on stack-marker is a real defect and MUST be filed.
+    const fp = '444555666777';
+    const allowlist = writeAllowlistWithExpectedDefect(/* includeStackMarker */ true);
+    const desc = writeCropDesc(fp, 'component cropped by overflow: hidden');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 930 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: StackMarkerPill truncated by container overflow (stack-marker)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-aabbcc',
+          '--run-id', 'run-bld2460-test',
+          '--scenario', 'stack-marker',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      // stack-marker has no expectedDefectRegex -> crop is NOT suppressed -> issue created.
+      expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+      expect(state.createCalls).toHaveLength(1);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('AC-B3 (regression): stack-marker + near-empty finding => still SUPPRESSED (BLD-1773 unchanged)', async () => {
+    // Confirm that adding bld-480-prefix expectedDefectRegex does NOT break
+    // the existing BLD-1773 near-empty suppression for stack-marker.
+    const fp = '555666777888';
+    const allowlist = writeAllowlistWithExpectedDefect(/* includeStackMarker */ true);
+    const desc = writeNearEmptyDesc(fp, 'near-empty screen');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 940 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: near-empty screen (stack-marker)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-aabbcc',
+          '--run-id', 'run-bld2460-test',
+          '--scenario', 'stack-marker',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED stack-marker');
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('AC-B4: completed-workout (non-allowlisted) + crop finding => NOT suppressed (real defects always filed)', async () => {
+    // A crop finding on a real production scenario (not an isolation harness)
+    // must always be filed. Suppression is allowlist-scoped only.
+    const fp = '666777888999';
+    const allowlist = writeAllowlistWithExpectedDefect();
+    const desc = writeCropDesc(fp, 'ExerciseCard cropped below fold');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 950 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: ExerciseCard cropped below fold (completed-workout)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-aabbcc',
+          '--run-id', 'run-bld2460-test',
+          '--scenario', 'completed-workout',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      // completed-workout is not in allowlist => crop is NOT suppressed => issue created.
+      expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+      expect(state.createCalls).toHaveLength(1);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('exact-match guard: bld-480-prefix-extra does NOT match the bld-480-prefix entry', async () => {
+    // Scenario names that are a prefix of an allowlisted entry must NOT be suppressed.
+    const fp = '777888999aaa';
+    const allowlist = writeAllowlistWithExpectedDefect();
+    const desc = writeCropDesc(fp, 'MusclesWorkedCard cropped');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 960 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: MusclesWorkedCard cropped (bld-480-prefix-extra)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-aabbcc',
+          '--run-id', 'run-bld2460-test',
+          '--scenario', 'bld-480-prefix-extra', // NOT in allowlist
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      // bld-480-prefix-extra is not listed -> no suppression -> issue created.
+      expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+      expect(state.createCalls).toHaveLength(1);
       expect(state.commentCalls).toHaveLength(0);
     } finally {
       fs.unlinkSync(desc);

--- a/scripts/audit-create-finding.sh
+++ b/scripts/audit-create-finding.sh
@@ -29,15 +29,19 @@
 #      separate additive concern after fixing legibility (navy foreground). The
 #      daily audit re-filing the same aesthetic finding is audit noise, not a
 #      defect. Suppressed here per BLD-2464.
-#   1. (BLD-1773) If --scenario is provided and the scenario appears in
+#   1. (BLD-1773 + BLD-2460) If --scenario is provided and the scenario appears in
 #      `audit-isolation-harness-allowlist.json`, AND the finding title or
-#      description matches the near-empty/content-missing regex, the finding
-#      is suppressed: print `SUPPRESSED <scenario>` and exit 0. No issue is
-#      created or commented on. This prevents isolation-harness scenarios from
-#      re-filing daily false-positive "near-empty screen" findings whose
-#      fingerprint changes per-commit (evading the regular dedup check).
-#      Non-allowlisted scenarios that genuinely render near-empty are still
-#      flagged normally — the suppression is allowlist-scoped, not a blanket mute.
+#      description matches either:
+#        (a) the near-empty/content-missing regex (NEAR_EMPTY_RE), OR
+#        (b) the per-entry 'expectedDefectRegex' field in the allowlist
+#            (BLD-2460 — for expected-defect anchor fixtures like bld-480-prefix),
+#      then the finding is suppressed: print `SUPPRESSED <scenario>` and exit 0.
+#      No issue is created or commented on. This prevents isolation-harness
+#      scenarios from re-filing daily false-positive findings whose fingerprint
+#      changes per-commit (evading the regular dedup check).
+#      Entries without 'expectedDefectRegex' (e.g. stack-marker) keep
+#      today's near-empty-only behaviour — no regression for stack-marker.
+#      Non-allowlisted scenarios are never suppressed.
 #   2. Search project issues whose description contains "Fingerprint: <hash>".
 #   3. For each candidate, fetch the full issue and confirm:
 #        - description contains the EXACT case-sensitive substring
@@ -68,7 +72,7 @@
 #   the element remains distinguishable) it must be suppressed as audit noise.
 #   See CVD_KNOWN_HUE_SHIFT_RE below and the SUPPRESSED-CVD exit path.
 #
-# Refs: BLD-969, BLD-952, BLD-956, BLD-939, BLD-1773, BLD-1901, BLD-2464.
+# Refs: BLD-969, BLD-952, BLD-956, BLD-939, BLD-1773, BLD-1901, BLD-2460, BLD-2464.
 
 set -euo pipefail
 
@@ -98,11 +102,12 @@ aesthetic), the finding is suppressed globally: print `SUPPRESSED-CVD <scenario>
 and exit 0. This is independent of the allowlist (no --scenario gating required).
 See BLD-1901 (deferral decision) and BLD-2464 (this suppression).
 
-Isolation-harness suppression (BLD-1773): If --scenario is provided and that
-scenario is listed in the isolation-harness allowlist
+Isolation-harness suppression (BLD-1773 + BLD-2460): If --scenario is provided
+and that scenario is listed in the isolation-harness allowlist
 (audit-isolation-harness-allowlist.json) and the finding title or description
-matches "near-empty / content missing" keywords, the finding is suppressed:
-print `SUPPRESSED <scenario>` and exit 0. No issue is created or commented on.
+matches "near-empty / content missing" keywords OR the allowlist entry's
+'expectedDefectRegex' field (when present), the finding is suppressed:
+no issue is created or commented on.
 
 Exit codes:
   0  Reused an existing issue (printed `RECURRENCE <ID>`),
@@ -246,13 +251,19 @@ if is_cvd_finding "$TITLE" "$DESC_FILE"; then
   fi
 fi
 
-# ---------- isolation-harness suppression (BLD-1773) ----------
+# ---------- isolation-harness suppression (BLD-1773, BLD-2460) ----------
 # If --scenario is provided and the scenario is listed in the isolation-harness
-# allowlist, AND the finding title or description body indicates a "near-empty /
-# content missing" defect, suppress the finding entirely. This prevents
-# dev-only harnesses (e.g. stack-marker) that intentionally render sparse
-# from filing daily false-positive audit findings whose fingerprint changes
-# per-commit (evading the regular dedup check).
+# allowlist, suppress the finding if EITHER:
+#   (a) the finding title or description body indicates a "near-empty /
+#       content missing" defect (NEAR_EMPTY_RE — original BLD-1773 path), OR
+#   (b) the allowlist entry has an 'expectedDefectRegex' field AND the finding
+#       title or description matches that regex (BLD-2460 — for expected-defect
+#       anchor fixtures like bld-480-prefix whose known-bad defect is a crop,
+#       not a near-empty state).
+#
+# Entries without 'expectedDefectRegex' (e.g. stack-marker) keep today's
+# near-empty-only behaviour — no regression for stack-marker.
+# Non-allowlisted scenarios are never suppressed.
 #
 # Regex for near-empty/content-missing findings (case-insensitive). Covers the
 # typical ux-designer phrasings seen in BLD-1667 and BLD-1766:
@@ -281,6 +292,35 @@ is_isolation_harness_scenario() {
   return 1
 }
 
+# Extract the 'expectedDefectRegex' for an allowlisted scenario (BLD-2460).
+# Returns an empty string if the entry has no such field (stack-marker style).
+# Uses python3 for reliable JSON parsing; falls back to empty on any error.
+get_expected_defect_regex() {
+  local scenario="$1"
+  local allowlist_file="$2"
+
+  if [[ ! -f "$allowlist_file" ]]; then
+    echo ""
+    return
+  fi
+
+  python3 - "$scenario" "$allowlist_file" 2>/dev/null <<'PY'
+import json, sys
+scenario = sys.argv[1]
+path     = sys.argv[2]
+try:
+    with open(path) as f:
+        data = json.load(f)
+    for entry in data.get("isolationHarnesses", []):
+        if entry.get("scenario") == scenario:
+            print(entry.get("expectedDefectRegex", ""))
+            sys.exit(0)
+except Exception:
+    pass
+print("")
+PY
+}
+
 is_near_empty_finding() {
   local title="$1"
   local desc_file="$2"
@@ -297,9 +337,35 @@ is_near_empty_finding() {
   return 1
 }
 
+# Check if title or description matches a given regex (case-insensitive).
+# Used for expectedDefectRegex matching (BLD-2460).
+matches_expected_defect_regex() {
+  local title="$1"
+  local desc_file="$2"
+  local regex="$3"
+
+  [[ -z "$regex" ]] && return 1
+
+  if echo "$title" | grep -qiE "$regex"; then
+    return 0
+  fi
+  if grep -qiE "$regex" "$desc_file" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
 if [[ -n "$SCENARIO" ]]; then
   if is_isolation_harness_scenario "$SCENARIO" "$ALLOWLIST"; then
+    # Path (a): near-empty suppression — original BLD-1773 logic.
     if is_near_empty_finding "$TITLE" "$DESC_FILE"; then
+      echo "SUPPRESSED $SCENARIO"
+      exit 0
+    fi
+    # Path (b): expected-defect suppression — BLD-2460 extension.
+    # Only applies when the allowlist entry has an 'expectedDefectRegex' field.
+    EXPECTED_DEFECT_RE="$(get_expected_defect_regex "$SCENARIO" "$ALLOWLIST")"
+    if matches_expected_defect_regex "$TITLE" "$DESC_FILE" "$EXPECTED_DEFECT_RE"; then
       echo "SUPPRESSED $SCENARIO"
       exit 0
     fi

--- a/scripts/audit-isolation-harness-allowlist.json
+++ b/scripts/audit-isolation-harness-allowlist.json
@@ -14,6 +14,17 @@
     "missing' findings when the finding's scenario matches an entry here.",
     "All other finding types for these scenarios are still audited normally.",
     "",
+    "Entries may also carry an optional 'expectedDefectRegex' field. When",
+    "present, findings whose title or description match that regex are ALSO",
+    "suppressed for that scenario. This is used for 'expected-defect' anchors",
+    "— scenarios that intentionally reproduce a known visual defect so that",
+    "scripts/regression-smoke.sh (QD#2) can assert the vision pipeline is",
+    "still sensitive to it. The crop/truncation finding on bld-480-prefix is",
+    "the canonical example: the defect is expected and the real safety net is",
+    "regression-smoke.sh asserting directly against the vision API response.",
+    "Suppressing the crop finding at audit-create-finding.sh intake does NOT",
+    "weaken the QD#2 trust anchor.",
+    "",
     "To add a new isolation harness: append one entry below and explain WHY",
     "the scenario is intentionally sparse. Include the BLD ticket that introduced",
     "the harness and a pointer back to BLD-1773 (where this mechanism lives).",
@@ -21,7 +32,7 @@
     "NON-allowlisted scenarios that genuinely render near-empty are NOT suppressed.",
     "The suppression is scoped to the allowlist, not a blanket mute.",
     "",
-    "Refs: BLD-1773, BLD-1767, BLD-1666, BLD-1126."
+    "Refs: BLD-1773, BLD-1767, BLD-1666, BLD-1126, BLD-2460."
   ],
   "isolationHarnesses": [
     {
@@ -41,6 +52,13 @@
       "reason": "Dev-only harness (app/__test__/rest-coach.tsx) renders ReminderSection's Smart Rest Coach rows (pre-end cue segmented control + show-next-set toggle) in isolation at /__test__/rest-coach. The component content fills only the top ~25% of the 390×844 viewport; the remaining ~75% is blank by design — there is no footer or scroll content. The three toggle rows and the segmented control are the full content of this harness. Its e2e spec (e2e/scenarios/rest-coach.spec.ts) asserts toggle visibility and AC11 disabled-state text — those assertions are the regression safety net. Introduced by BLD-1137. False-positive audit findings: BLD-2454. Suppression introduced by BLD-2454.",
       "introducedBy": "BLD-1137",
       "suppressionTicket": "BLD-2454"
+    },
+    {
+      "scenario": "bld-480-prefix",
+      "reason": "This is the intentional BLD-480 pre-fix trust-anchor fixture: it deliberately re-imposes a maxHeight: 200 clamp on MusclesWorkedCard (components/session/summary/__fixtures__/MusclesWorkedCardPreFix.tsx, route app/__fixtures__/bld-480-prefix.tsx) so the vision pipeline has a known-bad crop to detect. Detecting the crop there is a PASS for scripts/regression-smoke.sh (QD#2), which asserts directly against the vision API response and NEVER calls audit-create-finding.sh. Suppressing the crop finding at the audit intake layer does NOT weaken the QD#2 trust anchor. Introduced by BLD-951. False-positive audit findings: BLD-2452. Suppression introduced by BLD-2460. Analogous to BLD-1773 (stack-marker near-empty suppression).",
+      "introducedBy": "BLD-951",
+      "suppressionTicket": "BLD-2460",
+      "expectedDefectRegex": "crop|truncat|clip|maxHeight|cut off|MusclesWorkedCard|body-figure"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Stops the recurring false-positive stream from the `bld-480-prefix` trust-anchor fixture by suppressing its expected-defect (crop) findings at the `audit-create-finding.sh` intake layer. Mirrors the BLD-1773 pattern for `stack-marker`.

## Problem

The daily UX-audit pipeline was filing false-positive issues against the `bld-480-prefix` scenario (latest: BLD-2452). That scenario deliberately re-imposes the BLD-480 `maxHeight: 200` clamp so `regression-smoke.sh` (QD#2) has a known-bad crop to detect. The crop is **expected** — the suggested fix on those issues (remove the clamp) would **destroy the trust anchor**.

The root cause was two gaps:
1. `scripts/audit-isolation-harness-allowlist.json` did not list `bld-480-prefix`
2. `audit-create-finding.sh` only suppressed near-empty findings (no crop suppression path)

## Changes

### `scripts/audit-isolation-harness-allowlist.json`
- Add `bld-480-prefix` entry with `expectedDefectRegex: "crop|truncat|clip|maxHeight|cut off|MusclesWorkedCard|body-figure"`
- Includes `reason`, `introducedBy: BLD-951`, `suppressionTicket: BLD-2460`, cites BLD-2452 false positive and BLD-1773 precedent

### `scripts/audit-create-finding.sh`
- Add `get_expected_defect_regex()` helper (python3 JSON parse)
- Add `matches_expected_defect_regex()` check
- Suppression block: after near-empty check (path a), also check `expectedDefectRegex` when present (path b)
- Entries without the field (e.g. `stack-marker`) keep existing near-empty-only behaviour — **zero regression**

### `scripts/__tests__/audit-isolation-harness-allowlist.test.ts`
- 7 new BLD-2460 test cases covering full AC matrix (14 total, all pass)

## Safety invariant verified

`regression-smoke.sh` asserts the crop finding **directly against the vision API response** and never calls `audit-create-finding.sh`. Suppressing the crop at intake **does not weaken the QD#2 trust anchor**.

## Testing

All 14 tests pass:
```
npx jest scripts/__tests__/audit-isolation-harness-allowlist.test.ts
```

## Out of scope

`/skills/agents/ui-ux-designer/AGENTS.md` is read-only from the repo worktree. Requirement 3 (exclusion note in ux-designer Audit Flow) must be landed separately by @ceo — the code-enforced suppression (requirements 1+2) is the primary safety net.

## Issue

Resolves BLD-2460