### PR TITLE
fix: add PRAGMA busy_timeout = 5000 to prevent database locks (BLD-3119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
+- **Prevent transient database-locked errors** — SQLite connection initialization now sets a 5-second busy timeout before running database migrations or schema upgrades. This allows CableSnap to automatically wait out momentary lock contention and prevent transient "database is locked" errors. (BLD-3119)
 
 ## v0.26.65 — 2026-07-07
 <!-- versionCode: 135 -->

--- a/__tests__/lib/db/helpers-foreign-keys-pragma.test.ts
+++ b/__tests__/lib/db/helpers-foreign-keys-pragma.test.ts
@@ -68,6 +68,17 @@ describe("BLD-1094 — getDatabase() enables PRAGMA foreign_keys = ON", () => {
     expect(fkIdx).toBeGreaterThan(journalIdx);
   });
 
+  it("issues PRAGMA busy_timeout = 5000 before journal_mode on the main path", async () => {
+    const helpers = require("../../../lib/db/helpers");
+    await helpers.getDatabase();
+
+    const timeoutIdx = execCalls.findIndex((s) => /PRAGMA\s+busy_timeout\s*=\s*5000/i.test(s));
+    const journalIdx = execCalls.findIndex((s) => s.includes("journal_mode"));
+
+    expect(timeoutIdx).toBeGreaterThanOrEqual(0);
+    expect(journalIdx).toBeGreaterThan(timeoutIdx);
+  });
+
   it("the web in-memory fallback also enables PRAGMA foreign_keys = ON", async () => {
     // Make the primary openDatabaseAsync throw to force the fallback path on web.
     const expoSqlite = require("expo-sqlite") as { openDatabaseAsync: jest.Mock };
@@ -83,5 +94,26 @@ describe("BLD-1094 — getDatabase() enables PRAGMA foreign_keys = ON", () => {
     await helpers.getDatabase();
 
     expect(execCalls.some((s) => /PRAGMA\s+foreign_keys\s*=\s*ON/i.test(s))).toBe(true);
+  });
+
+  it("the web in-memory fallback also enables PRAGMA busy_timeout = 5000 before PRAGMA foreign_keys = ON", async () => {
+    // Make the primary openDatabaseAsync throw to force the fallback path on web.
+    const expoSqlite = require("expo-sqlite") as { openDatabaseAsync: jest.Mock };
+    expoSqlite.openDatabaseAsync.mockReset();
+    expoSqlite.openDatabaseAsync
+      .mockImplementationOnce(() => Promise.reject(new Error("simulated open failure")))
+      .mockImplementationOnce(() => Promise.resolve(mockDb));
+
+    // Force Platform.OS = 'web' so the fallback branch is taken.
+    jest.doMock("react-native", () => ({ Platform: { OS: "web" } }));
+    const helpers = require("../../../lib/db/helpers");
+
+    await helpers.getDatabase();
+
+    const timeoutIdx = execCalls.findIndex((s) => /PRAGMA\s+busy_timeout\s*=\s*5000/i.test(s));
+    const fkIdx = execCalls.findIndex((s) => /PRAGMA\s+foreign_keys\s*=\s*ON/i.test(s));
+
+    expect(timeoutIdx).toBeGreaterThanOrEqual(0);
+    expect(fkIdx).toBeGreaterThan(timeoutIdx);
   });
 });

--- a/lib/db/helpers.ts
+++ b/lib/db/helpers.ts
@@ -235,6 +235,9 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
         currentPhase = "probe";
         await instance.execAsync("SELECT 1");
         currentPhase = "pragma";
+        // BLD-3119: set busy_timeout to prevent "database is locked" errors
+        // during migrations or concurrent write attempts.
+        await instance.execAsync("PRAGMA busy_timeout = 5000");
         await instance.execAsync("PRAGMA journal_mode = WAL");
         // BLD-1094: enable foreign-key enforcement on every connection so
         // the FK declarations in lib/db/tables.ts (strava_sync_log,
@@ -282,6 +285,8 @@ export async function getDatabase(): Promise<SQLite.SQLiteDatabase> {
         if (Platform.OS === "web") {
           try {
             const instance = await SQLite.openDatabaseAsync(":memory:");
+            // BLD-3119: set busy_timeout for web in-memory fallback.
+            await instance.execAsync("PRAGMA busy_timeout = 5000");
             // BLD-1094: same pragma on the web in-memory fallback.
             await instance.execAsync("PRAGMA foreign_keys = ON");
             dbBreadcrumb("pre_migrate", { db_name: ":memory:" });


### PR DESCRIPTION
## Summary

Set PRAGMA busy_timeout = 5000 during database initialization/connection setup on both the main SQLite path and the web in-memory fallback. This ensures SQLite waits up to 5 seconds before throwing a 'database is locked' error during concurrent operations or migrations.

## Changes

- Configured `PRAGMA busy_timeout = 5000` on primary database connection setup.
- Configured `PRAGMA busy_timeout = 5000` on web in-memory fallback database connection setup.
- Added corresponding unit tests to verify that `PRAGMA busy_timeout = 5000` is issued on both connection paths.

## Testing

- Ran `npm run typecheck` to verify no TypeScript compilation issues.
- Ran test `__tests__/lib/db/helpers-foreign-keys-pragma.test.ts` and verified all tests pass perfectly.

## Issue

Resolves BLD-3119