### PR TITLE
infra: add pre-push changelog gate (BLD-3078)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -56,6 +56,18 @@ if [ -f "scripts/check-changelog-parity.sh" ]; then
   fi
 fi
 
+# ─── CHANGELOG Unreleased Bullet Gate (BLD-3078) ────────────────
+# Blocks push if user-facing code changes are being pushed without a
+# corresponding bullet point under '## Unreleased' in CHANGELOG.md.
+# Mirrors the CI 'changelog-gate' workflow check to catch missing entries
+# before pushing.
+if [ -f "scripts/check-changelog-gate.ts" ]; then
+  echo "📝 Verifying CHANGELOG ## Unreleased bullet (BLD-3078)..."
+  if ! npx tsx scripts/check-changelog-gate.ts; then
+    exit 1
+  fi
+fi
+
 # ─── Exercise Illustration Bundle Gate (BLD-561) ────────────────
 # Blocks push if assets/exercise-illustrations/**/*.webp exceeds the hard-fail
 # bundle budget (R2 plan: target ≤8MB, hard fail >12MB).

--- a/__tests__/scripts/check-changelog-gate.test.ts
+++ b/__tests__/scripts/check-changelog-gate.test.ts
@@ -2,7 +2,7 @@ import {
   isUserFacing,
   extractUnreleasedBullets,
   runChangelogGateCheck,
-} from "../check-changelog-gate";
+} from "../../scripts/check-changelog-gate";
 
 describe("isUserFacing", () => {
   it("classifies user-facing paths correctly", () => {
@@ -15,7 +15,7 @@ describe("isUserFacing", () => {
     expect(isUserFacing("plugins/sentry.js")).toBe(true);
   });
 
-  it("classifies internal/override paths as exempt (false)", () => {
+  it("classifies non-user-facing paths as exempt", () => {
     expect(isUserFacing("app/screens/__tests__/Workout.test.tsx")).toBe(false);
     expect(isUserFacing("lib/changelog.generated.ts")).toBe(false);
     expect(isUserFacing("e2e/scenario.spec.ts")).toBe(false);
@@ -65,11 +65,7 @@ Some explanatory text.
 ### Some sub-heading
 - Another bullet under sub-heading.
 `;
-    // Stopping at ##, but ### or text doesn't stop it (as long as it's not ##).
-    // Let's verify our implementation behavior.
-    // In our implementation, we stop at any heading starting with "## ".
-    // If it's "### ", it doesn't stop.
-    // Let's see: text or "- Another bullet" under "### " will count.
+    // Heading '###' does not terminate section; only a heading level-2 ('## ') ends '## Unreleased'.
     expect(extractUnreleasedBullets(content)).toBe(2);
   });
 });
@@ -79,11 +75,8 @@ describe("runChangelogGateCheck", () => {
     changedFiles: [],
     baseContent: null,
     headContent: null,
-    skipChangelogEnv: false,
-    hasSkipChangelogCommitMsg: false,
     isDependabotBranch: false,
     isDependabotAuthor: false,
-    hasSkipChangelogBranchName: false,
   };
 
   it("passes when no files changed", () => {
@@ -156,26 +149,6 @@ describe("runChangelogGateCheck", () => {
     expect(res.reason).toContain("Changelog gate passed");
   });
 
-  it("bypasses when SKIP_CHANGELOG env is true", () => {
-    const res = runChangelogGateCheck({
-      ...defaultOptions,
-      changedFiles: ["app/screens/Workout.tsx"],
-      skipChangelogEnv: true,
-    });
-    expect(res.passed).toBe(true);
-    expect(res.reason).toContain("Bypassed via environment variable");
-  });
-
-  it("bypasses when skip-changelog is in branch name", () => {
-    const res = runChangelogGateCheck({
-      ...defaultOptions,
-      changedFiles: ["app/screens/Workout.tsx"],
-      hasSkipChangelogBranchName: true,
-    });
-    expect(res.passed).toBe(true);
-    expect(res.reason).toContain("Bypassed via skip-changelog in branch name");
-  });
-
   it("bypasses for Dependabot changes", () => {
     const res = runChangelogGateCheck({
       ...defaultOptions,
@@ -184,15 +157,5 @@ describe("runChangelogGateCheck", () => {
     });
     expect(res.passed).toBe(true);
     expect(res.reason).toContain("Bypassed for Dependabot changes");
-  });
-
-  it("bypasses when skip-changelog is in commit message", () => {
-    const res = runChangelogGateCheck({
-      ...defaultOptions,
-      changedFiles: ["app/screens/Workout.tsx"],
-      hasSkipChangelogCommitMsg: true,
-    });
-    expect(res.passed).toBe(true);
-    expect(res.reason).toContain("Bypassed via skip-changelog in commit message");
   });
 });

--- a/scripts/__tests__/check-changelog-gate.test.ts
+++ b/scripts/__tests__/check-changelog-gate.test.ts
@@ -1,0 +1,198 @@
+import {
+  isUserFacing,
+  extractUnreleasedBullets,
+  runChangelogGateCheck,
+} from "../check-changelog-gate";
+
+describe("isUserFacing", () => {
+  it("classifies user-facing paths correctly", () => {
+    expect(isUserFacing("app/screens/Workout.tsx")).toBe(true);
+    expect(isUserFacing("components/Button.tsx")).toBe(true);
+    expect(isUserFacing("lib/helpers.ts")).toBe(true);
+    expect(isUserFacing("hooks/useRestTimer.ts")).toBe(true);
+    expect(isUserFacing("package.json")).toBe(true);
+    expect(isUserFacing("app.config.ts")).toBe(true);
+    expect(isUserFacing("plugins/sentry.js")).toBe(true);
+  });
+
+  it("classifies internal/override paths as exempt (false)", () => {
+    expect(isUserFacing("app/screens/__tests__/Workout.test.tsx")).toBe(false);
+    expect(isUserFacing("lib/changelog.generated.ts")).toBe(false);
+    expect(isUserFacing("e2e/scenario.spec.ts")).toBe(false);
+    expect(isUserFacing("scripts/audit-tests.sh")).toBe(false);
+    expect(isUserFacing(".github/workflows/ci.yml")).toBe(false);
+    expect(isUserFacing(".plans/PLAN-BLD-3078.md")).toBe(false);
+  });
+});
+
+describe("extractUnreleasedBullets", () => {
+  it("extracts bullet count correctly", () => {
+    const content = `
+# Changelog
+
+## Unreleased
+
+- Bullet one.
+- Bullet two.
+
+## v0.26.64 — 2026-07-05
+- Stale bullet.
+`;
+    expect(extractUnreleasedBullets(content)).toBe(2);
+  });
+
+  it("handles empty unreleased section", () => {
+    const content = `
+# Changelog
+
+## Unreleased
+
+## v0.26.64 — 2026-07-05
+- Stale bullet.
+`;
+    expect(extractUnreleasedBullets(content)).toBe(0);
+  });
+
+  it("ignores non-bullet lines", () => {
+    const content = `
+# Changelog
+
+## Unreleased
+
+Some explanatory text.
+- Valid bullet.
+
+### Some sub-heading
+- Another bullet under sub-heading.
+`;
+    // Stopping at ##, but ### or text doesn't stop it (as long as it's not ##).
+    // Let's verify our implementation behavior.
+    // In our implementation, we stop at any heading starting with "## ".
+    // If it's "### ", it doesn't stop.
+    // Let's see: text or "- Another bullet" under "### " will count.
+    expect(extractUnreleasedBullets(content)).toBe(2);
+  });
+});
+
+describe("runChangelogGateCheck", () => {
+  const defaultOptions = {
+    changedFiles: [],
+    baseContent: null,
+    headContent: null,
+    skipChangelogEnv: false,
+    hasSkipChangelogCommitMsg: false,
+    isDependabotBranch: false,
+    isDependabotAuthor: false,
+    hasSkipChangelogBranchName: false,
+  };
+
+  it("passes when no files changed", () => {
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: [],
+    });
+    expect(res.passed).toBe(true);
+    expect(res.reason).toContain("No user-facing files changed");
+  });
+
+  it("passes when only exempt/internal files changed", () => {
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: ["e2e/test.spec.ts", ".github/workflows/ci.yml"],
+    });
+    expect(res.passed).toBe(true);
+    expect(res.reason).toContain("No user-facing files changed");
+  });
+
+  it("fails when user-facing files changed but CHANGELOG.md is not modified", () => {
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: ["app/screens/Workout.tsx"],
+    });
+    expect(res.passed).toBe(false);
+    expect(res.message).toContain("touches user-facing code but does not modify CHANGELOG.md");
+  });
+
+  it("fails when CHANGELOG.md is modified but no new bullets are added to Unreleased", () => {
+    const baseContent = `
+## Unreleased
+- Bullet A
+## v0.1.0
+`;
+    const headContent = `
+## Unreleased
+- Bullet A
+## v0.1.0
+`;
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: ["app/screens/Workout.tsx", "CHANGELOG.md"],
+      baseContent,
+      headContent,
+    });
+    expect(res.passed).toBe(false);
+    expect(res.message).toContain("the `## Unreleased` section did not gain any new bullet");
+  });
+
+  it("passes when CHANGELOG.md is modified and a new bullet is added to Unreleased", () => {
+    const baseContent = `
+## Unreleased
+- Bullet A
+## v0.1.0
+`;
+    const headContent = `
+## Unreleased
+- Bullet A
+- New Bullet B
+## v0.1.0
+`;
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: ["app/screens/Workout.tsx", "CHANGELOG.md"],
+      baseContent,
+      headContent,
+    });
+    expect(res.passed).toBe(true);
+    expect(res.reason).toContain("Changelog gate passed");
+  });
+
+  it("bypasses when SKIP_CHANGELOG env is true", () => {
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: ["app/screens/Workout.tsx"],
+      skipChangelogEnv: true,
+    });
+    expect(res.passed).toBe(true);
+    expect(res.reason).toContain("Bypassed via environment variable");
+  });
+
+  it("bypasses when skip-changelog is in branch name", () => {
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: ["app/screens/Workout.tsx"],
+      hasSkipChangelogBranchName: true,
+    });
+    expect(res.passed).toBe(true);
+    expect(res.reason).toContain("Bypassed via skip-changelog in branch name");
+  });
+
+  it("bypasses for Dependabot changes", () => {
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: ["app/screens/Workout.tsx"],
+      isDependabotBranch: true,
+    });
+    expect(res.passed).toBe(true);
+    expect(res.reason).toContain("Bypassed for Dependabot changes");
+  });
+
+  it("bypasses when skip-changelog is in commit message", () => {
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: ["app/screens/Workout.tsx"],
+      hasSkipChangelogCommitMsg: true,
+    });
+    expect(res.passed).toBe(true);
+    expect(res.reason).toContain("Bypassed via skip-changelog in commit message");
+  });
+});

