### PR TITLE
feat: distinguish no-vision-key from pipeline-degraded in daily audit (BLD-3039)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,21 @@ SENTRY_AUTH_TOKEN=
 # manifest in `assets/exercise-illustrations/`. Never log or commit the value.
 OPENAI_API_KEY=
 
+# Vision pipeline / regression-smoke trust anchor (BLD-959 / BLD-3039).
+# `scripts/regression-smoke.sh` (invoked by `scripts/daily-audit.sh`) feeds a
+# known-bad PNG into a vision model to verify the audit pipeline is still
+# detecting visual regressions. At least one of these keys must be set in the
+# daily audit environment. Anthropic is preferred; OpenAI is the fallback.
+#
+# WITHOUT either key: `regression-smoke.sh` exits 4 and `daily-audit.sh`
+# aborts with a FATAL error (production default). Set
+# AUDIT_ALLOW_NO_VISION_KEY=1 in the environment to instead run in
+# SKIPPED/UNVERIFIED mode (sandbox/CI opt-in — the audit completes but trust
+# status is marked UNVERIFIED, never PASS).
+ANTHROPIC_API_KEY=
+# OPENAI_API_KEY is shared with the image-generation script above; a single
+# entry covers both uses — the vision pipeline auto-detects it as fallback.
+
 # Strava developer-dashboard internal API credentials, used by the
 # `cablesnap--strava-oauth` skill scripts in
 # `.claude/skills/cablesnap--strava-oauth/scripts/`. Required ONLY when

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -84,3 +84,40 @@ issue it files so CEO can reproduce against the exact commit and route.
   before upload; workflow logs a `::warning::`.
 - **Playwright HTML report** — uploaded as `ux-audit-playwright-report-<run>`
   on failure for triage.
+
+## Vision pipeline / regression-smoke
+
+`scripts/regression-smoke.sh` is the **trust anchor** of the daily audit. It
+feeds a "known-bad" PNG (the BLD-480 pre-fix MusclesWorkedCard capture) into
+a vision model and asserts the model's response contains canonical regression
+terms. If the pipeline is silently degraded (model stops detecting the
+regression), the smoke catches it before the audit can produce false positives.
+
+### API keys
+
+At least one of these must be set in the daily audit environment:
+
+| Variable | Notes |
+|---|---|
+| `ANTHROPIC_API_KEY` | Preferred — `claude-sonnet-4` via `/v1/messages` |
+| `OPENAI_API_KEY` | Fallback — `gpt-4o` via `/v1/chat/completions` |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Smoke **PASSED** — pipeline still detects the known regression. |
+| `2` | Smoke **FAILED** — pipeline did NOT emit a matching finding. The daily audit MUST NOT trust HEAD findings. Real degradation alarm. |
+| `3` | **CONFIG ERROR** — fixture PNG missing, missing system dependency (`curl`/`python3`/`base64`), forced `API_PROVIDER=x` with that key unset, or unknown `API_PROVIDER`. Genuine error even in a keyless sandbox. |
+| `4` | **No vision key** — neither `ANTHROPIC_API_KEY` nor `OPENAI_API_KEY` is set AND `API_PROVIDER` was not forced. The pipeline was never invoked; this is an infra/config gap, not pipeline degradation. |
+
+### AUDIT_ALLOW_NO_VISION_KEY — sandbox opt-in
+
+In a keyless CI/sandbox environment, you can opt into **SKIPPED/UNVERIFIED** mode by setting `AUDIT_ALLOW_NO_VISION_KEY=1` when running `daily-audit.sh`.
+
+- The audit will **not** abort on smoke exit code 4.
+- A loud multi-line `SKIPPED/UNVERIFIED` banner is emitted to stderr.
+- The final status line prints `regression-smoke: SKIPPED (UNVERIFIED — no vision key)` — **never** `PASS`.
+- HEAD and prefix captures still run; any real HEAD regression is still surfaced.
+
+Without the flag (production default): `daily-audit.sh` aborts with exit code 4 and an error message naming the missing keys and the `AUDIT_ALLOW_NO_VISION_KEY=1` opt-in.

