### PR TITLE
fix: replace Intl-dependent month labels with MONTH_NAMES array (BLD-2584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Fixed blank month labels in the Progress tab date carousels** — the monthly report header and calendar month labels relied on `toLocaleDateString`, which returns an empty string on React Native's Hermes engine (no bundled Intl/ICU data), so the month name rendered blank. Month labels now use a deterministic, locale-independent name table and always display correctly (e.g. "July 2026"). (BLD-2584)
 
 ## v0.26.52 — 2026-07-01
 <!-- versionCode: 122 -->

--- a/__tests__/calendar.test.ts
+++ b/__tests__/calendar.test.ts
@@ -149,8 +149,24 @@ describe("getWeekDayLabels", () => {
 // --- formatMonthYear ---
 
 describe("formatMonthYear", () => {
-  it("formats April 2026 (locale-tolerant year check)", () => {
-    expect(formatMonthYear(2026, 3)).toContain("2026");
+  it("formats April 2026 with full month name", () => {
+    expect(formatMonthYear(2026, 3)).toBe("April 2026");
+  });
+
+  it("formats January (month 0)", () => {
+    expect(formatMonthYear(2025, 0)).toBe("January 2025");
+  });
+
+  it("formats December (month 11)", () => {
+    expect(formatMonthYear(2025, 11)).toBe("December 2025");
+  });
+
+  it("returns a non-empty label for all 12 month indices", () => {
+    for (let m = 0; m < 12; m++) {
+      const label = formatMonthYear(2026, m);
+      expect(label.length).toBeGreaterThan(0);
+      expect(label).toContain("2026");
+    }
   });
 });
 

--- a/__tests__/hooks/useMonthlyReport.test.ts
+++ b/__tests__/hooks/useMonthlyReport.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for pure helper functions exported from hooks/useMonthlyReport.ts.
+ *
+ * formatMonthLabel is the function previously affected by the Hermes Intl bug:
+ * it called Date.prototype.toLocaleDateString() which returns "" on Hermes
+ * because no ICU data is bundled. The fix replaces it with a hardcoded
+ * MONTH_NAMES array (same pattern as getWeekDayLabels in lib/db/calendar.ts).
+ */
+
+import { formatMonthLabel, formatVolume, volumeChangePercent, sessionCountDelta } from "../../hooks/useMonthlyReport";
+
+// --- formatMonthLabel ---
+
+describe("formatMonthLabel", () => {
+  it("formats July 2026 correctly (monthIndex=6)", () => {
+    expect(formatMonthLabel(2026, 6)).toBe("July 2026");
+  });
+
+  it("formats January (monthIndex=0)", () => {
+    expect(formatMonthLabel(2026, 0)).toBe("January 2026");
+  });
+
+  it("formats December (monthIndex=11)", () => {
+    expect(formatMonthLabel(2025, 11)).toBe("December 2025");
+  });
+
+  it("returns a non-empty label containing the year for all 12 month indices", () => {
+    for (let m = 0; m < 12; m++) {
+      const label = formatMonthLabel(2026, m);
+      expect(label.length).toBeGreaterThan(0);
+      expect(label).toContain("2026");
+    }
+  });
+
+  it("does not rely on toLocaleDateString (output is deterministic across locales)", () => {
+    // These exact strings must match regardless of system locale or Intl availability.
+    const expected = [
+      "January 2024",   "February 2024",  "March 2024",
+      "April 2024",     "May 2024",       "June 2024",
+      "July 2024",      "August 2024",    "September 2024",
+      "October 2024",   "November 2024",  "December 2024",
+    ];
+    for (let m = 0; m < 12; m++) {
+      expect(formatMonthLabel(2024, m)).toBe(expected[m]);
+    }
+  });
+});
+
+// --- formatVolume ---
+
+describe("formatVolume", () => {
+  it("rounds and returns plain string for values below 1M", () => {
+    expect(formatVolume(12345.6)).toBe("12,346");
+  });
+
+  it("returns k-suffix for values >= 1M", () => {
+    expect(formatVolume(1_500_000)).toBe("1,500k");
+  });
+});
+
+// --- volumeChangePercent ---
+
+describe("volumeChangePercent", () => {
+  it("returns null when previous is null", () => {
+    expect(volumeChangePercent(100, null)).toBeNull();
+  });
+
+  it("returns null when previous is 0 (avoid divide by zero)", () => {
+    expect(volumeChangePercent(100, 0)).toBeNull();
+  });
+
+  it("returns null when change rounds to 0%", () => {
+    expect(volumeChangePercent(1000, 999)).toBeNull();
+  });
+
+  it("returns positive percent string with + prefix", () => {
+    expect(volumeChangePercent(110, 100)).toBe("+10%");
+  });
+
+  it("returns negative percent string", () => {
+    expect(volumeChangePercent(90, 100)).toBe("-10%");
+  });
+});
+
+// --- sessionCountDelta ---
+
+describe("sessionCountDelta", () => {
+  it("returns null when previous is null", () => {
+    expect(sessionCountDelta(5, null)).toBeNull();
+  });
+
+  it("returns null when delta is 0", () => {
+    expect(sessionCountDelta(5, 5)).toBeNull();
+  });
+
+  it("returns positive delta with + prefix", () => {
+    expect(sessionCountDelta(8, 5)).toBe("+3");
+  });
+
+  it("returns negative delta", () => {
+    expect(sessionCountDelta(3, 5)).toBe("-2");
+  });
+});

--- a/hooks/useMonthlyReport.ts
+++ b/hooks/useMonthlyReport.ts
@@ -8,6 +8,7 @@ import * as FileSystem from "expo-file-system";
 import { getMonthlyReport, getBodySettings } from "@/lib/db";
 import type { MonthlyReportData } from "@/lib/db";
 import type { BodySettings } from "@/lib/types";
+import { MONTH_NAMES } from "@/lib/format";
 
 // ─── Constants ─────────────────────────────────────────────────────
 
@@ -16,8 +17,7 @@ export const MAX_MONTHS_BACK = 12;
 // ─── Helpers ───────────────────────────────────────────────────────
 
 export function formatMonthLabel(year: number, monthIndex: number): string {
-  const d = new Date(year, monthIndex, 1);
-  return d.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+  return `${MONTH_NAMES[monthIndex]} ${year}`;
 }
 
 export function formatVolume(vol: number): string {

--- a/lib/db/calendar.ts
+++ b/lib/db/calendar.ts
@@ -1,6 +1,7 @@
 import { and, sql, isNotNull, gte, lt, eq } from "drizzle-orm";
 import { query, getDrizzle } from "./helpers";
 import { workoutSessions, workoutSets, exercises } from "./schema";
+import { MONTH_NAMES } from "@/lib/format";
 
 // --- Types ---
 
@@ -265,8 +266,7 @@ export function getWeekDayLabels(weekStartDay: number): string[] {
 }
 
 export function formatMonthYear(year: number, month: number): string {
-  const date = new Date(year, month, 1);
-  return date.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+  return `${MONTH_NAMES[month]} ${year}`;
 }
 
 export function dateToISO(year: number, month: number, day: number): string {

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -2,6 +2,14 @@ import { toDisplay } from "./units";
 
 export const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
 
+// Hardcoded month names — intentionally avoids Date.prototype.toLocaleDateString()
+// because the Hermes JS engine (React Native) ships without Intl/ICU data, causing
+// that API to return an empty string for the month portion of the output.
+export const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+] as const;
+
 export function formatDuration(seconds: number | null | undefined): string {
   if (!seconds) return "-";
   const h = Math.floor(seconds / 3600);


### PR DESCRIPTION
## Summary

Fix blank month labels in progress-tab date carousels. `Date.prototype.toLocaleDateString()` returns empty strings on the Hermes JS engine (React Native) because no Intl/ICU data is bundled. Replace both formatters with a hardcoded `MONTH_NAMES` array — the same pattern already used for `DAYS` in `lib/format.ts` and `getWeekDayLabels` in `lib/db/calendar.ts`.

## Changes

- **`lib/format.ts`**: Add `MONTH_NAMES` constant (12 full English month names). Comment explains the Hermes rationale.
- **`hooks/useMonthlyReport.ts`**: `formatMonthLabel(year, monthIndex)` now returns ``${MONTH_NAMES[monthIndex]} ${year}`` instead of using `toLocaleDateString()`.
- **`__tests__/calendar.test.ts`**: Strengthen existing `formatMonthYear` test — now asserts exact full month name (was only checking year substring). Adds Jan/Dec edge cases and all-12-months loop.
- **`__tests__/hooks/useMonthlyReport.test.ts`**: New test file. Covers `formatMonthLabel` for all 12 months, determinism across locales, and edge months. Also covers `formatVolume`, `volumeChangePercent`, `sessionCountDelta`.

## Testing

- `tsc --noEmit` — zero errors
- `jest calendar.test.ts useMonthlyReport.test.ts MonthlyReportSegment` — 48/48 green

## Issue

Resolves BLD-2584 (parent: BLD-2582)