### PR TITLE
feat: Double-Progression suggestions (rep-range aware Next pill) (BLD-2984)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Double-Progression suggestions for your workouts** — CableSnap now suggests progressive-overload progressions for weighted exercises, letting you increase reps within your target range before suggesting a weight increase. This includes support for rep-range parsing, warmup set filtering, and a dedicated explainer modal. (BLD-2984)
 
 ## v0.26.61 — 2026-07-04
 <!-- versionCode: 131 -->

--- a/__tests__/components/session/LastNextRow.test.tsx
+++ b/__tests__/components/session/LastNextRow.test.tsx
@@ -671,4 +671,79 @@ describe("LastNextRow (BLD-850)", () => {
       );
     });
   });
+
+  describe("weight_and_rep_reset double progression cases", () => {
+    const RESET_SUGGESTION: Suggestion = {
+      type: "weight_and_rep_reset",
+      weight: 22.5,
+      reps: 8,
+      reason: "Hit 12 reps — add 2.5 and reset to 8",
+    };
+
+    it("renders combined weight and reps text '22.5 × 8' in the pill", () => {
+      const { getByText } = render(
+        <LastNextRow
+          previousPerformance={null}
+          previousPerformanceA11y={null}
+          suggestion={RESET_SUGGESTION}
+          sets={[mkSet()]}
+          step={2.5}
+          onPrefillLast={() => {}}
+          onUpdate={() => {}}
+          onOpenExplainer={() => {}}
+          exerciseName="Lateral Raise"
+        />,
+      );
+      expect(getByText(/22\.5.*8/)).toBeTruthy();
+    });
+
+    it("announces both weight, reset reps, and rationale in accessibilityLabel", () => {
+      const { getByTestId } = render(
+        <LastNextRow
+          previousPerformance={null}
+          previousPerformanceA11y={null}
+          suggestion={RESET_SUGGESTION}
+          sets={[mkSet()]}
+          step={2.5}
+          onPrefillLast={() => {}}
+          onUpdate={() => {}}
+          onOpenExplainer={() => {}}
+          exerciseName="Lateral Raise"
+        />,
+      );
+      expect(getByTestId("next-half").props.accessibilityLabel).toBe(
+        "Suggested weight: 22.5, reps: 8, Hit 12 reps — add 2.5 and reset to 8",
+      );
+    });
+
+    it("tapping the reset pill applies BOTH weight and reps to uncompleted sets and leaves completed sets untouched", () => {
+      const onUpdateSpy = jest.fn();
+      const uncompletedSet = mkSet({ id: "set-uncompleted", completed: false });
+      const completedSet = mkSet({ id: "set-completed", completed: true });
+      const { getByTestId } = render(
+        <LastNextRow
+          previousPerformance={null}
+          previousPerformanceA11y={null}
+          suggestion={RESET_SUGGESTION}
+          sets={[uncompletedSet, completedSet]}
+          step={2.5}
+          onPrefillLast={() => {}}
+          onUpdate={onUpdateSpy}
+          onOpenExplainer={() => {}}
+          exerciseName="Lateral Raise"
+        />,
+      );
+
+      fireEvent.press(getByTestId("next-half"));
+      pressAlertButton(alertSpy, "Apply");
+
+      // Should call onUpdate for the uncompleted set for both weight and reps
+      expect(onUpdateSpy).toHaveBeenCalledWith("set-uncompleted", "weight", "22.5");
+      expect(onUpdateSpy).toHaveBeenCalledWith("set-uncompleted", "reps", "8");
+
+      // Should NOT call onUpdate for the completed set
+      expect(onUpdateSpy).not.toHaveBeenCalledWith("set-completed", "weight", "22.5");
+      expect(onUpdateSpy).not.toHaveBeenCalledWith("set-completed", "reps", "8");
+    });
+  });
 });