--- a/scripts/check-changelog-gate.ts
+++ b/scripts/check-changelog-gate.ts
@@ -1,0 +1,243 @@
+#!/usr/bin/env tsx
+/**
+ * BLD-3078 — Changelog gate verifier.
+ *
+ * Catches missing '## Unreleased' bullets on user-facing branches locally,
+ * mirroring the exact logic and rules of `.github/workflows/changelog-gate.yml`
+ * to prevent CI-gate friction.
+ *
+ * This verifier is wired into:
+ *   - .husky/pre-push (local guard before push)
+ *
+ * Run:
+ *   npx tsx scripts/check-changelog-gate.ts
+ */
+/* eslint-disable no-console */
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+const USER_FACING_REGEX = /^(app\/|app\.config\.ts$|components\/|screens\/|lib\/|hooks\/|assets\/exercise-illustrations\/|fdroid\/metadata\/com\.persoack\.cablesnap\.yml$|android\/app\/src\/main\/AndroidManifest\.xml$|package\.json$|plugins\/)/;
+const INTERNAL_OVERRIDE_REGEX = /(__tests__\/|\.test\.(ts|tsx|js|jsx)$|\.spec\.(ts|tsx|js|jsx)$|^lib\/changelog\.generated\.ts$|^lib\/.*\/__fixtures__\/|^e2e\/)/;
+
+export function isUserFacing(file: string): boolean {
+  return USER_FACING_REGEX.test(file) && !INTERNAL_OVERRIDE_REGEX.test(file);
+}
+
+export function extractUnreleasedBullets(content: string): number {
+  const lines = content.split(/\r?\n/);
+  let inUnreleased = false;
+  let count = 0;
+  for (const line of lines) {
+    if (/^##\s+Unreleased\s*$/i.test(line.trim())) {
+      inUnreleased = true;
+      continue;
+    }
+    if (inUnreleased && /^##\s+/.test(line.trim())) {
+      break;
+    }
+    if (inUnreleased && /^\s*-\s+/.test(line)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+export interface CheckResult {
+  passed: boolean;
+  message?: string;
+  reason?: string;
+}
+
+export function runChangelogGateCheck(options: {
+  changedFiles: string[];
+  baseContent: string | null;
+  headContent: string | null;
+  skipChangelogEnv: boolean;
+  hasSkipChangelogCommitMsg: boolean;
+  isDependabotBranch: boolean;
+  isDependabotAuthor: boolean;
+  hasSkipChangelogBranchName: boolean;
+}): CheckResult {
+  const {
+    changedFiles,
+    baseContent,
+    headContent,
+    skipChangelogEnv,
+    hasSkipChangelogCommitMsg,
+    isDependabotBranch,
+    isDependabotAuthor,
+    hasSkipChangelogBranchName,
+  } = options;
+
+  // 1. Check escape hatches/exemptions
+  if (skipChangelogEnv) {
+    return { passed: true, reason: "Bypassed via environment variable SKIP_CHANGELOG." };
+  }
+  if (hasSkipChangelogBranchName) {
+    return { passed: true, reason: "Bypassed via skip-changelog in branch name." };
+  }
+  if (isDependabotBranch || isDependabotAuthor) {
+    return { passed: true, reason: "Bypassed for Dependabot changes." };
+  }
+  if (hasSkipChangelogCommitMsg) {
+    return { passed: true, reason: "Bypassed via skip-changelog in commit message." };
+  }
+
+  // 2. Classify changed files
+  const userFacingFiles = changedFiles.filter(isUserFacing);
+  if (userFacingFiles.length === 0) {
+    return { passed: true, reason: "No user-facing files changed — CHANGELOG entry not required." };
+  }
+
+  // 3. Verify CHANGELOG.md was modified
+  const changelogModified = changedFiles.includes("CHANGELOG.md");
+  if (!changelogModified) {
+    const fileList = userFacingFiles.map(f => `  - ${f}`).join("\n");
+    return {
+      passed: false,
+      message: `🚨 CHANGELOG Gate Violation: This push touches user-facing code but does not modify CHANGELOG.md.
+
+User-facing files changed:
+${fileList}
+
+Add a bullet describing the user-visible change to the \`## Unreleased\`
+section of CHANGELOG.md. The auto-releaser (\`scheduled-release.yml\`)
+gates on a populated \`## Unreleased\` section, so PRs that skip this
+step block the next scheduled release silently.
+
+If this push is genuinely internal-only (refactor with no user impact,
+test-only fix, lockfile bump, etc.), use one of the escape hatches below.`,
+    };
+  }
+
+  // 4. Require head > base bullets
+  const baseBullets = baseContent ? extractUnreleasedBullets(baseContent) : 0;
+  const headBullets = headContent ? extractUnreleasedBullets(headContent) : 0;
+
+  if (headBullets <= baseBullets) {
+    return {
+      passed: false,
+      message: `🚨 CHANGELOG Gate Violation: CHANGELOG.md was modified, but the \`## Unreleased\` section did not gain any new bullet (\`-\` lines): base=${baseBullets} head=${headBullets}.
+
+Add at least one bullet under \`## Unreleased\` describing the
+user-visible change introduced. If this is genuinely internal-only,
+use one of the escape hatches below.`,
+    };
+  }
+
+  return {
+    passed: true,
+    reason: `Changelog gate passed: \`## Unreleased\` gained ${headBullets - baseBullets} bullet(s).`,
+  };
+}
+
+function main(): void {
+  try {
+    // Determine base and head SHAs
+    const remoteBranch = execSync(
+      'git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "origin/main"',
+      { encoding: "utf8" }
+    ).trim();
+
+    // Find the merge base (where our branch diverged from the remote/origin branch)
+    let baseSha = "";
+    try {
+      baseSha = execSync(`git merge-base "${remoteBranch}" HEAD`, { encoding: "utf8" }).trim();
+    } catch {
+      baseSha = execSync('git rev-parse origin/main', { encoding: "utf8" }).trim();
+    }
+
+    const headSha = "HEAD";
+
+    if (!baseSha) {
+      console.log("ℹ️  Could not determine base SHA — skipping CHANGELOG pre-push check.");
+      process.exit(0);
+    }
+
+    // Get list of changed files
+    const changedFiles = execSync(`git diff --name-only "${baseSha}" "${headSha}"`, { encoding: "utf8" })
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+
+    // Skip check if no changes are being pushed
+    if (changedFiles.length === 0) {
+      process.exit(0);
+    }
+
+    // Read base and head CHANGELOG.md contents
+    let baseContent: string | null = null;
+    try {
+      baseContent = execSync(`git show "${baseSha}":CHANGELOG.md`, { encoding: "utf8", stdio: ["pipe", "pipe", "ignore"] });
+    } catch {
+      // base CHANGELOG.md might not exist or couldn't be loaded, keep as null
+    }
+
+    let headContent: string | null = null;
+    try {
+      headContent = execSync(`git show "${headSha}":CHANGELOG.md`, { encoding: "utf8", stdio: ["pipe", "pipe", "ignore"] });
+    } catch {
+      // head CHANGELOG.md might not exist or couldn't be loaded, keep as null
+    }
+
+    // Check escape hatches/exemptions
+    const skipChangelogEnv =
+      process.env.SKIP_CHANGELOG === "true" ||
+      process.env.SKIP_CHANGELOG === "1" ||
+      process.env.skip_changelog === "true";
+
+    const branchName = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim();
+    const isDependabotBranch = branchName.startsWith("dependabot/");
+    const hasSkipChangelogBranchName = branchName.includes("skip-changelog");
+
+    let hasSkipChangelogCommitMsg = false;
+    let isDependabotAuthor = false;
+    try {
+      const commitMessages = execSync(`git log "${baseSha}..${headSha}" --format="%B"`, { encoding: "utf8" });
+      hasSkipChangelogCommitMsg = /skip-changelog/i.test(commitMessages);
+
+      const authors = execSync(`git log "${baseSha}..${headSha}" --format="%an"`, { encoding: "utf8" });
+      isDependabotAuthor = /dependabot/i.test(authors);
+    } catch {
+      // Fallback if git log fails
+    }
+
+    const result = runChangelogGateCheck({
+      changedFiles,
+      baseContent,
+      headContent,
+      skipChangelogEnv,
+      hasSkipChangelogCommitMsg,
+      isDependabotBranch,
+      isDependabotAuthor,
+      hasSkipChangelogBranchName,
+    });
+
+    if (result.passed) {
+      if (result.reason) {
+        console.log(`📝 ${result.reason}`);
+      }
+      process.exit(0);
+    } else {
+      console.error(result.message);
+      console.error(`
+💡 Escape hatches:
+  - Set environment variable: SKIP_CHANGELOG=true git push
+  - Include 'skip-changelog' in any of your commit messages
+  - Include 'skip-changelog' in your branch name
+  - Bypass hooks entirely (governance escape hatch only): git push --no-verify
+`);
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error("⚠️  Error executing CHANGELOG gate check, skipping:", error instanceof Error ? error.message : error);
+    process.exit(0);
+  }
+}
+
+const invokedAsScript =
+  require.main === module ||
+  (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename));
+if (invokedAsScript) {
+  main();
+}

--- a/scripts/check-changelog-gate.ts
+++ b/scripts/check-changelog-gate.ts
@@ -52,35 +52,20 @@ export function runChangelogGateCheck(options: {
   changedFiles: string[];
   baseContent: string | null;
   headContent: string | null;
-  skipChangelogEnv: boolean;
-  hasSkipChangelogCommitMsg: boolean;
   isDependabotBranch: boolean;
   isDependabotAuthor: boolean;
-  hasSkipChangelogBranchName: boolean;
 }): CheckResult {
   const {
     changedFiles,
     baseContent,
     headContent,
-    skipChangelogEnv,
-    hasSkipChangelogCommitMsg,
     isDependabotBranch,
     isDependabotAuthor,
-    hasSkipChangelogBranchName,
   } = options;
 
   // 1. Check escape hatches/exemptions
-  if (skipChangelogEnv) {
-    return { passed: true, reason: "Bypassed via environment variable SKIP_CHANGELOG." };
-  }
-  if (hasSkipChangelogBranchName) {
-    return { passed: true, reason: "Bypassed via skip-changelog in branch name." };
-  }
   if (isDependabotBranch || isDependabotAuthor) {
     return { passed: true, reason: "Bypassed for Dependabot changes." };
-  }
-  if (hasSkipChangelogCommitMsg) {
-    return { passed: true, reason: "Bypassed via skip-changelog in commit message." };
   }
 
   // 2. Classify changed files
@@ -131,20 +116,28 @@ use one of the escape hatches below.`,
   };
 }
 
+function execGitCommand(command: string): string {
+  try {
+    return execSync(command, { encoding: "utf8", stdio: ["pipe", "pipe", "ignore"] }).trim();
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    throw new Error(`Git command execution failed: "${command}".\nDetails: ${errorMsg}`);
+  }
+}
+
 function main(): void {
   try {
     // Determine base and head SHAs
-    const remoteBranch = execSync(
-      'git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "origin/main"',
-      { encoding: "utf8" }
-    ).trim();
+    const remoteBranch = execGitCommand(
+      'git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null || echo "origin/main"'
+    );
 
     // Find the merge base (where our branch diverged from the remote/origin branch)
     let baseSha = "";
     try {
-      baseSha = execSync(`git merge-base "${remoteBranch}" HEAD`, { encoding: "utf8" }).trim();
+      baseSha = execGitCommand(`git merge-base "${remoteBranch}" HEAD`);
     } catch {
-      baseSha = execSync('git rev-parse origin/main', { encoding: "utf8" }).trim();
+      baseSha = execGitCommand('git rev-parse origin/main');
     }
 
     const headSha = "HEAD";
@@ -155,10 +148,8 @@ function main(): void {
     }
 
     // Get list of changed files
-    const changedFiles = execSync(`git diff --name-only "${baseSha}" "${headSha}"`, { encoding: "utf8" })
-      .trim()
-      .split("\n")
-      .filter(Boolean);
+    const changedFilesOutput = execGitCommand(`git diff --name-only "${baseSha}" "${headSha}"`);
+    const changedFiles = changedFilesOutput.split("\n").filter(Boolean);
 
     // Skip check if no changes are being pushed
     if (changedFiles.length === 0) {
@@ -181,22 +172,12 @@ function main(): void {
     }
 
     // Check escape hatches/exemptions
-    const skipChangelogEnv =
-      process.env.SKIP_CHANGELOG === "true" ||
-      process.env.SKIP_CHANGELOG === "1" ||
-      process.env.skip_changelog === "true";
-
-    const branchName = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim();
+    const branchName = execGitCommand("git rev-parse --abbrev-ref HEAD");
     const isDependabotBranch = branchName.startsWith("dependabot/");
-    const hasSkipChangelogBranchName = branchName.includes("skip-changelog");
 
-    let hasSkipChangelogCommitMsg = false;
     let isDependabotAuthor = false;
     try {
-      const commitMessages = execSync(`git log "${baseSha}..${headSha}" --format="%B"`, { encoding: "utf8" });
-      hasSkipChangelogCommitMsg = /skip-changelog/i.test(commitMessages);
-
-      const authors = execSync(`git log "${baseSha}..${headSha}" --format="%an"`, { encoding: "utf8" });
+      const authors = execGitCommand(`git log "${baseSha}..${headSha}" --format="%an"`);
       isDependabotAuthor = /dependabot/i.test(authors);
     } catch {
       // Fallback if git log fails
@@ -206,11 +187,8 @@ function main(): void {
       changedFiles,
       baseContent,
       headContent,
-      skipChangelogEnv,
-      hasSkipChangelogCommitMsg,
       isDependabotBranch,
       isDependabotAuthor,
-      hasSkipChangelogBranchName,
     });
 
     if (result.passed) {
@@ -222,9 +200,7 @@ function main(): void {
       console.error(result.message);
       console.error(`
 💡 Escape hatches:
-  - Set environment variable: SKIP_CHANGELOG=true git push
-  - Include 'skip-changelog' in any of your commit messages
-  - Include 'skip-changelog' in your branch name
+  - Dependabot authored branches bypass this check automatically.
   - Bypass hooks entirely (governance escape hatch only): git push --no-verify
 `);
       process.exit(1);


### PR DESCRIPTION
## Summary

This PR adds a local pre-push hook to detect missing `## Unreleased` bullet entries in CHANGELOG.md on user-facing branches, mirroring the logic used by the CI check. Catching this locally avoids the chronic round-trip where a user-facing PR fails the "Require `## Unreleased` bullet" CI gate only after push (11+ PRs affected — see BLD-3078).

## Changes

- Added `scripts/check-changelog-gate.ts` — the parsing, classification, validation, and exit logic.
- Added `__tests__/scripts/check-changelog-gate.test.ts` — 11 unit tests covering path classification, `## Unreleased` bullet extraction, the bullet-delta rule, and the Dependabot exemption (both blocking and passing paths).
- Integrated the check into `.husky/pre-push`, right after the existing top-level changelog↔app.config parity gate.

## Parity with CI Workflow

This pre-push hook replicates the exact rules of the CI check implemented in `.github/workflows/changelog-gate.yml`. Verified line-by-line (techlead parity table on BLD-3078):

1. **Trigger paths** — same `USER_FACING_REGEX` matching user-facing directories (`app/`, `components/`, `screens/`, `lib/`, `hooks/`, `assets/exercise-illustrations/`, `plugins/`, `package.json`, etc.).
2. **Internal overrides** — same `INTERNAL_OVERRIDE_REGEX` filtering test/spec files, generated files, fixtures, and `e2e/`.
3. **Bullet-delta detection** — parses the `## Unreleased` section of both the BASE and HEAD trees, counts lines starting with a dash, and requires HEAD bullets strictly greater than BASE bullets (matches CI's `HEAD_BULLETS > BASE_BULLETS`).

## Exemptions & escape hatch

To stay in **strict parity** with CI, the only automated exemption is **Dependabot** (detected locally via a `dependabot/` branch prefix or a Dependabot git author — the local analog of CI's Dependabot-author check). The prior local-only bypasses (`SKIP_CHANGELOG` env var, `skip-changelog` in branch name, `skip-changelog` in commit message) were **removed** in `61b33f9a` because CI does not honor them; keeping them would let a push slip through locally and still fail CI, defeating the hook's purpose.

CI's remaining exemption — the `skip-changelog` PR **label** — cannot be observed by a pre-push hook without network access. For that case (or any genuinely internal-only push), the standard Husky escape hatch is `git push --no-verify`.

## Testing

- `npm test -- --runTestsByPath __tests__/scripts/check-changelog-gate.test.ts` → 11 tests pass.
- Typecheck (`npm run typecheck`) and ESLint green.
- Dogfood proof: the "Require `## Unreleased` bullet" CI gate on this PR is green — the hook's own diff (`scripts/` + `.husky/` + `__tests__/`) is correctly classified as non-user-facing, so no Unreleased entry is required.

## Issue

Resolves BLD-3078
