### PR TITLE
feat: handle Strava token refresh 400 error (BLD-3178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ marker) at release time.
 
 ## Unreleased
 
+- **Strava token refresh terminal failure handling** — when a Strava token refresh fails with a 400 Bad Request error (e.g. revoked, expired, or rotated refresh token), the connection is cleanly disconnected and the sync is marked as failed, ending any infinite retry loop. This terminal state is logged at warn level and no longer reported to Sentry as an exception. (BLD-3178)
 - **Prevent transient database-locked errors** — SQLite connection initialization now sets a 5-second busy timeout before running database migrations or schema upgrades. This allows CableSnap to automatically wait out momentary lock contention and prevent transient "database is locked" errors. (BLD-3119)
 - **Internal: Sentry filter drops HeadlessChrome/CI events** — the localhost and CI event filter now also drops events originating from a headless browser environment (such as HeadlessChrome in E2E/CI tests) or where the user-agent headers contain "Headless", preventing development and test traffic from polluting the production Sentry dashboard. (BLD-3124)
 - **Progress tab no longer shows conflicting error and empty states** — when there is no workout data, the Progress tab now shows only the "Track your progress" empty state. The Weekly Summary is suppressed when empty, and its error card now features a clear error icon and a working retry button so you can reload without leaving the screen. (BLD-3066)

