### PR TITLE
feat: Extend Sentry filter to drop HeadlessChrome/CI events (BLD-3124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ marker) at release time.
 ## Unreleased
 
 - **Prevent transient database-locked errors** — SQLite connection initialization now sets a 5-second busy timeout before running database migrations or schema upgrades. This allows CableSnap to automatically wait out momentary lock contention and prevent transient "database is locked" errors. (BLD-3119)
+- **Internal: Sentry filter drops HeadlessChrome/CI events** — the localhost and CI event filter now also drops events originating from a headless browser environment (such as HeadlessChrome in E2E/CI tests) or where the user-agent headers contain "Headless", preventing development and test traffic from polluting the production Sentry dashboard. (BLD-3124)
 
 ## v0.26.65 — 2026-07-07
 <!-- versionCode: 135 -->

--- a/__tests__/lib/sentry-localhost-filter.test.ts
+++ b/__tests__/lib/sentry-localhost-filter.test.ts
@@ -164,3 +164,73 @@ describe('filterLocalhostEvents — request.url support for Web client', () => {
     expect(filterLocalhostEvents(event)).toBe(event);
   });
 });
+
+describe('filterLocalhostEvents — BLD-3124: Headless / User-Agent detection', () => {
+  it('drops an event with browser.name containing Headless and no localhost URL', () => {
+    const event = {
+      type: undefined,
+      contexts: {
+        browser: {
+          name: 'HeadlessChrome',
+        },
+      },
+    } as unknown as ErrorEvent;
+    expect(filterLocalhostEvents(event)).toBeNull();
+  });
+
+  it('drops an event with browser.name being exactly Headless', () => {
+    const event = {
+      type: undefined,
+      contexts: {
+        browser: {
+          name: 'Headless',
+        },
+      },
+    } as unknown as ErrorEvent;
+    expect(filterLocalhostEvents(event)).toBeNull();
+  });
+
+  it('drops an event with a Headless User-Agent in headers (case-insensitive key)', () => {
+    const event1 = {
+      type: undefined,
+      request: {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/120.0.0.0 Safari/537.36',
+        },
+      },
+    } as unknown as ErrorEvent;
+    expect(filterLocalhostEvents(event1)).toBeNull();
+
+    const event2 = {
+      type: undefined,
+      request: {
+        headers: {
+          'user-agent': 'HeadlessChrome/120.0.0.0',
+        },
+      },
+    } as unknown as ErrorEvent;
+    expect(filterLocalhostEvents(event2)).toBeNull();
+  });
+
+  it('keeps a production event with a real User-Agent, real URL, and environment=production', () => {
+    const event = {
+      type: undefined,
+      environment: 'production',
+      tags: {
+        url: 'https://app.example.com/home',
+      },
+      request: {
+        url: 'https://app.example.com/home',
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+        },
+      },
+      contexts: {
+        browser: {
+          name: 'Mobile Safari',
+        },
+      },
+    } as unknown as ErrorEvent;
+    expect(filterLocalhostEvents(event)).toBe(event);
+  });
+});

--- a/lib/sentry-localhost-filter.ts
+++ b/lib/sentry-localhost-filter.ts
@@ -1,16 +1,19 @@
 /**
- * BLD-2446 — Sentry localhost/CI event filter.
+ * BLD-2446 / BLD-3124 — Sentry localhost/CI event filter.
  *
  * The Sentry real-user dashboard was polluted by CI/E2E traffic originating
- * from localhost:8081 (Metro dev server). Real users on iOS/Android never
- * hit localhost. This module provides a `beforeSend` hook that drops any
- * event whose `url` tag host resolves to a local-only address.
+ * from localhost:8081 (Metro dev server) or HeadlessChrome in CI. Real users
+ * on iOS/Android never run on localhost or in HeadlessChrome. This module
+ * provides a `beforeSend` hook that drops any event whose `url` tag host
+ * resolves to a local-only address, or whose browser context/user-agent
+ * indicates a headless browser environment.
  *
  * Design decisions:
- *   - Filter on URL host, NOT on `environment` tag. The `environment` tag is
- *     forgeable by misconfigured CI (proven by REACT-NATIVE-F in BLD-2444).
- *   - Fail-open: if the `url` tag is absent or the URL is malformed, the
- *     event is sent unchanged. We never silently swallow real errors.
+ *   - Filter on URL host and Headless/User-Agent, NOT on `environment` tag.
+ *     The `environment` tag is forgeable by misconfigured CI (proven by
+ *     REACT-NATIVE-F in BLD-2444).
+ *   - Fail-open: if the local-only/headless signals are absent, the event is
+ *     sent unchanged. We never silently swallow real errors.
  *   - The filter is a pure function so it can be unit-tested without
  *     initialising the Sentry SDK.
  */
@@ -38,8 +41,38 @@ function isLocalUrl(urlString: string): boolean {
 }
 
 /**
+ * Returns `true` if the event context or user-agent headers indicate a
+ * headless browser environment (such as HeadlessChrome in E2E tests).
+ */
+function isHeadlessEvent(event: ErrorEvent): boolean {
+  // Check browser name in contexts
+  const contexts = event.contexts as Record<string, Record<string, string>> | undefined;
+  const browserName = contexts?.browser?.name;
+  if (typeof browserName === 'string' && browserName.includes('Headless')) {
+    return true;
+  }
+
+  // Check User-Agent in request headers (case-insensitive key)
+  const request = event.request as Record<string, unknown> | undefined;
+  const headers = request?.headers as Record<string, string> | undefined;
+  if (headers && typeof headers === 'object') {
+    const userAgentKey = Object.keys(headers).find(
+      (key) => key.toLowerCase() === 'user-agent'
+    );
+    if (userAgentKey) {
+      const userAgent = String(headers[userAgentKey]);
+      if (userAgent.includes('Headless')) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
  * Sentry `beforeSend` callback that drops CI/dev events originating from
- * a localhost URL.
+ * a localhost URL or headless browser environment.
  *
  * Usage:
  *   Sentry.init({ ..., beforeSend: filterLocalhostEvents });
@@ -48,6 +81,12 @@ function isLocalUrl(urlString: string): boolean {
  * @returns The event unchanged, or `null` to drop it.
  */
 export function filterLocalhostEvents(event: ErrorEvent): ErrorEvent | null {
+  // 1. Headless environment check → drop immediately
+  if (isHeadlessEvent(event)) {
+    return null;
+  }
+
+  // 2. Localhost URL check
   const urlTag = event.tags?.['url'];
   const requestUrl = event.request?.url;
 


### PR DESCRIPTION
## Summary

This PR extends the existing Sentry `beforeSend` localhost filter to drop events originating from HeadlessChrome or other Headless environments, avoiding E2E/CI noise pollution in Sentry.

## Changes

- Extended `filterLocalhostEvents` in `lib/sentry-localhost-filter.ts` with a check for `Headless` in the browser context name (`event.contexts?.browser?.name`) and the User-Agent header (`event.request?.headers?.['User-Agent']`).
- Retained the existing localhost-URL drop and the fail-open behaviors.
- Added comprehensive unit tests in `__tests__/lib/sentry-localhost-filter.test.ts` to verify that synthetic headless events are dropped, production events are kept, and existing local URL/regression behaviors are preserved.

## Testing

- Added 4 new unit test cases covering headless and production scenarios.
- Ran tests: `npm test` (27/27 passed).
- Ran TypeScript typecheck: clean.
- Ran linter: clean.

## Issue

Resolves BLD-3124