### PR TITLE
fix: suppress stepper on all cable rows, not just calibrated (BLD-2688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-- **Quick Weight Stepper — one-tap +/− to adjust set weight without opening the keyboard** — the active-session set row now shows a full-width `−` / `+` footer strip for plain-weight exercises. Tapping `+` or `−` increments or decrements the weight by the exercise step (e.g. 2.5 kg) and saves immediately, without summoning the numeric keyboard. Bodyweight rows and calibrated-cable marker rows are unaffected. (BLD-2674)
+- **Quick Weight Stepper — one-tap +/− to adjust set weight without opening the keyboard** — the active-session set row now shows a full-width `−` / `+` footer strip for plain-weight exercises. Tapping `+` or `−` increments or decrements the weight by the exercise step (e.g. 2.5 kg) and saves immediately, without summoning the numeric keyboard. Bodyweight rows, duration rows, and all cable rows (which use the stack-marker / manual-weight UI) are unaffected. (BLD-2674)
 - **Training-Day Macro Adjustment — calorie cycling for lifters** — CableSnap can now automatically show a higher calorie target on days you train and a lower one on rest days, while keeping your weekly total exactly equal to your base target. The feature is off by default; enable it in Settings › Training-Day Macros, where you can set your split percentage and training days per week and preview both day-type targets. The day-type badge on the nutrition screen shows `Training day · fueled` or `Rest day · recovery` and taps to explain the adjustment. No reward framing — this is fuel/recovery periodisation, not earning calories. (BLD-2641)
 
 ## v0.26.53 — 2026-07-02

--- a/__tests__/components/session/SessionWeightStepper.test.tsx
+++ b/__tests__/components/session/SessionWeightStepper.test.tsx
@@ -445,9 +445,10 @@ describe("SetRow — SessionWeightStepper gate (BLD-2674)", () => {
     expect(queryByLabelText("Increase by 2.5")).toBeNull();
   });
 
-  it("Cable without calibration (uncalibrated cable = Case C): stepper IS PRESENT", () => {
-    // No stacks passed = no calibration = isCaseBRow=false → stepper shows
-    const { getByLabelText } = render(
+  it("Cable without calibration (uncalibrated cable): stepper ABSENT (BLD-2688 — all cable suppressed)", () => {
+    // BLD-2688: gate widened from !isCaseBRow (calibrated-cable only) to !isCable (all cable).
+    // No stacks = no calibration, but cable rows never show the stepper now.
+    const { queryByLabelText } = render(
       <SetRow
         {...baseProps({
           equipment: "cable" as Equipment,
@@ -457,8 +458,8 @@ describe("SetRow — SessionWeightStepper gate (BLD-2674)", () => {
         })}
       />
     );
-    expect(getByLabelText("Decrease by 2.5")).toBeTruthy();
-    expect(getByLabelText("Increase by 2.5")).toBeTruthy();
+    expect(queryByLabelText("Decrease by 2.5")).toBeNull();
+    expect(queryByLabelText("Increase by 2.5")).toBeNull();
   });
 
   it("Case C stepper + 320px layout: weight testID present and unchanged (stepper is footer sibling)", () => {

--- a/__tests__/components/session/SetRow-weight-stepper.test.tsx
+++ b/__tests__/components/session/SetRow-weight-stepper.test.tsx
@@ -1,5 +1,6 @@
 /**
  * BLD-2674 — SessionWeightStepper acceptance tests.
+ * BLD-2688 — Gate fix: all cable rows (calibrated + uncalibrated) suppress stepper.
  *
  * Covers all plan ACs headlessly:
  *  - Case C (plain numeric): stepper renders; tap + / tap − changes value
@@ -13,6 +14,7 @@
  *  - tap target ≥ 44 effective via style or hitSlop
  *  - bodyweight row → stepper absent
  *  - Case B (calibrated cable) row → stepper absent
+ *  - uncalibrated cable row → stepper absent (BLD-2688)
  *  - completed + RPE → stepper absent (suppress option B)
  *  - SetRow renders stepper testID on a Case C row
  *  - 320px layout guard: stepper is a sibling footer, not inside pickerCol
@@ -491,9 +493,10 @@ describe("SetRow — weight stepper gating (BLD-2674)", () => {
     expect(queryByTestId("set-1-weight-stepper")).toBeNull();
   });
 
-  it("uncalibrated cable row (Case C): stepper DOES render", () => {
-    // isCable + no calibrations = uncalibrated cable → stepper should appear
-    const { getByTestId } = render(
+  it("uncalibrated cable row: stepper does NOT render (BLD-2688 — all cable suppressed)", () => {
+    // BLD-2688: gate widened from !isCaseBRow (calibrated-cable only) to !isCable (all cable).
+    // Uncalibrated cable rows render StackMarkerHint, not the weight stepper.
+    const { queryByTestId } = render(
       <SetRow
         {...baseProps({
           equipment: "cable" as Equipment,
@@ -503,7 +506,7 @@ describe("SetRow — weight stepper gating (BLD-2674)", () => {
         })}
       />
     );
-    expect(getByTestId("set-1-weight-stepper")).toBeTruthy();
+    expect(queryByTestId("set-1-weight-stepper")).toBeNull();
   });
 
   it("duration mode row: stepper does NOT render", () => {

--- a/components/session/SetRow.tsx
+++ b/components/session/SetRow.tsx
@@ -339,11 +339,13 @@ export const SetRow = memo(function SetRow({
   //     (TL required condition (d))
   //   Bodyweight: no stepper (isBodyweight guard + pickerCol renders BodyweightModifierChip)
   //   Duration: no stepper (weight irrelevant)
-  const isCaseBRow = isCable && hasCalibration; // manual/legacy cable row
+  //   Cable (any variant): SUPPRESS — cable rows use stack marker / manual weight UI;
+  //     both calibrated (Case B) and uncalibrated rows show StackMarkerHint instead.
+  //     BLD-2688: widen gate from !isCaseBRow (calibrated-cable only) to !isCable (all cable).
   const isCompletedWithRpe = set.completed && captureRpe;
   const showWeightStepper =
     !isBodyweight &&
-    !isCaseBRow &&
+    !isCable &&
     !isDurationMode &&
     !isCompletedWithRpe;
 


### PR DESCRIPTION
## Summary

QD-BLOCK fix for BLD-2688. The `showWeightStepper` gate in `SetRow.tsx` used `!isCaseBRow` where `isCaseBRow = isCable && hasCalibration`. This meant uncalibrated cable rows (`isCable && !hasCalibration`) still showed the stepper — they should not, since they already render `StackMarkerHint` and the approved gate for this release is `!isCable`.

## Changes

- `components/session/SetRow.tsx`: Replace `!isCaseBRow` with `!isCable` in `showWeightStepper`; remove unused `isCaseBRow` variable; add comment referencing BLD-2688
- `__tests__/components/session/SetRow-weight-stepper.test.tsx`: Replace 'uncalibrated cable = stepper present' test with suppression test
- `__tests__/components/session/SessionWeightStepper.test.tsx`: Same replacement

## Testing

- Targeted Jest: 88/88 pass
- TypeScript typecheck: zero errors
- QD-identified failing cases now assert stepper absent on uncalibrated cable rows

## Issue

Resolves BLD-2688 (QD gate fix follow-up to BLD-2680 / PR #723)