### PR TITLE
feat(infra): add Jest coverageThreshold ratchet + CI coverage step (BLD-2854)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,39 @@ jobs:
         # usage predictable on the GitHub-hosted runner.
         run: npm test -- --ci --runInBand
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    # BLD-2854: Coverage ratchet — enforce the coverageThreshold.global floor
+    # defined in jest.config.js. Scoped to the same collectCoverageFrom set
+    # (app/, lib/, components/) but run --runInBand (same as the jest job above)
+    # and with NODE_OPTIONS to avoid OOM (per BLD-2482 memory-aware fix).
+    # If this job OOMs or times out, narrow collectCoverageFrom in jest.config.js
+    # to lib/+hooks/ (pure-logic dirs) and document the scope change here.
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Coverage
+        # --ci disables watch/snapshot-write; --runInBand keeps memory usage
+        # predictable (mirrors jest job). --coverageReporters=text-summary
+        # avoids writing html/lcov artifacts to disk (saves ~50 MB, speeds
+        # up job). coverageThreshold enforcement is in jest.config.js — Jest
+        # exits non-zero if any metric drops below its floor.
+        run: npm run test:coverage -- --ci --runInBand --coverageReporters=text-summary
+        env:
+          NODE_OPTIONS: --experimental-sqlite
+
   android-lint:
     name: Backup XML validation
     runs-on: ubuntu-latest

--- a/jest.config.js
+++ b/jest.config.js
@@ -136,4 +136,25 @@ module.exports = {
     '!**/*.d.ts',
     '!**/node_modules/**'
   ],
+  // BLD-2854: Coverage ratchet — floor at 1-2 pts below the measured baseline
+  // so the build is green immediately while preventing silent coverage erosion.
+  //
+  // Measured baseline on 2026-07-03 (432 suites, 5306 tests, all pass):
+  //   Statements : 61.68%  (10666 / 17290)
+  //   Branches   : 57.20%  ( 7078 / 12373)
+  //   Functions  : 54.93%  ( 2316 /  4216)
+  //   Lines      : 62.80%  ( 9711 / 15462)
+  //
+  // Floor = baseline − 2 pts (rounds down to nearest integer for stability).
+  // To raise the floor: run `npm run test:coverage`, check the new summary
+  // numbers, bump each value here 1 pt below the new measurement, commit.
+  // Never lower these values — that defeats the ratchet.
+  coverageThreshold: {
+    global: {
+      statements: 59,
+      branches: 55,
+      functions: 52,
+      lines: 60,
+    },
+  },
 };


### PR DESCRIPTION
## Summary

Add a Jest `coverageThreshold.global` block to prevent silent coverage erosion, plus a new `coverage` CI job that enforces the threshold on every PR. The ratchet is set at current-baseline − 2 pts so the build is green immediately.

## Coverage Baseline (measured 2026-07-03)

| Metric | Measured | Floor (threshold) |
|--------|----------|-------------------|
| Statements | 61.68% (10666/17290) | 59% |
| Branches | 57.20% (7078/12373) | 55% |
| Functions | 54.93% (2316/4216) | 52% |
| Lines | 62.80% (9711/15462) | 60% |

Measurement run: 432 suites, 5306 tests, 0 failures — `npm run test:coverage -- --ci --runInBand`.

## Changes

- `jest.config.js`: adds `coverageThreshold.global` block with the four floor values; inline comment documents the measured baseline, the floor formula (baseline − 2 pts), and the ratchet contract (raise, never lower).
- `.github/workflows/ci.yml`: adds `coverage` job after `jest` job — runs `npm run test:coverage -- --ci --runInBand --coverageReporters=text-summary`, NODE_OPTIONS via env, 25 min timeout (jest job is 15 min; coverage adds ~30% overhead under `--runInBand`).

## CI wall-time / memory impact

- Coverage runs in serial (`--runInBand`) exactly as the existing `jest` job — same memory-safe pattern from BLD-2482.
- `--coverageReporters=text-summary` skips writing html/lcov artifacts (~50 MB on disk, material time saving).
- Full-app scope (`app/ lib/ components/`) was verified locally — 0 OOM, 0 failures. If CI runner has less headroom than the local container, scope can be narrowed to `lib/+hooks/` by updating `collectCoverageFrom` in `jest.config.js` (documented in the CI job comment).
- Separate job keeps the PR status UI granular (jest failures are distinct from coverage failures).

## Testing

- `node -e "require('./jest.config.js')"` — parses without error.
- Local coverage run with `--ci --runInBand --coverageReporters=text-summary`: 432 suites, 5306 tests, 0 failures, all four metrics above floor, Jest exits 0.
- `npm run test:coverage -- --ci --runInBand` completes successfully with thresholds satisfied.

## Issue

Closes BLD-2854