### PR TITLE
fix: CVD-safe pacing segments — distinct non-color cue per Working/Rest/Other (BLD-2713, BLD-2714, BLD-2725)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Accessibility: Pacing segments now visually distinct under color vision deficiency** — the session summary pacing bar and legend previously relied solely on color to differentiate Working (coral), Rest (blue), and Other (grey) segments, making them indistinguishable for red-green CVD users. Working segments now display a horizontal-dash texture and Other segments a dot/stipple texture, so all three segments are mutually distinguishable in grayscale, under deuteranopia, and under protanopia. No segment colors, labels, or pacing math were changed. (BLD-2713, BLD-2714, BLD-2725)
 
 ## v0.26.54 — 2026-07-03
 <!-- versionCode: 124 -->

--- a/__tests__/components/session/summary/PacingCard.cvd.test.tsx
+++ b/__tests__/components/session/summary/PacingCard.cvd.test.tsx
@@ -1,24 +1,29 @@
 /**
- * PacingCard.cvd.test.tsx — BLD-1939
+ * PacingCard.cvd.test.tsx — BLD-1939, BLD-2713, BLD-2714
  *
- * Headless proxy tests for the CVD (colour-vision-deficiency) fix on the
- * pacing bar. The original finding is a deuteranopia emulation visual
- * judgment that cannot be re-run headlessly; these tests cover the same
- * risk by verifying the structural properties that make the fix work:
+ * Headless proxy tests for the CVD (colour-vision-deficiency) fixes on the
+ * pacing bar. Visual CVD emulation judgments cannot be re-run headlessly;
+ * these tests cover the same risk by verifying the structural properties
+ * that make each fix work.
  *
- * 1. The "Other" bar segment renders the diagonal hatch pattern element.
- * 2. The "Other" legend dot renders the diagonal hatch pattern element.
- * 3. "Working" and "Rest" bar/dot do NOT carry the hatch.
- * 4. Each segment still has its base backgroundColor (additive, not replacement).
- * 5. The hatch overlay is decorative: a11y hidden, pointer-events none.
- * 6. Empty state path (otherFrac == 0) does not crash and hatch is absent.
- * 7. Source contracts (labels/copy) are unchanged.
+ * Fix inventory:
+ *   BLD-1939  — "Other" bar + legend dot carry a dot/stipple texture (HatchOverlay).
+ *   BLD-2725  — Stripes → dots on Other (same testIDs; stripe was "disabled"-looking).
+ *   BLD-2713/2714 — "Working" bar + legend dot carry a distinct horizontal-dash
+ *                   overlay (WorkingDashOverlay) so all three segs are mutually
+ *                   distinguishable in grayscale and under red-green CVD.
+ *   BLD-2205  — Bar Other hatch covers the full segment (full-fill, not 18px).
+ *
+ * Per-segment non-color cue summary:
+ *   Working → horizontal-dash pattern (pacing-seg-working-pattern / pacing-dot-working-pattern)
+ *   Rest    → solid only              (no pattern overlay)
+ *   Other   → dot stipple             (pacing-seg-other-pattern  / pacing-dot-other-pattern)
  */
 
 import React from "react";
 import { Platform } from "react-native";
 import { render } from "@testing-library/react-native";
-import PacingCard, { HatchOverlay } from "../../../../components/session/summary/PacingCard";
+import PacingCard, { HatchOverlay, WorkingDashOverlay } from "../../../../components/session/summary/PacingCard";
 import type { PacingBreakdown } from "@/lib/session-pacing";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
@@ -75,26 +80,35 @@ describe("PacingCard — CVD hatch fix (BLD-1939)", () => {
     expect(dotHatch).toBeTruthy();
   });
 
