### PR TITLE
fix(scripts): checkout-issue sends expectedStatuses field (BLD-2510)

### DIFF
--- a/scripts/__tests__/clip-error-surfacing.test.ts
+++ b/scripts/__tests__/clip-error-surfacing.test.ts
@@ -224,6 +224,89 @@ describe('clip.sh — BLD-846 error surfacing', () => {
     });
   });
 
+  describe('BLD-2510 — checkout-issue expectedStatuses field', () => {
+    it('sends expectedStatuses array in POST body by default', async () => {
+      let capturedBody: string | undefined;
+      const server = await startMockServer((req, res) => {
+        let body = '';
+        req.on('data', (c) => (body += c));
+        req.on('end', () => {
+          capturedBody = body;
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ id: 'issue-1', status: 'todo' }));
+        });
+      });
+      try {
+        const r = await runClip(['checkout-issue', 'BLD-99'], server.url);
+        expect(r.status).toBe(0);
+        // Verify the body was sent and contains expectedStatuses
+        expect(capturedBody).toBeDefined();
+        const parsed = JSON.parse(capturedBody!);
+        expect(parsed).toHaveProperty('agentId');
+        expect(parsed).toHaveProperty('expectedStatuses');
+        expect(Array.isArray(parsed.expectedStatuses)).toBe(true);
+        expect(parsed.expectedStatuses.length).toBeGreaterThan(0);
+        // Default must include the common actionable statuses
+        expect(parsed.expectedStatuses).toContain('todo');
+        expect(parsed.expectedStatuses).toContain('in_progress');
+        expect(parsed.expectedStatuses).toContain('in_review');
+        expect(parsed.expectedStatuses).toContain('blocked');
+        expect(parsed.expectedStatuses).toContain('backlog');
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('honours --expected-status flags when provided', async () => {
+      let capturedBody: string | undefined;
+      const server = await startMockServer((req, res) => {
+        let body = '';
+        req.on('data', (c) => (body += c));
+        req.on('end', () => {
+          capturedBody = body;
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ id: 'issue-1', status: 'in_review' }));
+        });
+      });
+      try {
+        const r = await runClip(
+          ['checkout-issue', 'BLD-99', '--expected-status', 'in_review', '--expected-status', 'in_progress'],
+          server.url,
+        );
+        expect(r.status).toBe(0);
+        expect(capturedBody).toBeDefined();
+        const parsed = JSON.parse(capturedBody!);
+        expect(parsed.expectedStatuses).toEqual(['in_review', 'in_progress']);
+      } finally {
+        await server.close();
+      }
+    });
+
+    it('400 on missing expectedStatuses surfaces the validation error (regression guard)', async () => {
+      // Simulates the pre-BLD-2510 server rejecting a body with no expectedStatuses.
+      // After the fix, clip.sh always sends the field, so a real server should no
+      // longer 400. But if something regresses (e.g. jq missing), the error must
+      // still surface on stderr rather than being silently swallowed.
+      const server = await startMockServer((_req, res) => {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({
+            error: 'Validation error',
+            details: [{ path: ['expectedStatuses'], message: 'Required' }],
+          }),
+        );
+      });
+      try {
+        const r = await runClip(['checkout-issue', 'BLD-99'], server.url);
+        expect(r.status).not.toBe(0);
+        expect(r.stderr).toContain('400');
+        expect(r.stderr).toContain('expectedStatuses');
+      } finally {
+        await server.close();
+      }
+    });
+  });
+
   describe('exit code propagation', () => {
     it('the failure is detectable under `set -e`', async () => {
       const server = await startMockServer((_req, res) => {

--- a/scripts/clip.sh
+++ b/scripts/clip.sh
@@ -188,12 +188,45 @@ case "$cmd" in
     ;;
 
   checkout-issue)
+    # BLD-2510: The server now requires an `expectedStatuses` array in the
+    # checkout POST body. Without it the server returns:
+    #   HTTP 400 {"error":"Validation error","details":[{"path":["expectedStatuses"],"message":"Required"}]}
+    #
+    # Usage:
+    #   checkout-issue <ID> [--expected-status S] [--expected-status S ...] [run-id]
+    #
+    # --expected-status (repeatable): add a status to the expected-statuses
+    #   filter. Defaults to the full set of actionable statuses so that a
+    #   bare `checkout-issue BLD-N` still succeeds regardless of the issue's
+    #   current status (matching the pre-BLD-2510 behaviour).
     issue_id="$1"; shift
-    run_id="${1:-$(python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo "manual-$(date +%s)")}"
+    # Parse optional --expected-status flags; collect remaining positional
+    # arg as run_id.
+    expected_statuses=()
+    remaining_args=()
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --expected-status) expected_statuses+=("$2"); shift 2;;
+        *) remaining_args+=("$1"); shift;;
+      esac
+    done
+    # Default: all non-terminal actionable statuses (mirrors agent heartbeat
+    # expectations — agents never need to check out a done/cancelled issue).
+    if [[ ${#expected_statuses[@]} -eq 0 ]]; then
+      expected_statuses=("backlog" "todo" "in_progress" "in_review" "blocked")
+    fi
+    # Build JSON array for expectedStatuses.
+    expected_statuses_json=$(printf '%s\n' "${expected_statuses[@]}" | jq -R . | jq -sc .)
+    run_id="${remaining_args[0]:-$(python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo "manual-$(date +%s)")}"
     # Route through api() so 4xx/5xx bodies surface (BLD-846).
+    # BLD-2510: include expectedStatuses in the body — required by the server.
+    checkout_body=$(jq -n \
+      --arg agentId "$AGENT" \
+      --argjson expectedStatuses "$expected_statuses_json" \
+      '{agentId: $agentId, expectedStatuses: $expectedStatuses}')
     api POST "/issues/$issue_id/checkout" \
       -H "X-Paperclip-Run-Id: $run_id" \
-      -d "{\"agentId\":\"$AGENT\"}" | jq_or_cat '.'
+      -d "$checkout_body" | jq_or_cat '.'
     echo "Run ID: $run_id" >&2
     ;;
 
@@ -424,7 +457,11 @@ ISSUES:
   create-issue --title T [--description D] [--status S] [--priority P] [--goal-id G]
   update-issue <ID> [--title T] [--status S] [--priority P] [--comment C]
   comment-issue <ID> --body TEXT [--reopen]
-  checkout-issue <ID> [run-id]
+  checkout-issue <ID> [--expected-status S] ... [run-id]
+                    Checkout an issue. --expected-status (repeatable) restricts
+                    checkout to issues in the given status(es). Default: all
+                    actionable statuses (backlog, todo, in_progress, in_review,
+                    blocked). BLD-2510: required by server since 2026-07-01.
   release-issue <ID>
 
 GOALS:


### PR DESCRIPTION
## Summary

The Paperclip server now requires an `expectedStatuses` array in the `POST /issues/:id/checkout` body. Without it the server returns HTTP 400, blocking any agent from self-checking-out an issue that the harness didn't pre-checkout.

## Changes

- **`scripts/clip.sh`**: Expanded `checkout-issue` to parse optional `--expected-status <s>` (repeatable) flags and always include `expectedStatuses` in the POST body. Default is all non-terminal actionable statuses (`backlog`, `todo`, `in_progress`, `in_review`, `blocked`), matching the broad behaviour callers need for cross-boundary closeouts.
- **`scripts/__tests__/clip-error-surfacing.test.ts`**: Added 3 regression tests covering default body, custom flags, and 400 error surfacing.

## Testing

- All 11 tests in `clip-error-surfacing.test.ts` pass (8 original + 3 new)
- TypeScript: `tsc --noEmit` zero errors
- Manually verified against live Paperclip server: bare `checkout-issue BLD-N` no longer returns HTTP 400

## Issue

Resolves BLD-2510