--- a/scripts/__tests__/daily-audit-set-e-ordering.test.ts
+++ b/scripts/__tests__/daily-audit-set-e-ordering.test.ts
@@ -72,6 +72,8 @@ function buildSandbox(opts: {
   prefixExitCode?: number;
   smokeExitCode: number;
   dropPrefixCapture?: boolean;
+  /** Pass AUDIT_ALLOW_NO_VISION_KEY=1 into the daily-audit.sh environment (BLD-3039). */
+  allowNoVisionKey?: boolean;
 }): { dir: string; run: () => RunResult } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bld-1023-"));
 
@@ -197,6 +199,7 @@ esac
       PREFIX_EXIT_CODE: String(opts.prefixExitCode ?? 0),
       SMOKE_EXIT_CODE: String(opts.smokeExitCode),
       DROP_PREFIX_CAPTURE: opts.dropPrefixCapture ? "1" : "0",
+      ...(opts.allowNoVisionKey ? { AUDIT_ALLOW_NO_VISION_KEY: "1" } : {}),
     };
     const proc = spawnSync("bash", [path.join(dir, "scripts", "daily-audit.sh")], {
       cwd: dir,
@@ -330,5 +333,114 @@ describe("daily-audit.sh — BLD-966 set -e ordering + BLD-1023 wrapper-fixture"
     } finally {
       cleanup(dir);
     }
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // BLD-3039: distinguish "no vision key" (exit 4) from "pipeline degraded"
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it("AC6 (BLD-3039): smokeRC=4 + AUDIT_ALLOW_NO_VISION_KEY=1 → exit 0, SKIPPED banner, no PASS", () => {
+    const { dir, run } = buildSandbox({
+      headExitCode: 0,
+      smokeExitCode: 4,
+      allowNoVisionKey: true,
+    });
+    try {
+      const r = run();
+      // Audit should complete successfully (capture ran, anchor was skipped).
+      expect(r.status).toBe(0);
+      // Must print SKIPPED/UNVERIFIED status — never PASS.
+      expect(r.combined).toContain("regression-smoke: SKIPPED (UNVERIFIED — no vision key)");
+      expect(r.combined).not.toContain("regression-smoke: PASS");
+      // Must emit the loud SKIPPED/UNVERIFIED warning banner.
+      expect(r.combined).toMatch(/SKIPPED.*no vision API key|UNVERIFIED/i);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it("AC7 (BLD-3039): smokeRC=4 WITHOUT flag → exit 4, names missing keys, mentions opt-in, no 'degraded' wording", () => {
+    const { dir, run } = buildSandbox({
+      headExitCode: 0,
+      smokeExitCode: 4,
+      allowNoVisionKey: false,
+    });
+    try {
+      const r = run();
+      // Must abort with the smoke's exit code (4).
+      expect(r.status).toBe(4);
+      // Must name the missing keys.
+      expect(r.combined).toMatch(/ANTHROPIC_API_KEY|OPENAI_API_KEY/);
+      // Must mention the sandbox opt-in.
+      expect(r.combined).toContain("AUDIT_ALLOW_NO_VISION_KEY");
+      // Must NOT use "vision pipeline degraded" / "silent degradation" wording
+      // (that message is reserved for the real alarm, RC 2).
+      expect(r.combined).not.toMatch(/vision.pipeline.*(degrad|silent)/i);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  it("AC8 (BLD-3039): smokeRC=2 (real degradation) → unchanged: exit 2, FAILED/trust-anchor message", () => {
+    const { dir, run } = buildSandbox({
+      headExitCode: 0,
+      smokeExitCode: 2,
+    });
+    try {
+      const r = run();
+      expect(r.status).toBe(2);
+      expect(r.combined).toMatch(/regression-smoke FAILED|trust anchor/);
+      // SKIPPED wording must NOT appear on the real-degradation path.
+      expect(r.combined).not.toContain("SKIPPED");
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // BLD-3047: Direct exit-4 unit test running the REAL scripts/regression-smoke.sh
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it("regression-smoke.sh unit: exits 4 with clean error message when no vision API key is configured", () => {
+    const REGRESSION_SMOKE = path.join(REPO_ROOT, "scripts", "regression-smoke.sh");
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "bld-3047-"));
+    const tempPng = path.join(tempDir, "fixture.png");
+    fs.writeFileSync(tempPng, "fake png bytes");
+
+    const env = { ...process.env };
+    delete env.ANTHROPIC_API_KEY;
+    delete env.OPENAI_API_KEY;
+    delete env.API_PROVIDER;
+
+    try {
+      const proc = spawnSync("bash", [REGRESSION_SMOKE, tempPng], {
+        env,
+        encoding: "utf8",
+      });
+
+      expect(proc.status).toBe(4);
+      expect(proc.stderr).toContain("no vision API key configured");
+      expect(proc.stderr).toContain("AUDIT_ALLOW_NO_VISION_KEY=1");
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("regression-smoke.sh unit: exits 3 if fixture PNG is missing", () => {
+    const REGRESSION_SMOKE = path.join(REPO_ROOT, "scripts", "regression-smoke.sh");
+    const missingPng = path.join(os.tmpdir(), "nonexistent-fixture-bld-3047.png");
+
+    const env = { ...process.env };
+    delete env.ANTHROPIC_API_KEY;
+    delete env.OPENAI_API_KEY;
+    delete env.API_PROVIDER;
+
+    const proc = spawnSync("bash", [REGRESSION_SMOKE, missingPng], {
+      env,
+      encoding: "utf8",
+    });
+
+    expect(proc.status).toBe(3);
+    expect(proc.stderr).toContain("fixture not found");
   });
 });

--- a/scripts/daily-audit.sh
+++ b/scripts/daily-audit.sh
@@ -356,29 +356,81 @@ FINDINGS_OUT="$SMOKE_FINDINGS" \
   scripts/regression-smoke.sh "$PREFIX_FIXTURE_PNG"
 SMOKE_RC=$?
 set -e
+SMOKE_SKIPPED=0
 
 if [[ $SMOKE_RC -ne 0 ]]; then
-  echo "[daily-audit] 🚨 FATAL: regression-smoke FAILED (vision-pipeline trust anchor)." >&2
-  echo "[daily-audit] Today's HEAD findings MUST NOT be trusted." >&2
-  exit $SMOKE_RC
+  if [[ $SMOKE_RC -eq 4 ]]; then
+    if [[ "${AUDIT_ALLOW_NO_VISION_KEY:-}" == "1" ]]; then
+      # Opt-in sandbox mode: no key is present but the operator has explicitly
+      # accepted running without the vision trust anchor. Emit a loud,
+      # unmistakable warning and continue — but never upgrade this to PASS.
+      echo "" >&2
+      echo "╔══════════════════════════════════════════════════════════════════╗" >&2
+      echo "║  WARNING: regression-smoke SKIPPED — no vision API key set      ║" >&2
+      echo "║                                                                  ║" >&2
+      echo "║  The vision-pipeline trust anchor was NOT run today.             ║" >&2
+      echo "║  Audit trust status: UNVERIFIED                                  ║" >&2
+      echo "║  HEAD findings were captured but NOT validated by the smoke.     ║" >&2
+      echo "║                                                                  ║" >&2
+      echo "║  To restore the trust anchor, set one of:                        ║" >&2
+      echo "║    ANTHROPIC_API_KEY   (preferred — powers regression-smoke.sh)  ║" >&2
+      echo "║    OPENAI_API_KEY      (fallback)                                ║" >&2
+      echo "╚══════════════════════════════════════════════════════════════════╝" >&2
+      echo "" >&2
+      SMOKE_SKIPPED=1
+    else
+      # No key AND the operator has NOT opted in — this is a misconfiguration
+      # that must not silently produce an unverified audit. Abort with a
+      # message that names the missing keys and explains the sandbox opt-in.
+      echo "[daily-audit] 🚨 FATAL: regression-smoke aborted — no vision API key configured." >&2
+      echo "[daily-audit] Set ANTHROPIC_API_KEY (preferred) or OPENAI_API_KEY to enable" >&2
+      echo "[daily-audit] the vision-pipeline trust anchor." >&2
+      echo "[daily-audit] In a keyless sandbox, set AUDIT_ALLOW_NO_VISION_KEY=1 to opt into" >&2
+      echo "[daily-audit] SKIPPED/UNVERIFIED mode (the audit will complete but trust status" >&2
+      echo "[daily-audit] will be marked UNVERIFIED — never PASS)." >&2
+      exit $SMOKE_RC
+    fi
+  else
+    echo "[daily-audit] 🚨 FATAL: regression-smoke FAILED (vision-pipeline trust anchor)." >&2
+    echo "[daily-audit] Today's HEAD findings MUST NOT be trusted." >&2
+    exit $SMOKE_RC
+  fi
 fi
 
-# Smoke passed. If HEAD or pre-fix scenarios failed, surface that — the
-# pipeline itself is healthy, so a HEAD failure is a real regression.
+# Smoke passed (or was explicitly skipped as UNVERIFIED). If HEAD or pre-fix
+# scenarios failed, surface that — a HEAD failure still matters even in an
+# UNVERIFIED run. However, never upgrade an UNVERIFIED run to a trusted PASS.
+SMOKE_STATUS_LABEL="PASS (findings → $SMOKE_FINDINGS)"
+if [[ $SMOKE_SKIPPED -eq 1 ]]; then
+  SMOKE_STATUS_LABEL="SKIPPED (UNVERIFIED — no vision key)"
+fi
+
 if [[ $HEAD_RC -ne 0 ]]; then
-  echo "[daily-audit] HEAD scenarios failed (rc=$HEAD_RC) but smoke PASSED — vision pipeline is healthy, the HEAD failure is a real regression." >&2
-  echo "[daily-audit] regression-smoke: PASS (findings → $SMOKE_FINDINGS)"
+  if [[ $SMOKE_SKIPPED -eq 1 ]]; then
+    echo "[daily-audit] HEAD scenarios failed (rc=$HEAD_RC) and smoke was SKIPPED/UNVERIFIED — treat HEAD findings with caution." >&2
+  else
+    echo "[daily-audit] HEAD scenarios failed (rc=$HEAD_RC) but smoke PASSED — vision pipeline is healthy, the HEAD failure is a real regression." >&2
+  fi
+  echo "[daily-audit] regression-smoke: $SMOKE_STATUS_LABEL"
   exit $HEAD_RC
 fi
 
 if [[ $PREFIX_RC -ne 0 ]]; then
-  echo "[daily-audit] pre-fix fixture spec failed (rc=$PREFIX_RC) but smoke PASSED — vision pipeline is healthy, the fixture-spec failure needs investigation." >&2
-  echo "[daily-audit] regression-smoke: PASS (findings → $SMOKE_FINDINGS)"
+  if [[ $SMOKE_SKIPPED -eq 1 ]]; then
+    echo "[daily-audit] pre-fix fixture spec failed (rc=$PREFIX_RC) and smoke was SKIPPED/UNVERIFIED." >&2
+  else
+    echo "[daily-audit] pre-fix fixture spec failed (rc=$PREFIX_RC) but smoke PASSED — vision pipeline is healthy, the fixture-spec failure needs investigation." >&2
+  fi
+  echo "[daily-audit] regression-smoke: $SMOKE_STATUS_LABEL"
   exit $PREFIX_RC
 fi
 
 echo ""
 echo "[daily-audit] bundles ready at $HEAD_COPY and $PINNED_OUT"
-echo "[daily-audit] regression-smoke: PASS (findings → $SMOKE_FINDINGS)"
-echo "[daily-audit] next step: scripts/audit-bundle.sh uploads to GH Releases,"
-echo "[daily-audit] then ux-designer agent pulls + reviews."
+echo "[daily-audit] regression-smoke: $SMOKE_STATUS_LABEL"
+if [[ $SMOKE_SKIPPED -eq 1 ]]; then
+  echo "[daily-audit] NOTE: audit trust status is UNVERIFIED — vision pipeline was not validated today."
+else
+  echo "[daily-audit] next step: scripts/audit-bundle.sh uploads to GH Releases,"
+  echo "[daily-audit] then ux-designer agent pulls + reviews."
+fi

--- a/scripts/regression-smoke.sh
+++ b/scripts/regression-smoke.sh
@@ -12,7 +12,14 @@
 #   0  smoke PASSED — vision pipeline still flags the known regression.
 #   2  smoke FAILED — vision pipeline did NOT emit a matching finding;
 #      the daily audit must NOT trust today's HEAD findings (alarm).
-#   3  configuration error — fixture missing, no API key, malformed args.
+#   3  configuration error — fixture missing, malformed args, missing
+#      dependency (curl/python3/base64), or forced API_PROVIDER= with its
+#      matching key unset. These are genuine errors even in a keyless sandbox.
+#   4  no vision API key configured — neither ANTHROPIC_API_KEY nor
+#      OPENAI_API_KEY is set AND API_PROVIDER was not forced. In a keyless
+#      sandbox the pipeline was never invoked; this is an infra/config gap,
+#      not a pipeline degradation. Set AUDIT_ALLOW_NO_VISION_KEY=1 in
+#      daily-audit.sh to treat this as a loudly-warned SKIPPED run.
 #
 # This is the *primary* trust anchor of the daily audit loop. If a vision
 # model regression silently degrades the pipeline, this smoke is what
@@ -82,9 +89,11 @@ if [[ -z "$PROVIDER" ]]; then
   elif [[ -n "${OPENAI_API_KEY:-}" ]]; then
     PROVIDER="openai"
   else
-    echo "[regression-smoke] CONFIG ERROR: no vision API key set." >&2
-    echo "[regression-smoke] Set ANTHROPIC_API_KEY or OPENAI_API_KEY." >&2
-    exit 3
+    echo "[regression-smoke] CONFIG ERROR: no vision API key configured." >&2
+    echo "[regression-smoke] Set ANTHROPIC_API_KEY (preferred) or OPENAI_API_KEY." >&2
+    echo "[regression-smoke] In a keyless sandbox, set AUDIT_ALLOW_NO_VISION_KEY=1 in" >&2
+    echo "[regression-smoke] the daily audit environment to opt into SKIPPED/UNVERIFIED mode." >&2
+    exit 4
   fi
 fi
 


### PR DESCRIPTION
## Summary

Distinguishes two previously conflated failure modes in the daily visual UX audit:
- **exit 4** — no vision API key configured (infra gap; pipeline never invoked)
- **exit 2** — vision pipeline silently degraded (the real alarm; HEAD findings untrustworthy)

Before this change, a keyless sandbox container would emit a misleading "vision pipeline degraded / trust anchor FAILED" message when the actual problem was simply a missing API key.

## Changes

- **`scripts/regression-smoke.sh`**: new exit code `4` when both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are unset and `API_PROVIDER` is not forced; all other error paths remain exit `3`; updated exit-code doc block
- **`scripts/daily-audit.sh`**: handles smoke RC=4 explicitly — with `AUDIT_ALLOW_NO_VISION_KEY=1` emits a loud SKIPPED/UNVERIFIED banner and continues (never prints `PASS`); without the flag, aborts with improved message naming the missing keys + pointing at the opt-in; RC=2/3 path is byte-for-byte unchanged
- **`.env.example`**: documents `ANTHROPIC_API_KEY` for the vision pipeline trust anchor
- **`e2e/README.md`**: adds "Vision pipeline / regression-smoke" subsection documenting exit codes, keys, and the `AUDIT_ALLOW_NO_VISION_KEY=1` sandbox opt-in

## Testing

- All 10 tests pass: `npx jest scripts/__tests__/daily-audit-set-e-ordering.test.ts`
  - Existing AC1–AC5 + boundary tests: all green (no regression)
  - New AC6: smoke=4 + opt-in flag → exit 0, SKIPPED/UNVERIFIED banner, no PASS
  - New AC7: smoke=4 without flag → exit 4, names missing keys, mentions opt-in, no 'degraded' wording
  - New AC8: smoke=2 (real degradation) → exit 2, FAILED/trust-anchor message unchanged
- Manual edge-case verification:
  - No key + valid fixture → exit 4 (new)
  - Missing fixture → exit 3 (unchanged)
  - Forced `API_PROVIDER=anthropic` + missing key → exit 3 (unchanged)
- `bash -n` syntax check: both scripts pass

## Issue

Resolves BLD-3039
Parent: BLD-3038 (INFRA: Missing API keys in audit container)