### PR TITLE
test(strava): narrow stale strava footer structural test (BLD-3231)

### DIFF
--- a/__tests__/lib/share-settings.test.ts
+++ b/__tests__/lib/share-settings.test.ts
@@ -188,7 +188,13 @@ describe("Share Settings — Structural", () => {
   });
 
   it("buildActivityDescription no longer contains hardcoded old footer string", () => {
-    expect(stravaSrc).not.toContain("https://github.com/alankyshum/cablesnap");
+    // The old hardcoded footer was appended inline in buildActivityDescription as
+    // "…\n—\nTracked with CableSnap · https://github.com/alankyshum/cablesnap".
+    // It was replaced by the configurable promo-caption system + DEFAULT_STRAVA_ATTRIBUTION.
+    // Assert the specific old footer form is gone — NOT the bare repo URL, which is a
+    // legitimate attribution constant (DEFAULT_STRAVA_ATTRIBUTION) referenced elsewhere.
+    expect(stravaSrc).not.toContain("—\nTracked with CableSnap");
+    expect(stravaSrc).not.toContain("Tracked with CableSnap · https://github.com/alankyshum/cablesnap");
   });
 
   it("updateActivityDescription exists in lib/strava.ts", () => {


### PR DESCRIPTION
## Summary

Narrow the overly broad structural assertion on Strava footer in __tests__/lib/share-settings.test.ts.

## Changes

- Modified `__tests__/lib/share-settings.test.ts` to check for specific old footer structures rather than the bare canonical GitHub repository URL, which is now a valid attribution constant.

## Testing

- Ran Jest test suite on share-settings.test.ts (`node node_modules/.bin/jest __tests__/lib/share-settings.test.ts --runInBand`) -> 12 passed.
- Ran type checking (`tsc --noEmit`) -> Passed with zero errors.

## Issue

Resolves BLD-3231