### PR TITLE
fix(audit): suppress known brand-coral CVD hue-shift false-positives globally (BLD-2464)

### DIFF
--- a/.agents/AGENTS-ux-designer.md
+++ b/.agents/AGENTS-ux-designer.md
@@ -75,9 +75,26 @@ Paperclip routine (09:00 PT, ab23d3ed-e434-4357-ab62-7ccf41159989)
 2. **For EACH `<scenario>/<viewport>{,-deuteranopia,-protanopia,-tritanopia}.png` + sibling `.json`**, run vision with the canned prompt (§ Vision Prompt below). Tag each invocation with its `cvd` mode (`baseline`, `deuteranopia`, `protanopia`, `tritanopia`) — pass it to the prompt and carry it through to the finding fingerprint.
 3. **Normalize findings**: each finding must include `{scenario, label,
    severity, description, suggested_fix}`.
-4. **Dedup before filing** (§ Dedup Logic below).
-5. **Check BLD-480 regression-catcher acceptance** (§ BLD-480 Trust Anchor below).
-6. **Update the audit issue**: post a summary comment (counts by severity),
+4. **Apply CVD no-info-loss exclusion (BLD-2464)**: Before filing any CVD-mode
+   finding (deuteranopia / protanopia / tritanopia), check whether the ONLY
+   problem is the known brand-coral (`#FF6038` / `#FF7A55` "Electric Coral")
+   desaturating to olive/gold-brown, where the element remains distinguishable
+   and no state or category information is lost (purely aesthetic hue shift).
+   **Do NOT file a standalone issue for this known pattern.** It is a
+   deliberately-deferred aesthetic condition per BLD-1901 (CVD legibility was
+   fixed via navy foreground in BLD-1904; hue distinctness is a separate
+   additive concern, scoped out by design). Pass the finding to
+   `audit-create-finding.sh` normally — the script will suppress it with
+   `SUPPRESSED-CVD`.
+   You **may and must** still file CVD findings when:
+   - Two UI states become indistinguishable (e.g. active vs inactive tabs,
+     filled vs empty state — category/state information IS lost).
+   - A screen introduces a new color-only affordance that collapses under CVD.
+   - The desaturation causes actual text legibility failure (not just hue change).
+   Refs: BLD-1901 (deferral decision), BLD-2464 (suppression implementation).
+5. **Dedup before filing** (§ Dedup Logic below).
+6. **Check BLD-480 regression-catcher acceptance** (§ BLD-480 Trust Anchor below).
+7. **Update the audit issue**: post a summary comment (counts by severity),
    link the finding issues, close to `done`. If clean: `Clean audit ✅`.
 
 > **Acceptance for the CVD extension (BLD-958):** the audit must execute the vision prompt against all 4 PNGs per scenario (baseline + 3 CVD). On clean bundles, returning `[]` for all CVD passes is allowed; the requirement is that the iteration code path runs.

--- a/scripts/__tests__/audit-isolation-harness-allowlist.test.ts
+++ b/scripts/__tests__/audit-isolation-harness-allowlist.test.ts
@@ -440,3 +440,264 @@ describe('audit-create-finding.sh — BLD-1773 isolation-harness allowlist suppr
     }
   });
 });
