### PR TITLE
feat(ci): add scenario-gate-pr advisory job — Playwright crash/DOM gate on PRs (BLD-2861)

### DIFF
--- a/.github/workflows/ux-audit.yml
+++ b/.github/workflows/ux-audit.yml
@@ -54,6 +54,60 @@ jobs:
       - name: Run vocab consistency audit
         run: bash scripts/audit-vocab.sh
 
+  scenario-gate-pr:
+    name: Playwright scenario gate (mobile, assert-only)
+    # Run on every PR and push-to-main as a fast advisory gate.
+    # The heavy `capture` job stays cron-only (visual capture + CVD).
+    # AC6: advisory only — do NOT add to branch protection required checks until
+    # Phase 2 (≥50 PR runs + ≥98% pass rate observed). BLD-2861.
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    concurrency:
+      group: scenario-gate-pr-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Export web bundle (dev mode for scenario seed hook)
+        run: npx expo export -p web --dev --no-minify
+
+      - name: Run scenario assertions (mobile only, no visual diff)
+        # SCENARIO_ASSERT_ONLY=1 skips toHaveScreenshot() in adaptive-rest.spec.ts
+        # while keeping all DOM/IA assertions and pageerror/react-crash-overlay guards.
+        # All other specs in e2e/scenarios/ run unchanged (they have no toHaveScreenshot).
+        # AC2: crash guards + structural DOM assertions still execute.
+        env:
+          CI: 'true'
+          E2E_USE_STATIC: '1'
+          SCENARIO_ASSERT_ONLY: '1'
+        run: |
+          npx playwright test \
+            'e2e/scenarios/[^_]*.spec.ts' \
+            --project=mobile
+
+      - name: Upload Playwright report on failure
+        # AC5: failure artifacts so red runs are actionable, not noisy.
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scenario-gate-pr-report-${{ github.run_id }}
+          path: playwright-report
+          retention-days: 7
+
   capture:
     name: Capture scenario screenshots
     # Only run the heavy screenshot capture on schedule or manual dispatch,

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -28,9 +28,6 @@ function getWeekLabel(now: Date): string {
   return `${start}–${end}`;
 }
 
