### PR TITLE
fix: restore NumericStepper raw-next bound guard (BLD-2688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ marker) at release time.
 
 - **Quick Weight Stepper — one-tap +/− to adjust set weight without opening the keyboard** — the active-session set row now shows a full-width `−` / `+` footer strip for plain-weight exercises. Tapping `+` or `−` increments or decrements the weight by the exercise step (e.g. 2.5 kg) and saves immediately, without summoning the numeric keyboard. Bodyweight rows, duration rows, and all cable rows (which use the stack-marker / manual-weight UI) are unaffected. (BLD-2674)
 - **Training-Day Macro Adjustment — calorie cycling for lifters** — CableSnap can now automatically show a higher calorie target on days you train and a lower one on rest days, while keeping your weekly total exactly equal to your base target. The feature is off by default; enable it in Settings › Training-Day Macros, where you can set your split percentage and training days per week and preview both day-type targets. The day-type badge on the nutrition screen shows `Training day · fueled` or `Rest day · recovery` and taps to explain the adjustment. No reward framing — this is fuel/recovery periodisation, not earning calories. (BLD-2641)
+- **Weight stepper no longer clamps to the boundary on a near-edge tap** — pressing − (or +) when the step would cross below the minimum (or above the maximum) now does nothing instead of snapping to the bound. (BLD-2688)
 
 ## v0.26.53 — 2026-07-02
 <!-- versionCode: 123 -->

--- a/__tests__/components/session/SetRow-weight-stepper.test.tsx
+++ b/__tests__/components/session/SetRow-weight-stepper.test.tsx
@@ -641,52 +641,50 @@ describe("NumericStepper — stepWeight refactor characterization (BLD-2674)", (
     expect(onValueChange).toHaveBeenCalledTimes(1);
   });
 
-  // ── At-bound: next === value after stepWeight clamps → no call ────────────
+  // ── At-bound: button is disabled, no call ────────────────────────────────
 
