### PR TITLE
fix(release-infra): unblock Scheduled Release past poisoned v0.26.68 + harden against future immutable-release ghosts (BLD-3223)

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -175,7 +175,16 @@ jobs:
       - name: Compute next version
         if: steps.check_commits.outputs.has_new_commits == 'true' && steps.changelog_gate.outputs.should_release == 'true'
         id: next_version
+        env:
+          # GH_TOKEN is used by `scripts/compute-next-release-version.sh`
+          # for the belt-and-suspenders GitHub-Release existence check
+          # inside its `version_is_poisoned` helper. GITHUB_TOKEN has
+          # repo-scoped read on releases which is sufficient — no PAT
+          # needed for this read.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
+          set -euo pipefail
           # Republish mode (BLD-1101): use the version already committed in
           # package.json. The bump/promote steps below are skipped, and the
           # tag must not yet exist.
@@ -189,23 +198,16 @@ jobs:
             echo "Republish version (from package.json): $NEXT"
             exit 0
           fi
+          # BLD-3223: bump-path next-version computation is delegated to
+          # `scripts/compute-next-release-version.sh`, which encapsulates a
+          # bounded skip loop over three independent poisoning signals
+          # (local tag, remote tag, GitHub Release). Extracted from the
+          # workflow so it can be unit-tested with stubbed git/gh (see
+          # scripts/__tests__/compute-next-release-version.test.ts).
+          # See the script's own header for the ghost-release caveat and
+          # the create-time counterpart in "Create GitHub Release with APK".
           TAG="${{ steps.latest_tag.outputs.tag }}"
-          if [ -z "$TAG" ]; then
-            NEXT="0.1.0"
-          else
-            VERSION="${TAG#v}"
-            MAJOR=$(echo "$VERSION" | cut -d. -f1)
-            MINOR=$(echo "$VERSION" | cut -d. -f2)
-            PATCH=$(echo "$VERSION" | cut -d. -f3)
-            PATCH=$((PATCH + 1))
-            NEXT="$MAJOR.$MINOR.$PATCH"
-            # Skip past any tags that already exist (e.g. created manually)
-            while git tag -l "v$NEXT" | grep -q .; do
-              echo "Tag v$NEXT already exists, incrementing..."
-              PATCH=$((PATCH + 1))
-              NEXT="$MAJOR.$MINOR.$PATCH"
-            done
-          fi
+          NEXT=$(bash scripts/compute-next-release-version.sh "$TAG")
           echo "version=$NEXT" >> "$GITHUB_OUTPUT"
           echo "Next version: $NEXT"
 
@@ -816,11 +818,47 @@ jobs:
             exit 0
           fi
 
+          # BLD-3223: capture stderr and exit code so a failing create doesn't
+          # bail out of `set -e` before we can classify the failure mode
+          # (immutable-ghost collision vs any other error). `|| create_rc=$?`
+          # neutralises the -e exit while still preserving the real rc.
+          create_rc=0
           gh release create "v$VERSION" \
             cablesnap.apk \
             cablesnap-fdroid.apk \
             cablesnap-wear.apk \
             --title "v$VERSION" \
             --target main \
-            --notes "$RELEASE_NOTES"
+            --notes "$RELEASE_NOTES" 2> gh_release_create.stderr || create_rc=$?
+          if [ "$create_rc" -ne 0 ]; then
+            cat gh_release_create.stderr >&2
+            # BLD-3223: detect GitHub Immutable-Release ghost collisions. If
+            # a prior release attempt for this exact tag partially succeeded
+            # (e.g. an internal 500 after the ref was reserved), GitHub keeps
+            # the tag_name as a permanently-reserved immutable-release ghost.
+            # The ghost is invisible to /releases, /releases/tags/... and to
+            # `gh release view` (all 404), so the "Compute next version"
+            # skip loop cannot pre-detect it. It only surfaces here as:
+            #     HTTP 422 ... pre_receive Repository rule violations found
+            #     Cannot create ref due to creations being restricted.
+            #     tag_name was used by an immutable release
+            # For the BUMP path, this is a recoverable class: bumping past
+            # the poisoned tag on the NEXT scheduled run will succeed.
+            # Emit an operator-actionable diagnostic. Republish mode is
+            # DELIBERATELY exempt from soft handling — a republish colliding
+            # with an existing/immutable tag is always a hard operator error
+            # (BLD-1101 / BLD-2316 strictness invariant), and the more
+            # obscure diagnostic below still fires plainly.
+            if grep -qE 'tag_name was used by an immutable release|creations being restricted' gh_release_create.stderr; then
+              echo "::error title=Immutable-release ghost blocks v$VERSION::GitHub's Immutable Releases feature is holding a permanent reservation on tag_name v$VERSION from a prior partial release attempt. The tag/release APIs return 404 for this version but the ref-creation is blocked at the pre_receive rule level, so no pre-check on the compute step can detect it."
+              if [ "${{ inputs.republish_current }}" != "true" ]; then
+                echo "::error::Recovery (bump path): land a commit on main that skips past v$VERSION (e.g. revert package.json / app.config.ts / fdroid metadata to the last-shipped version and re-curate '## Unreleased'), then push a lightweight placeholder tag 'v$VERSION' pointing at that commit via 'gh api -X POST repos/${{ github.repository }}/git/refs -f ref=refs/tags/v$VERSION -f sha=<merged-sha>'. The next Scheduled Release will compute the next patch and publish normally. See BLD-3223 plan doc for the reference procedure."
+              else
+                echo "::error::Recovery (republish path): republish for v$VERSION is impossible while the immutable-release ghost holds the tag_name. Bump past v$VERSION on the next scheduled run (see BLD-3223) — republish cannot recover this class."
+              fi
+            fi
+            rm -f gh_release_create.stderr
+            exit "$create_rc"
+          fi
+          rm -f gh_release_create.stderr
           echo "Released v$VERSION with phone (Play + F-Droid) and Wear OS APKs attached."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,6 @@ marker) at release time.
 
 ## Unreleased
 
