### PR TITLE
fix(tests): update settings tests for declutter refactor (BLD-2913)

### DIFF
--- a/__tests__/acceptance/accessibility.acceptance.test.tsx
+++ b/__tests__/acceptance/accessibility.acceptance.test.tsx
@@ -384,7 +384,6 @@ describe('Accessibility Compliance Audit', () => {
       const screen = renderScreen(<Settings />)
       await waitFor(() => {
         expect(screen.getByLabelText('Workout Reminders')).toBeTruthy()
-        expect(screen.getByLabelText('Timer Sound')).toBeTruthy()
       })
     })
   })

--- a/__tests__/acceptance/settings.test.tsx
+++ b/__tests__/acceptance/settings.test.tsx
@@ -139,7 +139,6 @@ import Settings, { SETTINGS_SCROLL_EXTRA_BOTTOM } from '../../app/(tabs)/setting
 import { FLOATING_TAB_BAR_HEIGHT } from '../../components/FloatingTabBar'
 import { spacing } from '../../constants/design-tokens'
 
-const { setEnabled: mockSetAudioEnabled } = require('../../lib/audio')
 const { requestPermission, scheduleReminders, cancelAll, getPermissionStatus } = require('../../lib/notifications')
 
 describe('Settings Screen Acceptance', () => {
@@ -159,8 +158,8 @@ describe('Settings Screen Acceptance', () => {
   it('renders all section titles, app name/version, and open-source description', async () => {
     const { findByText } = renderScreen(<Settings />)
     expect(await findByText('Units')).toBeTruthy()
-    expect(await findByText('Preferences')).toBeTruthy()
-    expect(await findByText('Data Management')).toBeTruthy()
+    expect(await findByText('Training')).toBeTruthy()
+    expect(await findByText('Notifications')).toBeTruthy()
     expect(await findByText('Feedback & Reports')).toBeTruthy()
     expect(await findByText('About')).toBeTruthy()
     expect(await findByText(/CableSnap v/)).toBeTruthy()
@@ -245,46 +244,12 @@ describe('Settings Screen Acceptance', () => {
     })
   })
 
-  // ── Timer Sound Toggle ──────────────────────────────────
-
-  it('Timer Sound switch renders, has accessible label, and saves setting on toggle off', async () => {
-    const { findByLabelText } = renderScreen(<Settings />)
-    const toggle = await findByLabelText('Timer Sound')
-    expect(toggle).toBeTruthy()
-
-    fireEvent(toggle, 'valueChange', false)
-
-    await waitFor(() => {
-      expect(mockSetAudioEnabled).toHaveBeenCalledWith('timer', false)
-    })
-    await waitFor(() => {
-      expect(mockSetAppSetting).toHaveBeenCalledWith('timer_sound_enabled', 'false')
-    })
-  })
-
-  it('Timer Sound switch saves setting on toggle on (starting from off)', async () => {
-    mockGetAppSetting.mockResolvedValue('false')
-
-    const { findByLabelText } = renderScreen(<Settings />)
-    const toggle = await findByLabelText('Timer Sound')
-
-    fireEvent(toggle, 'valueChange', true)
-
-    await waitFor(() => {
-      expect(mockSetAudioEnabled).toHaveBeenCalledWith('timer', true)
-    })
-    await waitFor(() => {
-      expect(mockSetAppSetting).toHaveBeenCalledWith('timer_sound_enabled', 'true')
-    })
-  })
-
   // ── Workout Reminders Toggle ──────────────────────────────────
 
   it('Workout Reminders switch renders, has accessible label, and enables reminders when toggled on', async () => {
     // Start with reminders off
     mockGetAppSetting.mockImplementation((key: string) => {
       if (key === 'reminders_enabled') return Promise.resolve('false')
-      if (key === 'timer_sound_enabled') return Promise.resolve('true')
       return Promise.resolve(null)
     })
 
@@ -306,7 +271,6 @@ describe('Settings Screen Acceptance', () => {
     // Start with reminders on
     mockGetAppSetting.mockImplementation((key: string) => {
       if (key === 'reminders_enabled') return Promise.resolve('true')
-      if (key === 'timer_sound_enabled') return Promise.resolve('true')
       return Promise.resolve(null)
     })
 
@@ -329,7 +293,6 @@ describe('Settings Screen Acceptance', () => {
 
     mockGetAppSetting.mockImplementation((key: string) => {
       if (key === 'reminders_enabled') return Promise.resolve('false')
-      if (key === 'timer_sound_enabled') return Promise.resolve('true')
       return Promise.resolve(null)
     })
 
@@ -354,7 +317,6 @@ describe('Settings Screen Acceptance', () => {
 
     mockGetAppSetting.mockImplementation((key: string) => {
       if (key === 'reminders_enabled') return Promise.resolve('false')
-      if (key === 'timer_sound_enabled') return Promise.resolve('true')
       return Promise.resolve(null)
     })
 
@@ -378,7 +340,6 @@ describe('Settings Screen Acceptance', () => {
     mockGetAppSetting.mockImplementation((key: string) => {
       if (key === 'rest_notification_enabled') return Promise.resolve('true')
       if (key === 'reminders_enabled') return Promise.resolve('false')
-      if (key === 'timer_sound_enabled') return Promise.resolve('true')
       return Promise.resolve(null)
     })
 
@@ -397,7 +358,6 @@ describe('Settings Screen Acceptance', () => {
     mockGetAppSetting.mockImplementation((key: string) => {
       if (key === 'rest_notification_enabled') return Promise.resolve('true')
       if (key === 'reminders_enabled') return Promise.resolve('false')
-      if (key === 'timer_sound_enabled') return Promise.resolve('true')
       return Promise.resolve(null)
     })
 
@@ -477,12 +437,9 @@ describe('Settings Screen Acceptance', () => {
 
   it('all switches have accessibilityRole="switch" and accessibilityHint text', async () => {
     const { findByLabelText } = renderScreen(<Settings />)
-    const timerSound = await findByLabelText('Timer Sound')
     const remindersToggle = await findByLabelText('Workout Reminders')
 
-    expect(timerSound.props.accessibilityRole).toBe('switch')
     expect(remindersToggle.props.accessibilityRole).toBe('switch')
-    expect(timerSound.props.accessibilityHint).toBeTruthy()
     expect(remindersToggle.props.accessibilityHint).toBeTruthy()
   })
 

--- a/__tests__/components/session/SessionHeaderToolbar.test.tsx
+++ b/__tests__/components/session/SessionHeaderToolbar.test.tsx
@@ -331,7 +331,7 @@ describe("SessionHeaderToolbar", () => {
     expect(queryByTestId("adaptive-chip")).toBeNull();
   });
 
-  it("renders adaptive chip when rest_show_breakdown setting is explicitly 'true'", async () => {
+  it("does NOT render adaptive chip regardless of rest_show_breakdown setting (feature removed)", async () => {
     mockGetAppSetting.mockImplementation(async (key: string) => {
       if (key === "rest_show_breakdown") return "true";
       return null;
@@ -352,7 +352,9 @@ describe("SessionHeaderToolbar", () => {
     await act(async () => {
       await Promise.resolve();
     });
-    expect(queryByTestId("adaptive-chip")).toBeTruthy();
+    // rest_show_breakdown setting was removed in the settings declutter refactor;
+    // the adaptive chip is now permanently off (showBreakdownChip = false).
+    expect(queryByTestId("adaptive-chip")).toBeNull();
   });
 
   it("does NOT render adaptive chip when rest_show_breakdown is 'false'", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cablesnap",
-  "version": "0.26.53",
+  "version": "0.26.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cablesnap",
-      "version": "0.26.53",
+      "version": "0.26.58",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {


### PR DESCRIPTION
## Summary

Updates three test files to match the settings declutter refactor (commit `d3868bda`), which removed the Timer Sound toggle and the Preferences section from settings, and hardcoded `showBreakdownChip = false` in SessionHeaderToolbar.

## Changes

- `__tests__/acceptance/settings.test.tsx`: Remove Timer Sound toggle tests (2 tests); update section title test to check for 'Training' / 'Notifications' instead of removed 'Preferences'; remove `timer_sound_enabled` from mock implementations in unrelated tests
- `__tests__/acceptance/accessibility.acceptance.test.tsx`: Remove 'Timer Sound' from toggle-switches accessibility test (switch was removed from UI)
- `__tests__/components/session/SessionHeaderToolbar.test.tsx`: Update adaptive-chip test to assert chip is always `null` (rest_show_breakdown setting removed, showBreakdownChip hardcoded to `false`)

## Testing

All three previously-failing suites now pass locally:
- `__tests__/acceptance/settings.test.tsx` — 60 tests, all passing
- `__tests__/acceptance/accessibility.acceptance.test.tsx` — included
- `__tests__/components/session/SessionHeaderToolbar.test.tsx` — included

## Issue

Resolves BLD-2913