-  it("decrement at min: value=0, step=2.5, min=0 → onValueChange NOT called (next===value)", () => {
+  it("decrement at min: value=0, step=2.5, min=0 → onValueChange NOT called (button disabled)", () => {
     const onValueChange = jest.fn();
     const { getByLabelText } = render(
       <NumericStepper value={0} onValueChange={onValueChange} min={0} step={2.5} unit="kg" />,
     );
     // Button is disabled (value <= min). Even if fireEvent bypasses disabled:
-    // stepWeight(0, 2.5, -1, {min:0}) = 0; guard: 0 >= 0 && 0 !== 0 → false → NO CALL
+    // rawNext = 0 - 2.5 = -2.5; guard: -2.5 >= 0 → false → NO CALL
     fireEvent.press(getByLabelText("Decrease by 2.5"));
     expect(onValueChange).not.toHaveBeenCalled();
   });
 
-  it("increment at max: value=500, step=5, max=500 → onValueChange NOT called (next===value)", () => {
+  it("increment at max: value=500, step=5, max=500 → onValueChange NOT called (button disabled)", () => {
     const onValueChange = jest.fn();
     const { getByLabelText } = render(
       <NumericStepper value={500} onValueChange={onValueChange} min={0} step={5} unit="kg" max={500} />,
     );
     // Button is disabled (value >= max). Even if fireEvent bypasses disabled:
-    // stepWeight(500, 5, 1, {max:500}) = 500; guard: 500 <= 500 && 500 !== 500 → false → NO CALL
+    // rawNext = 500 + 5 = 505; guard: 505 <= 500 → false → NO CALL
     fireEvent.press(getByLabelText("Increase by 5"));
     expect(onValueChange).not.toHaveBeenCalled();
   });
 
-  // ── Near-bound clamping fires with clamped value ──────────────────────────
+  // ── Near-bound off-grid: raw step out-of-bounds → NO callback ────────────
 
-  it("decrement near-min: value=1, step=2.5, min=0 → onValueChange(0) (stepWeight clamps; guard 0>=0 passes)", () => {
+  it("decrement near-min: value=1, step=2.5, min=0 → NO callback (raw -1.5 < 0; BLD-2688)", () => {
     const onValueChange = jest.fn();
     const { getByLabelText } = render(
       <NumericStepper value={1} onValueChange={onValueChange} min={0} step={2.5} unit="kg" />,
     );
-    // Button NOT disabled (1 > 0).
-    // stepWeight(1, 2.5, -1, {min:0}) = 0 (clamps -1.5 to 0); 0 >= 0 && 0 !== 1 → fires
+    // Button NOT disabled (1 > 0). But raw next = 1 - 2.5 = -1.5 < min=0 → guard blocks.
+    // BLD-2688: restored original pre-BLD-2674 guard: check rawNext >= min, not clamped next.
     fireEvent.press(getByLabelText("Decrease by 2.5"));
-    expect(onValueChange).toHaveBeenCalledWith(0);
-    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).not.toHaveBeenCalled();
   });
 
-  it("increment near-max: value=498, step=5, max=500 → onValueChange(500) (stepWeight clamps; guard 500<=500 passes)", () => {
+  it("increment near-max: value=498, step=5, max=500 → NO callback (raw 503 > 500; BLD-2688)", () => {
     const onValueChange = jest.fn();
     const { getByLabelText } = render(
       <NumericStepper value={498} onValueChange={onValueChange} min={0} step={5} unit="kg" max={500} />,
     );
-    // stepWeight(498, 5, 1, {max:500}) = 500 (clamps 503 to 500); 500 <= 500 && 500 !== 498 → fires
+    // Button NOT disabled (498 < 500). But raw next = 498 + 5 = 503 > max=500 → guard blocks.
     fireEvent.press(getByLabelText("Increase by 5"));
-    expect(onValueChange).toHaveBeenCalledWith(500);
-    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).not.toHaveBeenCalled();
   });
 });

--- a/components/exercise/NumericStepper.tsx
+++ b/components/exercise/NumericStepper.tsx
@@ -3,9 +3,6 @@ import { StyleSheet, View } from "react-native";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { useThemeColors } from "@/hooks/useThemeColors";
-// BLD-2674: shared float-safe step helper. Extracted so both NumericStepper
-// (goal forms) and SessionWeightStepper (session rows) use the same logic.
-import { stepWeight } from "@/lib/weight-step";
 
 type Props = {
   value: number;
@@ -20,17 +17,18 @@ export default function NumericStepper({ value, onValueChange, min, step, unit, 
   const colors = useThemeColors();
 
   const decrement = () => {
-    const next = stepWeight(value, step, -1, { min, max });
-    // Restore original >= min guard: stepWeight clamps to min, so explicitly
-    // re-check to preserve the same guard semantics as pre-refactor main.
-    if (next >= min && next !== value) onValueChange(next);
+    // BLD-2688: guard on the raw (pre-clamp) next value, matching original behavior
+    // (pre-BLD-2674). stepWeight clamps -1.5 to 0 for value=1 step=2.5 min=0, but
+    // the original code used if (next >= min) where next was the RAW computed value.
+    // Off-grid near-bound inputs (raw < min) must NOT fire onValueChange.
+    const rawNext = Math.round((value - step) * 10) / 10;
+    if (rawNext >= min) onValueChange(rawNext);
   };
 
   const increment = () => {
-    const next = stepWeight(value, step, 1, { min, max });
-    // Restore original <= max guard: stepWeight clamps to max, so explicitly
-    // re-check to preserve the same guard semantics as pre-refactor main.
-    if (next <= max && next !== value) onValueChange(next);
+    // Same pattern: guard on raw next, not clamped next.
+    const rawNext = Math.round((value + step) * 10) / 10;
+    if (rawNext <= max) onValueChange(rawNext);
   };
 
   return (


### PR DESCRIPTION
## Summary

QD-BLOCK fix. PR #724 claimed to restore the original `NumericStepper` bound guard but incorrectly used the clamped result from `stepWeight`. For near-bound off-grid inputs (`value=1, step=2.5, min=0`), `stepWeight` returns `0` (clamped from `-1.5`), and the subsequent guard `0 >= 0 && 0 !== 1` passed, firing `onValueChange(0)` — wrong behavior.

The original pre-BLD-2674 code computed `rawNext = Math.round((value - step) * 10) / 10` and guarded `if (rawNext >= min)` — raw `-1.5 >= 0` is false, so no callback fires.

## Changes

- `components/exercise/NumericStepper.tsx`: Revert to original raw-next guard. Remove unused `stepWeight` import. Add BLD-2688 comment explaining why clamped-result guard is wrong.
- `__tests__/components/session/SetRow-weight-stepper.test.tsx`: Replace two 'near-bound fires clamped value' assertions with 'near-bound off-grid → NO callback' assertions.

## Testing

- Targeted Jest: 87/87 pass
- TypeScript typecheck: zero errors

## Issue

Fixes QD-BLOCK on BLD-2688 (follow-up to BLD-2680 / PR #723, #724, #725)