### PR TITLE
test(progress): guard visible CTA label in WorkoutEmptyState (BLD-2581)

### DIFF
--- a/__tests__/components/progress/WorkoutEmptyState.test.tsx
+++ b/__tests__/components/progress/WorkoutEmptyState.test.tsx
@@ -46,6 +46,17 @@ describe('WorkoutEmptyState', () => {
     expect(getByLabelText('Start your first workout')).toBeTruthy()
   })
 
+  // Regression guard for BLD-2581: the audit flagged the primary CTA as a
+  // "solid coral pill with no visible text label". The a11y-label assertion
+  // above passes even when the *visible* label is blank (the accessibility
+  // label "Start your first workout" differs from the visible label
+  // "Start a workout"), so it could not catch a genuine blanking of the
+  // on-pill text. Assert the visible label explicitly.
+  it('renders the visible "Start a workout" text on the CTA (BLD-2581)', () => {
+    const { getByText } = render(<WorkoutEmptyState />)
+    expect(getByText('Start a workout')).toBeTruthy()
+  })
+
   it('has an accessibility label on the container for screen readers', () => {
     const { getByLabelText } = render(<WorkoutEmptyState />)
     expect(getByLabelText('No workouts logged yet')).toBeTruthy()


### PR DESCRIPTION
## Summary

Closes **BLD-2581** — "UX: Primary CTA button has no visible text label (progress-tab)".

**The reported bug is a screenshot capture-timing artifact, not a code defect.** No product code is changed. This PR adds one regression-guard assertion so a *genuine* future blanking of the CTA text would be caught by CI.

## Investigation (why no product fix)

The audit (commit `5ccb2166`) flagged the progress-tab empty-state CTA as a "solid coral pill with no visible text label". I traced the full render path and pulled the actual audit screenshot:

| Check | Result |
|---|---|
| CTA text color token `primaryForeground` | navy `#1A2138` on coral `#FF6038` → **5.29:1** (light) / **6.19:1** (dark) — passes WCAG AA |
| `__tests__/theme/primary-contrast.test.ts` | green |
| Mount-time opacity/fade hiding text | none — `brightness`/`scale` init at `1`; opacity = `1` on first frame (`button.tsx:81-82,270`) |
| Custom font that could fail to load | none — app ships zero custom fonts; system font paints on first frame |
| `WorkoutEmptyState.test.tsx` render test | green — headline + description + CTA all render |

The audit screenshot (`progress-tab/progress-top-mobile.png`) shows the coral pill blank — **but so is every other text element on the screen** (headline, description, WeeklySummary card, date carousel per BLD-2582), and sibling captures (nutrition-tab, stack-marker) are near-blank too. Root cause is in the harness: `e2e/scenarios/progress-tab.spec.ts` gates on `progress-screen-container` visibility (the shell mounts immediately on empty test DB) + double-rAF + 300ms, **before React commits the async-data-driven text content**. There is no `data-test-ready`-equivalent gate for the progress screen. (Follow-up note filed on the ticket re: the harness gate — out of scope here.)

## Change

`WorkoutEmptyState.test.tsx` asserted the CTA's **accessibility** label (`"Start your first workout"`) but not its **visible** label (`"Start a workout"`) — the exact thing the audit flagged. This PR adds an explicit `getByText('Start a workout')` assertion.

Verified it is a real guard (not a no-op): temporarily removing the `label` prop makes the new assertion fail with *"Unable to find an element with text: Start a workout"*.

## Test plan

- `npx jest __tests__/components/progress/WorkoutEmptyState.test.tsx` → **5/5 pass** (was 4/4)
- `npx jest __tests__/theme/primary-contrast.test.ts` → 4/4 pass
- `npx eslint __tests__/components/progress/WorkoutEmptyState.test.tsx` → clean

## Scope

1 file, +11 lines (test-only). No product code touched.
