### PR TITLE
fix(pacing): enforce min visible width for non-zero segments (BLD-2712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ marker) at release time.
 - **Session notes textarea now immediately visible** — the Session notes input on the summary and detail screens was previously hidden behind a tap-to-expand gesture, making it unclear the area was interactive. The textarea is now always shown with a visible outline border and placeholder text ("Add notes about this workout...") so users can tap directly to add notes without any extra step. (BLD-2711)
 - **Settings: improved sponsor-badge tap targets and spacing** — the Buy Me a Coffee and thanks.dev badge buttons in the About card now have 48dp minimum tap targets (up from 24dp for thanks.dev) and increased vertical spacing between them, making them easier to tap accurately. (BLD-2730, BLD-2731)
 - **Fixed broken trophy/achievement icons on web** — achievement and level icons previously appeared as tofu boxes (empty squares) on web because emoji glyphs are not available in the default system font there. All icons are now drawn with bundled vector icons and display correctly on every platform. (BLD-2708)
+- **Pacing bar always shows a visible Working segment** — when working time was a very small fraction of total session time, the Working segment rendered too thin to see. It now has a guaranteed minimum visual width so all non-zero segments are always visible. (BLD-2712)
 
 ## v0.26.54 — 2026-07-03
 <!-- versionCode: 124 -->

