### PR TITLE
feat: training-day macros settings screen (BLD-2641 PR4)

### DIFF
--- a/__tests__/acceptance/training-day-macros-settings.test.tsx
+++ b/__tests__/acceptance/training-day-macros-settings.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Component tests for app/settings/training-day-macros.tsx
+ *
+ * AC14: C2 verbatim settings explainer body is rendered
+ * AC19: Default OFF state shown, off-ramp line (C5) present, logged-workout copy (QD5)
+ * AC20: Live preview shows training day, rest day, and weekly average
+ */
+
+import React from "react";
+import { fireEvent, waitFor } from "@testing-library/react-native";
+import { renderScreen } from "../helpers/render";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGetEnabled = jest.fn().mockResolvedValue(false);
+const mockGetSplitPercent = jest.fn().mockResolvedValue(10);
+const mockGetTrainingDaysPerWeek = jest.fn().mockResolvedValue(4);
+const mockSetEnabled = jest.fn().mockResolvedValue(undefined);
+const mockSetSplitPercent = jest.fn().mockResolvedValue(undefined);
+const mockSetTrainingDaysPerWeek = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("../../lib/db/training-day-settings", () => ({
+  getEnabled: (...args: unknown[]) => mockGetEnabled(...args),
+  getSplitPercent: (...args: unknown[]) => mockGetSplitPercent(...args),
+  getTrainingDaysPerWeek: (...args: unknown[]) => mockGetTrainingDaysPerWeek(...args),
+  setEnabled: (...args: unknown[]) => mockSetEnabled(...args),
+  setSplitPercent: (...args: unknown[]) => mockSetSplitPercent(...args),
+  setTrainingDaysPerWeek: (...args: unknown[]) => mockSetTrainingDaysPerWeek(...args),
+}));
+
+const mockGetMacroTargets = jest.fn().mockResolvedValue({
+  id: "test-id",
+  calories: 2400,
+  protein: 160,
+  carbs: 250,
+  fat: 65,
+  updated_at: Date.now(),
+});
+
+jest.mock("../../lib/db", () => ({
+  getMacroTargets: (...args: unknown[]) => mockGetMacroTargets(...args),
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn(), back: jest.fn() }),
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useFocusEffect: (cb: () => () => void) => {
+    const { useEffect } = require("react");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => { const cleanup = cb(); return typeof cleanup === "function" ? cleanup : undefined; }, []);
+  },
+  Stack: { Screen: () => null },
+}));
+
+import TrainingDayMacrosScreen from "../../app/settings/training-day-macros";
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("TrainingDayMacrosScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEnabled.mockResolvedValue(false);
+    mockGetSplitPercent.mockResolvedValue(10);
+    mockGetTrainingDaysPerWeek.mockResolvedValue(4);
+    mockGetMacroTargets.mockResolvedValue({
+      id: "test-id",
+      calories: 2400,
+      protein: 160,
+      carbs: 250,
+      fat: 65,
+      updated_at: Date.now(),
+    });
+  });
+
+  // ── AC19: Default OFF state ────────────────────────────────────────
+
+  it("AC19: renders the enable switch with correct accessible label", async () => {
+    const { findByLabelText } = renderScreen(<TrainingDayMacrosScreen />);
+    const sw = await findByLabelText("Enable Training-Day Macro Adjustment");
+    expect(sw).toBeTruthy();
+  });
+
+  it("AC19: switch starts in OFF state when getEnabled returns false", async () => {
+    const { findByLabelText } = renderScreen(<TrainingDayMacrosScreen />);
+    const sw = await findByLabelText("Enable Training-Day Macro Adjustment");
+    // Switch value should be false → accessibilityState.checked = false
+    expect(sw.props.value).toBe(false);
+  });
+
+  // ── AC14: C2 verbatim settings explainer ──────────────────────────
+
+  it("AC14: renders the C2 verbatim settings opt-in body", async () => {
+    const { findByText } = renderScreen(<TrainingDayMacrosScreen />);
+    // Check for the key phrase from the psychologist-approved C2 copy
+    expect(
+      await findByText(/This is about fueling recovery, not a reward for exercising/)
+    ).toBeTruthy();
+  });
+
+  it("AC14: renders the section heading 'How it works'", async () => {
+    const { findByText } = renderScreen(<TrainingDayMacrosScreen />);
+    expect(await findByText("How it works")).toBeTruthy();
+  });
+
+  // ── AC19: C5 off-ramp line ─────────────────────────────────────────
+
+  it("AC19 (C5): renders the off-ramp line", async () => {
+    const { findByText } = renderScreen(<TrainingDayMacrosScreen />);
+    expect(
+      await findByText(/Not for everyone — if adjusting food around workouts feels stressful/)
+    ).toBeTruthy();
+  });
+
+  // ── AC19: QD5 logged-workout copy ─────────────────────────────────
+
+  it("AC19 (QD5): renders 'logged workouts' note", async () => {
+    const { findByText } = renderScreen(<TrainingDayMacrosScreen />);
+    expect(
+      await findByText(/based on your logged workouts/)
+    ).toBeTruthy();
+  });
+
+  // ── AC20: Live preview when enabled ──────────────────────────────
+
+  it("AC20: renders preview with Training day, Rest day, Weekly average when enabled", async () => {
+    mockGetEnabled.mockResolvedValue(true);
+    const { findByText } = renderScreen(<TrainingDayMacrosScreen />);
+    expect(await findByText("Training day")).toBeTruthy();
+    expect(await findByText("Rest day")).toBeTruthy();
+    expect(await findByText("Weekly average")).toBeTruthy();
+  });
+
+  it("AC20: preview section is NOT shown when feature is disabled", async () => {
+    mockGetEnabled.mockResolvedValue(false);
+    const { queryByText } = renderScreen(<TrainingDayMacrosScreen />);
+    await waitFor(() => {
+      expect(queryByText("Training day")).toBeNull();
+      expect(queryByText("Rest day")).toBeNull();
+    });
+  });
+
+  // ── Parameter controls when enabled ──────────────────────────────
+
+  it("renders split percent stepper when enabled", async () => {
+    mockGetEnabled.mockResolvedValue(true);
+    const { findByText } = renderScreen(<TrainingDayMacrosScreen />);
+    expect(await findByText("Training boost")).toBeTruthy();
+    expect(await findByText("10%")).toBeTruthy();
+  });
+
+  it("renders training days stepper when enabled", async () => {
+    mockGetEnabled.mockResolvedValue(true);
+    const { findByText } = renderScreen(<TrainingDayMacrosScreen />);
+    expect(await findByText("Training days per week")).toBeTruthy();
+    expect(await findByText("4/week")).toBeTruthy();
+  });
+
+  // ── Toggle calls setter ────────────────────────────────────────────
+
+  it("toggling the switch calls setEnabled with true", async () => {
+    const { findByLabelText } = renderScreen(<TrainingDayMacrosScreen />);
+    const sw = await findByLabelText("Enable Training-Day Macro Adjustment");
+    fireEvent(sw, "onValueChange", true);
+    await waitFor(() => {
+      expect(mockSetEnabled).toHaveBeenCalledWith(true);
+    });
+  });
+
+  // ── No banned copy in badge/dynamic copy ─────────────────────────
+
+  it("AC16 (C1): preview labels do not use banned reward-framing words (badge-style copy)", async () => {
+    mockGetEnabled.mockResolvedValue(true);
+    const { findByText } = renderScreen(<TrainingDayMacrosScreen />);
+    // Wait for preview to render
+    const trainingLabel = await findByText("Training day");
+    const restLabel = await findByText("Rest day");
+
+    // The badge-style labels must not contain banned lexemes
+    // (The C2 verbatim explanation is exempt as psychologist-approved copy)
+    const bannedInBadges = ["earned", "bonus", "reward", "unlock", "penalty", "punish"];
+    for (const banned of bannedInBadges) {
+      expect(trainingLabel.props.children).not.toMatch(new RegExp(banned, "i"));
+      expect(restLabel.props.children).not.toMatch(new RegExp(banned, "i"));
+    }
+  });
+});

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -46,6 +46,7 @@ import {
   type BackupCategoryName,
 } from '@/lib/db';
 import { getEnabled as getMacroCoachEnabled } from '@/lib/db/macro-coach-settings';
