### PR TITLE
feat(infra): add tsc --noEmit typecheck gate to pre-push hook (BLD-2853)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,6 +15,20 @@ if $all_deletes; then
   exit 0
 fi
 
+# ─── TypeScript Type-Check Gate (BLD-2853) ──────────────────────
+# Runs tsc --noEmit (via npm run typecheck) to catch orphaned imports and
+# type errors that ESLint misses. Fast structural failures surface early,
+# before the slower gates run.
+# Mirrors the CI typecheck step locally — no round-trip needed.
+echo "🔎 Type-checking (tsc --noEmit)..."
+if ! npm run typecheck --silent; then
+  echo ""
+  echo "TypeScript type errors detected. Fix the type errors above before pushing."
+  echo "Run 'npm run typecheck' locally to see the full error list."
+  echo "To skip this check (governance escape hatch only): git push --no-verify"
+  exit 1
+fi
+
 # ─── License Integrity Gate ──────────────────────────────────────
 # Blocks push if LICENSE file has been tampered with
 if [ -f "scripts/check-license.sh" ]; then


### PR DESCRIPTION
## Summary

Adds a TypeScript type-check gate as the first substantive gate in `.husky/pre-push`, immediately after the branch-delete skip block.

The gate runs `npm run typecheck` (`tsc --noEmit`) to catch orphaned imports and type errors that ESLint misses. BLD-326 documented this exact blind spot: file deletions/renames leave dangling imports that only `tsc` catches, resulting in CI failures and a full round-trip fix cycle.

## Changes

- `.husky/pre-push`: insert TypeScript type-check gate after the branch-delete skip block, before the License Integrity Gate

## Gate Behaviour

- Runs **after** the all-deletes skip (branch deletes still bypass cleanly)
- Blocks push with `exit 1` + clear remediation message when tsc fails
- Documents the `git push --no-verify` escape hatch in the failure output
- Emits a status line (`🔎 Type-checking (tsc --noEmit)...`) matching existing gate style
- Placed early so fast structural failures surface before the slower license/changelog/curation/FTA gates run

## Testing

- `npm run typecheck` runs clean on `origin/main` with this gate in place (verified locally)
- Manual verification: introduce a temporary type error (e.g. add `const x: string = 123` to any .ts file), run `git push` — the gate blocks with the expected error message. Remove the error, push proceeds normally.

## Edge Cases Verified

| Scenario | Behaviour |
|---|---|
| Branch-delete push | Gate skipped (branch-delete block exits 0 before this gate) |
| Clean tree, no type errors | Gate passes after printing status line |
| Orphaned import after file delete | `tsc --noEmit` fails → push blocked with remediation message |
| Emergency escape needed | `git push --no-verify` bypasses (documented in failure message) |

## Out of Scope

- No CI workflow changes (CI already typechecks)
- No tsconfig changes
- No pre-commit (lint-staged) changes

## Issue

Resolves BLD-2853