-  // ── 3. Working segment has NO hatch ───────────────────────────────────────
-  it("does NOT render a hatch on the Working bar segment", () => {
-    const { queryByTestId } = render(<PacingCard pacing={makePacing()} />);
-    expect(queryByTestId("pacing-seg-working-pattern", { includeHiddenElements: true })).toBeNull();
+  // ── 3. Working bar segment carries the horizontal-dash cue (BLD-2713/BLD-2714)
+  //
+  // Previously: test asserted Working had NO pattern (testIDs absent).
+  // Updated: Working must NOW carry WorkingDashOverlay so all three segments
+  // are mutually distinguishable in grayscale and under red-green CVD.
+  it("renders the dash pattern overlay on the Working bar segment", () => {
+    const { getByTestId } = render(<PacingCard pacing={makePacing()} />);
+    const dash = getByTestId("pacing-seg-working-pattern", { includeHiddenElements: true });
+    expect(dash).toBeTruthy();
   });
 
-  // ── 4. Rest segment has NO hatch ──────────────────────────────────────────
-  it("does NOT render a hatch on the Rest bar segment", () => {
+  // ── 4. Rest segment has NO pattern overlay ────────────────────────────────
+  it("does NOT render a pattern on the Rest bar segment", () => {
     const { queryByTestId } = render(<PacingCard pacing={makePacing()} />);
     expect(queryByTestId("pacing-seg-rest-pattern", { includeHiddenElements: true })).toBeNull();
   });
 
-  // ── 5. Working dot has NO hatch ────────────────────────────────────────────
-  it("does NOT render a hatch on the Working legend dot", () => {
-    const { queryByTestId } = render(<PacingCard pacing={makePacing()} />);
-    expect(queryByTestId("pacing-dot-working-pattern", { includeHiddenElements: true })).toBeNull();
+  // ── 5. Working legend dot carries the horizontal-dash cue (BLD-2713/BLD-2714)
+  //
+  // Previously: test asserted Working dot had NO pattern.
+  // Updated: Working dot must carry WorkingDashOverlay.
+  it("renders the dash pattern overlay on the Working legend dot", () => {
+    const { getByTestId } = render(<PacingCard pacing={makePacing()} />);
+    const dotDash = getByTestId("pacing-dot-working-pattern", { includeHiddenElements: true });
+    expect(dotDash).toBeTruthy();
   });
 
-  // ── 6. Rest dot has NO hatch ──────────────────────────────────────────────
-  it("does NOT render a hatch on the Rest legend dot", () => {
+  // ── 6. Rest dot has NO pattern overlay ────────────────────────────────────
+  it("does NOT render a pattern on the Rest legend dot", () => {
     const { queryByTestId } = render(<PacingCard pacing={makePacing()} />);
     expect(queryByTestId("pacing-dot-rest-pattern", { includeHiddenElements: true })).toBeNull();
   });
@@ -124,7 +138,7 @@ describe("PacingCard — CVD hatch fix (BLD-1939)", () => {
     expect(flat.backgroundColor).toBeTruthy();
   });
 
-  // ── 8. Hatch overlay is a11y-hidden (Platform-aware — BLD-1994) ──────────
+  // ── 8. HatchOverlay is a11y-hidden (Platform-aware — BLD-1994) ──────────
   //
   // On native, accessibilityElementsHidden must be true so screen readers skip
   // the decorative overlay. On web, the prop must NOT be true — react-native-svg's
@@ -155,12 +169,41 @@ describe("PacingCard — CVD hatch fix (BLD-1939)", () => {
     }
   });
 
+  // ── 8b. WorkingDashOverlay is a11y-hidden (BLD-2713/BLD-2714, BLD-1994) ──
+  it("dash overlay accessibilityElementsHidden is Platform-gated (true on native, false on web)", () => {
+    const { getByTestId } = render(<PacingCard pacing={makePacing()} />);
+    const dash = getByTestId("pacing-seg-working-pattern", { includeHiddenElements: true });
+    if (Platform.OS === 'web') {
+      expect(dash.props.accessibilityElementsHidden).not.toBe(true);
+    } else {
+      expect(dash.props.accessibilityElementsHidden).toBe(true);
+    }
+  });
+
+  it("dash overlay importantForAccessibility is undefined on web", () => {
+    const { getByTestId } = render(<PacingCard pacing={makePacing()} />);
+    const dash = getByTestId("pacing-seg-working-pattern", { includeHiddenElements: true });
+    if (Platform.OS === 'web') {
+      expect(dash.props.importantForAccessibility).toBeUndefined();
+    } else {
+      expect(dash.props.importantForAccessibility).toBe('no-hide-descendants');
+    }
+  });
+
   // ── 9. Empty state — otherFrac == 0: no crash, hatch absent ───────────────
   it("does not render hatch on Other segment when other time is zero", () => {
     // working + rest == gross leaves otherFrac = 0
     const pacing = makePacing({ working: 900, rest: 900, other: 0, gross: 1800 });
     const { queryByTestId } = render(<PacingCard pacing={pacing} />);
     expect(queryByTestId("pacing-seg-other-pattern", { includeHiddenElements: true })).toBeNull();
+  });
+
+  // ── 9b. workingFrac == 0: no crash, dash absent ────────────────────────────
+  it("does not render dash on Working segment when working time is zero", () => {
+    // rest == gross leaves workingFrac = 0
+    const pacing = makePacing({ working: 0, rest: 1800, other: 0, gross: 1800 });
+    const { queryByTestId } = render(<PacingCard pacing={pacing} />);
+    expect(queryByTestId("pacing-seg-working-pattern", { includeHiddenElements: true })).toBeNull();
   });
 
   // ── 10. isEmpty path renders without crash ────────────────────────────────
@@ -170,6 +213,7 @@ describe("PacingCard — CVD hatch fix (BLD-1939)", () => {
     // No bar segments in empty state
     expect(queryByTestId("pacing-seg-other", { includeHiddenElements: true })).toBeNull();
     expect(queryByTestId("pacing-seg-other-pattern", { includeHiddenElements: true })).toBeNull();
+    expect(queryByTestId("pacing-seg-working-pattern", { includeHiddenElements: true })).toBeNull();
   });
 
   // ── 11. Copy contracts unchanged ─────────────────────────────────────────
@@ -193,6 +237,17 @@ describe("PacingCard — CVD hatch fix (BLD-1939)", () => {
 
   it("HatchOverlay returns null when height is 0", () => {
     const { toJSON } = render(<HatchOverlay width={18} height={0} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  // ── 12b. WorkingDashOverlay unit: returns null for zero/negative dims ─────
+  it("WorkingDashOverlay returns null when width is 0", () => {
+    const { toJSON } = render(<WorkingDashOverlay width={0} height={18} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it("WorkingDashOverlay returns null when height is 0", () => {
+    const { toJSON } = render(<WorkingDashOverlay width={18} height={0} />);
     expect(toJSON()).toBeNull();
   });
 
@@ -237,5 +292,41 @@ describe("PacingCard — CVD hatch fix (BLD-1939)", () => {
     // Legend dot is fixed 8×8 — must NOT use "100%" (that would scale with the dot container)
     expect(dotHatch.props.width).toBe(8);
     expect(dotHatch.props.height).toBe(8);
+  });
+
+  // ── 13b. Working dash bar must be full-fill (BLD-2713/BLD-2714) ──────────
+  //
+  // Same regression guard as BLD-2205: the dash SVG canvas must be "100%×100%"
+  // to cover the full flex-sized bar segment.
+  it("bar Working dash SVG canvas is full-fill (width/height = '100%')", () => {
+    const { getByTestId } = render(<PacingCard pacing={makePacing()} />);
+    const dash = getByTestId("pacing-seg-working-pattern", { includeHiddenElements: true });
+    expect(dash.props.width).toBe("100%");
+    expect(dash.props.height).toBe("100%");
+  });
+
+  it("legend dot dash SVG canvas keeps explicit 8×8 dimensions (not full-fill)", () => {
+    const { getByTestId } = render(<PacingCard pacing={makePacing()} />);
+    const dotDash = getByTestId("pacing-dot-working-pattern", { includeHiddenElements: true });
+    expect(dotDash.props.width).toBe(8);
+    expect(dotDash.props.height).toBe(8);
+  });
+
+  // ── 14. Working dash and Other dot use distinct SVG pattern IDs ───────────
+  //
+  // The two overlays must use DIFFERENT SVG Pattern IDs so they render distinct
+  // shapes. If both had the same ID, the second Defs block would shadow the first
+  // and both segments would look identical — defeating the CVD fix.
+  //
+  // Both use url(#...) pattern fills; we distinguish by finding both Defs
+  // patterns and asserting that the Pattern elements have different IDs.
+  it("Other dot and Working dash patterns have distinct SVG Pattern IDs", () => {
+    const { UNSAFE_getAllByType } = render(<PacingCard pacing={makePacing()} />);
+    const { Pattern } = require("react-native-svg");
+    const patterns = UNSAFE_getAllByType(Pattern);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ids = new Set(patterns.map((p: any) => p.props.id as string | undefined));
+    // Must have at least two distinct IDs (one for dot, one for dash)
+    expect(ids.size).toBeGreaterThanOrEqual(2);
   });
 });

--- a/components/session/summary/PacingCard.tsx
+++ b/components/session/summary/PacingCard.tsx
@@ -11,9 +11,11 @@
  * in this file — enforced by source-contracts-batch.test.ts.
  * ⓘ disclosure copy is verbatim per AC§147 — locked by source-contracts.
  *
- * CVD accessibility (BLD-1939): The "Other" segment carries a diagonal hatch
+ * CVD accessibility (BLD-1939, BLD-2725): The "Other" segment carries a dot/stipple
  * overlay so it is distinguishable from "Working" under deuteranopia/protanopia.
- * The hatch is additive — full-colour appearance for sighted users is unchanged.
+ * Dots replaced diagonal stripes (BLD-2725) — stripes imply a disabled/unavailable
+ * state, dots do not carry that connotation while still providing a non-hue texture.
+ * The overlay is additive — full-colour appearance for sighted users is unchanged.
  */
 
 import { useState } from "react";
@@ -23,7 +25,7 @@ import {
   StyleSheet,
   View,
 } from "react-native";
-import Svg, { Defs, Line, Pattern, Rect } from "react-native-svg";
+import Svg, { Circle, Defs, Pattern, Rect } from "react-native-svg";
 import { Card, CardContent } from "@/components/ui/card";
 import { Text } from "@/components/ui/text";
 import { useThemeColors } from "@/hooks/useThemeColors";
@@ -45,19 +47,22 @@ function useSegmentColors() {
   };
 }
 
-// ─── Diagonal hatch overlay (BLD-1939 CVD fix) ───────────────────────────────
+// ─── Dot/stipple overlay (BLD-1939 CVD fix, BLD-2725 UX fix) ─────────────────
 //
-// Renders an SVG diagonal stripe pattern as an absolute-fill overlay.
+// Renders an SVG dot/stipple pattern as an absolute-fill overlay.
+// Replaced diagonal stripes (BLD-2725): stripes carry a 'disabled/unavailable'
+// visual connotation. Dots provide the same non-hue texture for CVD without
+// implying a disabled state.
 // The overlay is purely decorative: aria-hidden + accessibilityElementsHidden
 // so it does not pollute the a11y tree. pointerEvents="none" ensures taps
 // pass through to the parent Pressable.
 //
-// The hatch stroke colour is semi-transparent white so it works on both
+// The dot fill colour is semi-transparent white so it works on both
 // light and dark themes without hardcoding a specific shade.
 
 const HATCH_PATTERN_ID = "pacing-other-hatch";
-const HATCH_SIZE = 6;          // tile size in px
-const HATCH_STROKE_WIDTH = 1.5;
+const HATCH_SIZE = 6;          // tile size in px (dot spacing)
+const HATCH_DOT_RADIUS = 1.1;  // dot radius in px — subtle but visible
 const HATCH_STROKE_COLOR = "rgba(255,255,255,0.55)"; // semi-white for theme-agnostic contrast
 
 type HatchOverlayProps =
@@ -79,7 +84,7 @@ type HatchOverlayProps =
     };
 
 /**
- * HatchOverlay — decorative diagonal stripe fill.
+ * HatchOverlay — decorative dot/stipple fill (BLD-2725: replaced diagonal stripes).
  * Caller is responsible for positioning (absoluteFill or explicit dimensions).
  *
  * Two modes:
@@ -120,15 +125,12 @@ export function HatchOverlay({ fill, width, height, testID }: HatchOverlayProps)
           width={HATCH_SIZE}
           height={HATCH_SIZE}
           patternUnits="userSpaceOnUse"
-          patternTransform="rotate(45)"
         >
-          <Line
-            x1="0"
-            y1="0"
-            x2="0"
-            y2={HATCH_SIZE}
-            stroke={HATCH_STROKE_COLOR}
-            strokeWidth={HATCH_STROKE_WIDTH}
+          <Circle
+            cx={HATCH_SIZE / 2}
+            cy={HATCH_SIZE / 2}
+            r={HATCH_DOT_RADIUS}
+            fill={HATCH_STROKE_COLOR}
           />
         </Pattern>
       </Defs>
@@ -238,7 +240,7 @@ export default function PacingCard({ pacing, exerciseNames = {} }: Props) {
                     { flex: restFrac, backgroundColor: segColors.rest },
                   ]}
                 />
-                {/* Other segment: hatch overlay for CVD (BLD-1939) */}
+                {/* Other segment: dot/stipple overlay for CVD (BLD-1939, BLD-2725) */}
                 <View
                   testID="pacing-seg-other"
                   style={[
@@ -303,7 +305,7 @@ function LabelChip({
 }) {
   return (
     <View style={styles.labelChip}>
-      {/* Legend dot with optional hatch overlay (BLD-1939) */}
+      {/* Legend dot with optional dot/stipple overlay (BLD-1939, BLD-2725) */}
       <View
         testID={`pacing-dot-${label.toLowerCase()}`}
         style={[styles.legendDot, { backgroundColor: color }]}

--- a/components/session/summary/PacingCard.tsx
+++ b/components/session/summary/PacingCard.tsx
@@ -11,11 +11,22 @@
  * in this file — enforced by source-contracts-batch.test.ts.
  * ⓘ disclosure copy is verbatim per AC§147 — locked by source-contracts.
  *
- * CVD accessibility (BLD-1939, BLD-2725): The "Other" segment carries a dot/stipple
- * overlay so it is distinguishable from "Working" under deuteranopia/protanopia.
- * Dots replaced diagonal stripes (BLD-2725) — stripes imply a disabled/unavailable
- * state, dots do not carry that connotation while still providing a non-hue texture.
- * The overlay is additive — full-colour appearance for sighted users is unchanged.
+ * CVD accessibility (BLD-1939, BLD-2713, BLD-2714, BLD-2725):
+ * All three pacing segments carry a distinct non-color structural cue so that
+ * the bar and legend are mutually distinguishable under deuteranopia, protanopia,
+ * and in pure grayscale — following the dual-channel encoding pattern (BLD-65/BLD-732).
+ *
+ *   "Working"  — horizontal-dash overlay (WorkingDashOverlay): short horizontal
+ *                rectangles in a repeating tile pattern. Resolves BLD-2713/BLD-2714.
+ *                Distinct from Other's circular dots (shape: dash ≠ dot) and from
+ *                solid Rest (texture ≠ no texture) in any color mode.
+ *   "Other"    — dot/stipple pattern overlay (HatchOverlay): repeating 6px circular dots.
+ *                Replaces diagonal stripes (BLD-2725: stripes imply disabled state).
+ *   "Rest"     — solid (blue; high inherent luminance contrast vs both textured segs).
+ *
+ * Both overlays are additive: full-colour sighted appearance is unchanged.
+ * Both are purely decorative: aria-hidden (web) + accessibilityElementsHidden (native).
+ * Both use distinct SVG Pattern IDs so they render distinct shapes (BLD-2714 requirement).
  */
 
 import { useState } from "react";
@@ -47,7 +58,12 @@ function useSegmentColors() {
   };
 }
 
-// ─── Dot/stipple overlay (BLD-1939 CVD fix, BLD-2725 UX fix) ─────────────────
+// ─── Shared overlay colour ────────────────────────────────────────────────────
+// Semi-transparent white works on both light and dark themes without
+// hardcoding a specific shade. Used by both overlay types for visual consistency.
+const OVERLAY_COLOR = "rgba(255,255,255,0.55)";
+
+// ─── Dot/stipple overlay — "Other" segment (BLD-1939 CVD fix, BLD-2725 UX fix) ─
 //
 // Renders an SVG dot/stipple pattern as an absolute-fill overlay.
 // Replaced diagonal stripes (BLD-2725): stripes carry a 'disabled/unavailable'
@@ -56,14 +72,34 @@ function useSegmentColors() {
 // The overlay is purely decorative: aria-hidden + accessibilityElementsHidden
 // so it does not pollute the a11y tree. pointerEvents="none" ensures taps
 // pass through to the parent Pressable.
-//
-// The dot fill colour is semi-transparent white so it works on both
-// light and dark themes without hardcoding a specific shade.
 
 const HATCH_PATTERN_ID = "pacing-other-hatch";
 const HATCH_SIZE = 6;          // tile size in px (dot spacing)
 const HATCH_DOT_RADIUS = 1.1;  // dot radius in px — subtle but visible
-const HATCH_STROKE_COLOR = "rgba(255,255,255,0.55)"; // semi-white for theme-agnostic contrast
+const HATCH_STROKE_COLOR = OVERLAY_COLOR;
+
+// ─── Horizontal-dash overlay — "Working" segment (BLD-2713/BLD-2714 CVD fix) ─
+//
+// Renders short horizontal rectangle dashes in a repeating tile pattern as an
+// absolute-fill overlay on the Working bar segment and legend dot.
+//
+// Chosen as the Working cue because it is structurally distinct from Other's
+// circular dots (shape: dash ≠ dot) and from solid Rest (texture ≠ no texture).
+// The distinction holds in pure grayscale AND under red-green CVD, relying solely
+// on luminance (semi-white dashes) and shape, not hue.
+//
+// Uses a different PATTERN_ID from the Other dot pattern so both render distinct
+// shapes when present in the same SVG tree.
+//
+// Does NOT imply "disabled/unavailable" (BLD-2725 lesson): short horizontal lines
+// read as a textured fill, not as a "strikethrough" or diagonal-disabled cue.
+
+const DASH_PATTERN_ID = "pacing-working-dash";
+const DASH_TILE_W = 8;    // tile width — wider than dot tile for distinct horizontal rhythm
+const DASH_TILE_H = 6;    // tile height — same as dot tile height
+const DASH_W = 4;         // dash width: noticeably longer than the 2.2px dot diameter
+const DASH_H = 1.5;       // dash height: thin horizontal bar, not a block
+const DASH_COLOR = OVERLAY_COLOR;
 
 type HatchOverlayProps =
   | {
@@ -85,7 +121,8 @@ type HatchOverlayProps =
 
 /**
  * HatchOverlay — decorative dot/stipple fill (BLD-2725: replaced diagonal stripes).
- * Caller is responsible for positioning (absoluteFill or explicit dimensions).
+ * Used for the "Other" segment. Caller is responsible for positioning (absoluteFill
+ * or explicit dimensions).
  *
  * Two modes:
  *   fill=true  — SVG canvas is "100%×100%" so it fills any flex-sized parent
@@ -140,6 +177,82 @@ export function HatchOverlay({ fill, width, height, testID }: HatchOverlayProps)
         width={svgWidth}
         height={svgHeight}
         fill={`url(#${HATCH_PATTERN_ID})`}
+      />
+    </Svg>
+  );
+}
+
+type WorkingDashOverlayProps =
+  | {
+      /** Fill mode: SVG canvas is "100%×100%" to cover the flex-sized bar segment. */
+      fill: true;
+      width?: never;
+      height?: never;
+      testID?: string;
+    }
+  | {
+      /** Explicit-size mode: pass exact pixel dimensions (e.g. legend dot 8×8). */
+      fill?: false;
+      width: number;
+      height: number;
+      testID?: string;
+    };
+
+/**
+ * WorkingDashOverlay — decorative horizontal-dash fill for the "Working" segment.
+ * Resolves BLD-2713 (deuteranopia) and BLD-2714 (protanopia).
+ *
+ * Short horizontal rectangles spaced at regular vertical intervals provide a
+ * distinct texture from Other's circular dots (shape: dash vs circle) and from
+ * solid Rest. The cue is hue-independent: works in pure grayscale and under any
+ * CVD type. Uses DASH_PATTERN_ID (distinct from HATCH_PATTERN_ID) so both patterns
+ * render their own shapes in the same SVG tree.
+ *
+ * Shares the same two modes as HatchOverlay (fill / explicit-size).
+ */
+export function WorkingDashOverlay({ fill, width, height, testID }: WorkingDashOverlayProps) {
+  // In explicit-size mode, guard against non-positive dimensions.
+  if (!fill && (width <= 0 || height <= 0)) return null;
+
+  const svgWidth = fill ? "100%" : width;
+  const svgHeight = fill ? "100%" : height;
+
+  return (
+    <Svg
+      width={svgWidth}
+      height={svgHeight}
+      style={StyleSheet.absoluteFillObject}
+      {...(Platform.OS !== 'web' ? { accessibilityElementsHidden: true } : {})}
+      {...(Platform.OS !== 'web' ? { importantForAccessibility: 'no-hide-descendants' } : {})}
+      aria-hidden
+      pointerEvents="none"
+      testID={testID}
+    >
+      <Defs>
+        <Pattern
+          id={DASH_PATTERN_ID}
+          x="0"
+          y="0"
+          width={DASH_TILE_W}
+          height={DASH_TILE_H}
+          patternUnits="userSpaceOnUse"
+        >
+          {/* Centered horizontal dash within the tile */}
+          <Rect
+            x={(DASH_TILE_W - DASH_W) / 2}
+            y={(DASH_TILE_H - DASH_H) / 2}
+            width={DASH_W}
+            height={DASH_H}
+            fill={DASH_COLOR}
+          />
+        </Pattern>
+      </Defs>
+      <Rect
+        x="0"
+        y="0"
+        width={svgWidth}
+        height={svgHeight}
+        fill={`url(#${DASH_PATTERN_ID})`}
       />
     </Svg>
   );
@@ -226,13 +339,21 @@ export default function PacingCard({ pacing, exerciseNames = {} }: Props) {
                 style={styles.barContainer}
                 {...(Platform.OS !== 'web' ? { accessibilityElementsHidden: true } : {})}
               >
+                {/* Working segment: horizontal-dash overlay for CVD (BLD-2713/BLD-2714) */}
                 <View
                   testID="pacing-seg-working"
                   style={[
                     styles.barSegment,
                     { flex: workingFrac, backgroundColor: segColors.working, borderTopLeftRadius: 4, borderBottomLeftRadius: 4 },
                   ]}
-                />
+                >
+                  {workingFrac > 0 && (
+                    <WorkingDashOverlay
+                      fill
+                      testID="pacing-seg-working-pattern"
+                    />
+                  )}
+                </View>
                 <View
                   testID="pacing-seg-rest"
                   style={[
@@ -259,9 +380,9 @@ export default function PacingCard({ pacing, exerciseNames = {} }: Props) {
 
               {/* Labels */}
               <View style={styles.labelsRow}>
-                <LabelChip label="Working" value={workingLabel} color={segColors.working} textColor={colors.onSurface} showHatch={false} />
-                <LabelChip label="Rest" value={restLabel} color={segColors.rest} textColor={colors.onSurface} showHatch={false} />
-                <LabelChip label="Other" value={otherLabel} color={segColors.other} textColor={colors.onSurface} showHatch />
+                <LabelChip label="Working" value={workingLabel} color={segColors.working} textColor={colors.onSurface} showHatch={false} showDash />
+                <LabelChip label="Rest" value={restLabel} color={segColors.rest} textColor={colors.onSurface} showHatch={false} showDash={false} />
+                <LabelChip label="Other" value={otherLabel} color={segColors.other} textColor={colors.onSurface} showHatch showDash={false} />
               </View>
 
               <Text
@@ -296,22 +417,31 @@ function LabelChip({
   color,
   textColor,
   showHatch,
+  showDash,
 }: {
   label: string;
   value: string;
   color: string;
   textColor: string;
   showHatch: boolean;
+  showDash: boolean;
 }) {
   return (
     <View style={styles.labelChip}>
-      {/* Legend dot with optional dot/stipple overlay (BLD-1939, BLD-2725) */}
+      {/* Legend dot with optional CVD overlay (BLD-1939, BLD-2713/2714, BLD-2725) */}
       <View
         testID={`pacing-dot-${label.toLowerCase()}`}
         style={[styles.legendDot, { backgroundColor: color }]}
       >
         {showHatch && (
           <HatchOverlay
+            width={LEGEND_DOT_SIZE}
+            height={LEGEND_DOT_SIZE}
+            testID={`pacing-dot-${label.toLowerCase()}-pattern`}
+          />
+        )}
+        {showDash && (
+          <WorkingDashOverlay
             width={LEGEND_DOT_SIZE}
             height={LEGEND_DOT_SIZE}
             testID={`pacing-dot-${label.toLowerCase()}-pattern`}


### PR DESCRIPTION
## Summary

All three pacing segments (Working / Rest / Other) now carry mutually distinct non-color structural cues so the stacked bar and legend are readable under deuteranopia, protanopia, and in pure grayscale.

- **Other**: fine dot/stipple pattern (replaces diagonal stripes that implied disabled state — BLD-2725)
- **Working**: horizontal-dash pattern (new — resolves BLD-2713/BLD-2714 where Working ≈ Other under red-green CVD)
- **Rest**: remains solid (blue; high inherent luminance contrast vs both textured segments)

Design approach follows BLD-65 (non-color dual-channel encoding) and BLD-2721 (shape encoding for CalendarGrid). No segment hues, labels, or copy were changed.

## Changes

- Replace diagonal stripes with dot pattern in HatchOverlay (Other segment) — BLD-2725
- Add WorkingDashOverlay component with DASH_PATTERN_ID distinct from HATCH_PATTERN_ID — BLD-2713/2714
- Both overlays use fill-mode for bar segment and explicit 8x8 for legend dot (BLD-2205 regression guard)
- Both overlays are decorative: aria-hidden (web) + Platform-gated accessibilityElementsHidden/importantForAccessibility (native)
- Update PacingCard.cvd.test.tsx: flip Working tests from asserting no-pattern to asserting dash-pattern; add tests for WorkingDashOverlay (a11y gating, full-fill, explicit 8x8, distinct Pattern IDs)
- New testIDs: pacing-seg-working-pattern / pacing-dot-working-pattern (BLD-2205 testIDs preserved)

## Testing

- 28/28 CVD tests pass (PacingCard.cvd.test.tsx)
- 123/123 source-contract tests pass (source-contracts-batch.test.ts)
- tsc --noEmit: clean (zero errors)
- npm install --legacy-peer-deps: clean

## Issues

Closes BLD-2713
Closes BLD-2714
Closes BLD-2725