### PR TITLE
fix(settings): sponsor-badge spacing + 48dp tap targets (BLD-2745)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Settings: improved sponsor-badge tap targets and spacing** — the Buy Me a Coffee and thanks.dev badge buttons in the About card now have 48dp minimum tap targets (up from 24dp for thanks.dev) and increased vertical spacing between them, making them easier to tap accurately. (BLD-2730, BLD-2731)
 
 ## v0.26.54 — 2026-07-03
 <!-- versionCode: 124 -->

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -395,7 +395,7 @@ export default function Settings() {
               onPress={() => Linking.openURL('https://buymeacoffee.com/alankyshum')}
               accessibilityRole="link"
               accessibilityLabel="Buy me a coffee"
-              style={{ marginTop: spacing.sm }}
+              style={{ marginTop: spacing.sm, minHeight: 48, justifyContent: 'center' }}
             >
               <Image
                 source={require('../../assets/badges/bmc-button.png')}
@@ -406,7 +406,7 @@ export default function Settings() {
               onPress={() => Linking.openURL('https://thanks.dev/u/gh/alankyshum')}
               accessibilityRole="link"
               accessibilityLabel="Sponsor on thanks.dev"
-              style={{ marginTop: spacing.sm }}
+              style={{ marginTop: spacing.md, minHeight: 48, justifyContent: 'center' }}
             >
               <Image
                 source={require('../../assets/badges/thanks-dev-button.png')}


### PR DESCRIPTION
## Summary

Fixes crowded sponsor-badge spacing and sub-44dp tap targets in the Settings About card. Both findings from the 2026-07-03 web-viewport audit, touching the same two Pressable elements.

## Changes

- **BMC badge Pressable**: add `minHeight: 48` + `justifyContent: 'center'` — tap target grows to 48dp, image stays centered at 180×50
- **thanks.dev badge Pressable**: increase `marginTop` from `spacing.sm` (8px) → `spacing.md` (12px), add `minHeight: 48` + `justifyContent: 'center'` — tap target grows to 48dp, image stays centered at 180×24
- Images untouched: `resizeMode: 'contain'`, original dimensions preserved
- `accessibilityRole` and `accessibilityLabel` preserved on both badges

## Testing

- TypeScript typecheck passes (zero errors in app source)
- Static style assertions: both Pressables now have `minHeight: 48`, `justifyContent: 'center'`; thanks.dev `marginTop` is now 12 (spacing.md)
- No behavior change: badge URLs unchanged, tap handlers unchanged

## Issue

Closes BLD-2730
Closes BLD-2731
Resolves BLD-2745