+
+/**
+ * BLD-2464 — Tests for the CVD no-info-loss hue-shift suppression in
+ * `scripts/audit-create-finding.sh`.
+ *
+ * Problem: The daily audit re-files the same known CVD aesthetic finding every
+ * run across every coral-CTA screen (BLD-2456, BLD-2457, BLD-2458) because the
+ * dedup fingerprint includes the commit SHA. This is the CVD analogue of the
+ * near-empty harness noise that BLD-1773 solved.
+ *
+ * Fix: audit-create-finding.sh globally suppresses a CVD finding when BOTH:
+ *   1. The finding is a CVD-mode finding (deuteranopia/protanopia/tritanopia).
+ *   2. The finding self-describes as a no-information-loss hue shift (the brand
+ *      coral primary desaturates to olive/gold-brown but remains distinguishable
+ *      and no state/category information is lost — purely aesthetic).
+ * This suppression is global (not scenario-gated): print `SUPPRESSED-CVD
+ * <scenario>` and exit 0. No issue created or commented on.
+ *
+ * Acceptance criteria (BLD-2464):
+ *   CVD-AC1. CVD finding with olive hue-shift + no-info-loss language => SUPPRESSED-CVD
+ *   CVD-AC2. CVD finding with actual information loss described => NOT suppressed (issue created)
+ *   CVD-AC3. Non-CVD near-empty finding on an allowlisted scenario => still uses BLD-1773 path
+ *   CVD-AC4. SUPPRESSED-CVD includes the --scenario name when provided
+ *   CVD-AC5. SUPPRESSED-CVD when no --scenario provided (global, not gated)
+ */
+
+/** Write a description file matching the CVD coral→olive no-info-loss pattern. */
+function writeCvdNoInfoLossDesc(fp: string, cvdMode: string, scenario: string): string {
+  const file = path.join(os.tmpdir(), `desc-cvd-noloss-${process.pid}-${Date.now()}.md`);
+  fs.writeFileSync(
+    file,
+    `## UX: CTA button desaturates to olive under ${cvdMode} (${scenario})\n\n` +
+      `**Fingerprint**: \`${fp}\`\n\n` +
+      `Under ${cvdMode} emulation, the primary CTA button (#FF6038 coral) desaturates ` +
+      `to an olive/gold-brown hue. The button remains distinguishable and still clearly ` +
+      `a button — no information loss or state confusion. This is a purely aesthetic ` +
+      `hue shift; the element is still readable and visible.\n\n` +
+      `**Suggested fix**: Add a non-color affordance (icon, border weight) to supplement ` +
+      `hue distinction. Note: BLD-1901 explicitly deferred this as a separate additive ` +
+      `concern after fixing legibility (navy foreground).\n`,
+  );
+  return file;
+}
+
+/** Write a description file for a CVD finding WITH actual information loss. */
+function writeCvdInfoLossDesc(fp: string, cvdMode: string, scenario: string): string {
+  const file = path.join(os.tmpdir(), `desc-cvd-infoloss-${process.pid}-${Date.now()}.md`);
+  fs.writeFileSync(
+    file,
+    `## UX: Active and inactive tabs become indistinguishable under ${cvdMode} (${scenario})\n\n` +
+      `**Fingerprint**: \`${fp}\`\n\n` +
+      `Under ${cvdMode} emulation, both the active tab (coral) and the inactive tab (grey) ` +
+      `collapse to the same olive/muted tone. Users cannot tell which tab is currently selected. ` +
+      `Category information is lost: the distinction between active and inactive state is ` +
+      `no longer conveyed by color alone, and there is no secondary visual channel.\n\n` +
+      `**Suggested fix**: Add an underline or bold weight to the active tab indicator.\n`,
+  );
+  return file;
+}
+
+describe('audit-create-finding.sh — BLD-2464 CVD hue-shift suppression', () => {
+  it('CVD-AC1: deuteranopia finding with coral→olive no-info-loss => SUPPRESSED-CVD', async () => {
+    const fp = 'aa11bb22cc33';
+    const allowlist = writeAllowlist(['stack-marker']);
+    const desc = writeCvdNoInfoLossDesc(fp, 'deuteranopia', 'progress-tab');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 900 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title',
+          'UX: progress-tab CTA button becomes olive-gold under deuteranopia (audit 2026-07-01, progress-tab)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-a1735164',
+          '--run-id', 'run-cvd-suppression-test',
+          '--scenario', 'progress-tab',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED-CVD progress-tab');
+      // No Paperclip API calls made.
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('CVD-AC1: protanopia finding with coral→olive no-info-loss => SUPPRESSED-CVD', async () => {
+    const fp = 'bb22cc33dd44';
+    const allowlist = writeAllowlist(['stack-marker']);
+    const desc = writeCvdNoInfoLossDesc(fp, 'protanopia', 'form-clips');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 910 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title',
+          'UX: form-clips CTA button becomes olive-gold under protanopia (audit 2026-07-01, form-clips)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-a1735164',
+          '--run-id', 'run-cvd-suppression-test',
+          '--scenario', 'form-clips',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED-CVD form-clips');
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('CVD-AC2: CVD finding with actual information loss (indistinguishable states) => NOT suppressed, issue created', async () => {
+    // A CVD finding where two states become indistinguishable MUST still file —
+    // this is real information loss, not a no-info-loss hue shift.
+    const fp = 'cc33dd44ee55';
+    const allowlist = writeAllowlist(['stack-marker']);
+    const desc = writeCvdInfoLossDesc(fp, 'deuteranopia', 'workout-history');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 920 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title',
+          'UX: active vs inactive tabs indistinguishable under deuteranopia (workout-history)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-a1735164',
+          '--run-id', 'run-cvd-suppression-test',
+          '--scenario', 'workout-history',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      // Must NOT be suppressed — real information loss.
+      expect(r.stdout).toMatch(/^CREATED BLD-\d+/);
+      expect(state.createCalls).toHaveLength(1);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('CVD-AC3: non-CVD near-empty finding on allowlisted scenario => uses BLD-1773 SUPPRESSED path (unchanged)', async () => {
+    // The BLD-1773 near-empty suppression must still work independently when
+    // the finding is not a CVD finding. The BLD-2464 path must not interfere.
+    const fp = 'dd44ee55ff66';
+    const allowlist = writeAllowlist(['stack-marker']);
+    const desc = writeNearEmptyDesc(fp, 'near-empty screen');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 930 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title', 'UX: near-empty screen (stack-marker)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-a1735164',
+          '--run-id', 'run-cvd-suppression-test',
+          '--scenario', 'stack-marker',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      // BLD-1773 path fires: SUPPRESSED (not SUPPRESSED-CVD)
+      expect(r.stdout.trim()).toBe('SUPPRESSED stack-marker');
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('CVD-AC4: SUPPRESSED-CVD includes scenario name when --scenario provided', async () => {
+    // Output must be `SUPPRESSED-CVD <scenario>` not bare `SUPPRESSED-CVD`.
+    const fp = 'ee55ff660011';
+    const allowlist = writeAllowlist(['stack-marker']);
+    const desc = writeCvdNoInfoLossDesc(fp, 'protanopia', 'nutrition-tab');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 940 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title',
+          'UX: nutrition meal-slot circles become olive-gold under protanopia (nutrition-tab)',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-a1735164',
+          '--run-id', 'run-cvd-suppression-test',
+          '--scenario', 'nutrition-tab',
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED-CVD nutrition-tab');
+      expect(state.createCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+
+  it('CVD-AC5: SUPPRESSED-CVD fires even without --scenario (global, not scenario-gated)', async () => {
+    // Unlike BLD-1773 (allowlist-gated), CVD suppression must fire globally.
+    // When --scenario is absent, output is just `SUPPRESSED-CVD` (no trailing name).
+    const fp = 'ff66001122aa';
+    const allowlist = writeAllowlist(['stack-marker']);
+    const desc = writeCvdNoInfoLossDesc(fp, 'deuteranopia', 'any-screen');
+    const state: MockState = { issues: [], commentCalls: [], createCalls: [], nextId: 950 };
+    const server = await startMockServer(makeMock(state));
+    try {
+      const r = await runWrapper(
+        [
+          '--fingerprint', fp,
+          '--title',
+          'UX: coral CTA desaturates to olive under deuteranopia — still distinguishable, purely aesthetic',
+          '--description-file', desc,
+          '--audit-tag', 'audit-2026-07-01-a1735164',
+          '--run-id', 'run-cvd-suppression-test',
+          // Note: no --scenario flag — suppression must still fire
+          '--project-id', '00000000-0000-0000-0000-0000000000aa',
+        ],
+        allowlist,
+        server.url,
+      );
+      expect(r.status).toBe(0);
+      expect(r.stdout.trim()).toBe('SUPPRESSED-CVD');
+      expect(state.createCalls).toHaveLength(0);
+      expect(state.commentCalls).toHaveLength(0);
+    } finally {
+      fs.unlinkSync(desc);
+      fs.unlinkSync(allowlist);
+      await server.close();
+    }
+  });
+});

--- a/scripts/audit-create-finding.sh
+++ b/scripts/audit-create-finding.sh
@@ -15,7 +15,21 @@
 #   or creates a new issue.
 #
 # Behaviour:
-#   0. (BLD-1773) If --scenario is provided and the scenario appears in
+#   0. (BLD-2464) If the finding is a CVD-mode finding (deuteranopia/protanopia/
+#      tritanopia) AND the title or description self-describes as a no-information-
+#      loss hue shift (i.e. the coral/orange brand primary desaturates to olive/
+#      gold-brown under CVD but every element remains distinguishable and no
+#      state/category information is lost — purely aesthetic), the finding is
+#      suppressed: print `SUPPRESSED-CVD <scenario>` and exit 0. No issue is
+#      created or commented on. This suppression is GLOBAL (not scenario-gated)
+#      because the brand coral (#FF6038 light / #FF7A55 dark) appears on many
+#      screens. It mirrors the BLD-1773 near-empty suppression in spirit but
+#      uses a separate code path and regex.
+#      Disposition: BLD-1901 explicitly deferred restoring hue-distinctness as a
+#      separate additive concern after fixing legibility (navy foreground). The
+#      daily audit re-filing the same aesthetic finding is audit noise, not a
+#      defect. Suppressed here per BLD-2464.
+#   1. (BLD-1773) If --scenario is provided and the scenario appears in
 #      `audit-isolation-harness-allowlist.json`, AND the finding title or
 #      description matches the near-empty/content-missing regex, the finding
 #      is suppressed: print `SUPPRESSED <scenario>` and exit 0. No issue is
@@ -24,17 +38,17 @@
 #      fingerprint changes per-commit (evading the regular dedup check).
 #      Non-allowlisted scenarios that genuinely render near-empty are still
 #      flagged normally — the suppression is allowlist-scoped, not a blanket mute.
-#   1. Search project issues whose description contains "Fingerprint: <hash>".
-#   2. For each candidate, fetch the full issue and confirm:
+#   2. Search project issues whose description contains "Fingerprint: <hash>".
+#   3. For each candidate, fetch the full issue and confirm:
 #        - description contains the EXACT case-sensitive substring
 #          `Fingerprint: <hash>` (or `\`<hash>\`` formatted equivalents),
 #        - status ∈ {todo, in_progress, in_review, backlog}
 #          (i.e. NOT cancelled, NOT done — re-occurrence after fix
 #          should re-open as a new issue per BLD-969 acceptance).
-#   3. If a match is found → comment on the existing issue with
+#   4. If a match is found → comment on the existing issue with
 #      "Same finding reproduced in audit-YYYY-MM-DD-<commit> (run <id>)"
 #      and print `RECURRENCE <identifier>` to stdout. Exit 0.
-#   4. Otherwise → invoke `clip.sh create-issue` with the provided args
+#   5. Otherwise → invoke `clip.sh create-issue` with the provided args
 #      and print `CREATED <identifier>` to stdout. Exit 0.
 #
 # Why a wrapper rather than embedding into clip.sh?
@@ -43,7 +57,18 @@
 #   and needs to know the fingerprint convention. Keeping it in a dedicated
 #   script also keeps the API helper's surface stable.
 #
-# Refs: BLD-969, BLD-952, BLD-956, BLD-939, BLD-1773.
+# Known-deferred CVD finding (BLD-1901 + BLD-2464):
+#   The brand-coral primary (#FF6038 light / #FF7A55 dark, "Electric Coral")
+#   desaturates to an olive/brown-gold hue under deuteranopia/protanopia CVD
+#   emulation. BLD-1901 fixed CVD *legibility* (foreground → navy #1A2138,
+#   WCAG AA) and explicitly scoped OUT restoring hue-distinctness as a
+#   separate additive concern. The desaturation itself is therefore a known,
+#   deliberately-deferred aesthetic condition — NOT a defect. When the audit
+#   detects only this aesthetic shift (no state/category information is lost,
+#   the element remains distinguishable) it must be suppressed as audit noise.
+#   See CVD_KNOWN_HUE_SHIFT_RE below and the SUPPRESSED-CVD exit path.
+#
+# Refs: BLD-969, BLD-952, BLD-956, BLD-939, BLD-1773, BLD-1901, BLD-2464.
 
 set -euo pipefail
 
@@ -65,15 +90,25 @@ Searches the active CableSnap project for an open issue containing the
 exact line `Fingerprint: <hash>`. If one exists, posts a recurrence
 comment on it. Otherwise creates a new issue from --description-file.
 
-If --scenario is provided and that scenario is listed in the isolation-harness
-allowlist (audit-isolation-harness-allowlist.json) and the finding title or
-description matches "near-empty / content missing" keywords, the finding is
-suppressed: no issue is created or commented on (BLD-1773).
+CVD hue-shift suppression (BLD-2464): If the finding title or description
+indicates a CVD-mode (deuteranopia/protanopia/tritanopia) finding that describes
+only a no-information-loss hue shift (coral/orange brand primary desaturates to
+olive/gold-brown, element still distinguishable, no state/category lost — purely
+aesthetic), the finding is suppressed globally: print `SUPPRESSED-CVD <scenario>`
+and exit 0. This is independent of the allowlist (no --scenario gating required).
+See BLD-1901 (deferral decision) and BLD-2464 (this suppression).
+
+Isolation-harness suppression (BLD-1773): If --scenario is provided and that
+scenario is listed in the isolation-harness allowlist
+(audit-isolation-harness-allowlist.json) and the finding title or description
+matches "near-empty / content missing" keywords, the finding is suppressed:
+print `SUPPRESSED <scenario>` and exit 0. No issue is created or commented on.
 
 Exit codes:
   0  Reused an existing issue (printed `RECURRENCE <ID>`),
      created a new one (printed `CREATED <ID>`),
-     or suppressed an isolation-harness false-positive (printed `SUPPRESSED <scenario>`).
+     suppressed an isolation-harness false-positive (printed `SUPPRESSED <scenario>`),
+     or suppressed a CVD no-info-loss hue-shift (printed `SUPPRESSED-CVD <scenario>`).
   2  Bad arguments / missing required flag.
   3  clip.sh failed unexpectedly.
 EOF
@@ -124,6 +159,91 @@ done
 if ! [[ "$FINGERPRINT" =~ ^[0-9a-fA-F]{6,64}$ ]]; then
   echo "fingerprint must be 6-64 hex chars (got: '$FINGERPRINT')" >&2
   exit 2
+fi
+
+# ---------- CVD hue-shift suppression (BLD-2464) ----------
+# If a finding is a CVD-mode finding (deuteranopia/protanopia/tritanopia) AND
+# the title or description self-describes as a no-information-loss hue shift
+# (the brand coral primary desaturates to olive/gold-brown but the element
+# remains distinguishable and no state/category information is lost — purely
+# aesthetic), suppress the finding globally (not scenario-gated).
+#
+# Disposition: BLD-1901 fixed CVD legibility (foreground → navy #1A2138, WCAG
+# AA) and explicitly scoped OUT restoring hue-distinctness as a separate
+# additive concern. The daily audit re-filing the same aesthetic hue-shift as a
+# new defect is audit noise. See BLD-1901 §Scope-Out + §UX-Design CVD note.
+# Suppression path introduced by BLD-2464.
+#
+# Suppression fires when BOTH conditions hold:
+#   1. CVD mode present: title/description mentions deuteranopia, protanopia,
+#      or tritanopia (the CVD-mode field/title from ux-designer).
+#   2. No-info-loss hue shift: title/description matches the coral→olive
+#      aesthetic pattern with explicit "no information lost / still
+#      distinguishable / purely aesthetic" language.
+#
+# The regex is intentionally conservative on condition 2 — it requires BOTH
+# a hue-shift indicator (olive|gold|brown) AND a no-loss signal
+# (distinguishable|no info|no state|no category|purely aesthetic|still
+# readable|still visible|still a button|aesthetic only). This prevents
+# over-suppression of real CVD findings where information IS lost.
+#
+# On match: print `SUPPRESSED-CVD <scenario>` (or `SUPPRESSED-CVD` if no
+# --scenario was passed) and exit 0. No issue created or commented on.
+# This is consistent with the existing `SUPPRESSED <scenario>` contract but
+# uses the `SUPPRESSED-CVD` prefix to distinguish the two suppression paths.
+
+# Regex for CVD-mode findings (case-insensitive). Matches the CVD simulation
+# mode name appearing in the ux-designer's finding title or description.
+CVD_MODE_RE='deuteranopia|protanopia|tritanopia|red.green.*color.blind|color.vision.deficien'
+
+# Regex for the no-information-loss hue-shift pattern (case-insensitive).
+# Requires: (a) an olive/gold/brown hue indicator AND (b) a no-loss signal.
+# This is a two-part match: both must be present. We check them in sequence
+# in is_cvd_no_info_loss_finding() below rather than trying to capture the
+# conjunction in a single regex, which would be unreadable.
+CVD_HUE_INDICATOR_RE='olive|gold.brown|brown.gold|desaturat|turns.*olive|becomes.*olive|olive.*hue|olive.*tone|olive.*tint|coral.*olive|orange.*olive|olive.*color|olive.*colour'
+CVD_NO_LOSS_SIGNAL_RE='no information loss|no info loss|no state.*lost|no category.*lost|still distinguishable|remains distinguishable|purely aesthetic|aesthetic only|still.*button|still.*readable|still.*visible|no loss of information|information.*not lost|does not lose|no data.*lost|aesthet'
+
+is_cvd_finding() {
+  local title="$1"
+  local desc_file="$2"
+
+  if echo "$title" | grep -qiE "$CVD_MODE_RE"; then
+    return 0
+  fi
+  if grep -qiE "$CVD_MODE_RE" "$desc_file" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+is_cvd_no_info_loss_finding() {
+  local title="$1"
+  local desc_file="$2"
+
+  # Concatenate title + description body for matching (avoids reading file twice).
+  local combined
+  combined="$(printf '%s\n' "$title"; cat "$desc_file" 2>/dev/null || true)"
+
+  # Both conditions must hold: hue-shift indicator AND no-loss signal.
+  if echo "$combined" | grep -qiE "$CVD_HUE_INDICATOR_RE"; then
+    if echo "$combined" | grep -qiE "$CVD_NO_LOSS_SIGNAL_RE"; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+if is_cvd_finding "$TITLE" "$DESC_FILE"; then
+  if is_cvd_no_info_loss_finding "$TITLE" "$DESC_FILE"; then
+    # Print SUPPRESSED-CVD with scenario if available, else just the tag.
+    if [[ -n "$SCENARIO" ]]; then
+      echo "SUPPRESSED-CVD $SCENARIO"
+    else
+      echo "SUPPRESSED-CVD"
+    fi
+    exit 0
+  fi
 fi
 
 # ---------- isolation-harness suppression (BLD-1773) ----------


### PR DESCRIPTION
## Summary

Prevents the daily UX audit from re-filing the known 'brand coral (#FF6038) desaturates to olive under deuteranopia/protanopia' finding as a new defect on every run. This is a known, deliberately-deferred aesthetic condition (BLD-1901) — not a defect.

## Problem

The dedup fingerprint includes the commit SHA, so the same aesthetic finding (BLD-2456, BLD-2457, BLD-2458 — all cancelled as won't-fix) evades dedup and re-files every audit run across every screen with a coral CTA.

## Changes

- **`scripts/audit-create-finding.sh`**: Added global CVD no-info-loss suppression path (before the existing BLD-1773 scenario-gated path). Fires when finding is a CVD-mode finding AND self-describes as a no-information-loss hue shift. Prints `SUPPRESSED-CVD <scenario>` and exits 0. Existing BLD-1773 near-empty suppression unchanged and independent. Disposition comment block at top cites BLD-1901 + BLD-2464.

- **`scripts/__tests__/audit-isolation-harness-allowlist.test.ts`**: 6 new test cases covering: (1) deuteranopia coral→olive no-info-loss → suppressed, (2) protanopia coral→olive no-info-loss → suppressed, (3) CVD with actual info loss → NOT suppressed, (4) non-CVD near-empty on allowlisted scenario → uses existing BLD-1773 path, (5) SUPPRESSED-CVD includes scenario name, (6) SUPPRESSED-CVD fires without --scenario (global).

- **`.agents/AGENTS-ux-designer.md`**: Updated Audit Flow section with explicit CVD no-info-loss exclusion rule (step 4), with references to BLD-1901 and BLD-2464, and explicit cases that MUST still be filed.

## Testing

- 7 existing allowlist suppression tests: PASS (55 total audit-related tests)
- 4 manual bash tests confirming suppression behavior: all PASS
- regression-smoke.sh: unchanged (no trust-anchor assertions modified)
- TypeScript: no new errors introduced (pre-existing TS error in origin/main unrelated to changes)

## Issue

Resolves BLD-2464