### PR TITLE
feat: Harden F-Droid Pages deploy against transient errors (BLD-3016)

### DIFF
--- a/.github/workflows/fdroid-release.yml
+++ b/.github/workflows/fdroid-release.yml
@@ -81,7 +81,12 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment-retry.outputs.page_url || steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
+        uses: actions/deploy-pages@v4
+        continue-on-error: true
+
+      - id: deployment-retry
+        if: steps.deployment.outcome == 'failure'
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Hardens the F-Droid GitHub Pages deploy step against transient platform-side failures by implementing a 2-attempt retry policy.

## Changes

- Modified `.github/workflows/fdroid-release.yml` to split the `deploy-pages` step into a primary and retry step.
- Added `continue-on-error: true` on the primary deploy attempt.
- Configured a second `deployment-retry` step that only runs if the primary step fails.
- Resolved the environment URL to fall back to the successful deploy step's `page_url`.

## Testing

- Validated YAML syntax using `npx yaml-lint`.
- Ensured React Native TypeScript compilation (`tsc`) and unit tests pass locally with no regressions.

## Issue

Resolves BLD-3016