--- a/__tests__/components/session/summary/PacingCard.min-segment.test.tsx
+++ b/__tests__/components/session/summary/PacingCard.min-segment.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * PacingCard.min-segment.test.tsx — BLD-2712
+ *
+ * Unit tests for the applyMinSegmentFraction helper and component-level
+ * regression guard for the minimum-visible-width fix on the pacing bar.
+ *
+ * Coverage:
+ *   1. Pure helper: applyMinSegmentFraction
+ *      a. Tiny non-zero working segment is floored to MIN_SEGMENT_FRAC.
+ *      b. Zero segments stay zero (no forced visibility).
+ *      c. Normal data is a no-op (all segments already above MIN_SEGMENT_FRAC).
+ *      d. Sum invariant: floored fractions sum to 1.0 (± 1e-6).
+ *      e. Only one non-zero segment (= 1.0): stays 1.0.
+ *      f. Two tiny non-zero: both floored, donors reduced, sum preserved.
+ *
+ *   2. Component regression: flex prop on Working segment
+ *      a. Tiny working: flex >= MIN_SEGMENT_FRAC on pacing-seg-working.
+ *      b. working=0: flex == 0 on pacing-seg-working (no forced visibility).
+ *      c. Balanced session: flex unchanged (all above MIN_SEGMENT_FRAC).
+ *      d. working=0: no working-pattern overlay rendered.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react-native";
+import PacingCard, { applyMinSegmentFraction, MIN_SEGMENT_FRAC } from "../../../../components/session/summary/PacingCard";
+import type { PacingBreakdown } from "@/lib/session-pacing";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock("@/hooks/useThemeColors", () => ({
+  useThemeColors: () => {
+    const { makeMockThemeColors } = require("../../../helpers/theme");
+    return makeMockThemeColors("light");
+  },
+}));
+
+jest.mock(
+  "../../../../components/session/summary/PacingBreakdownSheet",
+  () => {
+    const React = require("react");
+    return {
+      __esModule: true,
+      default: () => React.createElement("PacingBreakdownSheet", null),
+    };
+  }
+);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePacing(overrides: Partial<PacingBreakdown> = {}): PacingBreakdown {
+  return {
+    working: 600,
+    rest: 900,
+    other: 300,
+    gross: 1800,
+    perExercise: [],
+    isEmpty: false,
+    ...overrides,
+  };
+}
+
+/** Extract flattened style from a rendered element (handles array or object styles). */
+function flatStyle(element: { props: { style?: object | object[] } }): Record<string, unknown> {
+  const { style } = element.props;
+  if (Array.isArray(style)) return Object.assign({}, ...style);
+  return (style as Record<string, unknown>) ?? {};
+}
+
+// ── 1. Pure helper unit tests ─────────────────────────────────────────────────
+
+describe("applyMinSegmentFraction — pure helper (BLD-2712)", () => {
+
+  // 1a. Tiny non-zero working → floored to MIN_SEGMENT_FRAC
+  it("floors a tiny non-zero working fraction to MIN_SEGMENT_FRAC", () => {
+    // working=60, rest=0, other=3540, gross=3600
+    // raw fracs: working≈0.0167 (< MIN), rest=0, other≈0.983
+    const gross = 3600;
+    const raw = {
+      working: 60 / gross,     // ≈ 0.0167 < MIN_SEGMENT_FRAC
+      rest: 0,
+      other: 3540 / gross,     // ≈ 0.983
+    };
+    const result = applyMinSegmentFraction(raw);
+    expect(result.working).toBeGreaterThanOrEqual(MIN_SEGMENT_FRAC);
+  });
+
+  // 1b. Zero segments stay zero
+  it("preserves zero segments — working=0 stays at 0", () => {
+    const raw = { working: 0, rest: 0.5, other: 0.5 };
+    const result = applyMinSegmentFraction(raw);
+    expect(result.working).toBe(0);
+  });
+
+  it("preserves zero segments — rest=0 stays at 0", () => {
+    const raw = { working: 60 / 3600, rest: 0, other: 3540 / 3600 };
+    const result = applyMinSegmentFraction(raw);
+    expect(result.rest).toBe(0);
+  });
+
+  // 1c. Normal data (all already above MIN_SEGMENT_FRAC) is a no-op
+  it("does not modify fractions that are already above MIN_SEGMENT_FRAC", () => {
+    // working=600, rest=900, other=300, gross=1800
+    const gross = 1800;
+    const raw = {
+      working: 600 / gross,   // 0.333
+      rest: 900 / gross,      // 0.5
+      other: 300 / gross,     // 0.167
+    };
+    const result = applyMinSegmentFraction(raw);
+    expect(result.working).toBeCloseTo(raw.working, 9);
+    expect(result.rest).toBeCloseTo(raw.rest, 9);
+    expect(result.other).toBeCloseTo(raw.other, 9);
+  });
+
+  // 1d. Sum invariant: floored fractions sum to 1.0 ± 1e-6
+  it("result fractions sum to 1.0 after flooring a tiny segment", () => {
+    const gross = 3600;
+    const raw = {
+      working: 60 / gross,
+      rest: 0,
+      other: 3540 / gross,
+    };
+    const result = applyMinSegmentFraction(raw);
+    const sum = result.working + result.rest + result.other;
+    expect(Math.abs(sum - 1.0)).toBeLessThan(1e-6);
+  });
+
+  it("result fractions sum to 1.0 with three non-zero segments (one tiny)", () => {
+    // working=30, rest=1800, other=1770, gross=3600
+    const gross = 3600;
+    const raw = {
+      working: 30 / gross,    // ≈ 0.0083 < MIN
+      rest: 1800 / gross,     // 0.5
+      other: 1770 / gross,    // ≈ 0.492
+    };
+    const result = applyMinSegmentFraction(raw);
+    const sum = result.working + result.rest + result.other;
+    expect(Math.abs(sum - 1.0)).toBeLessThan(1e-6);
+    expect(result.working).toBeGreaterThanOrEqual(MIN_SEGMENT_FRAC);
+  });
+
+  // 1e. Single non-zero segment = 1.0 stays at 1.0
+  it("single non-zero segment at 1.0 is unchanged", () => {
+    const raw = { working: 1.0, rest: 0, other: 0 };
+    const result = applyMinSegmentFraction(raw);
+    expect(result.working).toBeCloseTo(1.0, 9);
+    expect(result.rest).toBe(0);
+    expect(result.other).toBe(0);
+  });
+
+  // 1f. Two tiny non-zero segments: both floored, donors reduced, sum preserved
+  it("floors two tiny segments and preserves sum=1.0", () => {
+    // working=0.01, rest=0.01, other=0.98 — both working and rest below MIN
+    const raw = { working: 0.01, rest: 0.01, other: 0.98 };
+    const result = applyMinSegmentFraction(raw);
+    expect(result.working).toBeGreaterThanOrEqual(MIN_SEGMENT_FRAC);
+    expect(result.rest).toBeGreaterThanOrEqual(MIN_SEGMENT_FRAC);
+    expect(result.other).toBeGreaterThan(0); // other donated some, still positive
+    const sum = result.working + result.rest + result.other;
+    expect(Math.abs(sum - 1.0)).toBeLessThan(1e-6);
+  });
+});
+
+// ── 2. Component regression: flex prop on pacing segments ────────────────────
+
+describe("PacingCard — min segment flex guard (BLD-2712)", () => {
+
+  // 2a. Tiny working segment: flex >= MIN_SEGMENT_FRAC on the Working bar
+  it("Working segment flex is >= MIN_SEGMENT_FRAC when raw fraction is tiny but non-zero", () => {
+    // working=60, rest=0, other=3540, gross=3600
+    const pacing = makePacing({ working: 60, rest: 0, other: 3540, gross: 3600 });
+    const { getByTestId } = render(<PacingCard pacing={pacing} />);
+    const seg = getByTestId("pacing-seg-working", { includeHiddenElements: true });
+    const style = flatStyle(seg);
+    expect(typeof style.flex).toBe("number");
+    expect(style.flex as number).toBeGreaterThanOrEqual(MIN_SEGMENT_FRAC);
+  });
+
+  // 2b. working=0: flex == 0 on Working (no forced visibility)
+  it("Working segment flex is 0 when working=0 (no forced visibility)", () => {
+    const pacing = makePacing({ working: 0, rest: 1800, other: 0, gross: 1800 });
+    const { getByTestId } = render(<PacingCard pacing={pacing} />);
+    const seg = getByTestId("pacing-seg-working", { includeHiddenElements: true });
+    const style = flatStyle(seg);
+    expect(style.flex).toBe(0);
+  });
+
+  // 2c. working=0: no dash overlay rendered
+  it("does NOT render a Working dash pattern when working=0", () => {
+    const pacing = makePacing({ working: 0, rest: 1800, other: 0, gross: 1800 });
+    const { queryByTestId } = render(<PacingCard pacing={pacing} />);
+    expect(queryByTestId("pacing-seg-working-pattern", { includeHiddenElements: true })).toBeNull();
+  });
+
+  // 2d. Balanced session: Working flex effectively unchanged (already above MIN_SEGMENT_FRAC)
+  it("does not alter Working flex for a balanced session (already above MIN_SEGMENT_FRAC)", () => {
+    // working=600, rest=900, other=300, gross=1800 → workingFrac=0.333 >> MIN
+    const pacing = makePacing({ working: 600, rest: 900, other: 300, gross: 1800 });
+    const { getByTestId } = render(<PacingCard pacing={pacing} />);
+    const seg = getByTestId("pacing-seg-working", { includeHiddenElements: true });
+    const style = flatStyle(seg);
+    // Should be close to 600/1800 = 0.333..., i.e., unchanged
+    expect(style.flex as number).toBeCloseTo(600 / 1800, 3);
+  });
+});

