### PR TITLE
fix(release-pipeline): exempt release-bot from pre-push CHANGELOG gate (BLD-3166)

### DIFF
--- a/__tests__/scripts/check-changelog-gate.test.ts
+++ b/__tests__/scripts/check-changelog-gate.test.ts
@@ -2,6 +2,7 @@ import {
   isUserFacing,
   extractUnreleasedBullets,
   runChangelogGateCheck,
+  detectReleaseBotCommit,
 } from "../../scripts/check-changelog-gate";
 
 describe("isUserFacing", () => {
@@ -157,5 +158,161 @@ describe("runChangelogGateCheck", () => {
     });
     expect(res.passed).toBe(true);
     expect(res.reason).toContain("Bypassed for Dependabot changes");
+  });
+
+  // BLD-3166 — scheduled-release bot's `release: v<VERSION>` commit
+  // deliberately drains `## Unreleased`. It must bypass the head>base rule.
+  describe("release-bot bypass (BLD-3166)", () => {
+    const drainedBase = `
+## Unreleased
+- Bullet A
+- Bullet B
+- Bullet C
+## v0.26.65 — 2026-07-07
+- Prior shipped bullet.
+`;
+    const drainedHead = `
+## Unreleased
+## v0.26.66 — 2026-07-09
+- Bullet A
+- Bullet B
+- Bullet C
+## v0.26.65 — 2026-07-07
+- Prior shipped bullet.
+`;
+
+    it("release-bot author bypass — drained Unreleased passes when isReleaseBotCommit=true", () => {
+      // Sanity: without the bypass, this exact scenario is the reported failure
+      // (base=3 head=0 -> Gate Violation).
+      expect(extractUnreleasedBullets(drainedBase)).toBe(3);
+      expect(extractUnreleasedBullets(drainedHead)).toBe(0);
+
+      const res = runChangelogGateCheck({
+        ...defaultOptions,
+        changedFiles: [
+          "package.json",
+          "app.config.ts",
+          "CHANGELOG.md",
+          "lib/changelog.generated.ts",
+          "fdroid/metadata/com.persoack.cablesnap.yml",
+        ],
+        baseContent: drainedBase,
+        headContent: drainedHead,
+        isReleaseBotCommit: true,
+      });
+      expect(res.passed).toBe(true);
+      expect(res.reason).toContain("release-bot version-bump commit");
+    });
+
+    it("release: v subject bypass — drained Unreleased passes when isReleaseBotCommit=true (subject-derived)", () => {
+      // AC #3: subject signal alone (no matching author) still suffices at the
+      // gate boundary because `isReleaseBotCommit` is a single boolean fed in
+      // from either signal. Verified end-to-end via the pure detector below.
+      const res = runChangelogGateCheck({
+        ...defaultOptions,
+        changedFiles: ["CHANGELOG.md", "package.json"],
+        baseContent: drainedBase,
+        headContent: drainedHead,
+        isReleaseBotCommit: true,
+      });
+      expect(res.passed).toBe(true);
+      expect(res.reason).toContain("release-bot version-bump commit");
+    });
+
+    it("regression intact — NON-bot with drained Unreleased still fails", () => {
+      // A normal contributor cannot spoof the bypass. Same exact CHANGELOG.md
+      // as the release-bot scenario, but `isReleaseBotCommit=false`.
+      const res = runChangelogGateCheck({
+        ...defaultOptions,
+        changedFiles: ["app/screens/Workout.tsx", "CHANGELOG.md"],
+        baseContent: drainedBase,
+        headContent: drainedHead,
+        isReleaseBotCommit: false,
+      });
+      expect(res.passed).toBe(false);
+      expect(res.message).toContain(
+        "the `## Unreleased` section did not gain any new bullet"
+      );
+    });
+
+    it("release-bot bypass is evaluated BEFORE user-facing classification", () => {
+      // Release-bot commits touch user-facing files (package.json, app.config.ts)
+      // and drain Unreleased. The bypass must short-circuit both the missing-
+      // CHANGELOG path AND the head<=base path.
+      const res = runChangelogGateCheck({
+        ...defaultOptions,
+        changedFiles: ["app.config.ts", "package.json"], // no CHANGELOG.md included
+        isReleaseBotCommit: true,
+      });
+      expect(res.passed).toBe(true);
+      expect(res.reason).toContain("release-bot version-bump commit");
+    });
+  });
+});
+
+// BLD-3166 — verify the pure detector correctly extracts release-bot signals
+// from `git log --format=%an%x00%s%x1e` output. This is the unit that main()
+// wraps around execSync; keeping it pure makes AC #3 directly testable
+// without spawning git.
+describe("detectReleaseBotCommit (BLD-3166)", () => {
+  const NUL = "\x00";
+  const RS = "\x1e";
+
+  function makeRangeLog(commits: Array<{ author: string; subject: string }>): string {
+    return commits.map(c => `${c.author}${NUL}${c.subject}${RS}`).join("");
+  }
+
+  it("returns true when a commit is authored by 'CableSnap Release Bot'", () => {
+    const rangeLog = makeRangeLog([
+      { author: "CableSnap Release Bot", subject: "release: v0.26.66" },
+    ]);
+    expect(detectReleaseBotCommit(rangeLog)).toBe(true);
+  });
+
+  it("returns true when subject matches /^release: v\\d+\\.\\d+\\.\\d+/ even with non-bot author (AC #3)", () => {
+    const rangeLog = makeRangeLog([
+      { author: "Alan Shum", subject: "release: v0.26.66" },
+    ]);
+    expect(detectReleaseBotCommit(rangeLog)).toBe(true);
+  });
+
+  it("returns true when ANY commit in the range matches (mixed range)", () => {
+    const rangeLog = makeRangeLog([
+      { author: "Alan Shum", subject: "feat: normal work" },
+      { author: "Alan Shum", subject: "fix: something else" },
+      { author: "CableSnap Release Bot", subject: "release: v0.26.66" },
+    ]);
+    expect(detectReleaseBotCommit(rangeLog)).toBe(true);
+  });
+
+  it("returns false for a normal contributor push", () => {
+    const rangeLog = makeRangeLog([
+      { author: "Alan Shum", subject: "feat: add rest-timer polish" },
+      { author: "Alan Shum", subject: "test: cover edge case" },
+    ]);
+    expect(detectReleaseBotCommit(rangeLog)).toBe(false);
+  });
+
+  it("does not match subjects that only START LIKE 'release:' but lack a semver (defensive)", () => {
+    const rangeLog = makeRangeLog([
+      { author: "Alan Shum", subject: "release: prep notes" },
+      { author: "Alan Shum", subject: "release: v0.26" }, // missing patch
+      { author: "Alan Shum", subject: "chore: release the pipeline" },
+    ]);
+    expect(detectReleaseBotCommit(rangeLog)).toBe(false);
+  });
+
+  it("returns false on empty input (defensive)", () => {
+    expect(detectReleaseBotCommit("")).toBe(false);
+  });
+
+  it("handles trailing RS from a real git log output cleanly", () => {
+    // git log emits a trailing separator on the last record; the parser must
+    // skip the empty final chunk without falsely reporting a bot commit.
+    const rangeLog = makeRangeLog([
+      { author: "Alan Shum", subject: "feat: whatever" },
+    ]);
+    expect(rangeLog.endsWith(RS)).toBe(true);
+    expect(detectReleaseBotCommit(rangeLog)).toBe(false);
   });
 });

