### PR TITLE
feat(ux): reserve bottom bar viewport on other tab screens (BLD-3068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
+- **List items on other tab screens no longer hide behind bottom bar** — on the Workouts, Exercises, and Nutrition screens, list content is no longer partially obscured or clipped behind the floating bottom navigation bar. The scrollable area now ends cleanly above the bar so every row and element stays fully visible and tappable at all scroll offsets. (BLD-3068)
 - **Settings rows no longer hide behind the bottom bar** — on the Settings screen, list rows (like "Manage gyms, cable stacks, and marker calibrations") are no longer partially obscured or clipped behind the floating bottom navigation bar at the top of the list. The scrollable area now ends cleanly above the bar so every row stays fully visible and tappable. (BLD-3065)
 
 ## v0.26.64 — 2026-07-05

--- a/__tests__/acceptance/dashboard.test.tsx
+++ b/__tests__/acceptance/dashboard.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { fireEvent, waitFor } from '@testing-library/react-native'
+import { StyleSheet } from 'react-native'
 import { renderScreen } from '../helpers/render'
 import {
   createSession,
@@ -432,6 +433,17 @@ describe('Dashboard Acceptance', () => {
       await waitFor(() => {
         expect(getByLabelText('Create new program')).toBeTruthy()
       })
+    })
+
+    it('ScrollView reserves the floating tab bar viewport and keeps 80 scroll-bottom clearance', async () => {
+      const { getByTestId } = renderScreen(<Dashboard />)
+      // Wait for data load if needed
+      const scroll = getByTestId('home-scroll-view')
+      const style = scroll.props.contentContainerStyle
+      expect(style).not.toBeInstanceOf(Array)
+      const scrollStyle = StyleSheet.flatten(scroll.props.style)
+      expect(scrollStyle.marginBottom).toBe(88) // FLOATING_TAB_BAR_HEIGHT (with 0 inset in test environment)
+      expect(style.paddingBottom).toBe(80)
     })
   })
 })

--- a/__tests__/flows/exercise.test.tsx
+++ b/__tests__/flows/exercise.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { fireEvent, waitFor } from '@testing-library/react-native'
+import { StyleSheet } from 'react-native'
 import { renderScreen } from '../helpers/render'
 import { createExercise, resetIds } from '../helpers/factories'
 import type { Exercise } from '../../lib/types'
@@ -207,5 +208,16 @@ describe('Exercise Browser', () => {
     // With TanStack Query, errors are caught and retried; the screen remains mounted
     expect(queryByText).toBeDefined()
     ;(console.error as jest.Mock).mockRestore()
+  })
+
+  it('FlatList reserves the floating tab bar viewport and keeps 0 scroll-bottom clearance', async () => {
+    const { getByTestId, findByText } = renderScreen(<Exercises />)
+    await findByText('Bench Press')
+    const list = getByTestId('exercises-list')
+    const style = list.props.contentContainerStyle
+    expect(style).not.toBeInstanceOf(Array)
+    const listStyle = StyleSheet.flatten(list.props.style)
+    expect(listStyle.marginBottom).toBe(88) // FLOATING_TAB_BAR_HEIGHT
+    expect(style.paddingBottom).toBe(0)
   })
 })

--- a/__tests__/flows/nutrition.test.tsx
+++ b/__tests__/flows/nutrition.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { fireEvent, waitFor } from '@testing-library/react-native'
+import { StyleSheet } from 'react-native'
 import { renderScreen } from '../helpers/render'
 import { createFoodEntry, createDailyLog, createMacroTargets, resetIds } from '../helpers/factories'
 import type { DailyLog, FoodEntry, MacroTargets } from '../../lib/types'
@@ -231,5 +232,16 @@ describe('Nutrition Logging', () => {
     )
     expect(await findByText('Something went wrong')).toBeTruthy()
     ;(console.error as jest.Mock).mockRestore()
+  })
+
+  it('SectionList reserves the floating tab bar viewport and keeps 16 scroll-bottom clearance', async () => {
+    const { getByTestId, findByText } = renderScreen(<Nutrition />)
+    await findByText('Lunch')
+    const list = getByTestId('nutrition-scroll-view')
+    const style = list.props.contentContainerStyle
+    const listStyle = StyleSheet.flatten(list.props.style)
+    expect(listStyle.marginBottom).toBe(88) // FLOATING_TAB_BAR_HEIGHT
+    const flatStyle = StyleSheet.flatten(style)
+    expect(flatStyle.paddingBottom).toBe(16)
   })
 })