+import { getEnabled as getTrainingDayMacrosEnabled } from '@/lib/db/training-day-settings';
 import { useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -77,10 +78,12 @@ export default function Settings() {
   const [importCategories, setImportCategories] = useState<BackupCategoryName[]>([]);
   const [importCategoryCounts, setImportCategoryCounts] = useState<Partial<Record<BackupCategoryName, number>>>({});
   const [macroCoachEnabled, setMacroCoachEnabled] = useState<boolean | null>(null);
+  const [trainingDayMacrosEnabled, setTrainingDayMacrosEnabled] = useState<boolean | null>(null);
   const appVersion = Constants.expoConfig?.version ?? '0.0.0';
 
   useEffect(() => {
     getMacroCoachEnabled().then(setMacroCoachEnabled).catch(() => setMacroCoachEnabled(false));
+    getTrainingDayMacrosEnabled().then(setTrainingDayMacrosEnabled).catch(() => setTrainingDayMacrosEnabled(false));
   }, []);
 
   const {
@@ -281,6 +284,20 @@ export default function Settings() {
             }
             accessibilityLabel="Open Adaptive Macro Coach settings"
             onPress={() => router.push('/settings/macro-coach')}
+          />
+          <Separator style={styles.tileDivider} />
+          <SettingsLinkRow
+            colors={colors}
+            title="Training-Day Macros"
+            caption={
+              trainingDayMacrosEnabled === null
+                ? ''
+                : trainingDayMacrosEnabled
+                  ? 'On — different targets on training vs rest days'
+                  : 'Off — tap to set up'
+            }
+            accessibilityLabel="Open Training-Day Macro Adjustment settings"
+            onPress={() => router.push('/settings/training-day-macros')}
           />
           <Separator style={styles.tileDivider} />
           <HydrationCard colors={colors} toast={toast} bareContent />

--- a/app/settings/training-day-macros.tsx
+++ b/app/settings/training-day-macros.tsx
@@ -47,8 +47,9 @@ import { getMacroTargets } from "@/lib/db";
 
 // ─── Binding copy strings (psychologist C2 verbatim — AC14) ──────────────────
 // DO NOT modify these strings without psychologist sign-off.
+// Exported so the module-level lexeme-ban grep test (AC16) can import directly.
 
-const COPY = {
+export const COPY = {
   settingsOptInBody:
     "Match your fuel to your training. On days you work out, your body uses more energy — this shifts some of your calories (mostly carbs) to those days and eases them back on rest days. Your weekly total stays exactly the same as your base target. This is about fueling recovery, not a reward for exercising.",
   offRampLine:

--- a/app/settings/training-day-macros.tsx
+++ b/app/settings/training-day-macros.tsx
@@ -1,0 +1,363 @@
+/* eslint-disable max-lines-per-function */
+/**
+ * Training-Day Macro Adjustment — Settings screen.
+ *
+ * AC14: Uses C2 verbatim psychologist-approved copy (settings opt-in body + off-ramp line C5).
+ * AC19: Default OFF, off-ramp line (C5), no notifications, "logged workouts" copy (QD5).
+ * AC20: Live preview shows both days + weekly average (C6).
+ *
+ * PROHIBITION (AC16/C1): No "earn/earned/bonus/reward/treat/deserve/penalty/punish/
+ *   unlock/spend/burn it off/work it off/guilt/cheat" copy in this file or its callers.
+ * No directional color tokens on calorie numbers.
+ *
+ * @see PLAN-BLD-2634.md — binding copy strings, psychologist C2/C5 requirements
+ */
+
+import React, { useCallback, useState } from "react";
+import {
+  ScrollView,
+  StyleSheet,
+  Switch,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { Stack, useFocusEffect } from "expo-router";
+import { Text } from "@/components/ui/text";
+import { Card, CardContent } from "@/components/ui/card";
+import { useThemeColors } from "@/hooks/useThemeColors";
+import { useToast } from "@/components/ui/bna-toast";
+import { spacing, radii } from "@/constants/design-tokens";
+import {
+  getEnabled,
+  getSplitPercent,
+  getTrainingDaysPerWeek,
+  setEnabled,
+  setSplitPercent,
+  setTrainingDaysPerWeek,
+} from "@/lib/db/training-day-settings";
+import {
+  computeEffectiveTargets,
+  SPLIT_PERCENT_MIN,
+  SPLIT_PERCENT_MAX,
+  TRAINING_DAYS_MIN,
+  TRAINING_DAYS_MAX,
+  type PureMacroTargets,
+} from "@/lib/training-day-macros";
+import { getMacroTargets } from "@/lib/db";
+
+// ─── Binding copy strings (psychologist C2 verbatim — AC14) ──────────────────
+// DO NOT modify these strings without psychologist sign-off.
+
+const COPY = {
+  settingsOptInBody:
+    "Match your fuel to your training. On days you work out, your body uses more energy — this shifts some of your calories (mostly carbs) to those days and eases them back on rest days. Your weekly total stays exactly the same as your base target. This is about fueling recovery, not a reward for exercising.",
+  offRampLine:
+    "Not for everyone — if adjusting food around workouts feels stressful, keep this off and use a single steady target.",
+  loggedWorkoutsNote:
+    "Adjustments are based on your logged workouts — only sessions you complete in the app count.",
+} as const;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatKcal(n: number): string {
+  return `${n.toLocaleString()} kcal`;
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function TrainingDayMacrosScreen() {
+  const colors = useThemeColors();
+  const toast = useToast();
+
+  const [enabled, setEnabledState] = useState(false);
+  const [splitPercent, setSplitPercentState] = useState(10);
+  const [trainingDays, setTrainingDaysState] = useState(4);
+  const [baseTargets, setBaseTargets] = useState<PureMacroTargets | null>(null);
+  const [previewCals, setPreviewCals] = useState<{ training: number; rest: number; weeklyAvg: number } | null>(null);
+  const [weightKg] = useState<number>(75); // fallback default
+
+  const computePreview = useCallback(
+    (base: PureMacroTargets, p: number, n: number) => {
+      const trainingResult = computeEffectiveTargets(base, true, { splitPercent: p, trainingDaysPerWeek: n }, weightKg);
+      const restResult = computeEffectiveTargets(base, false, { splitPercent: p, trainingDaysPerWeek: n }, weightKg);
+      const weeklyAvg = Math.round((n * trainingResult.calories + (7 - n) * restResult.calories) / 7);
+      setPreviewCals({ training: trainingResult.calories, rest: restResult.calories, weeklyAvg });
+    },
+    [weightKg]
+  );
+
+  const load = useCallback(async () => {
+    const [en, sp, td, targets] = await Promise.all([
+      getEnabled(),
+      getSplitPercent(),
+      getTrainingDaysPerWeek(),
+      getMacroTargets(),
+    ]);
+
+    setEnabledState(en);
+    setSplitPercentState(sp);
+    setTrainingDaysState(td);
+
+    if (targets) {
+      const base: PureMacroTargets = {
+        calories: targets.calories,
+        protein: targets.protein,
+        carbs: targets.carbs,
+        fat: targets.fat,
+      };
+      setBaseTargets(base);
+      computePreview(base, sp, td);
+    }
+  }, [computePreview]);
+
+  useFocusEffect(useCallback(() => { load(); }, [load]));
+
+  const handleToggleEnabled = async (value: boolean) => {
+    setEnabledState(value);
+    await setEnabled(value);
+  };
+
+  const handleSplitPercentChange = async (delta: number) => {
+    const next = Math.max(SPLIT_PERCENT_MIN, Math.min(SPLIT_PERCENT_MAX, splitPercent + delta));
+    setSplitPercentState(next);
+    await setSplitPercent(next);
+    if (baseTargets) computePreview(baseTargets, next, trainingDays);
+  };
+
+  const handleTrainingDaysChange = async (delta: number) => {
+    const next = Math.max(TRAINING_DAYS_MIN, Math.min(TRAINING_DAYS_MAX, trainingDays + delta));
+    setTrainingDaysState(next);
+    await setTrainingDaysPerWeek(next);
+    if (baseTargets) computePreview(baseTargets, splitPercent, next);
+    toast.info(`Training days: ${next}/week`);
+  };
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={styles.content}
+    >
+      <Stack.Screen options={{ title: "Training-Day Macros" }} />
+
+      {/* ── Enable toggle ─────────────────────────────────────────────── */}
+      <Card style={{ backgroundColor: colors.surface, marginBottom: 16 }}>
+        <CardContent>
+          <View style={styles.row}>
+            <View style={{ flex: 1 }}>
+              <Text variant="subtitle" style={{ color: colors.onSurface }}>
+                Training-Day Macro Adjustment
+              </Text>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>
+                Different calorie targets on training vs rest days. Off by default.
+              </Text>
+            </View>
+            <Switch
+              value={enabled}
+              onValueChange={handleToggleEnabled}
+              accessibilityLabel="Enable Training-Day Macro Adjustment"
+              accessibilityRole="switch"
+            />
+          </View>
+        </CardContent>
+      </Card>
+
+      {/* ── How it works (C2 verbatim — AC14) ─────────────────────────── */}
+      <Card style={{ backgroundColor: colors.surface, marginBottom: 16 }}>
+        <CardContent>
+          <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 8 }}>
+            How it works
+          </Text>
+          {/* C2 verbatim body — DO NOT alter wording */}
+          <Text variant="body" style={{ color: colors.onSurfaceVariant, lineHeight: 22 }}>
+            {COPY.settingsOptInBody}
+          </Text>
+          {/* C5 off-ramp line — AC19 */}
+          <Text
+            variant="caption"
+            style={{ color: colors.onSurfaceVariant, marginTop: 12, fontStyle: "italic" }}
+          >
+            {COPY.offRampLine}
+          </Text>
+          {/* QD5 logged-workout copy — AC19 */}
+          <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginTop: 8 }}>
+            {COPY.loggedWorkoutsNote}
+          </Text>
+        </CardContent>
+      </Card>
+
+      {/* ── Parameters (only shown when enabled) ─────────────────────── */}
+      {enabled && (
+        <>
+          {/* Split percentage */}
+          <Card style={{ backgroundColor: colors.surface, marginBottom: 16 }}>
+            <CardContent>
+              <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 4 }}>
+                Training boost
+              </Text>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginBottom: 12 }}>
+                How much extra to add on training days (offset by rest days to keep weekly total steady).
+              </Text>
+              <View style={styles.stepper}>
+                <StepperButton
+                  label="−"
+                  onPress={() => handleSplitPercentChange(-5)}
+                  disabled={splitPercent <= SPLIT_PERCENT_MIN}
+                  colors={colors}
+                  accessibilityLabel="Decrease training boost"
+                />
+                <Text variant="subtitle" style={{ color: colors.onSurface, minWidth: 60, textAlign: "center" }}>
+                  {splitPercent}%
+                </Text>
+                <StepperButton
+                  label="+"
+                  onPress={() => handleSplitPercentChange(5)}
+                  disabled={splitPercent >= SPLIT_PERCENT_MAX}
+                  colors={colors}
+                  accessibilityLabel="Increase training boost"
+                />
+              </View>
+            </CardContent>
+          </Card>
+
+          {/* Training days per week */}
+          <Card style={{ backgroundColor: colors.surface, marginBottom: 16 }}>
+            <CardContent>
+              <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 4 }}>
+                Training days per week
+              </Text>
+              <Text variant="caption" style={{ color: colors.onSurfaceVariant, marginBottom: 12 }}>
+                Used to keep your weekly calorie average exactly equal to your base target.
+              </Text>
+              <View style={styles.stepper}>
+                <StepperButton
+                  label="−"
+                  onPress={() => handleTrainingDaysChange(-1)}
+                  disabled={trainingDays <= TRAINING_DAYS_MIN}
+                  colors={colors}
+                  accessibilityLabel="Decrease training days per week"
+                />
+                <Text variant="subtitle" style={{ color: colors.onSurface, minWidth: 60, textAlign: "center" }}>
+                  {trainingDays}/week
+                </Text>
+                <StepperButton
+                  label="+"
+                  onPress={() => handleTrainingDaysChange(1)}
+                  disabled={trainingDays >= TRAINING_DAYS_MAX}
+                  colors={colors}
+                  accessibilityLabel="Increase training days per week"
+                />
+              </View>
+            </CardContent>
+          </Card>
+
+          {/* Preview (C6 — AC20: shows both days + weekly avg) */}
+          {previewCals && (
+            <Card style={{ backgroundColor: colors.surface, marginBottom: 16 }}>
+              <CardContent>
+                <Text variant="subtitle" style={{ color: colors.onSurface, marginBottom: 8 }}>
+                  Preview
+                </Text>
+                <View style={styles.previewRow}>
+                  <Text variant="body" style={{ color: colors.onSurface }}>Training day</Text>
+                  <Text
+                    variant="body"
+                    style={{ color: colors.onSurface, fontWeight: "600" }}
+                    accessibilityLabel={`Training day target: ${formatKcal(previewCals.training)}`}
+                  >
+                    {formatKcal(previewCals.training)}
+                  </Text>
+                </View>
+                <View style={styles.previewRow}>
+                  <Text variant="body" style={{ color: colors.onSurface }}>Rest day</Text>
+                  <Text
+                    variant="body"
+                    style={{ color: colors.onSurface, fontWeight: "600" }}
+                    accessibilityLabel={`Rest day target: ${formatKcal(previewCals.rest)}`}
+                  >
+                    {formatKcal(previewCals.rest)}
+                  </Text>
+                </View>
+                <View style={[styles.previewRow, styles.previewDivider, { borderTopColor: colors.onSurfaceVariant + "40" }]}>
+                  <Text variant="caption" style={{ color: colors.onSurfaceVariant }}>Weekly average</Text>
+                  <Text
+                    variant="caption"
+                    style={{ color: colors.onSurfaceVariant }}
+                    accessibilityLabel={`Weekly average: ${formatKcal(previewCals.weeklyAvg)}`}
+                  >
+                    {formatKcal(previewCals.weeklyAvg)}
+                    {baseTargets && ` (= your base)`}
+                  </Text>
+                </View>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+    </ScrollView>
+  );
+}
+
+// ─── StepperButton ────────────────────────────────────────────────────────────
+
+function StepperButton({
+  label,
+  onPress,
+  disabled,
+  colors,
+  accessibilityLabel,
+}: {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  colors: ReturnType<typeof useThemeColors>;
+  accessibilityLabel?: string;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled}
+      style={[
+        styles.stepperBtn,
+        {
+          borderColor: disabled ? colors.onSurfaceVariant + "40" : colors.onSurface,
+          opacity: disabled ? 0.4 : 1,
+        },
+      ]}
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityRole="button"
+      hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+    >
+      <Text variant="subtitle" style={{ color: colors.onSurface }}>
+        {label}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  content: { padding: spacing.md, gap: spacing.md },
+  row: { flexDirection: "row", alignItems: "center", gap: 12 },
+  stepper: { flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 24 },
+  stepperBtn: {
+    width: 44,
+    height: 44,
+    borderWidth: 1,
+    borderRadius: radii.sm,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  previewRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 6,
+  },
+  previewDivider: {
+    borderTopWidth: 1,
+    marginTop: 4,
+    paddingTop: 10,
+  },
+});

