### PR TITLE
fix: bypass pre-push hooks for release-bot push + isReleaseCommit exemption (BLD-3165)

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -681,7 +681,7 @@ jobs:
           # `## Unreleased` bullets automatically.
           pushed=0
           for i in 1 2 3 4 5; do
-            if git push origin main; then
+            if git push --no-verify origin main; then
               pushed=1
               break
             fi

--- a/__tests__/scripts/check-changelog-gate.test.ts
+++ b/__tests__/scripts/check-changelog-gate.test.ts
@@ -77,6 +77,7 @@ describe("runChangelogGateCheck", () => {
     headContent: null,
     isDependabotBranch: false,
     isDependabotAuthor: false,
+    isReleaseCommit: false,
   };
 
   it("passes when no files changed", () => {
@@ -157,5 +158,71 @@ describe("runChangelogGateCheck", () => {
     });
     expect(res.passed).toBe(true);
     expect(res.reason).toContain("Bypassed for Dependabot changes");
+  });
+
+  it("bypasses for release-bot commit (isReleaseCommit=true) even when ## Unreleased is drained", () => {
+    // Simulates the release bot promoting ## Unreleased (3 bullets) → ## vX.Y.Z (0 bullets).
+    const baseContent = `
+## Unreleased
+
+- Fix: DB init locked error
+- Infra: Sentry filter for HeadlessChrome
+- UX: Progress tab conflicting states
+
+## v0.26.65
+`;
+    const headContent = `
+## Unreleased
+
+## v0.26.66
+
+- Fix: DB init locked error
+- Infra: Sentry filter for HeadlessChrome
+- UX: Progress tab conflicting states
+
+## v0.26.65
+`;
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: ["CHANGELOG.md", "lib/changelog.generated.ts"],
+      baseContent,
+      headContent,
+      isReleaseCommit: true,
+    });
+    expect(res.passed).toBe(true);
+    expect(res.reason).toBe("Bypassed for release-bot commit.");
+  });
+
+  it("still blocks normal human push that drains ## Unreleased without adding a bullet (regression guard)", () => {
+    // Same drained-CHANGELOG scenario, but isReleaseCommit=false — gate must still reject.
+    const baseContent = `
+## Unreleased
+
+- Fix: DB init locked error
+- Infra: Sentry filter for HeadlessChrome
+- UX: Progress tab conflicting states
+
+## v0.26.65
+`;
+    const headContent = `
+## Unreleased
+
+## v0.26.66
+
+- Fix: DB init locked error
+- Infra: Sentry filter for HeadlessChrome
+- UX: Progress tab conflicting states
+
+## v0.26.65
+`;
+    const res = runChangelogGateCheck({
+      ...defaultOptions,
+      changedFiles: ["app/screens/Workout.tsx", "CHANGELOG.md"],
+      baseContent,
+      headContent,
+      isReleaseCommit: false,
+    });
+    expect(res.passed).toBe(false);
+    expect(res.message).toContain("the `## Unreleased` section did not gain any new bullet");
   });
 });

--- a/scripts/check-changelog-gate.ts
+++ b/scripts/check-changelog-gate.ts
@@ -54,6 +54,7 @@ export function runChangelogGateCheck(options: {
   headContent: string | null;
   isDependabotBranch: boolean;
   isDependabotAuthor: boolean;
+  isReleaseCommit?: boolean;
 }): CheckResult {
   const {
     changedFiles,
@@ -61,11 +62,15 @@ export function runChangelogGateCheck(options: {
     headContent,
     isDependabotBranch,
     isDependabotAuthor,
+    isReleaseCommit = false,
   } = options;
 
   // 1. Check escape hatches/exemptions
   if (isDependabotBranch || isDependabotAuthor) {
     return { passed: true, reason: "Bypassed for Dependabot changes." };
+  }
+  if (isReleaseCommit) {
+    return { passed: true, reason: "Bypassed for release-bot commit." };
   }
 
   // 2. Classify changed files
@@ -183,12 +188,31 @@ function main(): void {
       // Fallback if git log fails
     }
 
+    // Detect release-bot commits: author == "CableSnap Release Bot" OR
+    // subject matches ^release: v<semver>. Mirrors the Dependabot exemption.
+    let isReleaseCommit = false;
+    try {
+      const commitLog = execGitCommand(`git log "${baseSha}..${headSha}" --format="%an|%s"`);
+      isReleaseCommit = commitLog.split("\n").filter(Boolean).some((line) => {
+        const pipeIdx = line.indexOf("|");
+        const author = pipeIdx >= 0 ? line.substring(0, pipeIdx).trim() : "";
+        const subject = pipeIdx >= 0 ? line.substring(pipeIdx + 1).trim() : "";
+        return (
+          author === "CableSnap Release Bot" ||
+          /^release: v\d+\.\d+\.\d+/.test(subject)
+        );
+      });
+    } catch {
+      // Fallback if git log fails
+    }
+
     const result = runChangelogGateCheck({
       changedFiles,
       baseContent,
       headContent,
       isDependabotBranch,
       isDependabotAuthor,
+      isReleaseCommit,
     });
 
     if (result.passed) {


### PR DESCRIPTION
## Summary

The nightly Scheduled Release was permanently deadlocked: the release bot drains `## Unreleased` (3→0 bullets) when promoting it to a versioned section, but the CHANGELOG Unreleased Bullet Gate (added in BLD-3078) rejects any push where `## Unreleased` doesn't *gain* bullets. Every retry hit the same gate. This PR applies a two-layer fix.

## Changes

### 1. `.github/workflows/scheduled-release.yml`
- Changed `git push origin main` → `git push --no-verify origin main` in the "Commit and push" step (the single statement inside the retry loop covers all 5 attempts)
- The release workflow already runs typecheck, lint, CHANGELOG↔config parity, build, and signature verification earlier in the pipeline; re-running pre-push hooks is redundant and — for the CHANGELOG gate — structurally impossible to satisfy

### 2. `scripts/check-changelog-gate.ts`
- Added `isReleaseCommit?: boolean` option to `runChangelogGateCheck`; returns `{ passed: true, reason: "Bypassed for release-bot commit." }` when set, mirroring the existing Dependabot exemption
- `main()` now computes `isReleaseCommit` from the push commit range: any commit whose author is "CableSnap Release Bot" OR whose subject matches `^release: v\d+\.\d+\.\d+` triggers the exemption

### 3. `__tests__/scripts/check-changelog-gate.test.ts`
- Updated `defaultOptions` to include `isReleaseCommit: false`
- New test: `isReleaseCommit=true` + drained CHANGELOG (3→0 bullets) → passes
- New test: `isReleaseCommit=false` + same drained scenario → still fails (regression guard)

## Testing

- All 13 unit tests pass (`jest __tests__/scripts/check-changelog-gate.test.ts`)
- TypeScript type-check passes with zero errors (`tsc --noEmit`)
- AC verified: `grep -n 'git push origin main' .github/workflows/scheduled-release.yml` returns 0 matches (only `--no-verify` variant remains)

## Issue

Resolves BLD-3165 (parent: BLD-3164)