### PR TITLE
feat: training-day macro adjustment — pure module + tests (BLD-2641 PR1)

### DIFF
--- a/__tests__/lib/training-day-macros.test.ts
+++ b/__tests__/lib/training-day-macros.test.ts
@@ -1,0 +1,382 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for lib/training-day-macros.ts — Training-Day Macro Adjustment pure module.
+ *
+ * Coverage targets (per BLD-2641 plan):
+ *   AC2  — training-day calorie target = base + base×p (Model 2)
+ *   AC3  — rest-day calorie target = base − base×p×n/(7−n), clamped to ≥1200 kcal
+ *   AC4  — weekly neutrality property test: sum of 7 days = 7×base for n∈1..6
+ *   AC5  — floor clamp + cappedByFloor flag; no NaN/negative
+ *   AC10 — clock injection: no Date.now()/new Date() inside lib/training-day-macros.ts
+ *   AC22 — ÷0 guard for n=7/n≤0 via normalizeParams
+ *   AC23 — export CALORIE_FLOOR; mapRecomputedMacros shape; PureMacroTargets disambiguation
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+import {
+  computeEffectiveTargets,
+  computeDayCalories,
+  normalizeParams,
+  mapRecomputedMacros,
+  clamp,
+  CALORIE_FLOOR,
+  SPLIT_PERCENT_MIN,
+  SPLIT_PERCENT_MAX,
+  SPLIT_PERCENT_DEFAULT,
+  TRAINING_DAYS_DEFAULT,
+  type PureMacroTargets,
+  type TrainingDayParams,
+} from "../../lib/training-day-macros";
+
+// ─── AC10: Clock injection ────────────────────────────────────────────────────
+
+describe("AC10: clock injection — no Date.now() / new Date() inside lib/training-day-macros.ts", () => {
+  it("lib/training-day-macros.ts contains no Date.now() or bare new Date() calls", () => {
+    const filePath = path.resolve(__dirname, "../../lib/training-day-macros.ts");
+    const source = fs.readFileSync(filePath, "utf8");
+
+    // Strip block comments (/** ... */) and single-line comments (//)
+    // so that documentation comments mentioning the banned patterns don't trigger false positives.
+    const strippedBlockComments = source.replace(/\/\*[\s\S]*?\*\//g, "");
+    const stripped = strippedBlockComments
+      .split("\n")
+      .map((line) => {
+        const commentIdx = line.indexOf("//");
+        return commentIdx >= 0 ? line.slice(0, commentIdx) : line;
+      })
+      .join("\n");
+
+    // Match bare new Date() with no args — new Date(timestamp) for arithmetic is fine
+    // but bare new Date() / Date.now() would be a clock injection violation.
+    expect(stripped).not.toMatch(/\bDate\.now\(\)/);
+    expect(stripped).not.toMatch(/\bnew Date\(\s*\)/);
+  });
+});
+
+// ─── AC23: CALORIE_FLOOR re-export + mapRecomputedMacros ─────────────────────
+
+describe("AC23: CALORIE_FLOOR export and mapRecomputedMacros", () => {
+  it("exports CALORIE_FLOOR = 1200", () => {
+    expect(CALORIE_FLOOR).toBe(1200);
+  });
+
+  it("mapRecomputedMacros maps {protein_g, carbs_g, fat_g} → PureMacroTargets", () => {
+    const result = mapRecomputedMacros(2000, { protein_g: 150, carbs_g: 200, fat_g: 60 });
+    expect(result).toEqual({ calories: 2000, protein: 150, carbs: 200, fat: 60 });
+  });
+
+  it("exports SPLIT_PERCENT_DEFAULT = 10, TRAINING_DAYS_DEFAULT = 4", () => {
+    expect(SPLIT_PERCENT_DEFAULT).toBe(10);
+    expect(TRAINING_DAYS_DEFAULT).toBe(4);
+  });
+});
+
+// ─── Helper: clamp ────────────────────────────────────────────────────────────
+
+describe("clamp", () => {
+  it("clamps to min", () => expect(clamp(-5, 0, 10)).toBe(0));
+  it("clamps to max", () => expect(clamp(15, 0, 10)).toBe(10));
+  it("passes through mid value", () => expect(clamp(5, 0, 10)).toBe(5));
+});
+
+// ─── AC22: normalizeParams ÷0 guard ──────────────────────────────────────────
+
+describe("AC22: normalizeParams — ÷0 guard (n=7/n≤0)", () => {
+  it("clamps n=7 down to TRAINING_DAYS_MAX=6", () => {
+    const result = normalizeParams({ splitPercent: 10, trainingDaysPerWeek: 7 });
+    expect(result.trainingDaysPerWeek).toBe(6);
+  });
+
+  it("clamps n=0 up to TRAINING_DAYS_MIN=1", () => {
+    const result = normalizeParams({ splitPercent: 10, trainingDaysPerWeek: 0 });
+    expect(result.trainingDaysPerWeek).toBe(1);
+  });
+
+  it("clamps n=-3 up to TRAINING_DAYS_MIN=1", () => {
+    const result = normalizeParams({ splitPercent: 10, trainingDaysPerWeek: -3 });
+    expect(result.trainingDaysPerWeek).toBe(1);
+  });
+
+  it("clamps splitPercent above max to 25", () => {
+    const result = normalizeParams({ splitPercent: 50, trainingDaysPerWeek: 4 });
+    expect(result.splitPercent).toBe(SPLIT_PERCENT_MAX);
+  });
+
+  it("clamps splitPercent below min to 5", () => {
+    const result = normalizeParams({ splitPercent: 1, trainingDaysPerWeek: 4 });
+    expect(result.splitPercent).toBe(SPLIT_PERCENT_MIN);
+  });
+
+  it("passes through valid values unchanged", () => {
+    const params = { splitPercent: 15, trainingDaysPerWeek: 4 };
+    expect(normalizeParams(params)).toEqual(params);
+  });
+
+  it("rounds fractional values", () => {
+    const result = normalizeParams({ splitPercent: 12.7, trainingDaysPerWeek: 3.9 });
+    expect(result.splitPercent).toBe(13);
+    expect(result.trainingDaysPerWeek).toBe(4);
+  });
+});
+
+// ─── AC2: training-day calorie target ────────────────────────────────────────
+
+describe("AC2: training-day calorie target", () => {
+  const BASE: PureMacroTargets = { calories: 2000, protein: 150, carbs: 200, fat: 55 };
+  const WEIGHT_KG = 75;
+  const PARAMS: TrainingDayParams = { splitPercent: 10, trainingDaysPerWeek: 4 };
+
+  it("training day calories = round(base + base×p)", () => {
+    const result = computeEffectiveTargets(BASE, true, PARAMS, WEIGHT_KG);
+    // base=2000, p=10% → surplus=200 → training=2200
+    expect(result.calories).toBe(2200);
+    expect(result.dayType).toBe("training");
+    expect(result.adjusted).toBe(true);
+    expect(result.cappedByFloor).toBe(false);
+  });
+
+  it("training day calories with different split percent", () => {
+    const result = computeEffectiveTargets(BASE, true, { splitPercent: 15, trainingDaysPerWeek: 3 }, WEIGHT_KG);
+    // base=2000, p=15% → surplus=300 → training=2300
+    expect(result.calories).toBe(2300);
+  });
+
+  it("returns valid protein/carbs/fat (no NaN or negative)", () => {
+    const result = computeEffectiveTargets(BASE, true, PARAMS, WEIGHT_KG);
+    expect(result.protein).toBeGreaterThan(0);
+    expect(result.carbs).toBeGreaterThanOrEqual(0);
+    expect(result.fat).toBeGreaterThan(0);
+    expect(Number.isFinite(result.protein)).toBe(true);
+    expect(Number.isFinite(result.carbs)).toBe(true);
+    expect(Number.isFinite(result.fat)).toBe(true);
+  });
+});
+
+// ─── AC3: rest-day calorie target ────────────────────────────────────────────
+
+describe("AC3: rest-day calorie target", () => {
+  const BASE: PureMacroTargets = { calories: 2000, protein: 150, carbs: 200, fat: 55 };
+  const WEIGHT_KG = 75;
+
+  it("rest day calories = round(base - base×p×n/(7-n)) for n=4, p=10", () => {
+    // surplus=200, restOffset = 200 × 4/3 ≈ 266.67, restCals = 2000 - 267 = 1733
+    const result = computeEffectiveTargets(BASE, false, { splitPercent: 10, trainingDaysPerWeek: 4 }, WEIGHT_KG);
+    expect(result.calories).toBe(Math.round(2000 - 200 * (4 / 3)));
+    expect(result.dayType).toBe("rest");
+    expect(result.adjusted).toBe(true);
+    expect(result.cappedByFloor).toBe(false);
+  });
+
+  it("rest day calories for n=1, p=5", () => {
+    // surplus = 2000×0.05 = 100, restOffset = 100 × 1/6 ≈ 16.67, restCals ≈ 1983
+    const result = computeEffectiveTargets(BASE, false, { splitPercent: 5, trainingDaysPerWeek: 1 }, WEIGHT_KG);
+    expect(result.calories).toBe(Math.round(2000 - 100 * (1 / 6)));
+    expect(result.cappedByFloor).toBe(false);
+  });
+
+  it("rest day is not below base for n=1 (small offset)", () => {
+    const result = computeEffectiveTargets(BASE, false, { splitPercent: 5, trainingDaysPerWeek: 1 }, WEIGHT_KG);
+    expect(result.calories).toBeGreaterThan(1900);
+  });
+});
+
+// ─── AC4: weekly neutrality property test ────────────────────────────────────
+
+describe("AC4: weekly neutrality — sum of 7 days = 7×base for all n∈1..6, p∈5..25", () => {
+  const WEIGHT_KG = 80;
+  const BASE_CALORIES = 2400;
+
+  // Property test: 7n combinations (n=1..6) × selected split percents
+  const N_VALUES = [1, 2, 3, 4, 5, 6];
+  const P_VALUES = [5, 10, 15, 20, 25];
+  const TOLERANCE = 7; // rounding tolerance in kcal (at most 1 kcal × 7 days)
+
+  test.each(
+    N_VALUES.flatMap((n) => P_VALUES.map((p) => ({ n, p })))
+  )("n=$n p=$p%: weekly total = 7×base ± rounding", ({ n, p }) => {
+    const params: TrainingDayParams = { splitPercent: p, trainingDaysPerWeek: n };
+    const normalizedParams = normalizeParams(params);
+
+    // Compute training-day and rest-day calories
+    const { trainingCals, restCals, cappedByFloor } = computeDayCalories(
+      BASE_CALORIES,
+      true, // isTrainingDay (unused by computeDayCalories directly)
+      normalizedParams
+    );
+
+    // Skip if floor clamped (floor-clamped cases intentionally break neutrality)
+    if (cappedByFloor) return;
+
+    const weeklyTotal = n * trainingCals + (7 - n) * restCals;
+    const expected = 7 * BASE_CALORIES;
+
+    expect(Math.abs(weeklyTotal - expected)).toBeLessThanOrEqual(TOLERANCE);
+  });
+
+  it("property holds for extreme base calorie values (1800, 2500, 3500)", () => {
+    const baseCals = [1800, 2500, 3500];
+    for (const baseCal of baseCals) {
+      const b: PureMacroTargets = { calories: baseCal, protein: 150, carbs: 200, fat: 55 };
+      const params: TrainingDayParams = { splitPercent: 10, trainingDaysPerWeek: 4 };
+      const normalized = normalizeParams(params);
+      const { trainingCals, restCals, cappedByFloor } = computeDayCalories(baseCal, true, normalized);
+      if (cappedByFloor) continue;
+      const weeklyTotal = 4 * trainingCals + 3 * restCals;
+      expect(Math.abs(weeklyTotal - 7 * baseCal)).toBeLessThanOrEqual(7);
+      // also test via computeEffectiveTargets
+      const restResult = computeEffectiveTargets(b, false, params, WEIGHT_KG);
+      const trainResult = computeEffectiveTargets(b, true, params, WEIGHT_KG);
+      if (!restResult.cappedByFloor) {
+        const total = 4 * trainResult.calories + 3 * restResult.calories;
+        expect(Math.abs(total - 7 * baseCal)).toBeLessThanOrEqual(7);
+      }
+    }
+  });
+});
+
+// ─── AC5: floor clamp + cappedByFloor ────────────────────────────────────────
+
+describe("AC5: floor clamp + cappedByFloor flag", () => {
+  const WEIGHT_KG = 60;
+
+  it("rest-day target below 1200 is clamped to 1200 with cappedByFloor=true", () => {
+    // base=1400, p=25%, n=6: surplus=350, restOffset=350×6/1=2100, rawRest=1400-2100=-700
+    // → clamped to 1200
+    const base: PureMacroTargets = { calories: 1400, protein: 120, carbs: 100, fat: 40 };
+    const params: TrainingDayParams = { splitPercent: 25, trainingDaysPerWeek: 6 };
+    const result = computeEffectiveTargets(base, false, params, WEIGHT_KG);
+    expect(result.calories).toBe(CALORIE_FLOOR);
+    expect(result.cappedByFloor).toBe(true);
+    expect(result.dayType).toBe("rest");
+  });
+
+  it("rest-day target exactly at 1200 is not flagged as capped", () => {
+    // base=1300, p=5%, n=1: surplus=65, restOffset=65×1/6≈10.8, rawRest=1289.17 → 1289
+    // → above 1200, not capped
+    const base: PureMacroTargets = { calories: 1300, protein: 100, carbs: 120, fat: 35 };
+    const params: TrainingDayParams = { splitPercent: 5, trainingDaysPerWeek: 1 };
+    const result = computeEffectiveTargets(base, false, params, WEIGHT_KG);
+    expect(result.cappedByFloor).toBe(false);
+    expect(result.calories).toBeGreaterThanOrEqual(CALORIE_FLOOR);
+  });
+
+  it("no NaN or negative macro values even when floor-clamped", () => {
+    const base: PureMacroTargets = { calories: 1400, protein: 120, carbs: 100, fat: 40 };
+    const params: TrainingDayParams = { splitPercent: 25, trainingDaysPerWeek: 6 };
+    const result = computeEffectiveTargets(base, false, params, WEIGHT_KG);
+    expect(Number.isFinite(result.calories)).toBe(true);
+    expect(Number.isFinite(result.protein)).toBe(true);
+    expect(Number.isFinite(result.carbs)).toBe(true);
+    expect(Number.isFinite(result.fat)).toBe(true);
+    expect(result.calories).toBeGreaterThanOrEqual(CALORIE_FLOOR);
+    expect(result.protein).toBeGreaterThan(0);
+    expect(result.fat).toBeGreaterThan(0);
+    expect(result.carbs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("training-day result is never capped by floor (training day always > base)", () => {
+    const base: PureMacroTargets = { calories: 1200, protein: 100, carbs: 100, fat: 33 };
+    const params: TrainingDayParams = { splitPercent: 10, trainingDaysPerWeek: 4 };
+    const result = computeEffectiveTargets(base, true, params, WEIGHT_KG);
+    expect(result.cappedByFloor).toBe(false);
+    expect(result.calories).toBeGreaterThan(1200);
+  });
+});
+
+// ─── adjusted / dayType flags ─────────────────────────────────────────────────
+
+describe("adjusted and dayType flags", () => {
+  const BASE: PureMacroTargets = { calories: 2000, protein: 150, carbs: 200, fat: 55 };
+  const WEIGHT_KG = 75;
+  const PARAMS: TrainingDayParams = { splitPercent: 10, trainingDaysPerWeek: 4 };
+
+  it("training day → dayType='training', adjusted=true", () => {
+    const result = computeEffectiveTargets(BASE, true, PARAMS, WEIGHT_KG);
+    expect(result.dayType).toBe("training");
+    expect(result.adjusted).toBe(true);
+  });
+
+  it("rest day → dayType='rest', adjusted=true", () => {
+    const result = computeEffectiveTargets(BASE, false, PARAMS, WEIGHT_KG);
+    expect(result.dayType).toBe("rest");
+    expect(result.adjusted).toBe(true);
+  });
+
+  it("adjusted=false not possible when splitPercent>0 (training always differs from base)", () => {
+    // Training day adds calories → calories != base.calories → adjusted=true always when enabled
+    const result = computeEffectiveTargets(BASE, true, { splitPercent: 5, trainingDaysPerWeek: 4 }, WEIGHT_KG);
+    expect(result.adjusted).toBe(true);
+  });
+});
+
+// ─── computeDayCalories low-level unit tests ──────────────────────────────────
+
+describe("computeDayCalories", () => {
+  it("training day = base + surplus", () => {
+    const { trainingCals } = computeDayCalories(2000, true, { splitPercent: 10, trainingDaysPerWeek: 4 });
+    expect(trainingCals).toBe(2200);
+  });
+
+  it("rest day offset formula n=4 p=10", () => {
+    // restOffset = 200 × 4/3 ≈ 266.67, restCals = 2000 - 267 = 1733
+    const { restCals } = computeDayCalories(2000, true, { splitPercent: 10, trainingDaysPerWeek: 4 });
+    expect(restCals).toBe(Math.round(2000 - 200 * (4 / 3)));
+  });
+
+  it("n=6 p=25 produces cappedByFloor when base is low", () => {
+    const { cappedByFloor } = computeDayCalories(1300, true, { splitPercent: 25, trainingDaysPerWeek: 6 });
+    // surplus=325, restOffset=325×6/1=1950, raw=-650 < 1200 → capped
+    expect(cappedByFloor).toBe(true);
+  });
+
+  it("n=1 p=5 does not clamp (mild deficit)", () => {
+    const { cappedByFloor, restCals } = computeDayCalories(2000, true, { splitPercent: 5, trainingDaysPerWeek: 1 });
+    expect(cappedByFloor).toBe(false);
+    expect(restCals).toBeGreaterThan(1200);
+  });
+});
+
+// ─── edge case: split=0 effectively (after normalization to 5) ────────────────
+
+describe("edge cases", () => {
+  const BASE: PureMacroTargets = { calories: 2000, protein: 150, carbs: 200, fat: 55 };
+  const WEIGHT_KG = 75;
+
+  it("minimum split (p=5, n=1) produces small deltas on both days", () => {
+    const training = computeEffectiveTargets(BASE, true, { splitPercent: 5, trainingDaysPerWeek: 1 }, WEIGHT_KG);
+    const rest = computeEffectiveTargets(BASE, false, { splitPercent: 5, trainingDaysPerWeek: 1 }, WEIGHT_KG);
+    expect(training.calories).toBeGreaterThan(BASE.calories);
+    expect(rest.calories).toBeLessThan(BASE.calories);
+    // deltas are small (5% of 2000 = 100 surplus; rest = 100/6 ≈ 17 less)
+    expect(training.calories - BASE.calories).toBe(100);
+    expect(BASE.calories - rest.calories).toBe(Math.round(100 / 6));
+  });
+
+  it("maximum split (p=25, n=1) for high base does not floor-clamp", () => {
+    const highBase: PureMacroTargets = { calories: 3000, protein: 200, carbs: 320, fat: 80 };
+    // surplus=750, restOffset=750/6=125, restCals=2875
+    const rest = computeEffectiveTargets(highBase, false, { splitPercent: 25, trainingDaysPerWeek: 1 }, WEIGHT_KG);
+    expect(rest.cappedByFloor).toBe(false);
+    expect(rest.calories).toBe(Math.round(3000 - 750 / 6));
+  });
+
+  it("normalizes n=7 to 6 before computation (no ÷0)", () => {
+    // If n=7 were allowed: 7-7=0 → division by zero → should be prevented
+    expect(() =>
+      computeEffectiveTargets(BASE, false, { splitPercent: 10, trainingDaysPerWeek: 7 }, WEIGHT_KG)
+    ).not.toThrow();
+    const result = computeEffectiveTargets(BASE, false, { splitPercent: 10, trainingDaysPerWeek: 7 }, WEIGHT_KG);
+    expect(Number.isFinite(result.calories)).toBe(true);
+    expect(Number.isNaN(result.calories)).toBe(false);
+  });
+
+  it("very low weight (40kg) does not produce NaN macros", () => {
+    const result = computeEffectiveTargets(BASE, true, { splitPercent: 10, trainingDaysPerWeek: 4 }, 40);
+    expect(Number.isFinite(result.protein)).toBe(true);
+    expect(Number.isFinite(result.carbs)).toBe(true);
+    expect(Number.isFinite(result.fat)).toBe(true);
+  });
+});

--- a/lib/nutrition-calc.ts
+++ b/lib/nutrition-calc.ts
@@ -47,7 +47,7 @@ const GOAL_ADJUSTMENTS: Record<Goal, number> = {
   bulk: 300,
 };
 
-const CALORIE_FLOOR = 1200;
+export const CALORIE_FLOOR = 1200;
 const PROTEIN_PER_KG = 2.2;
 const FAT_PERCENT = 0.25;
 

--- a/lib/training-day-macros.ts
+++ b/lib/training-day-macros.ts
@@ -1,0 +1,212 @@
+/**
+ * Training-Day Macro Adjustment — pure computation module.
+ *
+ * DESIGN INVARIANTS (enforced by tests in __tests__/lib/training-day-macros.test.ts):
+ *   1. No Date.now() / new Date() calls — all inputs injected by caller.
+ *   2. computeEffectiveTargets never returns a calorie value below CALORIE_FLOOR.
+ *   3. Weekly sum of 7 days' targets equals 7×base (Model 2) within rounding, unless floor clamping.
+ *   4. No DB / React Native imports — fully unit-testable in Node.
+ *   5. GTG (kind='day_session') exclusion is the caller's responsibility (wasWorkoutDay filter).
+ *
+ * PROHIBITION: No "earn/earned/bonus/reward/treat/deserve/penalty/punish/unlock/spend/
+ *   burn it off/work it off/guilt/cheat" copy in this module or its callers.
+ * No directional color tokens (no red/green/surplus/deficit coloring) on values from this module.
+ * Psychologist verdict C1 — AC16.
+ *
+ * @see PLAN-BLD-2634.md — Model 2 (frequency-balanced) is the shipped model.
+ */
+
+import {
+  CALORIE_FLOOR,
+  recomputeMacrosFromCalories,
+} from "./nutrition-calc";
+
+export { CALORIE_FLOOR } from "./nutrition-calc";
+
+// ─── Type disambiguation ──────────────────────────────────────────────────────
+
+/**
+ * Pure (in-memory) macro targets — no DB identity fields.
+ * This is the shape returned by recomputeMacrosFromCalories + nutrition-calc helpers.
+ * Distinct from lib/types.ts MacroTargets (DB row with id + updated_at).
+ */
+export interface PureMacroTargets {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+}
+
+/**
+ * Map the `{protein_g, carbs_g, fat_g}` shape returned by
+ * recomputeMacrosFromCalories to `{protein, carbs, fat}` + calories.
+ * AC23 — disambiguate the pure-vs-DB MacroTargets type.
+ */
+export function mapRecomputedMacros(
+  calories: number,
+  raw: { protein_g: number; carbs_g: number; fat_g: number }
+): PureMacroTargets {
+  return {
+    calories,
+    protein: raw.protein_g,
+    carbs: raw.carbs_g,
+    fat: raw.fat_g,
+  };
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type DayType = "training" | "rest";
+
+export interface TrainingDayParams {
+  /** Split percentage (5–25). Default 10. */
+  splitPercent: number;
+  /** Expected training days per week (1–6). Default 4. */
+  trainingDaysPerWeek: number;
+}
+
+export interface EffectiveTargets extends PureMacroTargets {
+  /** Whether the day was classified as a training day. */
+  dayType: DayType;
+  /** Whether the effective targets differ from base (feature is active). */
+  adjusted: boolean;
+  /**
+   * Whether the rest-day target was clamped to CALORIE_FLOOR.
+   * When true, the weekly average may exceed the base target.
+   */
+  cappedByFloor: boolean;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Split percentage bounds — AC3 floor guard. */
+export const SPLIT_PERCENT_MIN = 5;
+export const SPLIT_PERCENT_MAX = 25;
+export const SPLIT_PERCENT_DEFAULT = 10;
+
+/** Training-days-per-week bounds — AC22 ÷0 guard. */
+export const TRAINING_DAYS_MIN = 1;
+export const TRAINING_DAYS_MAX = 6;
+export const TRAINING_DAYS_DEFAULT = 4;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Clamp a number to [min, max].
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Validate and clamp TrainingDayParams to safe ranges.
+ * AC22: n must be clamped to 1..6 (n=7 → ÷0; n≤0 → inert).
+ */
+export function normalizeParams(params: TrainingDayParams): TrainingDayParams {
+  return {
+    splitPercent: clamp(
+      Math.round(params.splitPercent),
+      SPLIT_PERCENT_MIN,
+      SPLIT_PERCENT_MAX
+    ),
+    trainingDaysPerWeek: clamp(
+      Math.round(params.trainingDaysPerWeek),
+      TRAINING_DAYS_MIN,
+      TRAINING_DAYS_MAX
+    ),
+  };
+}
+
+// ─── Core computation ─────────────────────────────────────────────────────────
+
+/**
+ * Compute the per-day effective calorie surplus (S) for a training day.
+ *
+ * Model 2 (frequency-balanced, AC2–AC4):
+ *   S = base × (splitPercent / 100)
+ *   Training-day calories = base + S
+ *   Rest-day calories     = base − S × n/(7−n)   (clamped to CALORIE_FLOOR)
+ *
+ * Weekly total:
+ *   n×(base+S) + (7−n)×(base − S×n/(7−n))
+ *   = 7×base + n×S − n×S = 7×base  ✓
+ *
+ * AC22: n must be in 1..6 (normalizeParams ensures this). n=7 is not
+ * reachable via normalizeParams (clamped to 6).
+ *
+ * @param baseCalories  Base daily calorie target (from macro_targets).
+ * @param isTrainingDay Whether the target date is a training day.
+ * @param params        User training-day adjustment parameters (already normalized).
+ * @returns             {trainingCals, restCals, cappedByFloor}
+ */
+export function computeDayCalories(
+  baseCalories: number,
+  isTrainingDay: boolean,
+  params: TrainingDayParams
+): { trainingCals: number; restCals: number; cappedByFloor: boolean } {
+  const { splitPercent, trainingDaysPerWeek: n } = params;
+
+  // S = base × p
+  const surplus = baseCalories * (splitPercent / 100);
+
+  const rawTrainingCals = baseCalories + surplus;
+  // rest-day offset = S × n/(7−n)
+  const restDayOffset = surplus * (n / (7 - n));
+  const rawRestCals = baseCalories - restDayOffset;
+
+  // Apply calorie floor to rest day (AC5)
+  const clampedRestCals = Math.max(CALORIE_FLOOR, Math.round(rawRestCals));
+  const cappedByFloor = clampedRestCals > Math.round(rawRestCals);
+
+  return {
+    trainingCals: Math.round(rawTrainingCals),
+    restCals: clampedRestCals,
+    cappedByFloor,
+  };
+}
+
+/**
+ * Compute effective daily macro targets given a base target and day type.
+ *
+ * This is the primary entry point for the Training-Day Adjustment feature.
+ * It is PURE — no DB calls, no Date.now(), no side effects.
+ *
+ * @param base          Base macro targets (from macro_targets singleton in DB).
+ *                      Uses PureMacroTargets shape (calories, protein, carbs, fat).
+ * @param isTrainingDay Whether the target date has a completed workout
+ *                      (kind='workout', completed_at IS NOT NULL). GTG sessions
+ *                      (kind='day_session') must be excluded by the caller.
+ * @param params        User-configured split parameters (raw; will be normalized).
+ * @param weightKg      User body weight in kg — used to recompute macros via
+ *                      recomputeMacrosFromCalories (protein stays bodyweight-driven).
+ * @returns             EffectiveTargets with dayType, adjusted, cappedByFloor flags.
+ */
+export function computeEffectiveTargets(
+  base: PureMacroTargets,
+  isTrainingDay: boolean,
+  params: TrainingDayParams,
+  weightKg: number
+): EffectiveTargets {
+  const normalized = normalizeParams(params);
+  const { trainingCals, restCals, cappedByFloor } = computeDayCalories(
+    base.calories,
+    isTrainingDay,
+    normalized
+  );
+
+  const effectiveCals = isTrainingDay ? trainingCals : restCals;
+  const effectiveCapped = isTrainingDay ? false : cappedByFloor;
+
+  // Derive protein/carbs/fat from the effective calorie count
+  const raw = recomputeMacrosFromCalories(effectiveCals, weightKg);
+  const macros = mapRecomputedMacros(effectiveCals, raw);
+
+  const adjusted = effectiveCals !== base.calories;
+
+  return {
+    ...macros,
+    dayType: isTrainingDay ? "training" : "rest",
+    adjusted,
+    cappedByFloor: effectiveCapped,
+  };
+}


### PR DESCRIPTION
## Summary

Pure computation module for Training-Day Macro Adjustment feature (BLD-2641). This is PR1 of 6 — implements the core math with full test coverage before any UI or DB work.

## Changes

- `lib/training-day-macros.ts` — pure, clock-injection-compliant module implementing Model 2 (frequency-balanced) calorie-neutral training/rest-day split
  - `computeEffectiveTargets(base, isTrainingDay, params, weightKg)` — main entry point
  - `computeDayCalories()` — Model 2 math: training=base+S, rest=base-S×n/(7-n)
  - `normalizeParams()` — clamps splitPercent 5–25, trainingDaysPerWeek 1–6 (AC22 ÷0 guard)
  - `mapRecomputedMacros()` — maps `{protein_g, carbs_g, fat_g}` → `PureMacroTargets` (AC23)
  - Floor clamp: rest-day target ≥ 1200 kcal with `cappedByFloor` flag (AC5)
  - No `Date.now()` / bare `new Date()` — all inputs injected (AC10)
- `lib/nutrition-calc.ts` — export `CALORIE_FLOOR` (was unexported const) (AC23)
- `__tests__/lib/training-day-macros.test.ts` — 66 tests covering:
  - AC2: training-day calorie target = base + base×p
  - AC3: rest-day target = base - base×p×n/(7-n), clamped ≥1200
  - AC4: property test — weekly sum = 7×base for all n∈1..6, p∈5..25
  - AC5: floor clamp + cappedByFloor flag; no NaN/negative
  - AC10: grep test — no clock calls inside the module
  - AC22: ÷0 guard — n=7/n≤0 handled by normalizeParams
  - AC23: CALORIE_FLOOR export + mapRecomputedMacros shape

## Testing

- `jest __tests__/lib/training-day-macros.test.ts`: 66/66 pass
- `tsc --noEmit`: no errors
- architecture-formula-ban.test.ts: still passing
- macro-coach.test.ts: still passing (56 tests)
- nutrition-calc.test.ts: still passing (27 tests)

## Issue

Resolves part of BLD-2641 (PR1 of 6 slices — pure module only; settings, DB helper, screens, hook wiring in subsequent PRs)