--- a/lib/db/training-day-settings.ts
+++ b/lib/db/training-day-settings.ts
@@ -1,0 +1,108 @@
+/**
+ * Typed accessor for all `app_settings.training_day_macros.*` keys.
+ *
+ * This is the ONLY module allowed to read/write training-day macro settings.
+ *
+ * Backup behavior: all `training_day_macros.*` keys are stored in the
+ * `app_settings` table and are automatically included in the `app_preferences`
+ * backup category via `getAppSettingsCategory()` in import-export.ts:239.
+ * No changes to import-export.ts are required.
+ *
+ * Design invariants:
+ *   1. PREFIX is "training_day_macros." — unique namespace, no collisions.
+ *   2. No `model` key — Model 2 (frequency-balanced) is the only shipped model.
+ *   3. splitPercent is always stored clamped to [5, 25].
+ *   4. trainingDaysPerWeek is always stored clamped to [1, 6] (÷0 guard — AC22).
+ *   5. Default OFF — enabled defaults to false (psychologist C5, AC19).
+ */
+
+import { getAppSetting, setAppSetting } from "./settings";
+import {
+  SPLIT_PERCENT_MIN,
+  SPLIT_PERCENT_MAX,
+  SPLIT_PERCENT_DEFAULT,
+  TRAINING_DAYS_MIN,
+  TRAINING_DAYS_MAX,
+  TRAINING_DAYS_DEFAULT,
+  clamp,
+} from "../training-day-macros";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Unique key namespace — ONLY this module reads/writes these keys. */
+export const PREFIX = "training_day_macros.";
+
+// ─── Getters ──────────────────────────────────────────────────────────────────
+
+/**
+ * Whether the Training-Day Macro Adjustment feature is enabled.
+ * Default: false (OFF — psychologist C5, AC1/AC19).
+ */
+export async function getEnabled(): Promise<boolean> {
+  const v = await getAppSetting(`${PREFIX}enabled`);
+  return v === "1";
+}
+
+/**
+ * The user-configured split percentage (5–25, default 10).
+ * Controls how many extra calories training days get (S = base × splitPercent/100).
+ */
+export async function getSplitPercent(): Promise<number> {
+  const v = await getAppSetting(`${PREFIX}split_percent`);
+  if (v === null) return SPLIT_PERCENT_DEFAULT;
+  const n = parseFloat(v);
+  if (!Number.isFinite(n)) return SPLIT_PERCENT_DEFAULT;
+  return clamp(Math.round(n), SPLIT_PERCENT_MIN, SPLIT_PERCENT_MAX);
+}
+
+/**
+ * The user-configured training days per week (1–6, default 4).
+ * Used by Model 2 for calorie-neutral weekly distribution.
+ * Clamped to [1, 6] — n=7 would cause ÷0 in the Model 2 formula (AC22).
+ */
+export async function getTrainingDaysPerWeek(): Promise<number> {
+  const v = await getAppSetting(`${PREFIX}training_days_per_week`);
+  if (v === null) return TRAINING_DAYS_DEFAULT;
+  const n = parseFloat(v);
+  if (!Number.isFinite(n)) return TRAINING_DAYS_DEFAULT;
+  return clamp(Math.round(n), TRAINING_DAYS_MIN, TRAINING_DAYS_MAX);
+}
+
+/**
+ * Read all training-day macro settings in a single call.
+ * Convenience for hook consumers that need all three values.
+ */
+export async function getAllSettings(): Promise<{
+  enabled: boolean;
+  splitPercent: number;
+  trainingDaysPerWeek: number;
+}> {
+  const [enabled, splitPercent, trainingDaysPerWeek] = await Promise.all([
+    getEnabled(),
+    getSplitPercent(),
+    getTrainingDaysPerWeek(),
+  ]);
+  return { enabled, splitPercent, trainingDaysPerWeek };
+}
+
+// ─── Setters ──────────────────────────────────────────────────────────────────
+
+export async function setEnabled(enabled: boolean): Promise<void> {
+  await setAppSetting(`${PREFIX}enabled`, enabled ? "1" : "0");
+}
+
+/**
+ * Persist the split percentage. Clamped to [5, 25] at write time.
+ */
+export async function setSplitPercent(value: number): Promise<void> {
+  const clamped = clamp(Math.round(value), SPLIT_PERCENT_MIN, SPLIT_PERCENT_MAX);
+  await setAppSetting(`${PREFIX}split_percent`, String(clamped));
+}
+
+/**
+ * Persist the training days per week. Clamped to [1, 6] at write time (AC22).
+ */
+export async function setTrainingDaysPerWeek(value: number): Promise<void> {
+  const clamped = clamp(Math.round(value), TRAINING_DAYS_MIN, TRAINING_DAYS_MAX);
+  await setAppSetting(`${PREFIX}training_days_per_week`, String(clamped));
+}

