### PR TITLE
fix: do not captureException for known-permanent Strava app_inactive 403 (BLD-3063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- Stop reporting the known-permanent Strava "app inactive" 403 to Sentry as an exception (BLD-3063)
 
 ## v0.26.64 — 2026-07-05
 <!-- versionCode: 134 -->

--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -519,6 +519,7 @@ describe("Strava Integration — Behavioral", () => {
   });
 
   it("(BLD-2995) upload returns 403 Inactive → returns 'failed', marks permanently failed, does not disconnect", async () => {
+    const Sentry = require("@sentry/react-native");
     db.getStravaConnection.mockResolvedValue({ athlete_id: 1 });
     db.getSessionSets.mockResolvedValue([
       { exercise_name: "Row", weight: 70, reps: 10, completed: true, set_type: "working" },
@@ -553,9 +554,18 @@ describe("Strava Integration — Behavioral", () => {
     expect(db.markSyncFailed).toHaveBeenCalledWith("s-inactive", expect.stringContaining("Inactive"));
     expect(db.markSyncPermanentlyFailed).toHaveBeenCalledWith("s-inactive");
     expect(db.deleteStravaConnection).not.toHaveBeenCalled();
+
+    // BLD-3063: Sentry.captureException is NOT called for app_inactive errors
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    // BLD-3063: A stravaLog("warn", ...) is emitted instead
+    expect(Sentry.logger.warn).toHaveBeenCalledWith(
+      "strava_upload_app_inactive",
+      { sessionId: "s-inactive", status: 403, code: "app_inactive" }
+    );
   });
 
   it("(BLD-2995) upload returns 403 with non-JSON body → treated as permanent config error", async () => {
+    const Sentry = require("@sentry/react-native");
     db.getStravaConnection.mockResolvedValue({ athlete_id: 1 });
     db.getSessionSets.mockResolvedValue([
       { exercise_name: "Row", weight: 70, reps: 10, completed: true, set_type: "working" },
@@ -585,6 +595,11 @@ describe("Strava Integration — Behavioral", () => {
     expect((result as any).error.code).toBe("config");
     expect(db.markSyncPermanentlyFailed).toHaveBeenCalledWith("s-non-json");
     expect(db.deleteStravaConnection).not.toHaveBeenCalled();
+
+    // BLD-3063: Sentry.captureException IS still called for genuine config errors
+    expect(Sentry.captureException).toHaveBeenCalled();
+    // BLD-3063: logger.warn is NOT called
+    expect(Sentry.logger.warn).not.toHaveBeenCalled();
   });
 
   it("(BLD-2995) reconcileQueue: permanent app_inactive/config error short-circuits immediately", async () => {

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -395,7 +395,13 @@ async function uploadActivity(
     const isInactive = isStravaAppInactive(body);
     const errCode = isInactive ? "app_inactive" : "config";
     const err = new StravaError(errCode, `Strava API error 403: ${body}`, 403);
-    captureStravaError(err, "strava_upload", "api_call", { sessionId, status: response.status, responseBody: body });
+    if (isInactive) {
+      // Known-permanent, human-actionable (reactivate Strava app). Do not spam
+      // Sentry with an exception per upload — log at warn for visibility only.
+      stravaLog("warn", "strava_upload_app_inactive", { sessionId, status: 403, code: errCode });
+    } else {
+      captureStravaError(err, "strava_upload", "api_call", { sessionId, status: response.status, responseBody: body });
+    }
     throw err;
   }
 


### PR DESCRIPTION
## Summary

When the Strava developer application is inactive, every upload returns HTTP 403 with code `Inactive`. This is a known-permanent, human-actionable state (someone must reactivate the app on Strava's side). Reporting it to Sentry as an exception per upload floods the Sentry dashboard with non-actionable noise.

This fix stops calling `captureStravaError` (which calls `Sentry.captureException`) for `app_inactive` 403 errors. Instead, it emits a `stravaLog("warn", ...)` so the state is still visible in the Sentry logs dataset — but without triggering exception alerts.

## Changes

- `lib/strava.ts`: Split the 403 handler — `app_inactive` path calls `stravaLog("warn", ...)` only; `config` path still calls `captureStravaError` (genuine build misconfiguration that IS actionable)
- `__tests__/lib/strava.test.ts`: Extended the two BLD-2995 403 tests to additionally assert that `Sentry.captureException` is NOT called on `app_inactive` (but IS called on `config`), and that `Sentry.logger.warn` IS called on `app_inactive` (but NOT on `config`)

## Testing

- All 87 existing tests pass unchanged (BLD-2995 behavior fully preserved)
- New assertions in existing tests verify the Sentry routing:
  - `app_inactive` → `stravaLog warn` only, no `captureException`
  - `config` (non-JSON body) → `captureException` still called, no `stravaLog warn`
- TypeScript: `tsc --noEmit` clean

## Issue

Resolves BLD-3063
Parent: BLD-3062