### PR TITLE
feat: SegmentedControl 44dp touch target (BLD-3195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@ marker) at release time.
 
 ## Unreleased
 
+- **Segmented control touch targets are now larger and easier to tap** — individual segment toggle buttons in the segmented control (such as weight kg/lb and measurement cm/in Settings units switches) now have an interactive height of at least 44px to meet accessibility guidelines and prevent missed taps. (BLD-3195)
 - **Strava token refresh terminal failure handling** — when a Strava token refresh fails with a 400 Bad Request error (e.g. revoked, expired, or rotated refresh token), the connection is cleanly disconnected and the sync is marked as failed, ending any infinite retry loop. This terminal state is logged at warn level and no longer reported to Sentry as an exception. (BLD-3178)
 
 ## v0.26.66 — 2026-07-09
 <!-- versionCode: 136 -->
-
 - **Prevent transient database-locked errors** — SQLite connection initialization now sets a 5-second busy timeout before running database migrations or schema upgrades. This allows CableSnap to automatically wait out momentary lock contention and prevent transient "database is locked" errors. (BLD-3119)
 - **Internal: Sentry filter drops HeadlessChrome/CI events** — the localhost and CI event filter now also drops events originating from a headless browser environment (such as HeadlessChrome in E2E/CI tests) or where the user-agent headers contain "Headless", preventing development and test traffic from polluting the production Sentry dashboard. (BLD-3124)
 - **Progress tab no longer shows conflicting error and empty states** — when there is no workout data, the Progress tab now shows only the "Track your progress" empty state. The Weekly Summary is suppressed when empty, and its error card now features a clear error icon and a working retry button so you can reload without leaving the screen. (BLD-3066)

--- a/__tests__/components/ui/segmented-control.test.tsx
+++ b/__tests__/components/ui/segmented-control.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import { render, fireEvent } from "@testing-library/react-native";
+import { SegmentedControl, SEGMENT_MIN_TOUCH_TARGET } from "../../../components/ui/segmented-control";
+
+jest.mock("@/hooks/useColor", () => ({
+  useColor: (name: string) => {
+    switch (name) {
+      case "primary":
+        return "#FF6038";
+      case "mutedForeground":
+        return "#6B7280";
+      case "background":
+        return "#FAFAFA";
+      case "muted":
+        return "#E5E7EB";
+      default:
+        return "#000000";
+    }
+  },
+}));
+
+function resolveStyle(style: unknown) {
+  const resolved = typeof style === "function" ? (style as (s: { pressed: boolean }) => unknown)({ pressed: false }) : style;
+  return StyleSheet.flatten(resolved ?? {}) as Record<string, unknown>;
+}
+
+const TWO_BUTTONS = [
+  { value: "kg", label: "kg", accessibilityLabel: "Weight in kilograms" },
+  { value: "lb", label: "lb", accessibilityLabel: "Weight in pounds" },
+];
+
+describe("SegmentedControl (BLD-3195)", () => {
+  it("renders with two buttons", () => {
+    const { getByText } = render(
+      <SegmentedControl
+        value="kg"
+        onValueChange={() => {}}
+        buttons={TWO_BUTTONS}
+      />,
+    );
+
+    expect(getByText("kg")).toBeTruthy();
+    expect(getByText("lb")).toBeTruthy();
+  });
+
+  it("meets the 44px minimum touch target for each segment", () => {
+    const { getByLabelText } = render(
+      <SegmentedControl
+        value="kg"
+        onValueChange={() => {}}
+        buttons={TWO_BUTTONS}
+      />,
+    );
+
+    expect(SEGMENT_MIN_TOUCH_TARGET).toBe(44);
+
+    const kgSegment = getByLabelText("Weight in kilograms");
+    const lbSegment = getByLabelText("Weight in pounds");
+
+    const kgStyle = resolveStyle(kgSegment.props.style);
+    const lbStyle = resolveStyle(lbSegment.props.style);
+
+    expect(kgStyle.minHeight).toBeGreaterThanOrEqual(44);
+    expect(lbStyle.minHeight).toBeGreaterThanOrEqual(44);
+  });
+
+  it("fires onValueChange with the correct value on press", () => {
+    const onValueChange = jest.fn();
+    const { getByLabelText } = render(
+      <SegmentedControl
+        value="kg"
+        onValueChange={onValueChange}
+        buttons={TWO_BUTTONS}
+      />,
+    );
+
+    fireEvent.press(getByLabelText("Weight in pounds"));
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenCalledWith("lb");
+  });
+
+  it("asserts accessibilityRole === 'radio' and accessibilityState reflects active value", () => {
+    const { getByLabelText } = render(
+      <SegmentedControl
+        value="kg"
+        onValueChange={() => {}}
+        buttons={TWO_BUTTONS}
+      />,
+    );
+
+    const kgSegment = getByLabelText("Weight in kilograms");
+    const lbSegment = getByLabelText("Weight in pounds");
+
+    expect(kgSegment.props.accessibilityRole).toBe("radio");
+    expect(lbSegment.props.accessibilityRole).toBe("radio");
+
+    expect(kgSegment.props.accessibilityState.selected).toBe(true);
+    expect(lbSegment.props.accessibilityState.selected).toBe(false);
+  });
+});

--- a/components/ui/segmented-control.tsx
+++ b/components/ui/segmented-control.tsx
@@ -5,6 +5,8 @@ import { CORNERS, FONT_SIZE, HEIGHT } from "@/theme/globals";
 import React from "react";
 import { Pressable, TextStyle, View, ViewStyle } from "react-native";
 
+export const SEGMENT_MIN_TOUCH_TARGET = 44;
+
 export interface SegmentedControlButton {
   value: string;
   label: string;
@@ -60,6 +62,7 @@ export function SegmentedControl({
                 borderRadius: CORNERS,
                 paddingHorizontal: 8,
                 paddingVertical: 6,
+                minHeight: SEGMENT_MIN_TOUCH_TARGET,
                 backgroundColor: isActive ? activeBg : "transparent",
               },
               btn.style,


### PR DESCRIPTION
## Summary

Increase the touch target of the inner per-segment Pressables in `SegmentedControl` to >= 44px to meet accessibility guidelines and prevent missed taps.

## Changes

- Defined and exported `SEGMENT_MIN_TOUCH_TARGET = 44` in `components/ui/segmented-control.tsx`.
- Applied `minHeight: SEGMENT_MIN_TOUCH_TARGET` to the inner per-segment `Pressable` styles array.
- Created `__tests__/components/ui/segmented-control.test.tsx` to assert minimum height, onValueChange, active selected accessibilityState, and accessibilityRole.
- Updated `CHANGELOG.md` with a bullet describing the change under the `## Unreleased` section.

## Testing

- Added comprehensive component tests verifying minimum interactive height and other requirements in `__tests__/components/ui/segmented-control.test.tsx`.
- Verified typechecking with `tsc --noEmit`.
- Verified ESLint on modified/created files.
- Verified test suite with `jest`.

## Issue

Resolves BLD-3195