-// AC3 synthetic crash — BLD-2861 proof-of-failure. Reverted in next commit.
-throw new Error("BLD-2861 synthetic crash: nutrition tab pageerror guard test");
-
 export default function Nutrition() {
   const colors = useThemeColors();
   const layout = useLayout();

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -28,6 +28,9 @@ function getWeekLabel(now: Date): string {
   return `${start}–${end}`;
 }
 
+// AC3 synthetic crash — BLD-2861 proof-of-failure. Reverted in next commit.
+throw new Error("BLD-2861 synthetic crash: nutrition tab pageerror guard test");
+
 export default function Nutrition() {
   const colors = useThemeColors();
   const layout = useLayout();

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,88 @@
+# CI Configuration
+
+## Playwright PR Gate (`scenario-gate-pr`)
+
+### What it is
+
+`scenario-gate-pr` is an **advisory** CI job in `.github/workflows/ux-audit.yml` that
+runs the functional Playwright scenario suite (`e2e/scenarios/`) on every PR and push to
+`main`. It runs `--project=mobile` only, with `SCENARIO_ASSERT_ONLY=1` to skip visual
+pixel-diffs — keeping all crash guards and structural DOM assertions active.
+
+**Phase**: Advisory (Phase 1 of BLD-2855). It reports pass/fail but is **not** a
+required branch-protection check yet. Promotion to required happens after ≥50 consecutive
+green PR runs with ≥98% pass rate (separate follow-up ticket).
+
+### What it checks
+
+All 14 specs in `e2e/scenarios/` run on the `mobile` (390×844) viewport:
+
+| Guard type | Coverage |
+|---|---|
+| `pageerror` listeners | `completed-workout.spec.ts`, `completed-workout-prefix.spec.ts`, `nutrition-tab.spec.ts`, `progress-tab.spec.ts`, `session-pacing.spec.ts` |
+| `react-crash-overlay` DOM-attach | Same specs as above |
+| Structural `toBeAttached` / `toBeVisible` | All 14 specs |
+| Visual pixel-diff (`toHaveScreenshot`) | **Skipped on PR** (cron `capture` job only) |
+
+The only behavioral difference vs. the cron `capture` job is:
+
+1. `adaptive-rest.spec.ts`: `toHaveScreenshot()` is gated behind
+   `if (!process.env.SCENARIO_ASSERT_ONLY)` — DOM/chip-count assertions still run.
+2. Single viewport (`mobile`) instead of the full 4-viewport matrix on `settings.spec.ts`.
+
+### When does it go red?
+
+The gate turns RED when:
+
+- A `pageerror` fires on any scenario page (crash guard).
+- A `[data-testid="react-crash-overlay"]` element is attached (React error boundary tripped).
+- A structural `expect(locator).toBeAttached()` or `toBeVisible()` fails (DOM element
+  removed or renamed).
+- The bundle fails to export (`npx expo export -p web --dev --no-minify` exits non-zero).
+- Any spec exceeds its per-test timeout and hits the overall 12-minute wall-time cap.
+
+### Debugging a red run
+
+1. **Click the failing check** in the PR status area → "Details" → GitHub Actions run log.
+2. Look for the failing spec name in the Playwright output (e.g. `nutrition-tab.spec.ts › captures nutrition top`).
+3. If the run uploaded a `scenario-gate-pr-report-<run_id>` artifact (only on failure), download it:
+   ```bash
+   gh run download <run_id> --name scenario-gate-pr-report-<run_id> -R alankyshum/cablesnap
+   # Open playwright-report/index.html in a browser for full trace + DOM snapshot
+   ```
+4. Common causes:
+   - **Crash guard**: check for a recent change to the failing route (e.g. `/nutrition`, `/progress`).
+   - **DOM structural**: a `data-testid` was renamed or removed; grep for it and restore or update the spec.
+   - **Bundle timeout**: check `npx expo export` output for a new error or missing dependency.
+
+### Updating baselines
+
+Visual baselines are only used in the **cron** `capture` job — not in this PR gate.
+To update them, trigger a manual `workflow_dispatch` on the `UX Audit (Daily Visual Capture)`
+workflow or wait for the next scheduled cron run. See `e2e-update-snapshots.yml` for a
+dedicated baseline-update workflow.
+
+### Adding new scenario specs
+
+New specs in `e2e/scenarios/` are automatically picked up by the glob
+`'e2e/scenarios/[^_]*.spec.ts'` in both the cron `capture` job and this PR gate.
+
+If your new spec uses `toHaveScreenshot()`, wrap it in:
+
+```typescript
+if (!process.env.SCENARIO_ASSERT_ONLY) {
+  await expect(element).toHaveScreenshot('name.png', { ... });
+}
+```
+
+This prevents the PR gate from requiring a baseline that doesn't exist yet on CI.
+
+### Phase 1 → Phase 2 promotion criteria
+
+Tracked in a separate follow-up ticket. Requirements:
+
+- ≥50 consecutive `scenario-gate-pr` runs observed.
+- ≥98% pass rate (≤1 flake in 50 with documented root cause).
+- Wall-time p90 < 8 minutes.
+
+Refs: BLD-2855 (plan), BLD-2861 (this implementation), BLD-2859 (QD conditions).

--- a/e2e/scenarios/adaptive-rest.spec.ts
+++ b/e2e/scenarios/adaptive-rest.spec.ts
@@ -242,15 +242,21 @@ test.describe("@scenario adaptive-rest", () => {
       // margin while remaining well below a real color-token change (>>12%).
       // Root cause: environmental font-rendering drift on CI runners — NOT a
       // code change. Ref: BLD-2615. Do NOT tighten back to a low maxDiffPixels.
-      await expect(toolbar).toHaveScreenshot(`${name}.png`, {
-        maxDiffPixelRatio: 0.12,
-        threshold: 0.2,
-        mask: [
-          page.locator('[data-testid="rest-countdown-text"]'),
-          page.locator('[data-testid="elapsed-time"]'),
-          page.locator('[data-testid="elapsed-remaining"]'),
-        ],
-      });
+      //
+      // SCENARIO_ASSERT_ONLY=1: skip the visual pixel-diff on PR-time scenario-gate
+      // runs (BLD-2861). All DOM/IA assertions above still run unconditionally.
+      // The screenshot capture stays active on cron (`capture` job, no env var).
+      if (!process.env.SCENARIO_ASSERT_ONLY) {
+        await expect(toolbar).toHaveScreenshot(`${name}.png`, {
+          maxDiffPixelRatio: 0.12,
+          threshold: 0.2,
+          mask: [
+            page.locator('[data-testid="rest-countdown-text"]'),
+            page.locator('[data-testid="elapsed-time"]'),
+            page.locator('[data-testid="elapsed-remaining"]'),
+          ],
+        });
+      }
     });
   }
 });