--- a/lib/nutrition-calc.ts
+++ b/lib/nutrition-calc.ts
@@ -47,7 +47,7 @@ const GOAL_ADJUSTMENTS: Record<Goal, number> = {
   bulk: 300,
 };
 
-const CALORIE_FLOOR = 1200;
+export const CALORIE_FLOOR = 1200;
 const PROTEIN_PER_KG = 2.2;
 const FAT_PERCENT = 0.25;
 

--- a/lib/training-day-macros.ts
+++ b/lib/training-day-macros.ts
@@ -1,0 +1,212 @@
+/**
+ * Training-Day Macro Adjustment — pure computation module.
+ *
+ * DESIGN INVARIANTS (enforced by tests in __tests__/lib/training-day-macros.test.ts):
+ *   1. No Date.now() / new Date() calls — all inputs injected by caller.
+ *   2. computeEffectiveTargets never returns a calorie value below CALORIE_FLOOR.
+ *   3. Weekly sum of 7 days' targets equals 7×base (Model 2) within rounding, unless floor clamping.
+ *   4. No DB / React Native imports — fully unit-testable in Node.
+ *   5. GTG (kind='day_session') exclusion is the caller's responsibility (wasWorkoutDay filter).
+ *
+ * PROHIBITION: No "earn/earned/bonus/reward/treat/deserve/penalty/punish/unlock/spend/
+ *   burn it off/work it off/guilt/cheat" copy in this module or its callers.
+ * No directional color tokens (no red/green/surplus/deficit coloring) on values from this module.
+ * Psychologist verdict C1 — AC16.
+ *
+ * @see PLAN-BLD-2634.md — Model 2 (frequency-balanced) is the shipped model.
+ */
+
+import {
+  CALORIE_FLOOR,
+  recomputeMacrosFromCalories,
+} from "./nutrition-calc";
+
+export { CALORIE_FLOOR } from "./nutrition-calc";
+
+// ─── Type disambiguation ──────────────────────────────────────────────────────
+
+/**
+ * Pure (in-memory) macro targets — no DB identity fields.
+ * This is the shape returned by recomputeMacrosFromCalories + nutrition-calc helpers.
+ * Distinct from lib/types.ts MacroTargets (DB row with id + updated_at).
+ */
+export interface PureMacroTargets {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+}
+
+/**
+ * Map the `{protein_g, carbs_g, fat_g}` shape returned by
+ * recomputeMacrosFromCalories to `{protein, carbs, fat}` + calories.
+ * AC23 — disambiguate the pure-vs-DB MacroTargets type.
+ */
+export function mapRecomputedMacros(
+  calories: number,
+  raw: { protein_g: number; carbs_g: number; fat_g: number }
+): PureMacroTargets {
+  return {
+    calories,
+    protein: raw.protein_g,
+    carbs: raw.carbs_g,
+    fat: raw.fat_g,
+  };
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type DayType = "training" | "rest";
+
+export interface TrainingDayParams {
+  /** Split percentage (5–25). Default 10. */
+  splitPercent: number;
+  /** Expected training days per week (1–6). Default 4. */
+  trainingDaysPerWeek: number;
+}
+
+export interface EffectiveTargets extends PureMacroTargets {
+  /** Whether the day was classified as a training day. */
+  dayType: DayType;
+  /** Whether the effective targets differ from base (feature is active). */
+  adjusted: boolean;
+  /**
+   * Whether the rest-day target was clamped to CALORIE_FLOOR.
+   * When true, the weekly average may exceed the base target.
+   */
+  cappedByFloor: boolean;
+}
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Split percentage bounds — AC3 floor guard. */
+export const SPLIT_PERCENT_MIN = 5;
+export const SPLIT_PERCENT_MAX = 25;
+export const SPLIT_PERCENT_DEFAULT = 10;
+
+/** Training-days-per-week bounds — AC22 ÷0 guard. */
+export const TRAINING_DAYS_MIN = 1;
+export const TRAINING_DAYS_MAX = 6;
+export const TRAINING_DAYS_DEFAULT = 4;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Clamp a number to [min, max].
+ */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Validate and clamp TrainingDayParams to safe ranges.
+ * AC22: n must be clamped to 1..6 (n=7 → ÷0; n≤0 → inert).
+ */
+export function normalizeParams(params: TrainingDayParams): TrainingDayParams {
+  return {
+    splitPercent: clamp(
+      Math.round(params.splitPercent),
+      SPLIT_PERCENT_MIN,
+      SPLIT_PERCENT_MAX
+    ),
+    trainingDaysPerWeek: clamp(
+      Math.round(params.trainingDaysPerWeek),
+      TRAINING_DAYS_MIN,
+      TRAINING_DAYS_MAX
+    ),
+  };
+}
+
+// ─── Core computation ─────────────────────────────────────────────────────────
+
+/**
+ * Compute the per-day effective calorie surplus (S) for a training day.
+ *
+ * Model 2 (frequency-balanced, AC2–AC4):
+ *   S = base × (splitPercent / 100)
+ *   Training-day calories = base + S
+ *   Rest-day calories     = base − S × n/(7−n)   (clamped to CALORIE_FLOOR)
+ *
+ * Weekly total:
+ *   n×(base+S) + (7−n)×(base − S×n/(7−n))
+ *   = 7×base + n×S − n×S = 7×base  ✓
+ *
+ * AC22: n must be in 1..6 (normalizeParams ensures this). n=7 is not
+ * reachable via normalizeParams (clamped to 6).
+ *
+ * @param baseCalories  Base daily calorie target (from macro_targets).
+ * @param isTrainingDay Whether the target date is a training day.
+ * @param params        User training-day adjustment parameters (already normalized).
+ * @returns             {trainingCals, restCals, cappedByFloor}
+ */
+export function computeDayCalories(
+  baseCalories: number,
+  isTrainingDay: boolean,
+  params: TrainingDayParams
+): { trainingCals: number; restCals: number; cappedByFloor: boolean } {
+  const { splitPercent, trainingDaysPerWeek: n } = params;
+
+  // S = base × p
+  const surplus = baseCalories * (splitPercent / 100);
+
+  const rawTrainingCals = baseCalories + surplus;
+  // rest-day offset = S × n/(7−n)
+  const restDayOffset = surplus * (n / (7 - n));
+  const rawRestCals = baseCalories - restDayOffset;
+
+  // Apply calorie floor to rest day (AC5)
+  const clampedRestCals = Math.max(CALORIE_FLOOR, Math.round(rawRestCals));
+  const cappedByFloor = clampedRestCals > Math.round(rawRestCals);
+
+  return {
+    trainingCals: Math.round(rawTrainingCals),
+    restCals: clampedRestCals,
+    cappedByFloor,
+  };
+}
+
+/**
+ * Compute effective daily macro targets given a base target and day type.
+ *
+ * This is the primary entry point for the Training-Day Adjustment feature.
+ * It is PURE — no DB calls, no Date.now(), no side effects.
+ *
+ * @param base          Base macro targets (from macro_targets singleton in DB).
+ *                      Uses PureMacroTargets shape (calories, protein, carbs, fat).
+ * @param isTrainingDay Whether the target date has a completed workout
+ *                      (kind='workout', completed_at IS NOT NULL). GTG sessions
+ *                      (kind='day_session') must be excluded by the caller.
+ * @param params        User-configured split parameters (raw; will be normalized).
+ * @param weightKg      User body weight in kg — used to recompute macros via
+ *                      recomputeMacrosFromCalories (protein stays bodyweight-driven).
+ * @returns             EffectiveTargets with dayType, adjusted, cappedByFloor flags.
+ */
+export function computeEffectiveTargets(
+  base: PureMacroTargets,
+  isTrainingDay: boolean,
+  params: TrainingDayParams,
+  weightKg: number
+): EffectiveTargets {
+  const normalized = normalizeParams(params);
+  const { trainingCals, restCals, cappedByFloor } = computeDayCalories(
+    base.calories,
+    isTrainingDay,
+    normalized
+  );
+
+  const effectiveCals = isTrainingDay ? trainingCals : restCals;
+  const effectiveCapped = isTrainingDay ? false : cappedByFloor;
+
+  // Derive protein/carbs/fat from the effective calorie count
+  const raw = recomputeMacrosFromCalories(effectiveCals, weightKg);
+  const macros = mapRecomputedMacros(effectiveCals, raw);
+
+  const adjusted = effectiveCals !== base.calories;
+
+  return {
+    ...macros,
+    dayType: isTrainingDay ? "training" : "rest",
+    adjusted,
+    cappedByFloor: effectiveCapped,
+  };
+}


### PR DESCRIPTION
## Summary

Settings screen for Training-Day Macro Adjustment (BLD-2641 PR4 of 6).

## Changes

- `app/settings/training-day-macros.tsx` — new settings screen, mirrors `app/settings/macro-coach.tsx` pattern:
  - Master Switch (default OFF — AC1/AC19/C5)
  - `How it works` section with **C2 verbatim psychologist-approved body** (AC14)
  - C5 off-ramp line: *Not for everyone — if adjusting food around workouts feels stressful, keep this off and use a single steady target.* (AC19)
  - QD5 logged-workout copy note: *Adjustments are based on your logged workouts* (AC19)
  - Training boost stepper (5–25%, default 10%) with lower/upper bounds enforcement
  - Training days per week stepper (1–6, default 4) with AC22 ÷0 guard enforcement
  - Live preview showing Training day / Rest day / Weekly average when enabled (AC20/C6)
  - All interactive controls have ≥44dp `hitSlop` and `accessibilityLabel` (AC13)
  - No banned lexemes in badge-style copy (AC16/C1 — reward-framing banned words absent from label text)
- `app/(tabs)/settings.tsx` — add `SettingsLinkRow` for Training-Day Macros under Coaching section (line 288, mirrors Adaptive Macro Coach tile)

## Testing

- `jest __tests__/acceptance/training-day-macros-settings.test.tsx`: 12/12 pass
  - AC14: C2 verbatim body rendered, heading present
  - AC19: default OFF, C5 off-ramp, QD5 logged-workout note
  - AC20: preview shows training/rest/weekly-avg when enabled; hidden when disabled
  - AC16: badge-style labels free of reward-framing words
  - Toggle calls setter with correct value
- `jest __tests__/acceptance/settings.test.tsx`: 23/23 pass (no regressions)
- `tsc --noEmit`: zero errors

## Issue

Part of BLD-2641 (PR4 of 6 — settings screen only)