--- a/app/(tabs)/exercises.tsx
+++ b/app/(tabs)/exercises.tsx
@@ -88,8 +88,11 @@ export default function Exercises() {
   const toggle = useCallback((f: FilterType) => {
     setSelected((prev) => {
       const next = new Set(prev);
-      if (next.has(f)) next.delete(f);
-      else next.add(f);
+      if (next.has(f)) {
+        next.delete(f);
+      } else {
+        next.add(f);
+      }
       return next;
     });
   }, []);
@@ -226,12 +229,14 @@ export default function Exercises() {
         />
       </View>
       <FlatList
+        testID="exercises-list"
         data={filtered}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         numColumns={1}
         ListEmptyComponent={empty}
-        contentContainerStyle={{ paddingBottom: tabBarHeight }}
+        style={{ marginBottom: tabBarHeight }}
+        contentContainerStyle={{ paddingBottom: 0 }}
       />
       <ExerciseFilterSheet
         isVisible={filterSheet.isVisible}
@@ -243,18 +248,12 @@ export default function Exercises() {
     </View>
   );
 
-  if (!layout.atLeastMedium) {
-    return (
-      <View style={[styles.container, { backgroundColor: colors.background }]}>
-        {list}
-      </View>
-    );
-  }
-
   return (
-    <View style={[styles.container, styles.wideRow, { backgroundColor: colors.background }]}>
+    <View style={[styles.container, layout.atLeastMedium && styles.wideRow, { backgroundColor: colors.background }]}>
       {list}
-      <ExerciseDetailPane detail={detail} colors={colors} profileGender={profileGender} bottomInset={tabBarHeight} />
+      {layout.atLeastMedium && (
+        <ExerciseDetailPane detail={detail} colors={colors} profileGender={profileGender} bottomInset={tabBarHeight} />
+      )}
     </View>
   );
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -184,7 +184,15 @@ export default function Workouts() {
   return (
     // bounded list — ScrollView is intentional: renders fixed sub-components (stats, banners, templates/programs), not unbounded .map()
     <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingHorizontal: layout.horizontalPadding, paddingVertical: 16, paddingBottom: tabBarHeight + 80 }}>
+      <ScrollView
+        testID="home-scroll-view"
+        style={{ flex: 1, marginBottom: tabBarHeight }}
+        contentContainerStyle={{
+          paddingHorizontal: layout.horizontalPadding,
+          paddingVertical: 16,
+          paddingBottom: 80,
+        }}
+      >
         {/* Full-width header section: always single column */}
         <StatsRow colors={colors} streak={data?.streak ?? 0} progress={progress} prCount={(data?.recentPRs ?? []).length} />
         <ErrorBoundary>

--- a/app/(tabs)/nutrition.tsx
+++ b/app/(tabs)/nutrition.tsx
@@ -78,10 +78,10 @@ export default function Nutrition() {
         testID="nutrition-scroll-view"
         sections={sections}
         keyExtractor={(item) => item.id}
-        style={styles.scroll}
+        style={[styles.scroll, { marginBottom: tabBarHeight }]}
         contentContainerStyle={[
           styles.scrollContent,
-          { paddingHorizontal: layout.horizontalPadding, paddingBottom: tabBarHeight + 16 },
+          { paddingHorizontal: layout.horizontalPadding, paddingBottom: 16 },
         ]}
         stickySectionHeadersEnabled={false}
         renderSectionHeader={({ section }) => (


### PR DESCRIPTION
## Summary

On the Workouts, Exercises, and Nutrition screens, list content is no longer partially obscured or clipped behind the floating bottom navigation bar. The scrollable area now ends cleanly above the bar so every row and element stays fully visible and tappable at all scroll offsets.

## Changes

- **app/(tabs)/index.tsx**: Set `marginBottom: tabBarHeight` on ScrollView style and updated paddingBottom of contentContainerStyle from `tabBarHeight + 80` to `80`.
- **app/(tabs)/exercises.tsx**: Set `marginBottom: tabBarHeight` on FlatList style and updated paddingBottom of contentContainerStyle from `tabBarHeight` to `0`.
- **app/(tabs)/nutrition.tsx**: Set `marginBottom: tabBarHeight` on SectionList style and updated paddingBottom of contentContainerStyle from `tabBarHeight + 16` to `16`.
- **__tests__**: Added and verified regression tests in `dashboard.test.tsx`, `exercise.test.tsx`, and `nutrition.test.tsx` to lock in viewport reservation and scroll padding behaviors.

## Testing

- Ran typescript compiler checking: `npm run typecheck` (tsc) passes clean.
- Ran linter: `npm run lint` has 0 errors.
- Verified and ran Jest unit & acceptance tests: `__tests__/acceptance/dashboard.test.tsx`, `__tests__/flows/exercise.test.tsx`, and `__tests__/flows/nutrition.test.tsx` all pass successfully with new assertions.

## Issue

Resolves BLD-3068