-_No user-facing changes yet._
-
-## v0.26.68 — 2026-07-09
-<!-- versionCode: 138 -->
-
 - **Manual "Sync to Strava" for past workouts** — you can now trigger a manual sync or sync again for any past workout from the workout detail screen, allowing you to upload workouts that failed to sync initially.
 - **Form-encoded Strava upload with recap and attribution** — workout uploads to Strava are now form-encoded and include a detailed recap with exercise attribution and activity:read_all id capture.
 - **Fixed no-op Share button on workout detail** — the Share button on the workout detail screen now works correctly and opens the system share sheet.

--- a/app.config.ts
+++ b/app.config.ts
@@ -13,7 +13,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: "CableSnap",
   slug: "cablesnap",
-  version: "0.26.68",
+  version: "0.26.67",
   orientation: "default",
   icon: "./assets/icon.png",
   userInterfaceStyle: "automatic",
@@ -32,7 +32,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       backgroundColor: "#FF6038", // eslint-disable-line no-restricted-syntax
     },
     package: "com.persoack.cablesnap",
-    versionCode: 138,
+    versionCode: 137,
   },
   web: {
     favicon: "./assets/favicon.png",

--- a/fdroid/metadata/com.persoack.cablesnap.yml
+++ b/fdroid/metadata/com.persoack.cablesnap.yml
@@ -30,8 +30,8 @@ Description: |
   - CSV export and sharing
   - Dark mode support
 
-CurrentVersion: 0.26.68
-CurrentVersionCode: 138
+CurrentVersion: 0.26.67
+CurrentVersionCode: 137
 
 # F-Droid build server build recipe.
 #

--- a/fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/138.txt
+++ b/fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/138.txt
@@ -1,4 +1,0 @@
-- **Manual "Sync to Strava" for past workouts** — you can now trigger a manual sync or sync again for any past workout from the workout detail screen, allowing you to upload workouts that failed to sync initially.
-- **Form-encoded Strava upload with recap and attribution** — workout uploads to Strava are now form-encoded and include a detailed recap with exercise attribution and activity:read_all id capture.
-- **Fixed no-op Share button on workout detail** —
-…see in-app release notes

--- a/lib/changelog.generated.ts
+++ b/lib/changelog.generated.ts
@@ -10,12 +10,6 @@ export interface ReleaseEntry {
 
 export const CHANGELOG: ReleaseEntry[] = [
   {
-    "version": "0.26.68",
-    "date": "2026-07-09",
-    "versionCode": 138,
-    "body": "- **Manual \"Sync to Strava\" for past workouts** — you can now trigger a manual sync or sync again for any past workout from the workout detail screen, allowing you to upload workouts that failed to sync initially.\n- **Form-encoded Strava upload with recap and attribution** — workout uploads to Strava are now form-encoded and include a detailed recap with exercise attribution and activity:read_all id capture.\n- **Fixed no-op Share button on workout detail** — the Share button on the workout detail screen now works correctly and opens the system share sheet.\n- **Per-user Sentry telemetry and structured Strava sync-outcome logging** — Sentry telemetry is now tagged with unique per-user identifiers, and Strava sync outcomes are logged with structured events for more precise debugging."
-  },
-  {
     "version": "0.26.67",
     "date": "2026-07-09",
     "versionCode": 137,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cablesnap",
-  "version": "0.26.68",
+  "version": "0.26.67",
   "license": "AGPL-3.0-or-later",
   "main": "expo-router/entry",
   "engines": {

--- a/scripts/__tests__/compute-next-release-version.test.ts
+++ b/scripts/__tests__/compute-next-release-version.test.ts
@@ -1,0 +1,311 @@
+/**
+ * BLD-3223 — `scripts/compute-next-release-version.sh` skip-loop unit test.
+ *
+ * The extracted script encapsulates the bump-path next-version computation
+ * used by `.github/workflows/scheduled-release.yml` "Compute next version".
+ * It must skip past any candidate version that collides with an existing
+ * local tag, remote tag on origin, or GitHub Release — three independent
+ * poisoning signals. GitHub's immutable-release ghosts (invisible to
+ * `/releases/tags/…`) are handled at create-time by the workflow's
+ * collision-aware `gh release create` wrapper, not here.
+ *
+ * Test strategy: shadow `git` and `gh` on PATH with tiny bash stubs whose
+ * behavior is driven by env vars, then invoke the script with a canned
+ * `<latest-tag>` and assert on stdout. This proves the real script's
+ * decision logic without depending on network, a real git repo, or gh
+ * auth. Same PATH-shadow pattern used by other stub-driven tests here
+ * (see `scripts/__tests__/fixtures/audit-bundle-stubs/`).
+ *
+ * Coverage (mapped to BLD-3223 AC "unit-test the skip logic"):
+ *   1. No poisoning — returns latest+1.
+ *   2. Local tag poisons the immediate next version — skips exactly one.
+ *   3. Remote tag (not local) poisons — same skip behavior.
+ *   4. GitHub Release exists (no tag) — skip.
+ *   5. Multiple consecutive poisonings — skips all, lands on first clean.
+ *   6. Skip cap (100) — hits cap and exits non-zero with actionable error.
+ *   7. Empty latest-tag input — returns "0.1.0" (initial release).
+ *   8. Invalid latest-tag input — exits non-zero.
+ *   9. BLD-3223 replay — simulates v0.26.68 poisoning (remote tag + release
+ *      present at v0.26.68 only; v0.26.69 clean) — script returns "0.26.69".
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const SCRIPT = path.join(REPO_ROOT, "scripts", "compute-next-release-version.sh");
+
+/**
+ * PATH-shadowed `git` stub. Only `git tag -l vX.Y.Z` and
+ * `git ls-remote --tags origin refs/tags/vX.Y.Z` are supported. Any other
+ * `git` invocation is a test bug and exits non-zero with a diagnostic.
+ *
+ * Env inputs:
+ *   STUB_LOCAL_TAGS   space-separated list of vX.Y.Z tags "present locally"
+ *   STUB_REMOTE_TAGS  space-separated list of vX.Y.Z tags "present on origin"
+ *
+ * Written as a plain string (not a template literal) so `$var`/`${var}`
+ * bash references stay literal without JS-side escapes.
+ */
+const GIT_STUB = [
+    "#!/usr/bin/env bash",
+    "set -u",
+    'sub="${1:-}"',
+    'if [ "$sub" = "tag" ] && [ "${2:-}" = "-l" ]; then',
+    '  q="${3:-}"',
+    "  for t in ${STUB_LOCAL_TAGS:-}; do",
+    '    if [ "$t" = "$q" ]; then',
+    '      echo "$t"',
+    "      exit 0",
+    "    fi",
+    "  done",
+    "  exit 0",
+    "fi",
+    'if [ "$sub" = "ls-remote" ] && [ "${2:-}" = "--tags" ] && [ "${3:-}" = "origin" ]; then',
+    '  q="${4:-}"           # refs/tags/vX.Y.Z',
+    '  short="${q#refs/tags/}"',
+    "  for t in ${STUB_REMOTE_TAGS:-}; do",
+    '    if [ "$t" = "$short" ]; then',
+    '      echo -e "0000000000000000000000000000000000000000\\t$q"',
+    "      exit 0",
+    "    fi",
+    "  done",
+    "  exit 0",
+    "fi",
+    'echo "[git-stub] unsupported invocation: git $*" >&2',
+    "exit 2",
+    "",
+].join("\n");
+
+/**
+ * PATH-shadowed `gh` stub. Only the specific `gh api
+ * repos/.../releases/tags/vX.Y.Z --silent -i` shape the script uses is
+ * supported. Mirrors real `gh api -i` behavior: HTTP status header lines
+ * are printed to STDOUT for both 2xx and 4xx; 4xx also exits non-zero
+ * (real gh exits 1 on any 4xx even with -i).
+ *
+ * Env inputs:
+ *   STUB_RELEASES     space-separated list of vX.Y.Z tags "with a visible
+ *                     GitHub Release"
+ */
+const GH_STUB = [
+    "#!/usr/bin/env bash",
+    "set -u",
+    'sub="${1:-}"',
+    'if [ "$sub" != "api" ]; then',
+    '  echo "[gh-stub] unsupported subcommand: $sub" >&2',
+    "  exit 2",
+    "fi",
+    "# Locate the endpoint arg — it's the first positional after \"api\" that",
+    '# doesn\'t start with "-".',
+    "shift",
+    'endpoint=""',
+    'while [ "$#" -gt 0 ]; do',
+    '  case "$1" in',
+    "    -H) shift 2 ;;              # e.g. -H \"Accept: ...\"",
+    "    -*) shift ;;",
+    '    *) endpoint="$1"; shift ;;',
+    "  esac",
+    "done",
+    "# Endpoint shape: repos/OWNER/REPO/releases/tags/vX.Y.Z",
+    'tag=""',
+    'case "$endpoint" in',
+    '  repos/*/releases/tags/*) tag="${endpoint##*/}" ;;',
+    '  *) echo "[gh-stub] unsupported endpoint: $endpoint" >&2; exit 2 ;;',
+    "esac",
+    "for r in ${STUB_RELEASES:-}; do",
+    '  if [ "$r" = "$tag" ]; then',
+    '    echo "HTTP/2.0 200 OK"',
+    '    echo "Content-Type: application/json"',
+    '    echo ""',
+    "    exit 0",
+    "  fi",
+    "done",
+    "# 404 shape — real `gh api -i` still prints headers to stdout on 4xx,",
+    "# but exits 1.",
+    'echo "HTTP/2.0 404 Not Found"',
+    'echo "Content-Type: application/json"',
+    'echo ""',
+    "exit 1",
+    "",
+].join("\n");
+
+interface StubEnv {
+    localTags?: string[];
+    remoteTags?: string[];
+    releases?: string[];
+    repo?: string;
+}
+
+interface RunResult {
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+}
+
+function makeStubDir(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bld3223-stubs-"));
+    const gitPath = path.join(dir, "git");
+    const ghPath = path.join(dir, "gh");
+    fs.writeFileSync(gitPath, GIT_STUB, { mode: 0o755 });
+    fs.writeFileSync(ghPath, GH_STUB, { mode: 0o755 });
+    return dir;
+}
+
+function runScript(latestTag: string, stubs: StubEnv = {}): RunResult {
+    const stubDir = makeStubDir();
+    try {
+        const args = [SCRIPT, latestTag];
+        if (stubs.repo) {
+            args.push("--repo", stubs.repo);
+        }
+        // PATH-shadow: stubDir first so our git/gh win over the real ones.
+        const env: NodeJS.ProcessEnv = {
+            ...process.env,
+            PATH: `${stubDir}:${process.env.PATH ?? ""}`,
+            STUB_LOCAL_TAGS: (stubs.localTags ?? []).join(" "),
+            STUB_REMOTE_TAGS: (stubs.remoteTags ?? []).join(" "),
+            STUB_RELEASES: (stubs.releases ?? []).join(" "),
+        };
+        // If no explicit --repo given, honor GITHUB_REPOSITORY (as the
+        // script does when reading env). Set a canonical one so gh API
+        // call is exercised.
+        if (!stubs.repo) {
+            env.GITHUB_REPOSITORY = "alankyshum/cablesnap";
+        } else {
+            delete env.GITHUB_REPOSITORY;
+        }
+        const proc = spawnSync("bash", args, {
+            encoding: "utf8",
+            env,
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+        return {
+            stdout: (proc.stdout ?? "").toString(),
+            stderr: (proc.stderr ?? "").toString(),
+            exitCode: proc.status ?? -1,
+        };
+    } finally {
+        fs.rmSync(stubDir, { recursive: true, force: true });
+    }
+}
+
+describe("scripts/compute-next-release-version.sh (BLD-3223)", () => {
+    it("script is executable", () => {
+        expect(fs.existsSync(SCRIPT)).toBe(true);
+        const mode = fs.statSync(SCRIPT).mode & 0o111;
+        expect(mode).not.toBe(0);
+    });
+
+    it("returns latest+1 when no poisoning present", () => {
+        const r = runScript("v0.26.67");
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout.trim()).toBe("0.26.68");
+    });
+
+    it("skips a version poisoned by a local tag", () => {
+        const r = runScript("v0.26.67", { localTags: ["v0.26.68"] });
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout.trim()).toBe("0.26.69");
+        expect(r.stderr).toContain("v0.26.68 exists as a local tag");
+    });
+
+    it("skips a version poisoned only by a remote tag on origin", () => {
+        const r = runScript("v0.26.67", { remoteTags: ["v0.26.68"] });
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout.trim()).toBe("0.26.69");
+        expect(r.stderr).toContain("v0.26.68 exists as a remote tag on origin");
+    });
+
+    it("skips a version poisoned only by an existing GitHub Release", () => {
+        const r = runScript("v0.26.67", { releases: ["v0.26.68"] });
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout.trim()).toBe("0.26.69");
+        expect(r.stderr).toContain("v0.26.68 exists as a GitHub Release");
+    });
+
+    it("skips multiple consecutive poisoned versions and lands on first clean", () => {
+        const r = runScript("v0.26.67", {
+            localTags: ["v0.26.68"],
+            remoteTags: ["v0.26.69"],
+            releases: ["v0.26.70"],
+        });
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout.trim()).toBe("0.26.71");
+    });
+
+    it("hits the skip cap (100) and exits non-zero with actionable error", () => {
+        // Simulate 100 consecutive poisoned patches via remote tags:
+        // v0.26.68 through v0.26.167 (inclusive) — 100 tags.
+        const poisoned: string[] = [];
+        for (let p = 68; p <= 167; p++) {
+            poisoned.push(`v0.26.${p}`);
+        }
+        const r = runScript("v0.26.67", { remoteTags: poisoned });
+        expect(r.exitCode).not.toBe(0);
+        expect(r.stderr).toContain("Skip loop exhausted after 100 increments");
+    });
+
+    it("returns 0.1.0 for initial release (empty latest-tag input)", () => {
+        const r = runScript("");
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout.trim()).toBe("0.1.0");
+    });
+
+    it("rejects a latest-tag input that is not a v<semver>", () => {
+        const r = runScript("not-a-tag");
+        expect(r.exitCode).not.toBe(0);
+        expect(r.stderr).toContain("is not a valid v<semver>");
+    });
+
+    it("BLD-3223 replay: v0.26.68 has remote tag + release; script returns v0.26.69", () => {
+        // This is the exact scenario the fix targets after the placeholder
+        // tag is pushed to origin: latest_tag=v0.26.68 with both a remote
+        // tag and (post-fix, if someone forces a release record) a
+        // release. The script should still land on v0.26.69.
+        //
+        // (Once the placeholder tag is pushed, `latest_tag` in the
+        // workflow will actually be v0.26.68; but this test also exercises
+        // the more conservative case where latest_tag is still v0.26.67
+        // and v0.26.68 is a poisoned candidate.)
+        const r = runScript("v0.26.67", {
+            remoteTags: ["v0.26.68"],
+            releases: ["v0.26.68"],
+        });
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout.trim()).toBe("0.26.69");
+    });
+
+    it("also works when latest tag has moved to poisoned v0.26.68 itself", () => {
+        // Post-placeholder-push state: latest_tag=v0.26.68. Compute must
+        // yield v0.26.69 (68+1 = 69, which is clean).
+        const r = runScript("v0.26.68", {
+            localTags: ["v0.26.68"],
+            remoteTags: ["v0.26.68"],
+        });
+        expect(r.exitCode).toBe(0);
+        expect(r.stdout.trim()).toBe("0.26.69");
+    });
+});
+
+// Smoke — spawn the stub via execFileSync directly to prove it's shaped
+// correctly, independent of the script-under-test.
+describe("BLD-3223 test-stub sanity", () => {
+    it("git stub returns matching local tag when present in STUB_LOCAL_TAGS", () => {
+        const stubDir = makeStubDir();
+        try {
+            const out = execFileSync("bash", ["-c", "git tag -l v9.9.9"], {
+                encoding: "utf8",
+                env: {
+                    ...process.env,
+                    PATH: `${stubDir}:${process.env.PATH ?? ""}`,
+                    STUB_LOCAL_TAGS: "v9.9.9",
+                },
+            });
+            expect(out.trim()).toBe("v9.9.9");
+        } finally {
+            fs.rmSync(stubDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/scripts/compute-next-release-version.sh
+++ b/scripts/compute-next-release-version.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# BLD-3223 — Skip-loop-hardened next-version computer for scheduled release.
+#
+# Reads the latest git tag on the current repo and computes the next patch
+# version, SKIPPING any candidate version that collides with an existing
+# tag or GitHub Release (including versions from prior partial releases
+# whose git tag was never pushed but whose GitHub Release record — or
+# immutable-release ghost — still holds the tag_name).
+#
+# Skip signals (any match → poisoned → increment PATCH and retry):
+#   (a) local git tag exists                  (`git tag -l vX.Y.Z`)
+#   (b) remote git tag exists on origin       (`git ls-remote --tags origin`)
+#   (c) GitHub Release exists for that tag    (`gh api releases/tags/vX.Y.Z`)
+#
+# GHOST caveat (BLD-3223): GitHub's Immutable Releases feature can leave a
+# permanent tag_name reservation whose /releases/tags/... endpoint 404s —
+# such ghosts are NOT detectable here. Those are handled at create-time by
+# the workflow's collision-aware `gh release create` wrapper, which emits
+# an actionable diagnostic and fails so the operator can bump `main` past
+# the poisoned version.
+#
+# Bounded at MAX_SKIP=100 iterations to prevent an infinite loop from a
+# runaway poisoned namespace; 100 consecutive poisoned patch versions is a
+# real actionable escalation, not silent wedging.
+#
+# Usage:
+#   compute-next-release-version.sh <latest-tag> [--repo OWNER/REPO]
+#
+#   <latest-tag>  Latest v-prefixed tag on the repo (empty → initial 0.1.0).
+#   --repo        Optional; owner/repo for the `gh api` release check.
+#                 Defaults to $GITHUB_REPOSITORY (populated by Actions).
+#
+# Outputs (stdout):
+#   The bare next version, e.g. "0.26.69" — nothing else on stdout.
+#   All progress logging goes to stderr.
+#
+# Exit codes:
+#   0  next version printed on stdout
+#   1  usage error, invalid input, or skip cap exhausted
+#
+# Test stubs: this script calls `git tag`, `git ls-remote`, and `gh api`.
+# Any of them can be shadowed by tests via PATH-first stubs (see
+# scripts/__tests__/compute-next-release-version.test.ts). No global state.
+
+set -euo pipefail
+
+MAX_SKIP=100
+
+usage() {
+    echo "usage: $0 <latest-tag> [--repo OWNER/REPO]" >&2
+    exit 1
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+    usage
+fi
+
+LATEST_TAG="$1"
+shift || true
+
+REPO="${GITHUB_REPOSITORY:-}"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --repo)
+            REPO="$2"
+            shift 2
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# version_is_poisoned <version>
+#
+# Returns 0 (true) if version "$1" collides with ANY existing tag or
+# GitHub Release on origin — meaning the release pipeline should skip it.
+# Returns non-zero if clean.
+# ---------------------------------------------------------------------------
+version_is_poisoned() {
+    local v="$1"
+    # (a) local tag — populated by fetch-tags: true at checkout.
+    if git tag -l "v$v" | grep -q .; then
+        echo "  → v$v exists as a local tag" >&2
+        return 0
+    fi
+    # (b) remote tag — definitive origin view, resilient to future
+    # checkout-flag refactors.
+    if git ls-remote --tags origin "refs/tags/v$v" 2>/dev/null | grep -q .; then
+        echo "  → v$v exists as a remote tag on origin" >&2
+        return 0
+    fi
+    # (c) GitHub Release — an existing release (visible via the tags
+    # endpoint) MUST be skipped, otherwise `gh release create` would fail
+    # with "a release with the same tag name already exists" downstream.
+    # NOTE: this endpoint 404s for immutable-release GHOSTS (tag_name
+    # reserved but no queryable record). Those are handled at create-time,
+    # see file header.
+    if [ -n "$REPO" ]; then
+        # `gh api ... -i` returns HTTP headers on stdout followed by body;
+        # `--silent` suppresses the body. We parse just the status line.
+        # `|| true` neutralises gh's non-zero exit on 4xx so we don't
+        # trigger `set -e`.
+        local http_line
+        http_line=$(gh api \
+            "repos/${REPO}/releases/tags/v$v" \
+            --silent \
+            -H "Accept: application/vnd.github+json" \
+            -i 2>/dev/null | head -n1 || true)
+        local http_code
+        http_code=$(printf '%s' "$http_line" | awk '{print $2}')
+        if [ -n "$http_code" ] \
+           && [ "$http_code" -ge 200 ] 2>/dev/null \
+           && [ "$http_code" -lt 300 ] 2>/dev/null; then
+            echo "  → v$v exists as a GitHub Release (HTTP $http_code)" >&2
+            return 0
+        fi
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if [ -z "$LATEST_TAG" ]; then
+    # Initial release — no tags yet on the repo.
+    echo "0.1.0"
+    exit 0
+fi
+
+# Strip leading "v" if present.
+VERSION="${LATEST_TAG#v}"
+
+# Basic sanity: must look like semver X.Y.Z.
+if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    echo "::error::Latest tag '$LATEST_TAG' is not a valid v<semver> tag." >&2
+    exit 1
+fi
+
+MAJOR=$(echo "$VERSION" | cut -d. -f1)
+MINOR=$(echo "$VERSION" | cut -d. -f2)
+PATCH=$(echo "$VERSION" | cut -d. -f3)
+PATCH=$((PATCH + 1))
+NEXT="$MAJOR.$MINOR.$PATCH"
+
+skipped=0
+while [ "$skipped" -lt "$MAX_SKIP" ] && version_is_poisoned "$NEXT"; do
+    echo "Version v$NEXT is poisoned (tag or release exists), incrementing..." >&2
+    PATCH=$((PATCH + 1))
+    NEXT="$MAJOR.$MINOR.$PATCH"
+    skipped=$((skipped + 1))
+done
+
+if [ "$skipped" -ge "$MAX_SKIP" ]; then
+    echo "::error::Skip loop exhausted after $MAX_SKIP increments — cannot find a clean version. Investigate poisoned tag/release namespace on origin." >&2
+    exit 1
+fi
+
+# stdout: bare version, nothing else.
+echo "$NEXT"


### PR DESCRIPTION
## Summary

**Fixes BLD-3223 — release-blocking.** The Scheduled Release pipeline was DOWN: every run recomputed `v0.26.68` and failed identically at `gh release create` because GitHub's Immutable Releases feature holds a permanent tag_name reservation on `v0.26.68` from a prior partial release attempt. The ghost is invisible to every pre-check API (`/releases`, `/releases/tags/…`, `/releases/{id}`) — it only surfaces when `gh release create` tries to reserve the ref.

This PR does two things:
1. **Part A (immediate unblock)** — revert `main` to a clean pre-v0.26.68 working state and move the curated bullets back into `## Unreleased` so they ship attached to the next successful release (v0.26.69). Combined with a placeholder tag push after merge, this lets the next Scheduled Release compute `NEXT = latest_tag + 1 = v0.26.68 + 1 = v0.26.69`, a clean version.
2. **Part B (permanent robustness)** — refactor the workflow's next-version compute into a testable helper script with a bounded skip loop over THREE independent poisoning signals, and wrap `gh release create` with a collision-aware diagnostic that emits an operator-actionable recovery command on the immutable-ghost failure mode.

## Root cause (verified)

Failing run [#29040226182](https://github.com/alankyshum/cablesnap/actions/runs/29040226182):

```
HTTP 422: Validation Failed (.../releases/351724534)
pre_receive Repository rule violations found
Cannot create ref due to creations being restricted.
tag_name was used by an immutable release
Published releases must have a valid tag
```

Direct probing of GitHub state:

| Probe | Result |
|-------|-------:|
| `git/matching-refs/tags/v0.26.6*` | `v0.26.6, v0.26.60…v0.26.67` — **no v0.26.68** |
| `releases | select tag_name==v0.26.68` | `0` |
| `releases/tags/v0.26.68` | `404` |
| `releases/351724534` | `404` |
| Immutability on latest release | v0.26.67 `immutable: true` (feature is on) |
| Any tag-creation ruleset | empty — bumping past v0.26.68 (v0.26.69, …) will succeed |

So the ghost is a permanent tag_name reservation in GitHub's immutable-release table with no queryable record. **There is no compute-time API that returns the ghost.** Bumping past it is the accepted recovery path.

## Part A — file changes (immediate unblock)

- `package.json`: `0.26.68` → `0.26.67`.
- `app.config.ts`: `version 0.26.68` → `0.26.67`, `versionCode 138` → `137`.
- `fdroid/metadata/com.persoack.cablesnap.yml`: `CurrentVersion 0.26.68 / CurrentVersionCode 138` → `0.26.67 / 137`.
- `CHANGELOG.md`: delete the `## v0.26.68 — 2026-07-09 / <!-- versionCode: 138 -->` block; move its four curated bullets up under `## Unreleased`, replacing the `_No user-facing changes yet._` placeholder.
- `fdroid/metadata/com.persoack.cablesnap/en-US/changelogs/138.txt`: deleted (never shipped; will be regenerated as `139.txt` on the next successful run).
- `lib/changelog.generated.ts`: regenerated by `npm run changelog:gen` — v0.26.68 entry dropped, order otherwise unchanged.

`scripts/check-changelog-parity.sh` confirms parity on the reverted state: `✅ CHANGELOG.md ↔ app.config.ts parity OK (v0.26.67, versionCode 137)`.

## Part B — workflow hardening

### B1. `scripts/compute-next-release-version.sh` (new, extracted)

Encapsulates the bump-path next-version computation with a bounded skip loop across three independent poisoning signals:

- **(a) local tag** — `git tag -l vX.Y.Z` (populated by `fetch-depth: 0` + `fetch-tags: true` at checkout).
- **(b) remote tag** — `git ls-remote --tags origin refs/tags/vX.Y.Z` (definitive origin view; resilient to future checkout-flag refactors).
- **(c) GitHub Release** — `gh api repos/OWNER/REPO/releases/tags/vX.Y.Z` — catches every case where a pre-check IS possible.

Any (a)/(b)/(c) hit → poisoned → increment PATCH and retry. Cap: 100 iterations, then hard-fail with an actionable `::error::Skip loop exhausted…` — a genuine escalation, never a silent wedge. Ghost caveat documented in the script header (handled at create-time by B3).

### B2. Workflow "Compute next version" step

Refactored to delegate to `bash scripts/compute-next-release-version.sh "$TAG"`. Republish path unchanged (BLD-1101 hard-error preserved). `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` plumbed into the step for the API call.

### B3. Workflow "Create GitHub Release with APK" step — collision-aware wrapper

Existing BLD-2315/2316 idempotent-no-op guard (`gh release view "v$VERSION" >/dev/null 2>&1 && exit 0`) is left untouched — it still runs before create.

New: wrap `gh release create` with stderr capture and `|| create_rc=$?` (neutralises `set -e` so we can classify the failure):

```bash
gh release create "v$VERSION" ... 2> gh_release_create.stderr || create_rc=$?
if [ "$create_rc" -ne 0 ]; then
  cat gh_release_create.stderr >&2
  if grep -qE 'tag_name was used by an immutable release|creations being restricted' gh_release_create.stderr; then
    echo "::error title=Immutable-release ghost blocks v$VERSION::..."
    if bump-path: emit the exact recovery command (bump commit + placeholder tag push)
    if republish: emit the republish-cannot-recover diagnostic
  fi
  exit "$create_rc"
fi
```

Republish is deliberately exempt from soft handling — a republish colliding with the ghost is still a hard operator error (BLD-1101 / BLD-2316 strictness invariant). We only add clearer diagnostic output for it.

## Tests

New `scripts/__tests__/compute-next-release-version.test.ts` — 12 table-driven cases with PATH-shadowed `git`/`gh` stubs, mirroring the existing `audit-bundle-stubs/gh.sh` pattern:

| # | Scenario | Assertion |
|---|----------|-----------|
| 1 | Script is executable | mode bits set |
| 2 | No poisoning | latest+1 |
| 3 | Local tag poisons | skips 1 |
| 4 | Only remote tag poisons | skips 1 |
| 5 | Only GitHub Release poisons | skips 1 |
| 6 | Three consecutive poisonings (one per signal) | lands on first clean |
| 7 | 100 consecutive poisoned tags | exit non-zero, actionable error |
| 8 | Empty latest-tag → initial release | returns `0.1.0` |
| 9 | Invalid latest-tag input | exit non-zero |
| 10 | **BLD-3223 replay**: v0.26.68 has remote tag + release → returns `0.26.69` | pass |
| 11 | Post-placeholder-push state: latest_tag=v0.26.68 → v0.26.69 | pass |
| 12 | git-stub sanity | pass |

Runs in ~1.4s. Zero flakiness (no network, no real git repo).

Verification:
- `npm run lint` → 0 errors (16 pre-existing warnings unrelated to this PR)
- `npm run typecheck` → clean
- `npm test __tests__/lib` → 170/170 suites pass, 2479/2479 tests
- `npm test scripts/__tests__/compute-next-release-version` → 12/12
- `npm test scripts/__tests__/release-apply-bump` → 15/15 (no regression to BLD-1185/2316)
- `scripts/check-changelog-parity.sh` → `✅ OK (v0.26.67, versionCode 137)`

## Dry-run walkthrough — future re-poisoning cannot deadlock

Scenario: at some future time, another partial release poisons `v0.27.5` with an immutable ghost.

- `latest_tag = v0.27.4` (last-shipped tag).
- Bump-path compute: PATCH+1 → 5, `NEXT=v0.27.5`.
- `version_is_poisoned("v0.27.5")` — depends whether ghost is queryable:
  - **If queryable** (release visible before ghost dropped from `/releases`): (c) hits → skip → `NEXT=v0.27.6` → clean → publish. ✓
  - **If not queryable** (pure ghost): skip loop misses. Build proceeds. `gh release create v0.27.5` fails with the immutable/creations-restricted stderr. B3 wrapper matches the pattern → emits `::error title=Immutable-release ghost blocks v0.27.5` with the exact recovery command. Operator lands a small revert-and-placeholder-tag PR (like this one). NEXT scheduled run: `latest_tag = v0.27.5` (placeholder tag), compute → `v0.27.6` → clean → publish. ✓

Either way: two-run recovery max, never a deadlock. The diff between "solved automatically" (skip-loop path) and "one small human/agent commit" (ghost path) is small and the operator now has an exact recovery command in the failure log.

## Concurrency / BLD-2315/2316 preservation

- `concurrency.group: scheduled-release / cancel-in-progress: false` — unchanged.
- Existing idempotent-no-op guard at L813-819 (`gh release view … && exit 0`) — unchanged. Runs before the new collision wrapper.
- Republish-mode hard-fail on existing tag at compute-time (L184-187) — unchanged.
- New collision wrapper does NOT swallow the "release already exists" error class (that's caught earlier by the pre-check guard). It only classifies genuine `gh release create` failures — the immutable-ghost branch adds an operator-actionable recovery message; all other failure classes surface unchanged with the raw stderr.

## Follow-up (out of this PR, done immediately after merge)

Once this PR merges to `main` at commit `<merged-sha>`:

```bash
# Push the placeholder tag so the next Scheduled Release computes v0.26.69.
GH_CONFIG_DIR=/paperclip/.config/gh gh api -X POST \
  repos/alankyshum/cablesnap/git/refs \
  -f ref="refs/tags/v0.26.68" \
  -f sha="<merged-sha>"

# Trigger a Scheduled Release run.
GH_CONFIG_DIR=/paperclip/.config/gh gh workflow run \
  "Scheduled Release" --repo alankyshum/cablesnap --ref main

# Poll to completion; on success attach the run URL to BLD-3223.
```

The `techlead` agent will execute these steps and attach the successful run URL to BLD-3223 as part of the completion criteria. Not done in-PR because the placeholder tag must point at the merged-main SHA, which is only knowable post-merge.

## Related work

- BLD-2315, BLD-2316 — concurrent-run idempotent-create (preserved).
- BLD-1101 — republish-mode strictness (preserved).
- BLD-1185 — atomic release + push-recovery (preserved).
- BLD-2139 — atomic release (build/smoke before commit) (preserved).
- BLD-3222 — parent tracking issue for the failing run.
