### PR TITLE
fix(audit): eager-load MaterialCommunityIcons font so vector-icon glyphs paint in fontless container (BLD-2744)

### DIFF
--- a/scripts/__tests__/inject-audit-fonts.test.ts
+++ b/scripts/__tests__/inject-audit-fonts.test.ts
@@ -40,6 +40,25 @@
  *         readyState="loading", the emitted loader does NOT un-park until
  *         DOMContentLoaded fires, then un-parks exactly the entry bundle.
  *
+ * BLD-2744 — the same fontless container also blanks every
+ * @expo/vector-icons MaterialCommunityIcons glyph (icon renders <Text/> until
+ * fontfaceobserver resolves, and on Chromium that observer polls
+ * document.fonts.load('… "material-community"') which only matches a loaded
+ * FontFace). So the injector also eager-loads the bundled icon font:
+ *   AC-L. The injected loader registers a FontFace under the CSS family
+ *         `material-community` (the createIconSet name — NOT the ttf filename
+ *         `MaterialCommunityIcons`) with the ttf inlined as a data-URI, and
+ *         adds it to document.fonts inside the same document.fonts.ready gate.
+ *   AC-M. The icon ttf is resolved by GLOB (content-hashed basename), never a
+ *         hardcoded hash — a fixture ttf named `MaterialCommunityIcons.<hash>`
+ *         is still found and inlined.
+ *   AC-N. A dist missing the bundled icon ttf hard-errors (non-zero exit,
+ *         actionable message) and leaves dist/index.html untouched (no marker)
+ *         — mirroring the no-entry-bundle policy.
+ *   AC-O. Behavioral proof: the emitted loader adds the `material-community`
+ *         icon face to document.fonts (alongside the text families) before it
+ *         un-parks the entry bundle.
+ *
  * Strategy mirrors daily-audit-set-e-ordering.test.ts: drive the REAL script
  * via spawnSync against temp fixtures, assert on exit code + emitted HTML.
  */
@@ -50,7 +69,38 @@ import * as path from "node:path";
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..");
 const INJECTOR = path.join(REPO_ROOT, "scripts", "inject-audit-fonts.mjs");
+// The injector's own source — asserted against in AC-M to prove the icon ttf
+// hash is resolved by glob at runtime, never hardcoded in the script.
+const INJECTOR_SOURCE = fs.readFileSync(INJECTOR, "utf8");
 const FONT_ASSET = path.join(REPO_ROOT, "e2e", "assets", "fonts", "audit-latin.woff2");
+// The app's OWN bundled MaterialCommunityIcons ttf. `expo export` emits a
+// content-hashed copy under dist/assets/**; the injector must resolve it by
+// GLOB (never a hardcoded hash) and eager-load it under the CSS family
+// `material-community` so @expo/vector-icons glyphs paint (BLD-2744).
+const MCI_TTF_SRC = path.join(
+  REPO_ROOT,
+  "node_modules",
+  "@expo",
+  "vector-icons",
+  "build",
+  "vendor",
+  "react-native-vector-icons",
+  "Fonts",
+  "MaterialCommunityIcons.ttf",
+);
+// Where the injector globs for it inside a dist. A content hash is baked into
+// the basename to prove the resolver does not depend on a fixed name.
+const MCI_TTF_DIST_REL = path.join(
+  "assets",
+  "node_modules",
+  "@expo",
+  "vector-icons",
+  "build",
+  "vendor",
+  "react-native-vector-icons",
+  "Fonts",
+  "MaterialCommunityIcons.deadbeefdeadbeefdeadbeefdeadbeef.ttf",
+);
 
 // A minimal dist/index.html shaped like expo's output: entry bundle sits in
 // <body> after </head>, so any <head> injection precedes it.
@@ -75,9 +125,21 @@ interface RunResult {
   combined: string;
 }
 