--- a/__tests__/lib/strava.test.ts
+++ b/__tests__/lib/strava.test.ts
@@ -2346,6 +2346,89 @@ describe("Strava Integration — completeStravaCallback Behavior", () => {
     expect(result).toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
+
+  describe("(BLD-3178) refreshAccessToken handling", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const Sentry = require("@sentry/react-native");
+
+    function setupSyncMocks(sessionId: string) {
+      db.getStravaConnection.mockResolvedValue({ athlete_id: 1 });
+      db.getSessionSets.mockResolvedValue([
+        { exercise_name: "Bench", weight: 80, reps: 8, completed: true, set_type: "working" },
+      ]);
+      db.getSessionById.mockResolvedValue({
+        id: sessionId, name: "Test Session", started_at: Date.now(), duration_seconds: 3600,
+      });
+      db.getBodySettings.mockResolvedValue({ weight_unit: "kg" });
+      db.getEffectivePromoCaption.mockResolvedValue("Tracked with CableSnap · cablesnap.app");
+      db.getShareSettings.mockResolvedValue({
+        id: 1, promo_caption: "", promo_caption_enabled: 1, strava_description_enabled: 1, updated_at: Date.now(),
+      });
+      SecureStore.getItemAsync.mockImplementation(async (key: string) => {
+        if (key === "strava_token_expires_at") return "0"; // forces token refresh
+        if (key === "strava_refresh_token") return "some-refresh-token";
+        return null;
+      });
+    }
+
+    it("GIVEN Strava returns 400 with invalid_grant WHEN token refresh runs THEN disconnects, warn-logs body, no Sentry capture, and status=failed", async () => {
+      const sessionId = "bld-3178-invalid-grant";
+      setupSyncMocks(sessionId);
+
+      // Mock token refresh returning 400 invalid_grant
+      const errorBody = '{"error":"invalid_grant","error_description":"refresh token expired"}';
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => errorBody,
+      });
+
+      const result = await strava.syncSessionToStrava(sessionId);
+
+      expect(result.status).toBe("failed");
+      expect((result as any).error.message).toContain("Strava session expired");
+      expect(db.deleteStravaConnection).toHaveBeenCalled();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expect(Sentry.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("token revoked or invalid (invalid_grant)"),
+        expect.objectContaining({
+          flow: "strava_refresh",
+          step: "token_refresh",
+          status: 400,
+          body: errorBody,
+        }),
+      );
+    });
+
+    it("GIVEN Strava returns 400 with app_inactive WHEN token refresh runs THEN disconnects, warn-logs body, no Sentry capture, and status=failed", async () => {
+      const sessionId = "bld-3178-app-inactive";
+      setupSyncMocks(sessionId);
+
+      // Mock token refresh returning 400 with app inactive errors structure
+      const errorBody = '{"message":"Application Status Inactive","errors":[{"resource":"Application","field":"status","code":"inactive"}]}';
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => errorBody,
+      });
+
+      const result = await strava.syncSessionToStrava(sessionId);
+
+      expect(result.status).toBe("failed");
+      expect((result as any).error.message).toContain("inactive");
+      expect(db.deleteStravaConnection).toHaveBeenCalled();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expect(Sentry.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("app inactive"),
+        expect.objectContaining({
+          flow: "strava_refresh",
+          step: "token_refresh",
+          status: 400,
+          body: errorBody,
+        }),
+      );
+    });
+  });
 });
 
 describe("Strava Integration — IntegrationsCard wiring (BLD-505)", () => {

--- a/lib/strava.ts
+++ b/lib/strava.ts
@@ -161,9 +161,41 @@ async function refreshAccessToken(): Promise<string | null> {
     });
 
     if (!response.ok) {
-      // Token revoked or invalid — disconnect
-      if (response.status === 401 || response.status === 400) await disconnect();
-      throw new Error(`Token refresh failed: ${response.status}`);
+      const body = await response.text().catch(() => "");
+      const truncatedBody = body.substring(0, 500);
+
+      if (isStravaAppInactive(body)) {
+        stravaLog("warn", "strava refresh blocked — app inactive", {
+          flow: "strava_refresh",
+          step: "token_refresh",
+          status: response.status,
+          body: truncatedBody,
+        });
+        await disconnect();
+        throw new StravaError("app_inactive", "Strava app is inactive. Please contact support.", response.status);
+      } else if (response.status === 400 || response.status === 401) {
+        stravaLog("warn", "strava refresh failed — token revoked or invalid (invalid_grant)", {
+          flow: "strava_refresh",
+          step: "token_refresh",
+          status: response.status,
+          body: truncatedBody,
+        });
+        await disconnect();
+        throw new StravaError("auth_revoked", "Strava session expired. Please reconnect.", response.status);
+      } else {
+        const classifiedCode = classifyHttpStatus(response.status);
+        stravaLog("warn", `strava refresh failed — unexpected HTTP status (${response.status})`, {
+          flow: "strava_refresh",
+          step: "token_refresh",
+          status: response.status,
+          body: truncatedBody,
+        });
+        throw new StravaError(
+          classifiedCode,
+          `Token refresh failed: ${response.status}. Body: ${truncatedBody}`,
+          response.status
+        );
+      }
     }
 
     const data = await response.json();
@@ -171,6 +203,13 @@ async function refreshAccessToken(): Promise<string | null> {
     stravaLog("info", "strava refresh succeeded", { flow: "strava_refresh", step: "success" });
     return data.access_token;
   } catch (err) {
+    if (err instanceof StravaError && (err.code === "auth_revoked" || err.code === "app_inactive")) {
+      // BLD-3178: Propagate terminal authentication and app-inactive errors instead of swallowing
+      // to null so the upstream caller (uploadActivity / syncSessionToStrava) receives a clear signal
+      // to permanently fail the sync session instead of infinite queuing. Do not capture to Sentry.
+      throw err;
+    }
+
     if (isNetworkError(err)) {
       // Network outage during token refresh is a benign transient (device offline /
       // proxy unreachable). Do NOT report to Sentry — it is expected in an offline-


### PR DESCRIPTION
## Summary

Handles Strava token refresh failing with a 400 error (Sentry REACT-NATIVE-P) by cleanly disconnecting and marking the sync session as permanently failed to prevent infinite retry loops.

## Changes

- Captured and logged the response body on token refresh failures in `refreshAccessToken()`.
- Classified 400/401 errors as terminal `auth_revoked` errors, triggered clean disconnection, and propagated the `StravaError` upstream.
- Maintained existing Sentry exception handling and offline transient network error suppression.
- Added comprehensive unit tests asserting correct sync failure classification and Sentry logger warn suppression.
- Added unreleased bullet in CHANGELOG.md.

## Testing

- Verified all 111 tests in `__tests__/lib/strava.test.ts` pass perfectly.
- Confirmed typecheck clean with `tsc --noEmit`.

## Issue

Resolves BLD-3178