--- a/scripts/check-changelog-gate.ts
+++ b/scripts/check-changelog-gate.ts
@@ -48,12 +48,34 @@ export interface CheckResult {
   reason?: string;
 }
 
+/**
+ * BLD-3166: pure detector for the scheduled-release bot's version-bump commit.
+ *
+ * Given the NUL/RS-delimited output of
+ * `git log <range> --format=%an%x00%s%x1e`, return true iff ANY commit in the
+ * range was authored by `CableSnap Release Bot` OR has a subject matching
+ * `/^release: v\d+\.\d+\.\d+/`. The workflow uses BOTH signals in normal
+ * operation (scheduled-release.yml ~L650 sets the author, ~L665 and ~L698
+ * commit `release: v$VERSION`), and we accept either alone so the recovery
+ * loop and future author-rename refactors don't regress the gate.
+ */
+export function detectReleaseBotCommit(rangeLog: string): boolean {
+  for (const record of rangeLog.split("\x1e")) {
+    if (!record) continue;
+    const [author, subject] = record.split("\x00");
+    if (author === "CableSnap Release Bot") return true;
+    if (subject && /^release: v\d+\.\d+\.\d+/.test(subject)) return true;
+  }
+  return false;
+}
+
 export function runChangelogGateCheck(options: {
   changedFiles: string[];
   baseContent: string | null;
   headContent: string | null;
   isDependabotBranch: boolean;
   isDependabotAuthor: boolean;
+  isReleaseBotCommit?: boolean;
 }): CheckResult {
   const {
     changedFiles,
@@ -61,9 +83,17 @@ export function runChangelogGateCheck(options: {
     headContent,
     isDependabotBranch,
     isDependabotAuthor,
+    isReleaseBotCommit = false,
   } = options;
 
   // 1. Check escape hatches/exemptions
+  //    BLD-3166: release-bot's `release: v<VERSION>` commit deliberately drains
+  //    `## Unreleased` (promoting bullets into the new `## v<VERSION>` heading),
+  //    so head <= base is expected and correct — never a violation for that
+  //    commit. Must be evaluated BEFORE the user-facing/changelog checks below.
+  if (isReleaseBotCommit) {
+    return { passed: true, reason: "Bypassed for release-bot version-bump commit." };
+  }
   if (isDependabotBranch || isDependabotAuthor) {
     return { passed: true, reason: "Bypassed for Dependabot changes." };
   }
@@ -183,12 +213,32 @@ function main(): void {
       // Fallback if git log fails
     }
 
+    // BLD-3166: detect the scheduled-release bot's version-bump commit so its
+    // deliberately-drained `## Unreleased` section doesn't trip the gate. The
+    // workflow sets author name `CableSnap Release Bot` (scheduled-release.yml
+    // ~L650) and uses commit subject `release: v<VERSION>` (~L665, ~L698 for
+    // the retry loop). Match on EITHER signal so the recovery loop still
+    // passes even if a future refactor changes the author name.
+    let isReleaseBotCommit = false;
+    try {
+      const rangeLog = execGitCommand(
+        `git log "${baseSha}..${headSha}" --format=%an%x00%s%x1e`
+      );
+      isReleaseBotCommit = detectReleaseBotCommit(rangeLog);
+    } catch {
+      // Fail-safe: default to stricter gate. A false negative here only means
+      // the release-bot's push falls back to the (fixable) old behavior; the
+      // workflow will surface the failure in its CI log rather than silently
+      // shipping a bad state.
+    }
+
     const result = runChangelogGateCheck({
       changedFiles,
       baseContent,
       headContent,
       isDependabotBranch,
       isDependabotAuthor,
+      isReleaseBotCommit,
     });
 
     if (result.passed) {


### PR DESCRIPTION
## What

Exempt the scheduled-release bot's `release: v<VERSION>` version-bump commit from the pre-push `## Unreleased` bullet-growth gate added in **PR #770** (BLD-3078). Mirrors the existing Dependabot bypass in `scripts/check-changelog-gate.ts`; contributor pushes remain fully gated.

Fixes **BLD-3166**. Refs **BLD-3078** (regression source), **BLD-3163** (parent workflow-failure tracking issue).

## Why (release pipeline is DOWN)

Since PR #770 merged on 2026-07-07, the `Scheduled Release` workflow has been unable to publish. Every scheduled run — most recently [#28991850360](https://github.com/alankyshum/cablesnap/actions/runs/28991850360) — fails with:

```
🚨 CHANGELOG Gate Violation: ...`## Unreleased` section did not gain
any new bullet: base=3 head=0.
husky - pre-push script failed (code 1)
Failed to push release commit after 5 recovery attempts.
```

Root cause: the workflow's `Commit and push` step (scheduled-release.yml ~L644-706) runs `release-apply-bump.sh`, which **promotes** `## Unreleased` into a new `## v<VERSION>` heading — deliberately draining `## Unreleased` to 0 bullets. It then `git push origin main` (no `--no-verify` on purpose — we want typecheck/license/parity/FTA to still protect the release commit). The new BLD-3078 gate sees `head(0) <= base(3)` and rejects. The 5x retry loop hard-resets onto fresh origin/main and re-bumps each time and hits the same self-contradiction.

Last shipped: **v0.26.65** (2026-07-07 15:09, ~28 min before #770 merged). `## Unreleased` currently holds 3 owed bullets.

## How

1. **New `isReleaseBotCommit` option** on `runChangelogGateCheck()`. When true it returns `passed: true` with reason `"Bypassed for release-bot version-bump commit."` — evaluated **before** the user-facing/CHANGELOG classification so drained-Unreleased AND a release commit that omits CHANGELOG.md both short-circuit correctly.
2. **Detection with two signals (OR)** so either alone suffices — supports the 5x recovery loop and shields against a future author-rename refactor:
   - Author name equals `CableSnap Release Bot` (set at scheduled-release.yml ~L650)
   - Commit subject matches `/^release: v\d+\.\d+\.\d+/` (~L665 initial, ~L698 retry re-bump)
3. **Parses `git log --format=%an%x00%s%x1e`** — NUL-delimited fields, RS-delimited records so commit messages containing colons/newlines can't confuse the parser.
4. **Extracted a pure `detectReleaseBotCommit()` helper** so AC #3 (subject alone suffices) is directly unit-testable without spawning git.

**Regression safety.** The exemption is a single boolean fed into the check. Normal contributors cannot spoof it (they don't control `%an` for arbitrary commits landing on their branch, and they'd have to author `release: vX.Y.Z` themselves to trigger the subject path — anti-pattern that would be caught in review). Test `regression intact — NON-bot with drained Unreleased still fails` locks this in.

**Fail-safe.** If the `git log` invocation throws, `isReleaseBotCommit` defaults `false` — release-bot's push falls back to the pre-fix (visible) failure rather than silently bypassing the gate for anyone.

## Explicitly OUT of scope (per BLD-3166 ticket)

- ❌ Did NOT switch scheduled-release.yml to `git push --no-verify` — that would bypass ALL pre-push gates (typecheck, license, parity, FTA, changelog) on the release commit. Unacceptable loss of protection.
- ❌ Did NOT modify `.github/workflows/changelog-gate.yml` (PR-triggered only, not involved in this failure).
- ❌ Did NOT change `release-apply-bump.sh` promotion logic.

## Files

- \`scripts/check-changelog-gate.ts\` — add \`isReleaseBotCommit\` option + \`detectReleaseBotCommit()\` helper; wire detection in \`main()\`.
- \`__tests__/scripts/check-changelog-gate.test.ts\` — +11 tests covering bypass paths, regression intact for non-bot, detector edge cases (mixed range, defensive semver, empty input, trailing RS).

## Verification (local)

| Check | Result |
|---|---|
| \`npx jest __tests__/scripts/check-changelog-gate.test.ts\` | ✅ 22/22 pass (11 pre-existing + 11 new) |
| \`npx jest __tests__/scripts/\` | ✅ 43/43 pass (parity peer test unaffected) |
| \`npm run typecheck\` | ✅ OK |
| \`eslint --max-warnings=0\` on changed files | ✅ OK |
| Pre-push hook on this branch itself | ✅ passed (script/ + tests/ are non-user-facing per gate regex; no CHANGELOG bullet required) |

## Post-merge verification (recovery re-trigger)

After merge, re-run the workflow to confirm the pipeline recovers:

\`\`\`
GH_CONFIG_DIR=/paperclip/.config/gh gh workflow run scheduled-release.yml \\
  --repo alankyshum/cablesnap --ref main
\`\`\`

Then confirm a \`release: v<next>\` commit lands on \`main\` and the run concludes \`success\`. I'll follow up on the BLD-3166 issue thread with the run URL + resulting version.

## Changelog

This PR only touches \`scripts/\` and \`__tests__/\`, which are non-user-facing per the gate's own \`INTERNAL_OVERRIDE_REGEX\` / \`USER_FACING_REGEX\`. No CHANGELOG bullet is required and no \`skip-changelog\` label is needed. If the PR-side \`changelog-gate\` CI check disagrees, I'll add the label — but I do not expect it to fire.