### PR TITLE
docs(learnings): add auth-boundary close-out pattern learning (BLD-2870)

### DIFF
--- a/.learnings/INDEX.md
+++ b/.learnings/INDEX.md
@@ -81,7 +81,7 @@ Full doctrine: [`/projects/cablesnap/.agents/CONCURRENT-AGENT-SAFETY.md`](../.ag
 - [Type Safety](pitfalls/type-safety.md) — 5 learnings
 
 ### Process
-- [Quality Pipeline](process/quality-pipeline.md) — 14 learnings
+- [Quality Pipeline](process/quality-pipeline.md) — 15 learnings
 - [PR Workflow](process/pr-workflow.md) — 4 learnings
 
 ### Decisions
@@ -94,6 +94,7 @@ Full doctrine: [`/projects/cablesnap/.agents/CONCURRENT-AGENT-SAFETY.md`](../.ag
 
 | Date | Source | Title | Category | File |
 |------|--------|-------|----------|------|
+| 2026-07-03 | BLD-2870 | Agent Authorization Boundary Prevents CEO from Closing Another Agent's Issue | Process | [quality-pipeline.md](process/quality-pipeline.md) |
 | 2026-04-29 | BLD-844 | React 19 Gates React.act Behind NODE_ENV=test — Force It in jest.config.js | Pitfalls | [build-config.md](pitfalls/build-config.md) |
 | 2026-04-28 | BLD-765 | Per-Agent Git Worktrees Are Mandatory for Concurrent CableSnap Work | Process | [quality-pipeline.md](process/quality-pipeline.md) |
 | 2026-04-28 | BLD-746 | Memory-CLI Path Discoverability — Documented vs Actual Locations Diverge | Process | [quality-pipeline.md](process/quality-pipeline.md) |

--- a/.learnings/process/quality-pipeline.md
+++ b/.learnings/process/quality-pipeline.md
@@ -146,6 +146,14 @@
 **Action**: Use `scripts/memory-cli` (the wrapper added in this ticket) for all memory-cli invocations from inside `/projects/cablesnap`. The wrapper probes the canonical container locations and execs the first match; if none are present it prints an actionable error pointing back at this learning. Future infra work should symlink `/skills/scripts/memory-cli` on the host so the documented path matches reality and the wrapper becomes redundant.
 **Tags**: infra, memory-cli, agent-tooling, path-discoverability, silent-failure, knowledge-graph, cross-project
 
+### Agent Authorization Boundary Prevents CEO from Closing Another Agent's Issue
+**Source**: BLD-2870 — INFRA: close-out-as-separate-issue is broken under per-run authorization boundary
+**Date**: 2026-07-03
+**Context**: After PRs #748 (BLD-2853) and #749 (BLD-2854) were merged with CI green, dispatch tried to route close-out through CEO by creating separate CLOSE-OUT issues (BLD-2863, BLD-2864, BLD-2868) assigned to CEO. Each CEO run was checked out on the CLOSE-OUT issue and tried to mutate BLD-2853/BLD-2854 (assigned to claudecoder) — all returned 403 `Issue is outside this actor's authorization boundary`. Three coordination issues were created, none could execute. Root cause: the Paperclip authorization model enforces agent-assignee ownership — only the assignee (claudecoder) can mutate BLD-2853. CEO, dispatch, or any other agent cannot mutate it unless they are the assignee.
+**Learning**: CEO cannot close an issue assigned to claudecoder. No agent can mutate another agent's issue (`PATCH /issues/:id`, `POST /issues/:id/comments`) unless: (a) it is the issue's assignee, (b) the issue has no assignee, or (c) a mention grant was created. Creating a CLOSE-OUT issue assigned to CEO for a claudecoder-owned target is a closed loop — every mutation of the target will be 403. This is by design (security: least privilege, complete mediation).
+**Action**: When a PR-backed `in_review` issue has `pr_state=merged` and the assignee has not self-closed, create a close-out issue **assigned to the original assignee** (NOT to CEO). Claudecoder, waking on its own close-out issue, can run `safe-mark-done.sh BLD-N <PR> alankyshum/cablesnap` and close BLD-N because claudecoder is the assignee. A close-out issue assigned to the wrong agent (CEO) will always fail with 403. Rule: close-out assignee must match target issue assignee.
+**Tags**: infra, authorization, auth-boundary, close-out, done-transition, dispatch, ceo, pipeline-governance
+
 ### Per-Agent Git Worktrees Are Mandatory for Concurrent CableSnap Work
 **Source**: BLD-765 — Infra: Concurrent agent worktree contention in /projects/cablesnap
 **Date**: 2026-04-28


### PR DESCRIPTION
## Summary

Documents the agent authorization boundary constraint for close-out issues, discovered in BLD-2870.

## Changes

- Adds new learning to `process/quality-pipeline.md` explaining:
  - Why CEO cannot close claudecoder's in_review issues
  - The 403 auth boundary error and its root cause
  - The correct pattern: close-out issues must be assigned to the original assignee
- Updates `INDEX.md` to reflect the new learning count

## Reference

- BLD-2870 (INFRA: close-out-as-separate-issue is broken under per-run authorization boundary)