### PR TITLE
fix(settings): reserve floating tab bar viewport so no list row is obscured (BLD-3065)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Settings rows no longer hide behind the bottom bar** — on the Settings screen, list rows (like "Manage gyms, cable stacks, and marker calibrations") are no longer partially obscured or clipped behind the floating bottom navigation bar at the top of the list. The scrollable area now ends cleanly above the bar so every row stays fully visible and tappable. (BLD-3065)
 
 ## v0.26.64 — 2026-07-05
 <!-- versionCode: 134 -->

--- a/__tests__/acceptance/settings.test.tsx
+++ b/__tests__/acceptance/settings.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { fireEvent, waitFor } from '@testing-library/react-native'
+import { StyleSheet } from 'react-native'
 import { renderScreen } from '../helpers/render'
 
 const mockRouter = { push: jest.fn(), replace: jest.fn(), back: jest.fn() }
@@ -445,7 +446,7 @@ describe('Settings Screen Acceptance', () => {
 
   // ── Scroll padding rhythm (BLD-1106 regression + BLD-2034 tokenization) ──────
 
-  it('ScrollView contentContainerStyle is a flat object with paddingBottom === FLOATING_TAB_BAR_HEIGHT + SETTINGS_SCROLL_EXTRA_BOTTOM', () => {
+  it('ScrollView reserves the floating tab bar viewport and keeps extra scroll-bottom clearance', () => {
     const { getByTestId } = renderScreen(<Settings />)
     const scroll = getByTestId('settings-scroll-view')
     // contentContainerStyle must be a single flat object — no style-array merge ambiguity.
@@ -461,8 +462,10 @@ describe('Settings Screen Acceptance', () => {
     expect(style).not.toBeInstanceOf(Array)
     // Inset is a spacing-token expression, not an ad-hoc literal, and preserves the
     // validated foldable clearance.
+    const scrollStyle = StyleSheet.flatten(scroll.props.style)
     expect(SETTINGS_SCROLL_EXTRA_BOTTOM).toBe(spacing.xxl * 5)
     expect(SETTINGS_SCROLL_EXTRA_BOTTOM).toBeGreaterThanOrEqual(96)
-    expect(style.paddingBottom).toBe(FLOATING_TAB_BAR_HEIGHT + SETTINGS_SCROLL_EXTRA_BOTTOM)
+    expect(scrollStyle.marginBottom).toBe(FLOATING_TAB_BAR_HEIGHT)
+    expect(style.paddingBottom).toBe(SETTINGS_SCROLL_EXTRA_BOTTOM)
   })
 })

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -171,11 +171,17 @@ export default function Settings() {
   return (
     <ScrollView
       testID="settings-scroll-view"
-      style={[styles.container, { backgroundColor: colors.background }]}
+      style={[
+        styles.container,
+        {
+          backgroundColor: colors.background,
+          marginBottom: tabBarHeight,
+        },
+      ]}
       contentContainerStyle={{
         paddingTop: spacing.base,
         paddingHorizontal: layout.horizontalPadding,
-        paddingBottom: tabBarHeight + SETTINGS_SCROLL_EXTRA_BOTTOM,
+        paddingBottom: SETTINGS_SCROLL_EXTRA_BOTTOM,
       }}
     >
       {/*


### PR DESCRIPTION
## Summary

Fixes the Settings nav-overlap flagged in the 2026-07-07 UX audit (`settings-top-mobile`): a mid-list settings row ("Manage gyms, cable stacks, and marker calibrations >") rendered partially behind the fixed floating bottom tab bar at the top scroll position, making its label and tap target hard-clipped.

## Root cause

The floating tab bar (`components/FloatingTabBar.tsx`) is an **opaque** (`colors.surface`) `position: absolute` pill with rounded corners and a transparent gap beneath it. The Settings `ScrollView` previously reserved bar clearance only via `contentContainerStyle.paddingBottom = tabBarHeight + SETTINGS_SCROLL_EXTRA_BOTTOM`. That guarantees the **last** element clears the bar at max scroll, but content still paints **behind** the opaque pill at top/intermediate scroll offsets — so a mid-list row landing under the pill looks hard-clipped mid-text.

## Fix

Reserve the tab bar viewport by setting `marginBottom: tabBarHeight` on the ScrollView's own `style`, so the scrollable viewport ends above the bar and **no content paints behind the opaque pill at any scroll position**. `SETTINGS_SCROLL_EXTRA_BOTTOM` is retained as content bottom clearance — the validated foldable scroll-cutoff guard (BLD-1106 → BLD-1124, GH #533 Z-Fold regression) is preserved unchanged.

Layout-only change. No database, session, or workout-state paths touched. Risk: low.

## Regression guard

`__tests__/acceptance/settings.test.tsx` now asserts both contracts independently:
- viewport reservation `style.marginBottom === FLOATING_TAB_BAR_HEIGHT`
- content bottom padding `contentContainerStyle.paddingBottom === SETTINGS_SCROLL_EXTRA_BOTTOM`

## Verification

- `tsc --noEmit` — clean, no TypeScript errors.
- `npm test -- __tests__/acceptance/settings.test.tsx --runInBand` — **21/21 pass**. (Pre-existing `act()` warnings from `useBodyProfile` async state and the Jest force-exit warning in the SQLite test env are unrelated to this change.)

## Scope note

This change is intentionally scoped to **Settings** (the screen the audit flagged). Other tab screens (`index`, `exercises`, `nutrition`) still use the `paddingBottom: tabBarHeight + X` pattern (content scrolls behind the opaque pill). Whether they need the same viewport-reservation treatment is tracked as a separate follow-up rather than expanded into this PR.

Source issue: BLD-3065 · Packaging issue: BLD-3067