### PR DESCRIPTION
## Summary

Adds a `scenario-gate-pr` job to `.github/workflows/ux-audit.yml` that runs the full Playwright scenario suite (`e2e/scenarios/`) on every PR and push to `main`, in assert-only mode (mobile viewport, no visual pixel-diffs). This closes the pre-merge confidence gap where screen-level crash regressions could only be caught by the 09:00 UTC cron — up to 24 h after merge.

The gate is **advisory only** (Phase 1): it reports pass/fail but is not in branch protection required checks. Promotion criteria are documented in `docs/CI.md` and tracked as a separate follow-up ticket.

## Changes

- `.github/workflows/ux-audit.yml` — new `scenario-gate-pr` job: `pull_request` + `push` triggers, `--project=mobile`, 12-min timeout, `cancel-in-progress: true`, `SCENARIO_ASSERT_ONLY=1`, Playwright HTML report artifact on failure (3-7 day retention). The existing `capture` job is **byte-for-byte unchanged** (cron/dispatch only, full visual/CVD).
- `e2e/scenarios/adaptive-rest.spec.ts` — wrap `toHaveScreenshot()` in `if (!process.env.SCENARIO_ASSERT_ONLY)`. All DOM/chip-count assertions run unconditionally. This is the only `toHaveScreenshot()` in the scenarios directory.
- `docs/CI.md` (new) — Playwright PR gate runbook: what the gate checks, how to debug a red run, how to download failure artifacts, baseline update procedure, Phase 1→2 promotion criteria.

## AC3 — Proof of failure (RED → GREEN)

This PR contains 3 commits that demonstrate the gate's crash-detection capability:

**Commit `0a7a3e3f` (RED) — synthetic throw injected in `app/(tabs)/nutrition.tsx`:**
```
throw new Error("BLD-2861 synthetic crash: nutrition tab pageerror guard test");
```
**Expected failing check**: `Playwright scenario gate (mobile, assert-only)`
**Expected failing spec**: `nutrition-tab.spec.ts > @scenario nutrition-tab > captures nutrition top (header + macro ring)`

The `throw` fires at module evaluation time during the Expo web build and is caught by the `page.on('pageerror')` listener installed in `nutrition-tab.spec.ts`. The spec's crash guard assertion `expect(pageErrors).toHaveLength(0)` (line 96–99) then fails, turning the check RED.

**Commit `fb0b7c97` (GREEN) — throw reverted:**
The revert restores the correct module, and the gate should pass GREEN on the tip commit.

## Testing

- TypeScript: `tsc --noEmit` — zero errors.
- No changes to `ci.yml`, `bundle-gate.yml`, or any branch-protection required checks.
- Cron `capture` job: logic unchanged, only location in file changed (new job inserted before it).

## Issue

Resolves BLD-2861
Parent plan: BLD-2855 (approved by techlead, quality-director BLD-2859, CEO Phase 4)