### PR TITLE
test: repair stale structural guard in share-settings.test.ts (BLD-3228)

### DIFF
--- a/__tests__/lib/share-settings.test.ts
+++ b/__tests__/lib/share-settings.test.ts
@@ -187,8 +187,10 @@ describe("Share Settings — Structural", () => {
     expect(indexSrc).toContain("ShareSettingsRow");
   });
 
-  it("buildActivityDescription no longer contains hardcoded old footer string", () => {
-    expect(stravaSrc).not.toContain("https://github.com/alankyshum/cablesnap");
+  it("strava.ts attribution uses the canonical GitHub repo URL (not the dead cablesnap.app placeholder)", () => {
+    expect(stravaSrc).toContain("DEFAULT_STRAVA_ATTRIBUTION");
+    expect(stravaSrc).toContain("https://github.com/alankyshum/cablesnap");
+    expect(stravaSrc).not.toContain("cablesnap.app");
   });
 
   it("updateActivityDescription exists in lib/strava.ts", () => {


### PR DESCRIPTION
## Summary

Repairs the stale structural guard in `share-settings.test.ts` that is causing main to be RED.

## Changes

- Replaced the stale negative guard test in `__tests__/lib/share-settings.test.ts` with a positive invariant asserting that `DEFAULT_STRAVA_ATTRIBUTION` and the canonical GitHub repo URL are correctly present in `strava.ts`.

## Testing

- Ran `npm test __tests__/lib/share-settings.test.ts` (passes 12/12)
- Ran full suite `npm test` (all 5502 tests pass)
- Ran type checking and linter (all pass)

## Issue

Resolves BLD-3228