--- a/components/session/summary/PacingCard.tsx
+++ b/components/session/summary/PacingCard.tsx
@@ -258,6 +258,85 @@ export function WorkingDashOverlay({ fill, width, height, testID }: WorkingDashO
   );
 }
 
+// ─── Min-segment fraction helper (BLD-2712) ──────────────────────────────────
+//
+// Ensures every non-zero segment is wide enough to be perceptible at mobile
+// viewport widths. The bar inner width is ~330–350px at 390px viewport; 8px
+// corresponds to ~0.023. We use MIN_FRAC = 0.03 (~10px at 340px) to give a
+// comfortable margin.
+//
+// Segments that are exactly 0 stay 0 — a truly-absent segment must NOT appear
+// (e.g. working=0 must render nothing). Only non-zero raw fractions are raised.
+//
+// After flooring, the three fractions are re-normalised so they still sum to
+// 1.0 ± floating tolerance: the surplus (total of raises) is subtracted
+// proportionally from the segments that exceed MIN_FRAC.
+//
+// Edge cases handled:
+//   • Degenerate surplus-donor set empty (all non-zero segments are at or below
+//     MIN_FRAC after flooring) — fall back to returning the raw fractions.
+//   • All three segments zero — returns {0, 0, 0}.
+//   • Floating-point drift — result sums within 1e-6 of 1.0.
+
+/** Minimum display fraction for any non-zero pacing bar segment (~10px at 340px bar). */
+export const MIN_SEGMENT_FRAC = 0.03;
+
+export type SegmentFractions = {
+  working: number;
+  rest: number;
+  other: number;
+};
+
+/**
+ * Apply a minimum visible fraction to non-zero pacing bar segments and
+ * re-normalise so the three fractions still sum to 1.0.
+ *
+ * Pure function — no side effects, fully unit-testable.
+ */
+export function applyMinSegmentFraction(raw: SegmentFractions): SegmentFractions {
+  const keys: (keyof SegmentFractions)[] = ["working", "rest", "other"];
+
+  // Step 1: floor each non-zero segment to MIN_SEGMENT_FRAC and track total surplus raised.
+  const floored: SegmentFractions = { working: raw.working, rest: raw.rest, other: raw.other };
+  let surplus = 0;
+  for (const k of keys) {
+    if (raw[k] > 0 && raw[k] < MIN_SEGMENT_FRAC) {
+      surplus += MIN_SEGMENT_FRAC - raw[k];
+      floored[k] = MIN_SEGMENT_FRAC;
+    }
+  }
+
+  if (surplus === 0) {
+    // Nothing needed flooring — return as-is (no-op for normal data).
+    return floored;
+  }
+
+  // Step 2: find donor segments — those strictly above MIN_SEGMENT_FRAC (they can give).
+  const donors = keys.filter((k) => floored[k] > MIN_SEGMENT_FRAC);
+  if (donors.length === 0) {
+    // Degenerate: no segment has room to donate — fall back to raw fractions unchanged.
+    return raw;
+  }
+
+  // Step 3: subtract surplus proportionally from donors.
+  const donorTotal = donors.reduce((sum, k) => sum + floored[k], 0);
+  let remaining = surplus;
+  for (let i = 0; i < donors.length; i++) {
+    const k = donors[i];
+    if (i === donors.length - 1) {
+      // Last donor absorbs the remainder to prevent floating-point accumulation.
+      floored[k] = Math.max(MIN_SEGMENT_FRAC, floored[k] - remaining);
+    } else {
+      const share = (floored[k] / donorTotal) * surplus;
+      const reduced = Math.max(MIN_SEGMENT_FRAC, floored[k] - share);
+      remaining -= floored[k] - reduced;
+      floored[k] = reduced;
+    }
+  }
+
+  return floored;
+}
+
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 type Props = {
@@ -274,9 +353,18 @@ export default function PacingCard({ pacing, exerciseNames = {} }: Props) {
   const [disclosureOpen, setDisclosureOpen] = useState(false);
 
   const gross = pacing.gross > 0 ? pacing.gross : 1; // avoid division by zero
-  const workingFrac = pacing.working / gross;
-  const restFrac = pacing.rest / gross;
-  const otherFrac = Math.max(0, 1 - workingFrac - restFrac);
+  const rawWorkingFrac = pacing.working / gross;
+  const rawRestFrac = pacing.rest / gross;
+  const rawOtherFrac = Math.max(0, 1 - rawWorkingFrac - rawRestFrac);
+
+  // Apply minimum visible fraction to non-zero segments (BLD-2712).
+  // Gate on raw fraction > 0 so segments with zero working/rest/other stay at 0
+  // (a floored-up segment remains non-zero, which also correctly shows its texture).
+  const { working: workingFrac, rest: restFrac, other: otherFrac } = applyMinSegmentFraction({
+    working: rawWorkingFrac,
+    rest: rawRestFrac,
+    other: rawOtherFrac,
+  });
 
   const workingLabel = formatPacingTime(pacing.working);
   const restLabel = formatPacingTime(pacing.rest);


### PR DESCRIPTION
## Summary

The Working segment in the pacing progress bar rendered ~4px wide on the completed-workout summary when working time was a small fraction of total time (e.g. the seeded 1h session where working ≈ 2% of gross). This made it visually indistinguishable from zero.

## Changes

- **PacingCard.tsx**: Added `applyMinSegmentFraction()` pure helper (exported) that floors any non-zero segment to `MIN_SEGMENT_FRAC = 0.03` (~10px at 340px bar width) then re-normalises so the three fractions still sum to 1.0. Added `SegmentFractions` type. Applied helper before using fractions as flex props — no other structure changed (segment colors, textures, overlay gates, border-radii, overflow:hidden, copy unchanged).

- **PacingCard.min-segment.test.tsx** (new): 8 pure-helper unit tests covering all AC scenarios (tiny-nonzero floored, zero stays zero, balanced no-op, sum==1 invariant, single segment, two tiny) + 4 component regression tests asserting flex values on the Working segment.

## Testing

- 12 new tests in `PacingCard.min-segment.test.tsx` — all pass
- 28 existing CVD tests in `PacingCard.cvd.test.tsx` — all pass (no regressions)
- 11 session-pacing pure logic tests — all pass
- 123 source-contracts-batch tests — all pass
- TypeScript typecheck: zero errors
- npm install: clean

## Issue

Resolves BLD-2712 (parent: audit 2026-07-03)
Fix scoped to BLD-2766