-function makeDist(): string {
+// Write the bundled MCI ttf into a dist under a content-hashed name so the
+// injector's glob resolver is exercised realistically. Skips silently only if
+// the source ttf is somehow absent (it ships with @expo/vector-icons).
+function writeIconTtf(distDir: string): void {
+  const dest = path.join(distDir, MCI_TTF_DIST_REL);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(MCI_TTF_SRC, dest);
+}
+
+function makeDist(opts: { withIconTtf?: boolean } = {}): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bld-2586-inject-"));
   fs.writeFileSync(path.join(dir, "index.html"), FIXTURE_HTML, "utf8");
+  // By default include the icon ttf so injection succeeds (the injector
+  // hard-errors when it is missing — asserted separately in AC-N).
+  if (opts.withIconTtf !== false) writeIconTtf(dir);
   return dir;
 }
 
@@ -414,16 +476,167 @@ describe("inject-audit-fonts.mjs — BLD-2586 fontless-container text fix", () =
     }
   });
 
+  // BLD-2744 — icon-font eager-load. @expo/vector-icons renders a blank <Text/>
+  // until fontfaceobserver resolves; on Chromium that observer polls
+  // document.fonts.load('… "material-community"'), which only matches once a
+  // loaded FontFace under that family exists. So the injector must register the
+  // icon FontFace under the createIconSet family name `material-community`
+  // (NOT the ttf filename) and gate the entry bundle on it.
+  it("AC-L: registers a FontFace under the CSS family 'material-community' (not the ttf filename) inside the fonts.ready gate", () => {
+    const dist = makeDist();
+    try {
+      const r = runInjector(dist);
+      expect(r.status).toBe(0);
+      const html = readIndex(dist);
+      const loader = html.match(
+        /<script id="audit-font-loader">([\s\S]*?)<\/script>/,
+      )![1];
+
+      // The icon family must be the createIconSet NAME, which is what RNW sets
+      // as `font-family`. Registering under the ttf FILENAME would never match.
+      expect(loader).toContain('"material-community"');
+      expect(loader).not.toContain('"MaterialCommunityIcons"');
+
+      // The icon ttf is inlined as a data-URI and registered via the FontFace
+      // constructor (a CSS @font-face throws NetworkError on document.fonts.load
+      // in the fontless headless config — the whole reason for the ctor path).
+      expect(loader).toContain("data:font/ttf;base64,");
+      expect(loader).toContain('format("truetype")');
+      expect(loader).toContain("new FontFace(pair[0]");
+      // …and it is added to document.fonts (so the observer's load() matches).
+      expect(loader).toContain("document.fonts.add");
+
+      // Crucially the icon loads are part of the SAME promise set that gates the
+      // entry bundle on document.fonts.ready (they are pushed onto `loads`).
+      expect(loader).toContain("loads.push");
+      expect(loader).toContain("Promise.all(loads)");
+      expect(loader).toContain("document.fonts.ready");
+    } finally {
+      cleanup(dist);
+    }
+  });
+
+  it("AC-M: resolves the icon ttf by GLOB (content-hashed basename), never a hardcoded hash", () => {
+    // The fixture writes MaterialCommunityIcons.<hash>.ttf; the injector must
+    // find it by pattern, inline its bytes, and NOT depend on any fixed hash.
+    const dist = makeDist();
+    try {
+      const r = runInjector(dist);
+      expect(r.status).toBe(0);
+      const html = readIndex(dist);
+
+      // The exact bytes of the bundled ttf must be inlined (base64), proving the
+      // glob resolved the real hashed file rather than emitting an empty/dummy.
+      const expectedB64 = fs.readFileSync(MCI_TTF_SRC).toString("base64");
+      expect(html).toContain(expectedB64);
+
+      // The hashed basename must NOT appear literally in the SCRIPT source — the
+      // resolver globs, it does not hardcode the hash.
+      expect(INJECTOR_SOURCE).not.toContain("deadbeefdeadbeefdeadbeefdeadbeef");
+      // Only the un-hashed logical name may appear (as the glob target).
+      expect(INJECTOR_SOURCE).toContain("MaterialCommunityIcons");
+    } finally {
+      cleanup(dist);
+    }
+  });
+
+  it("AC-N: hard-errors when the bundled icon ttf is missing (no silent icon-blank build)", () => {
+    // A dist with an entry bundle but NO MaterialCommunityIcons ttf under
+    // assets/** must fail loudly — otherwise we'd emit an audit build that
+    // re-blanks every icon (the exact bug this fixes).
+    const dist = makeDist({ withIconTtf: false });
+    try {
+      const r = runInjector(dist);
+      expect(r.status).not.toBe(0);
+      expect(r.combined).toMatch(/icon font MaterialCommunityIcons.*not found/i);
+      // dist/index.html left untouched (no marker) on this failure.
+      expect(readIndex(dist)).not.toContain("audit-font-inject:BLD-2586");
+    } finally {
+      cleanup(dist);
+    }
+  });
+
+  it("AC-O: emitted loader adds the 'material-community' icon face (with the text families) before un-parking", () => {
+    // Behavioral proof (not just source-shape): run the real emitted loader in a
+    // DOM shim with synchronous-resolving FontFaces. Assert the icon family is
+    // among the faces added to document.fonts, and that un-parking still waits
+    // for DOMContentLoaded (the DOM gate must not regress).
+    const dist = makeDist();
+    try {
+      runInjector(dist);
+      const html = readIndex(dist);
+      const loaderSrc = html.match(
+        /<script id="audit-font-loader">([\s\S]*?)<\/script>/,
+      )![1];
+
+      const harness = `
+        const added = [];
+        const appended = [];
+        let readyState = "loading";
+        const dcl = [];
+        let parkedTag = null;
+        global.document = {
+          get readyState() { return readyState; },
+          fonts: {
+            _ready: Promise.resolve(),
+            get ready() { return this._ready; },
+            add(f) { added.push(f && f.__fam); },
+          },
+          addEventListener(type, cb) { if (type === "DOMContentLoaded") dcl.push(cb); },
+          querySelectorAll(sel) {
+            return (sel.includes("x-audit-parked-entry") && parkedTag) ? [parkedTag] : [];
+          },
+          createElement() { return { src: "", async: true, crossOrigin: "" }; },
+          head: { appendChild(el) { appended.push(el.src); } },
+        };
+        global.FontFace = function (fam) {
+          return { __fam: fam, load() { return Promise.resolve({ __fam: fam }); } };
+        };
+        ${loaderSrc}
+        setTimeout(() => {
+          const early = appended.length;
+          parkedTag = {
+            getAttribute: (k) => (k === "data-audit-entry-src" ? "/_expo/static/js/web/entry-abc.js" : null),
+            crossOrigin: "",
+          };
+          readyState = "interactive";
+          dcl.forEach((cb) => cb());
+          setTimeout(() => {
+            const hasIcon = added.includes("material-community");
+            const hasText = added.includes("Roboto");
+            if (early !== 0) { console.error("FAIL: un-parked before DCL"); process.exit(3); }
+            if (!hasIcon) { console.error("FAIL: icon face not added:", JSON.stringify(added)); process.exit(4); }
+            if (!hasText) { console.error("FAIL: text face not added:", JSON.stringify(added)); process.exit(5); }
+            if (appended.length !== 1 || appended[0] !== "/_expo/static/js/web/entry-abc.js") {
+              console.error("FAIL: entry not un-parked after DCL:", JSON.stringify(appended)); process.exit(6);
+            }
+            console.log("OK");
+          }, 0);
+        }, 0);
+      `;
+      const tmp = path.join(dist, "icon-loader-harness.mjs");
+      fs.writeFileSync(tmp, harness, "utf8");
+      const r = spawnSync("node", [tmp], { encoding: "utf8", timeout: 30_000 });
+      expect(r.stderr + r.stdout).toContain("OK");
+      expect(r.status).toBe(0);
+    } finally {
+      cleanup(dist);
+    }
+  });
+
   it("AC-i: hard-errors when no expo entry bundle is present (no silent no-fix)", () => {
     // A dist/index.html with fonts injected but NO entry bundle to gate would
     // mean the fonts race nothing / RNW is never gated — that must fail loudly
-    // rather than emit a build that silently reproduces the 0x0 bug.
+    // rather than emit a build that silently reproduces the 0x0 bug. The icon
+    // ttf IS present so we reach the entry-bundle check (the missing-icon-ttf
+    // hard error is asserted separately in AC-N).
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bld-2586-noentry-"));
     fs.writeFileSync(
       path.join(dir, "index.html"),
       `<!DOCTYPE html><html><head><title>x</title></head><body><div id="root"></div></body></html>`,
       "utf8",
     );
+    writeIconTtf(dir);
     try {
       const r = runInjector(dir);
       expect(r.status).not.toBe(0);

--- a/scripts/inject-audit-fonts.mjs
+++ b/scripts/inject-audit-fonts.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-env node */
 // inject-audit-fonts.mjs — make the visual-audit harness render text in the
 // fontless agent-runtime container (BLD-2586).
 //
@@ -10,8 +11,22 @@
 // (`fc-list`/`fc-match`) is absent. With no font to fall back to, Chromium
 // measures every sans/serif text run as **0x0** — so ALL app text vanishes
 // from audit screenshots and the audit emits a whole CLASS of false
-// "missing text/label" findings (BLD-2581 / BLD-2582 / BLD-2585). Only the
-// bundled `material-community` icon font renders.
+// "missing text/label" findings (BLD-2581 / BLD-2582 / BLD-2585).
+//
+// The SAME fontless container also blanks every `@expo/vector-icons`
+// `MaterialCommunityIcons` glyph (BLD-2744). Each vector icon renders an empty
+// `<Text/>` until `state.fontIsLoaded` flips, which only happens once
+// `Font.loadAsync('material-community', …)` → `fontfaceobserver` resolves. On
+// Chromium, fontfaceobserver takes its NATIVE branch —
+// `document.fonts.load('100px "material-community"', 'BESbswy')` — and in this
+// fontless config a CSS `@font-face` with a data/URL src makes that call throw
+// `NetworkError`, so the observer rejects and the glyph stays blank forever.
+// (The CSS family the app actually renders icons with is `material-community`,
+// from `createIconSet(glyphMap,'material-community',font)` — NOT the ttf
+// filename `MaterialCommunityIcons`.) Constructing the `FontFace` explicitly
+// and `document.fonts.add()`-ing it — exactly how we handle the text stack
+// below — makes `document.fonts.load(...)` match, so the observer resolves and
+// glyphs paint. So this script eager-loads the bundled icon font too.
 //
 // # What this does
 //
@@ -22,9 +37,15 @@
 //      pointing at a base64 data-URI of `e2e/assets/fonts/audit-latin.woff2`.
 //      (You CANNOT alias the reserved keywords `sans-serif`/`serif`/
 //      `monospace`/`system-ui`, but aliasing the concrete members makes the
-//      browser resolve the stack left-to-right to a real font.)
+//      browser resolve the stack left-to-right to a real font.) It also loads
+//      the bundled **icon** font family `material-community` from the ttf that
+//      `expo export` already emitted into `dist/assets/**` (resolved by glob so
+//      the content-hash is never hardcoded) — see the loader (step 2) which
+//      registers it via the `FontFace` constructor so `document.fonts.load()`
+//      matches and `@expo/vector-icons` glyphs paint (BLD-2744).
 //   2. Emit a blocking inline `<script>` (in `<head>`, BEFORE the expo entry
-//      bundle) that constructs a `FontFace` per family, `await ff.load()`,
+//      bundle) that constructs a `FontFace` per family (text families AND the
+//      `material-community` icon family), `await ff.load()`,
 //      `document.fonts.add(ff)`, then `await document.fonts.ready`.
 //   3. **Park the expo entry bundle so it cannot execute until step 2 finishes.**
 //      A CSS-only `@font-face` does NOT force-load in time, and — crucially —
@@ -58,21 +79,30 @@
 //
 // # Production safety
 //
-// The font asset lives under `e2e/` (never `public/` or `assets/`) and is
+// The text font asset lives under `e2e/` (never `public/` or `assets/`) and is
 // never imported by app code, so `expo export` of a normal build does not
-// bundle it and `public/index.html` is untouched. This script only ever edits
-// the transient `dist/index.html` produced for an audit run. The shipped app
-// bundle carries no new font and no visual-identity change (BLD-2586 AC3).
+// bundle it and `public/index.html` is untouched. The icon ttf is the app's
+// OWN already-bundled `MaterialCommunityIcons` font — we only re-reference it
+// (base64-inlined into the transient audit HTML), we never add a new asset to
+// the shipped bundle. This script only ever edits the transient
+// `dist/index.html` produced for an audit run. The shipped app bundle carries
+// no new font and no visual-identity change (BLD-2586 AC3 / BLD-2744).
 //
 // # Usage
 //   node scripts/inject-audit-fonts.mjs [--dist <dir>] [--force] [--quiet]
 //
-// Refs: BLD-2586 (this fix), BLD-2585 / BLD-2581 / BLD-2582 (false positives),
-//       BLD-645 (audit workflow), BLD-481 (audit loop).
+// Refs: BLD-2586 (text half), BLD-2744 (icon half), BLD-2585 / BLD-2581 /
+//       BLD-2582 (false positives), BLD-645 (audit workflow), BLD-481 (loop).
 
-import { readFileSync, writeFileSync, existsSync, statSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  statSync,
+  readdirSync,
+} from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, join } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -97,6 +127,76 @@ const FAMILIES = [
   "Arial",
   "Noto Sans",
 ];
+
+// Bundled `@expo/vector-icons` icon fonts to eager-load so their glyphs paint
+// in the fontless audit (BLD-2744). Each entry maps the CSS `font-family` the
+// app actually renders with (react-native-web sets `fontFamily` to the name
+// passed to `createIconSet`) to the ttf basename `expo export` emits under
+// `dist/assets/**`. NOTE the family is the createIconSet NAME
+// (`material-community`), NOT the ttf filename (`MaterialCommunityIcons`) — a
+// FontFace registered under the filename would never match the rendered
+// `font-family: material-community` and glyphs would stay blank.
+//
+// The daily audit's blank-glyph findings are all MaterialCommunityIcons (the
+// only vector family the app uses in the audited screens), so we register just
+// that one. Adding more families later is a one-line append here — the loader
+// treats icon families generically.
+const ICON_FONTS = [
+  { family: "material-community", ttfBasename: "MaterialCommunityIcons" },
+];
+
+// Resolve each ICON_FONTS entry to its built ttf under `<dist>/assets/**` by
+// GLOB (the content-hash in `MaterialCommunityIcons.<hash>.ttf` is
+// build-generated and MUST NOT be hardcoded). Returns
+// [{ family, dataUri }, …]. Missing a ttf is a hard error (mirrors the
+// `parkedCount===0` policy) so we never emit an audit build that silently
+// re-blanks the icons this script exists to fix.
+function resolveIconFonts(distDir) {
+  const assetsRoot = resolve(distDir, "assets");
+  return ICON_FONTS.map(({ family, ttfBasename }) => {
+    const ttf = findTtf(assetsRoot, ttfBasename);
+    if (!ttf) {
+      process.stderr.write(
+        `[inject-audit-fonts] ERROR: bundled icon font ${ttfBasename}.<hash>.ttf ` +
+          `not found under ${assetsRoot} — cannot eager-load the '${family}' ` +
+          `family, so @expo/vector-icons glyphs would render blank in the audit ` +
+          `(the exact bug this fixes). Did \`expo export -p web\` change its ` +
+          `asset layout?\n`,
+      );
+      process.exit(1);
+    }
+    const dataUri =
+      "data:font/ttf;base64," + readFileSync(ttf).toString("base64");
+    return { family, dataUri };
+  });
+}
+
+// Recursively find `<basename>.<hash>.ttf` (or bare `<basename>.ttf`) under
+// `dir`. Returns the absolute path of the first match, or null. Kept dependency
+// free (no glob package): a small readdir walk over the dist assets tree.
+function findTtf(dir, basename) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  // Match `<basename>.<anything>.ttf` and the un-hashed `<basename>.ttf`.
+  const re = new RegExp(
+    `^${basename.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(\\.[^/]+)?\\.ttf$`,
+    "i",
+  );
+  for (const ent of entries) {
+    const full = join(dir, ent.name);
+    if (ent.isDirectory()) {
+      const hit = findTtf(full, basename);
+      if (hit) return hit;
+    } else if (re.test(ent.name)) {
+      return full;
+    }
+  }
+  return null;
+}
 
 function parseArgs(argv) {
   const args = { dist: resolve(ROOT, "dist"), force: false, quiet: false };
@@ -174,6 +274,17 @@ function buildFontFaceStyle(dataUri) {
 // the audit font is loaded. If FontFace is unsupported we still un-park the
 // entry so the page is never permanently blank (graceful degradation).
 //
+// ICON FONTS (BLD-2744): the same Promise.all also constructs a FontFace for
+// each bundled `@expo/vector-icons` family (e.g. `material-community`) from its
+// own ttf data-URI and `document.fonts.add()`s it. This is what makes the icon
+// glyphs paint: `@expo/vector-icons` renders a blank `<Text/>` until its
+// `fontfaceobserver` resolves, and on Chromium that observer polls
+// `document.fonts.load('… "material-community"')` — which only matches once a
+// loaded FontFace under that family exists. Registering via the FontFace
+// constructor (not a CSS `@font-face`, which throws `NetworkError` on
+// `document.fonts.load` in the fontless headless config) is the empirically
+// verified working path.
+//
 // CRITICAL (BLD-2586 second review): boot() MUST also wait for the DOM.
 // This loader is injected in <head>, so it runs while
 // `document.readyState === "loading"` and BEFORE the parser has reached the
@@ -184,12 +295,18 @@ function buildFontFaceStyle(dataUri) {
 // is un-parked, and the app is permanently blank. So every boot path funnels
 // through bootWhenDomReady(), which defers boot() to `DOMContentLoaded` while
 // the document is still loading and runs it immediately once parsing is done.
-function buildLoader(dataUri) {
+function buildLoader(dataUri, iconFonts) {
   const families = JSON.stringify(FAMILIES);
+  // [ [family, dataUri], … ] — kept as a plain array literal so the emitted
+  // IIFE has no dependency on how the build resolved the ttf paths.
+  const icons = JSON.stringify(
+    (iconFonts || []).map(({ family, dataUri: uri }) => [family, uri]),
+  );
   const loader =
     `(function(){` +
     `var URI=${JSON.stringify(dataUri)};` +
     `var FAMS=${families};` +
+    `var ICONS=${icons};` +
     `var PARK=${JSON.stringify(PARKED_TYPE)};` +
     `var SRCATTR=${JSON.stringify(PARKED_SRC_ATTR)};` +
     // Re-inject every parked entry bundle as an executable <script src>, in
@@ -217,11 +334,21 @@ function buildLoader(dataUri) {
     // No FontFace API (or already-font-equipped host that we force-patched):
     // don't hang the page — un-park as soon as the DOM is ready.
     `if(typeof FontFace==="undefined"||!document.fonts){bootWhenDomReady();return;}` +
-    `Promise.all(FAMS.map(function(f){` +
+    // Text families: one shared woff2 data-URI aliased to every concrete name.
+    `var loads=FAMS.map(function(f){` +
     `try{var ff=new FontFace(f,'url("'+URI+'") format("woff2")',{weight:"100 900"});` +
     `return ff.load().then(function(l){document.fonts.add(l);}).catch(function(){});` +
     `}catch(e){return Promise.resolve();}` +
-    `})).then(function(){return document.fonts.ready;})` +
+    `});` +
+    // Icon families (BLD-2744): each has its OWN ttf data-URI. Registering a
+    // loaded FontFace under the createIconSet family name is what lets
+    // @expo/vector-icons' fontfaceobserver resolve so glyphs paint.
+    `ICONS.forEach(function(pair){` +
+    `try{var iff=new FontFace(pair[0],'url("'+pair[1]+'") format("truetype")');` +
+    `loads.push(iff.load().then(function(l){document.fonts.add(l);}).catch(function(){}));` +
+    `}catch(e){}` +
+    `});` +
+    `Promise.all(loads).then(function(){return document.fonts.ready;})` +
     // Boot after fonts settle whether the load resolved or rejected — a failed
     // font must not permanently block the app from mounting. bootWhenDomReady
     // additionally ensures the parked body tags exist before we query them.
@@ -232,11 +359,11 @@ function buildLoader(dataUri) {
 }
 
 // Build the <head> block: marker comment + @font-face rules + blocking loader.
-function buildInjection(dataUri) {
+function buildInjection(dataUri, iconFonts) {
   return (
-    `\n    <!-- ${MARKER} — E2E-only audit text font; no-op on font-equipped hosts. -->\n` +
+    `\n    <!-- ${MARKER} — E2E-only audit text+icon fonts; no-op on font-equipped hosts. -->\n` +
     `    ${buildFontFaceStyle(dataUri)}\n` +
-    `    ${buildLoader(dataUri)}\n`
+    `    ${buildLoader(dataUri, iconFonts)}\n`
   );
 }
 
@@ -301,6 +428,12 @@ function main() {
   const dataUri =
     "data:font/woff2;base64," + readFileSync(fontPath).toString("base64");
 
+  // Resolve the bundled icon fonts (glob, no hardcoded hash). Hard-errors if a
+  // ttf is missing so we never emit an audit build that re-blanks icons
+  // (BLD-2744). Done BEFORE we mutate `dist/index.html` so a missing ttf leaves
+  // the file untouched (no marker), consistent with the parkedCount===0 policy.
+  const iconFonts = resolveIconFonts(args.dist);
+
   // Park the expo entry bundle FIRST so the loader can gate its execution on
   // font readiness. If nothing parks, the fonts would race the bundle and RNW
   // would measure text 0x0 again (the exact bug this script fixes), so a
@@ -318,7 +451,7 @@ function main() {
   }
   html = parked.html;
 
-  const injection = buildInjection(dataUri);
+  const injection = buildInjection(dataUri, iconFonts);
   const idx = html.lastIndexOf("</head>");
   if (idx === -1) {
     process.stderr.write(
@@ -330,8 +463,14 @@ function main() {
   writeFileSync(indexPath, html, "utf8");
 
   const kb = (Buffer.byteLength(dataUri) / 1024).toFixed(1);
+  const iconKb = (
+    iconFonts.reduce((n, f) => n + Buffer.byteLength(f.dataUri), 0) / 1024
+  ).toFixed(1);
   log(
-    `injected font-gated loader (${FAMILIES.length} families, ${kb} KB data-URI); ` +
+    `injected font-gated loader (${FAMILIES.length} text families, ${kb} KB; ` +
+      `${iconFonts.length} icon font(s) [${iconFonts
+        .map((f) => f.family)
+        .join(", ")}], ${iconKb} KB); ` +
       `parked ${parked.parkedCount} entry bundle(s) until document.fonts.ready → ${indexPath}`,
   );
 }


### PR DESCRIPTION
## Summary
Fixes **BLD-2744**. The daily UX-audit runs Chromium in the fontless agent-runtime container, where **every `@expo/vector-icons` MaterialCommunityIcons glyph renders as a blank box**. This extends `scripts/inject-audit-fonts.mjs` (the harness-only injector that already fixes *text* rendering, BLD-2586) to also eager-load the **icon** font so glyphs paint — using the identical `FontFace`-constructor mechanism already proven for the text stack.

## Root cause (empirically verified, not just traced)
`@expo/vector-icons` renders a blank `<Text/>` until `state.fontIsLoaded` flips, which only happens once `Font.loadAsync('material-community') → fontfaceobserver` resolves. On Chromium, fontfaceobserver polls `document.fonts.load('… "material-community"')`. A headless-shell probe against the real bundled ttf (this fontless container):

| Scenario | `document.fonts.load('…material-community…')` | glyph width |
|---|---|---|
| CSS `@font-face` (today) | **throws `NetworkError`** → observer rejects | **0px (blank)** ← the bug |
| `new FontFace('material-community', url(ttf)).load()` + `document.fonts.add()` | matched=1 (resolves) | **16px (renders)** ← the fix |

**Two corrections to the ticket's writeup:**
1. The CSS family the app renders icons with is **`material-community`** (from `createIconSet(glyphMap, 'material-community', font)`), **not** `MaterialCommunityIcons` (that's only the ttf *filename*). A FontFace under the filename would never match `font-family: material-community` and icons would stay blank.
2. On Chromium the failing path is fontfaceobserver's **native** branch (`document.fonts.load`), which throws `NetworkError` for a data-URI CSS `@font-face` in this headless config — not the width-ruler-vs-generics path. Cure is identical: real `FontFace` + `.load()` + `document.fonts.add()`.

## What this fixes downstream
- **False-positive audit findings** — BLD-2710 ('rating control missing') is a proven false positive: `RatingWidget` uses the same MCI render path.
- **The audit can now verify its own icon fixes** — BLD-2708/2709 convert Unicode tofu → MCI; without this the audit would render the *fixed* icons blank and re-flag them forever.

## Changes
- `scripts/inject-audit-fonts.mjs`
  - Resolve the bundled MCI ttf under `dist/assets/**` by **glob** (content-hash **never** hardcoded); hard-error (non-zero exit, file untouched) if absent — mirrors the existing `parkedCount===0` policy.
  - Inline it as a data-URI and register a `FontFace('material-community', …)` inside the **existing** blocking loader's `Promise.all`, so it's awaited in the same `document.fonts.ready` gate that parks the entry bundle.
  - Correct the misleading header comment that claimed icons render unaided in the fontless container.
- `scripts/__tests__/inject-audit-fonts.test.ts` — new **AC-L…AC-O**: family-name (`material-community`, not the filename), glob resolution of a hashed ttf, missing-ttf hard error, and a behavioral proof the icon face is added to `document.fonts` **before** un-parking (DOM gate not regressed).

## Guarantees preserved
- ✅ Byte-for-byte **no-op** when `/usr/share/fonts` present (CI/desktop) — existing AC-c still green.
- ✅ Idempotent single `MARKER` guard (AC-b).
- ✅ `--force` still works; never touches `public/index.html` or the shipped app bundle (the icon ttf is the app's **own** already-bundled font, only re-referenced into the transient audit HTML).

## Verification
- `scripts/__tests__/inject-audit-fonts.test.ts`: **18/18 pass** (14 existing + 4 new).
- `eslint` clean on both files; `tsc --noEmit` clean.
- **Full headless-browser E2E** against the real built `dist/` served with COOP/COEP: `iconFaceLoaded=true`, `observerMatched=1`, MCI glyph width **100** vs **0** for a bogus family, zero console errors.

## Out of scope
No changes to `RatingWidget.tsx`, `PacingCard.tsx`, `AchievementsCard`, or any app component (those are BLD-2708/2709 or already correct). No production bundle change.

🤖 Authored by techlead.