### PR TITLE
fix(test): size jest worker pool to memory budget to end OOM flakiness (BLD-2482)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,12 +20,76 @@
 // guidance when React/RN are upgraded again.
 process.env.NODE_ENV = 'test';
 
+// BLD-2482: Size the Jest worker pool to the actual MEMORY budget, not just CPU.
+//
+// Symptom fixed: full parallel `npm run test` non-deterministically reported
+// "Test suite failed to run … signal=SIGKILL, exitCode=null" for a DIFFERENT
+// set of suites each run, with 0 failed assertions (4600+ tests all pass).
+// SIGKILL + null exit code on a Jest worker CHILD process is the definitive
+// kernel OOM-killer signature (the kernel kills it, so Node sees no exit code) —
+// not a real test failure. Confirmed via `--logHeapUsage`: per-worker heapUsed
+// climbs past ~1.1 GB (median ~651 MB) as the heavy react-native + jest-expo +
+// `--experimental-sqlite` module graph and SQLite state accumulate across files.
+//
+// Why CPU-based sizing was wrong: BLD-918 set `maxWorkers:'100%'`, which resolves
+// via os.availableParallelism()=2 on this box. But the container runs under a
+// 6 GB cgroup memory cap (/sys/fs/cgroup/memory.max) with a persistent ~2.2 GB
+// environmental floor, leaving only ~3.5 GB usable. Two workers peaking ~1.5–2 GB
+// RSS each blow past 6 GB → the kernel SIGKILLs whichever worker is mid-load →
+// the non-deterministic red suite. A previous attempt (workerIdleMemoryLimit
+// alone) only recycles heap BETWEEN files, so a single heavy file can still spike
+// RSS across the cap mid-run — it survived 5 runs then OOM'd on run 6 (6 SIGKILLs).
+//
+// Fix: derive maxWorkers from min(CPU parallelism, memory budget). memoryWorkers =
+// floor((memBudget − reserve) / perWorkerBudget). This yields 1 (serial) under
+// the 6 GB cgroup — which is exactly what CI's `--runInBand` job already does with
+// zero flakes — while still granting full parallelism on developer machines with
+// real RAM (e.g. 6 workers on a 16 GB/8-core laptop). It can never oversubscribe
+// memory, so the OOM is structurally impossible rather than merely less frequent.
+// No test is skipped or modified. CI wall-time is unchanged (CI already serial);
+// only the default local/agent `jest` run trades ~120 s for determinism.
+const os = require('os');
+const fs = require('fs');
+function cgroupMemLimitBytes() {
+  // cgroup v2 (this container): "max" means unlimited.
+  try {
+    const v = fs.readFileSync('/sys/fs/cgroup/memory.max', 'utf8').trim();
+    if (v && v !== 'max') {
+      const n = Number(v);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+  } catch {}
+  // cgroup v1 fallback: sentinel is a near-INT64 value ≈ unlimited.
+  try {
+    const v = Number(fs.readFileSync('/sys/fs/cgroup/memory/memory.limit_in_bytes', 'utf8').trim());
+    if (Number.isFinite(v) && v > 0 && v < os.totalmem() * 4) return v;
+  } catch {}
+  return null;
+}
+function memoryAwareMaxWorkers() {
+  const GB = 1024 ** 3;
+  const cg = cgroupMemLimitBytes();
+  const hostMem = os.totalmem();
+  const memBudget = cg && cg < hostMem ? cg : hostMem;
+  const RESERVE = 3.0 * GB;     // environmental floor (~2.2 GB anon) + spike headroom
+  const PER_WORKER = 2.0 * GB;  // observed peak worker RSS on this suite
+  const cpuMax = os.availableParallelism ? os.availableParallelism() : os.cpus().length;
+  const memMax = Math.max(1, Math.floor((memBudget - RESERVE) / PER_WORKER));
+  return Math.max(1, Math.min(cpuMax, memMax));
+}
+
 module.exports = {
   preset: 'jest-expo',
   testTimeout: 10000,
-  // BLD-918: Jest defaults to cpus−1 workers. Use all available parallelism
-  // (os.availableParallelism() already respects cgroup CPU limits).
-  maxWorkers: '100%',
+  // See the BLD-2482 block above: memory-budget-aware worker count. Falls back to
+  // full CPU parallelism when RAM is ample; clamps to 1 under a tight cgroup.
+  maxWorkers: memoryAwareMaxWorkers(),
+  // Defense-in-depth (kept from the first BLD-2482 attempt): even the surviving
+  // worker(s) get recycled once V8 heapUsed crosses this ceiling, capping RSS
+  // growth. Absolute bytes on purpose — jest-worker resolves a fraction/'%' against
+  // os.totalmem() (host RAM), which ignores the cgroup, so a percentage would be
+  // meaningless here. Harmless when only 1 worker runs; useful on parallel boxes.
+  workerIdleMemoryLimit: 768 * 1024 * 1024,
   transformIgnorePatterns: [
     'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@sentry/react-native|native-base|react-native-svg|react-native-reanimated|react-native-gesture-handler|victory-native|react-native-safe-area-context|@gorhom/bottom-sheet)'
   ],

--- a/jest.config.js
+++ b/jest.config.js
@@ -50,6 +50,7 @@ process.env.NODE_ENV = 'test';
 // only the default local/agent `jest` run trades ~120 s for determinism.
 const os = require('os');
 const fs = require('fs');
+const path = require('path');
 function cgroupMemLimitBytes() {
   // cgroup v2 (this container): "max" means unlimited.
   try {
@@ -78,6 +79,12 @@ function memoryAwareMaxWorkers() {
   return Math.max(1, Math.min(cpuMax, memMax));
 }
 
+function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');
+}
+
+const agentWorktreesPattern = `${escapeRegex(path.join(__dirname, '.paperclip', 'worktrees'))}/`;
+
 module.exports = {
   preset: 'jest-expo',
   testTimeout: 10000,
@@ -98,7 +105,7 @@ module.exports = {
   },
   // BLD-2161: Exclude paperclip agent worktrees so jest does not RUN test
   // files from isolated run-specific git worktrees.
-  testPathIgnorePatterns: ['/node_modules/', '__tests__/helpers/', '__tests__/fixtures/', '/e2e/', '/.paperclip/worktrees/'],
+  testPathIgnorePatterns: ['/node_modules/', '__tests__/helpers/', '__tests__/fixtures/', '/e2e/', agentWorktreesPattern],
   // BLD-2482 (primary flake): testPathIgnorePatterns only filters which test
   // FILES execute — it does NOT stop jest-haste-map from crawling those dirs to
   // build the module graph and register manual mocks. A sibling agent worktree
@@ -116,8 +123,8 @@ module.exports = {
   // __mocks__ are never registered and cannot shadow or dangle. modulePathIgnore-
   // Patterns is the jest-29 knob that gates haste-map registration (not just test
   // execution); watchPathIgnorePatterns keeps watch-mode from re-crawling them.
-  modulePathIgnorePatterns: ['/.paperclip/worktrees/'],
-  watchPathIgnorePatterns: ['/.paperclip/worktrees/'],
+  modulePathIgnorePatterns: [agentWorktreesPattern],
+  watchPathIgnorePatterns: [agentWorktreesPattern],
   globalSetup: './jest.global-setup.js',
   setupFiles: ['./jest.setup.js'],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -96,12 +96,28 @@ module.exports = {
   moduleNameMapper: {
     'react-native-reanimated': '<rootDir>/__mocks__/react-native-reanimated.js',
   },
-  // BLD-2161: Exclude paperclip agent worktrees so jest does not load test
-  // files from isolated run-specific git worktrees. Without this, a live
-  // worktree (e.g. .paperclip/worktrees/run/-issue-run/) causes duplicate
-  // manual-mock warnings and runs stale test variants against the main
-  // project's source, producing false failures that redden the gate.
+  // BLD-2161: Exclude paperclip agent worktrees so jest does not RUN test
+  // files from isolated run-specific git worktrees.
   testPathIgnorePatterns: ['/node_modules/', '__tests__/helpers/', '__tests__/fixtures/', '/e2e/', '/.paperclip/worktrees/'],
+  // BLD-2482 (primary flake): testPathIgnorePatterns only filters which test
+  // FILES execute — it does NOT stop jest-haste-map from crawling those dirs to
+  // build the module graph and register manual mocks. A sibling agent worktree
+  // under .paperclip/worktrees/ (e.g. .../run/-issue-run/__mocks__/) therefore
+  // still gets scanned: haste emits `duplicate manual mock found: <pkg>` and may
+  // pick the WORKTREE copy as canonical (shadowing the real <rootDir>/__mocks__).
+  // When another agent tears that worktree down MID-RUN (they churn constantly),
+  // the chosen mock file vanishes and every suite that transitively imports it
+  // dies with `Test suite failed to run: ENOENT ... /.paperclip/worktrees/.../
+  // __mocks__/<pkg>`. That is the non-deterministic "N suites failed, different
+  // set each run" symptom — reproduced here on clean main with a planted worktree
+  // mock (254 suites red from a single deleted __mocks__/@sentry/react-native.js).
+  //
+  // Fix: exclude the worktrees from the MODULE/haste registry entirely, so their
+  // __mocks__ are never registered and cannot shadow or dangle. modulePathIgnore-
+  // Patterns is the jest-29 knob that gates haste-map registration (not just test
+  // execution); watchPathIgnorePatterns keeps watch-mode from re-crawling them.
+  modulePathIgnorePatterns: ['/.paperclip/worktrees/'],
+  watchPathIgnorePatterns: ['/.paperclip/worktrees/'],
   globalSetup: './jest.global-setup.js',
   setupFiles: ['./jest.setup.js'],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],


### PR DESCRIPTION
## Problem (BLD-2482)

Full parallel `npm run test` non-deterministically reported **failing test suites with zero (or cascade-only) failing tests** — a **different** set of suites each run, every one passing in isolation. Two *distinct* resource/harness failure modes were hiding behind the same red gate.

## Two root causes (both fixed — `jest.config.js` only, no product/test change)

### Cause #1 — kernel OOM-killer on Jest workers
Signature: `A jest worker process (pid=…) was terminated by another process: signal=SIGKILL, exitCode=null` with **0 failed assertions**. `SIGKILL` + `exitCode=null` on a worker **child** is the definitive OOM-killer signature (the kernel kills it, so Node never sees an exit code). `--logHeapUsage` showed per-worker `heapUsed` climbing past **~1.1 GB** (median ~651 MB) as the heavy `react-native` + `jest-expo` + `--experimental-sqlite` graph and SQLite state accumulate across files.

The box runs under a **6 GB cgroup** (`/sys/fs/cgroup/memory.max`) with a persistent **~2.2 GB** floor, leaving ~3.5 GB usable. `maxWorkers:'100%'` (BLD-918) resolved via `os.availableParallelism()`=2, and two workers peaking ~1.5–2 GB RSS each breached the cap → whichever worker was mid-load got SIGKILLed.

**Fix:** size the pool to the **memory** budget, not just CPU:
```
memoryWorkers = floor((memBudget − reserve) / perWorkerBudget)   # reserve 3 GB, perWorker 2 GB
maxWorkers    = clamp(1, min(cpuMax, memoryWorkers))
```
- Reads cgroup v2 `memory.max` (falls back to `os.totalmem()`).
- **Under the 6 GB cgroup → 1 worker (serial)** — exactly what CI's `--runInBand` job already does with zero flakes.
- **16 GB / 8-core dev laptop → 6 workers** — developers keep full parallelism.
- The pool can **never oversubscribe memory**, so the OOM is *structurally impossible*, not merely rarer. `workerIdleMemoryLimit: 768 MB` kept as defense-in-depth.

### Cause #2 — jest-haste-map crawling sibling agent worktrees (ENOENT `__mocks__`)
Signature: `Test suite failed to run: ENOENT … /.paperclip/worktrees/…/__mocks__/<pkg>`, **0 SIGKILLs**, sometimes cascading into a handful of assertion failures (e.g. a seed test throws because it can't `require('expo-crypto')`).

`testPathIgnorePatterns` (BLD-2161) only stops worktree test **files from executing** — it does **not** stop jest-haste-map from **crawling** those dirs and registering their manual mocks. A sibling agent worktree under `.paperclip/worktrees/…/__mocks__/` therefore still gets scanned; haste may pick the **worktree copy** as canonical, and when another agent tears that worktree down **mid-run**, the chosen mock file vanishes → every suite that transitively imports it dies with `ENOENT … __mocks__/<pkg>`. That is the non-deterministic "N suites failed, different set each run" symptom (reproduced on clean main with a planted worktree mock: 254 suites red from a single deleted `__mocks__/@sentry/react-native.js`).

**Fix:** exclude worktrees from the **module/haste registry**, not just test execution:
```
modulePathIgnorePatterns: ['/.paperclip/worktrees/'],
watchPathIgnorePatterns:  ['/.paperclip/worktrees/'],
```
Their `__mocks__` are now never registered → cannot shadow the real `<rootDir>/__mocks__` and cannot dangle when a worktree is removed mid-run.

## Impact / wall-time
- **CI wall-time: unchanged** — `.github/workflows/ci.yml` already runs `npm test -- --ci --runInBand` (serial). Only the *default* local/agent `npm run test` path changes (~132 s 2-worker-flaky → ~250 s 1-worker-deterministic). Determinism buys back the reruns/misdiagnosis this flakiness caused (see BLD-2470).

## Verification
Runs the default `jest --ci` path (the one that flaked), **with a live sibling worktree present** so cause #2 is actually exercised. GREEN = `exit==0 AND 0 SIGKILLs AND 0 ENOENT-mock`.

_Final 10-consecutive-run table is being appended by the detached verifier (`/tmp/opencode/bld2482/verify10-final-results.txt`) against the complete fix at `210de672`; posted on the issue before merge is requested. Prior 10-run pass was 9/10 — the single RED was cause #2 firing **7 min before** the `modulePathIgnorePatterns` commit landed (all-ENOENT, 0 SIGKILLs), i.e. exactly what commit #2 fixes._

## Acceptance criteria
- [x] Root cause(s) identified & documented — **two**: OOM-killer + haste-map worktree race.
- [x] Fix applied (`jest.config.js` only) — no product/test behavior change.
- [~] `npm run test` passes **10 consecutive times**, 0 failed suites — re-verifying on the complete fix (both commits); table to follow.
- [x] CI wall-time not materially worse (**unchanged — CI already serial**).
- [x] No individual test disabled/skipped.

Closes BLD-2482.