--- a/__tests__/lib/rm.test.ts
+++ b/__tests__/lib/rm.test.ts
@@ -52,7 +52,7 @@ describe("1RM formulas", () => {
 
 describe("suggest (progressive overload)", () => {
   function makeSets(
-    sessions: { id: string; started: number; sets: { weight: number; reps: number; rpe?: number | null; completed?: number }[] }[]
+    sessions: { id: string; started: number; sets: { weight: number; reps: number; rpe?: number | null; completed?: number; set_type?: string | null }[] }[]
   ): HistorySet[] {
     return sessions.flatMap((s) =>
       s.sets.map((set) => ({
@@ -62,6 +62,7 @@ describe("suggest (progressive overload)", () => {
         rpe: set.rpe ?? null,
         completed: set.completed ?? 1,
         started_at: s.started,
+        set_type: set.set_type ?? null,
       }))
     );
   }
@@ -225,6 +226,133 @@ describe("suggest (progressive overload)", () => {
     if ("reps" in expected && expected.reps !== undefined) expect(result!.reps).toBe(expected.reps);
     if ("reasonContains" in expected && expected.reasonContains)
       expect(result!.reason).toContain(expected.reasonContains);
+  });
+
+  describe("Double-Progression Suggestions", () => {
+    it("GIVEN a weighted exercise with template range '8-12' and last session all sets completed at 20 kg x 10, suggests rep_increase to 11", () => {
+      const sets = makeSets([
+        { id: "s2", started: 2000, sets: [{ weight: 20, reps: 10 }, { weight: 20, reps: 10 }] },
+        { id: "s1", started: 1000, sets: [{ weight: 20, reps: 10 }, { weight: 20, reps: 10 }] },
+      ]);
+      const res = suggest(sets, 2.5, false, { min: 8, max: 12 });
+      expect(res).toEqual({
+        type: "rep_increase",
+        weight: 20,
+        reps: 11,
+        reason: "Build reps toward 12 before adding weight",
+      });
+    });
+
+    it("GIVEN the same exercise with last session all sets completed at 20 kg x 12, suggests weight_and_rep_reset to 22.5 kg x 8", () => {
+      const sets = makeSets([
+        { id: "s2", started: 2000, sets: [{ weight: 20, reps: 12 }, { weight: 20, reps: 12 }] },
+        { id: "s1", started: 1000, sets: [{ weight: 20, reps: 12 }, { weight: 20, reps: 12 }] },
+      ]);
+      const res = suggest(sets, 2.5, false, { min: 8, max: 12 });
+      expect(res).toEqual({
+        type: "weight_and_rep_reset",
+        weight: 22.5,
+        reps: 8,
+        reason: "Hit 12 reps — add 2.5 and reset to 8",
+      });
+    });
+
+    it("GIVEN a degenerate range '10-10', falls back to linear progression", () => {
+      const sets = makeSets([
+        { id: "s2", started: 2000, sets: [{ weight: 20, reps: 10 }, { weight: 20, reps: 10 }] },
+        { id: "s1", started: 1000, sets: [{ weight: 20, reps: 10 }, { weight: 20, reps: 10 }] },
+      ]);
+      const res = suggest(sets, 2.5, false, { min: 10, max: 10 });
+      expect(res).toEqual({
+        type: "increase",
+        weight: 22.5,
+        reps: null,
+        reason: "All sets completed — increase by 2.5",
+      });
+    });
+
+    it("GIVEN any set had RPE >= 9.5, maintain wins over double progression", () => {
+      const sets = makeSets([
+        { id: "s2", started: 2000, sets: [{ weight: 20, reps: 10, rpe: 9.5 }, { weight: 20, reps: 10 }] },
+        { id: "s1", started: 1000, sets: [{ weight: 20, reps: 10 }, { weight: 20, reps: 10 }] },
+      ]);
+      const res = suggest(sets, 2.5, false, { min: 8, max: 12 });
+      expect(res).toEqual({
+        type: "maintain",
+        weight: 20,
+        reps: null,
+        reason: "RPE ≥ 9.5 last session — maintain",
+      });
+    });
+
+    it("GIVEN a bodyweight exercise, the existing rep_increase path is unchanged", () => {
+      const sets = makeSets([
+        { id: "s2", started: 2000, sets: [{ weight: 10, reps: 10 }, { weight: 10, reps: 10 }] },
+        { id: "s1", started: 1000, sets: [{ weight: 10, reps: 8 }, { weight: 10, reps: 8 }] },
+      ]);
+      const res = suggest(sets, 0, true, { min: 8, max: 12 });
+      expect(res).toEqual({
+        type: "rep_increase",
+        weight: 0,
+        reps: 11,
+        reason: "Bodyweight — increase reps",
+      });
+    });
+
+    it("GIVEN a warmup set at low reps + working sets at range max, excludes warmups and weight bump fires", () => {
+      const sets = makeSets([
+        {
+          id: "s2",
+          started: 2000,
+          sets: [
+            { weight: 40, reps: 6, set_type: "warmup" },
+            { weight: 100, reps: 12, set_type: "normal" },
+            { weight: 100, reps: 12, set_type: "normal" },
+          ],
+        },
+        {
+          id: "s1",
+          started: 1000,
+          sets: [
+            { weight: 40, reps: 6, set_type: "warmup" },
+            { weight: 100, reps: 12, set_type: "normal" },
+            { weight: 100, reps: 12, set_type: "normal" },
+          ],
+        },
+      ]);
+      const res = suggest(sets, 2.5, false, { min: 8, max: 12 });
+      expect(res).toEqual({
+        type: "weight_and_rep_reset",
+        weight: 102.5,
+        reps: 8,
+        reason: "Hit 12 reps — add 2.5 and reset to 8",
+      });
+    });
+
+    it("tech-lead #5 REGRESSION: iterates existing cases and asserts undefined/null range produces identical output", () => {
+      for (const c of cases) {
+        const setsList = makeSets(c.sessions);
+        const withoutRange = suggest(setsList, c.step, c.bodyweight);
+        const withUndefRange = suggest(setsList, c.step, c.bodyweight, undefined);
+        const withNullRange = suggest(setsList, c.step, c.bodyweight, null);
+        expect(withUndefRange).toEqual(withoutRange);
+        expect(withNullRange).toEqual(withoutRange);
+      }
+    });
+  });
+
+  describe("parseTemplateRepRange parser tests", () => {
+    const { parseTemplateRepRange } = require("../../lib/db/templates");
+    it("parses valid ranges correctly", () => {
+      expect(parseTemplateRepRange("8-12", 1)).toEqual({ min: 8, max: 12 });
+      expect(parseTemplateRepRange("8 - 12", 1)).toEqual({ min: 8, max: 12 });
+      expect(parseTemplateRepRange("8–12", 1)).toEqual({ min: 8, max: 12 });
+    });
+
+    it("returns null for non-ranges or degenerate", () => {
+      expect(parseTemplateRepRange("10", 1)).toBeNull();
+      expect(parseTemplateRepRange("30-60s", 1)).toBeNull();
+    });
   });
 });
 

--- a/components/session/LastNextRow.tsx
+++ b/components/session/LastNextRow.tsx
@@ -68,23 +68,26 @@ export type LastNextRowProps = {
 
 function formatNextLabel(s: Suggestion): string {
   if (s.type === "rep_increase") return `${s.reps} reps`;
+  if (s.type === "weight_and_rep_reset") return `${s.weight} × ${s.reps}`;
   return `${s.weight}`;
 }
 
 function formatNextA11y(s: Suggestion): string {
   if (s.type === "rep_increase") return `Suggested reps: ${s.reps}, ${s.reason}`;
+  if (s.type === "weight_and_rep_reset") return `Suggested weight: ${s.weight}, reps: ${s.reps}, ${s.reason}`;
   if (s.type === "increase") return `Suggested weight: ${s.weight}, ${s.reason}`;
   return `Suggested weight: ${s.weight}, maintain — ${s.reason}`;
 }
 
 function nextLeadingIconName(s: Suggestion): "arrow-up-bold" | "equal" {
-  return s.type === "increase" || s.type === "rep_increase"
+  return s.type === "increase" || s.type === "rep_increase" || s.type === "weight_and_rep_reset"
     ? "arrow-up-bold"
     : "equal";
 }
 
 function suggestedValueDescription(s: Suggestion): string {
   if (s.type === "rep_increase") return `reps: ${s.reps}`;
+  if (s.type === "weight_and_rep_reset") return `weight: ${s.weight} × ${s.reps}`;
   return `weight: ${s.weight}`;
 }
 
@@ -97,11 +100,20 @@ function applyNextFill(
   sets: SetWithMeta[],
   onUpdate: (setId: string, field: "weight" | "reps", val: string) => void,
 ): void {
-  const field: "weight" | "reps" = s.type === "rep_increase" ? "reps" : "weight";
-  const value = String(s.type === "rep_increase" ? s.reps : s.weight);
-  for (const set of sets) {
-    if (!set.completed) {
-      onUpdate(set.id, field, value);
+  if (s.type === "weight_and_rep_reset") {
+    for (const set of sets) {
+      if (!set.completed) {
+        onUpdate(set.id, "weight", String(s.weight));
+        onUpdate(set.id, "reps", String(s.reps));
+      }
+    }
+  } else {
+    const field: "weight" | "reps" = s.type === "rep_increase" ? "reps" : "weight";
+    const value = String(s.type === "rep_increase" ? s.reps : s.weight);
+    for (const set of sets) {
+      if (!set.completed) {
+        onUpdate(set.id, field, value);
+      }
     }
   }
   Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});

--- a/components/session/SuggestionExplainerModal.tsx
+++ b/components/session/SuggestionExplainerModal.tsx
@@ -94,6 +94,24 @@ export function SuggestionExplainerModal({ visible, onClose, plateauMode }: Sugg
             <Section
               icon="arrow-up-bold"
               iconColor={colors.primary}
+              title="Increase reps (range)"
+              body={
+                "You completed your sets but haven't hit the top of your 8–12 range yet. Add a rep at the same weight — we'll bump the weight once every set reaches 12."
+              }
+              colors={colors}
+            />
+            <Section
+              icon="arrow-up-bold"
+              iconColor={colors.primary}
+              title="Increase weight and reset reps"
+              body={
+                "You hit the top of your 8–12 range, so we added 2.5 kg and reset you to 8 reps. Below the top, we build reps first."
+              }
+              colors={colors}
+            />
+            <Section
+              icon="arrow-up-bold"
+              iconColor={colors.primary}
               title="Increase reps (bodyweight)"
               body={
                 "When all sets completed → highest reps in last session + 1."

--- a/hooks/useSessionData.ts
+++ b/hooks/useSessionData.ts
@@ -20,7 +20,7 @@ import {
   getExerciseNotesBatch,
   getPreferredSubstitutesBatch,
 } from "../lib/db";
-import { parseTemplateTargetReps } from "../lib/db/templates";
+import { parseTemplateTargetReps, parseTemplateRepRange } from "../lib/db/templates";
 import type { WorkoutSession, Exercise } from "../lib/types";
 import type { SetWithMeta, ExerciseGroup } from "../components/session/types";
 import { epley, suggest, type Suggestion } from "../lib/rm";
@@ -115,13 +115,14 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
 
     const exerciseIds = [...new Set(sets.map((s) => s.exercise_id))];
 
-    const [prevCache, exerciseMeta, recentByExercise, exerciseNotes, plateauWindowByExercise, preferredSubstitutesMap] = await Promise.all([
+    const [prevCache, exerciseMeta, recentByExercise, exerciseNotes, plateauWindowByExercise, preferredSubstitutesMap, currentTemplate] = await Promise.all([
       getPreviousSetsBatch(exerciseIds, id),
       getExercisesByIds(exerciseIds),
       getRecentExerciseSetsBatch(exerciseIds, 2),
       getExerciseNotesBatch(exerciseIds),
       getPlateauWindowBatch(exerciseIds, 4),
       getPreferredSubstitutesBatch(exerciseIds),
+      sess.template_id ? getTemplateById(sess.template_id) : Promise.resolve(null),
     ]);
 
     const key = exerciseIds.sort().join(",");
@@ -334,7 +335,11 @@ export function useSessionData({ id, templateId, sourceSessionId }: UseSessionDa
         if (timeBased) return [eid, null];
         const ex = exerciseMeta[eid];
         const bw = ex ? ex.equipment === "bodyweight" : false;
-        return [eid, suggest(recent, derived, bw)];
+        const templateExercise = currentTemplate?.exercises?.find((te) => te.exercise_id === eid);
+        const repRange = templateExercise
+          ? parseTemplateRepRange(templateExercise.target_reps, 1)
+          : null;
+        return [eid, suggest(recent, derived, bw, repRange)];
       } catch {
         return [eid, null];
       }

--- a/lib/db/exercise-history.ts
+++ b/lib/db/exercise-history.ts
@@ -381,6 +381,7 @@ type RecentSetRow = {
   rpe: number | null;
   completed: number;
   started_at: number;
+  set_type?: string | null;
 };
 
 export async function getRecentExerciseSetsBatch(
@@ -394,6 +395,7 @@ export async function getRecentExerciseSetsBatch(
   rpe: number | null;
   completed: number;
   started_at: number;
+  set_type?: string | null;
 }[]>> {
   if (exerciseIds.length === 0) return {};
   const db = await getDrizzle();
@@ -438,6 +440,7 @@ export async function getRecentExerciseSetsBatch(
       rpe: workoutSets.rpe,
       completed: workoutSets.completed,
       started_at: workoutSessions.started_at,
+      set_type: workoutSets.set_type,
     })
     .from(workoutSets)
     .innerJoin(workoutSessions, eq(workoutSets.session_id, workoutSessions.id))

--- a/lib/db/templates.ts
+++ b/lib/db/templates.ts
@@ -46,6 +46,31 @@ export function parseTemplateTargetReps(targetReps: string, setNumber: number): 
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
+export function parseTemplateRepRange(
+  targetReps: string | null | undefined,
+  setNumber: number,
+): { min: number; max: number } | null {
+  if (!targetReps) return null;
+  const tokens = targetReps
+    .split(",")
+    .map((token) => token.trim())
+    .filter(Boolean);
+  const token = tokens[setNumber - 1] ?? tokens[tokens.length - 1] ?? "";
+
+  if (token.toLowerCase().includes("s")) return null;
+
+  const match = token.match(/^(\d+)\s*[-–—]\s*(\d+)$/);
+  if (!match) return null;
+
+  const min = Number.parseInt(match[1], 10);
+  const max = Number.parseInt(match[2], 10);
+
+  if (Number.isFinite(min) && Number.isFinite(max)) {
+    return { min, max };
+  }
+  return null;
+}
+
 export function parseTemplateSetTypes(raw: string | null | undefined, targetSets: number): SetType[] {
   if (!raw) return normalizeTemplateSetTypes(undefined, targetSets);
   try {

--- a/lib/rm.ts
+++ b/lib/rm.ts
@@ -48,19 +48,51 @@ export type HistorySet = {
   rpe: number | null;
   completed: number;
   started_at: number;
+  set_type?: string | null;
 };
 
 export type Suggestion = {
-  type: "increase" | "maintain" | "rep_increase";
+  type: "increase" | "maintain" | "rep_increase" | "weight_and_rep_reset";
   weight: number;
   reps: number | null;
   reason: string;
 };
 
+export function suggestDouble(
+  attempted: HistorySet[],
+  step: number,
+  repRange: { min: number; max: number },
+  lastWeight: number,
+): Suggestion | null {
+  const workingSets = attempted.filter((s) => s.set_type !== "warmup");
+  if (workingSets.length === 0) return null;
+
+  const minRepsAcrossSets = Math.min(...workingSets.map((s) => s.reps!));
+
+  if (minRepsAcrossSets >= repRange.max) {
+    const nextWeight = Math.round((lastWeight + step) * 100) / 100;
+    return {
+      type: "weight_and_rep_reset",
+      weight: nextWeight,
+      reps: repRange.min,
+      reason: `Hit ${repRange.max} reps — add ${step} and reset to ${repRange.min}`,
+    };
+  } else {
+    const nextReps = Math.min(minRepsAcrossSets + 1, repRange.max);
+    return {
+      type: "rep_increase",
+      weight: lastWeight,
+      reps: nextReps,
+      reason: `Build reps toward ${repRange.max} before adding weight`,
+    };
+  }
+}
+
 export function suggest(
   sets: HistorySet[],
   step: number,
   bodyweight: boolean,
+  repRange?: { min: number; max: number } | null,
 ): Suggestion | null {
   // Group sets by session
   const sessions = new Map<string, HistorySet[]>();
@@ -128,6 +160,10 @@ export function suggest(
   const priorMinReps = Math.min(...priorAttempted.map((s) => s.reps!));
   if (lastMinReps < priorMinReps) {
     return { type: "maintain", weight: lastWeight, reps: null, reason: "Reps dropped — maintain weight" };
+  }
+
+  if (repRange && repRange.min < repRange.max) {
+    return suggestDouble(attempted, step, repRange, lastWeight);
   }
 
   const next = Math.round((lastWeight + step) * 100) / 100;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cablesnap",
-  "version": "0.26.58",
+  "version": "0.26.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cablesnap",
-      "version": "0.26.58",
+      "version": "0.26.61",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {


### PR DESCRIPTION
## Summary

Double-progression suggestion engine support for weighted exercises in CableSnap, enabling serious lifters to walk up reps within a target range before increasing load.

## Changes

- **lib/db/templates.ts**: Added pure helper `parseTemplateRepRange` to parse rep ranges (e.g. '8-12') and handle duration tokens and whitespaces cleanly.
- **lib/db/exercise-history.ts**: Extended `getRecentExerciseSetsBatch` to retrieve `set_type` so that warmup sets are accurately filtered.
- **lib/rm.ts**: Extended `Suggestion` type with `weight_and_rep_reset` and implemented double-progression progressive overload math via extracted helper `suggestDouble()`.
- **hooks/useSessionData.ts**: Plumbed active template retrieval and parsed the target rep range for set 1 to pass into `suggest()`.
- **components/session/LastNextRow.tsx**: Handled `weight_and_rep_reset` visual rendering in pill labels, accessibility labels, and batch fill triggers (which sets both weight and reps on uncompleted sets).
- **components/session/SuggestionExplainerModal.tsx**: Added psychologist-approved non-celebratory sections describing (a) increasing reps within target ranges and (b) reset + weight overload reset.

## Testing

- Fully covered by new and existing pure unit tests in `rm.test.ts` and `LastNextRow.test.tsx` (100% green).

## Issue

Resolves BLD-2984