### PR TITLE
fix(audit): run Playwright in CI mode to stop data-test-ready seed flakiness (BLD-3253)

### DIFF
--- a/scripts/daily-audit.sh
+++ b/scripts/daily-audit.sh
@@ -126,7 +126,10 @@ run_scenarios() {
   echo "[daily-audit] running scenarios: $label ($commit_sha)"
   echo "[daily-audit] specs: $*"
   echo "=========================================================="
-  E2E_USE_STATIC=1 COMMIT_SHA="$commit_sha" \
+  # BLD-3253: export CI=1 to run Playwright in CI mode (workers: 1, retries: 2).
+  # This provides parity with the stable GitHub Actions run posture (ux-audit.yml)
+  # and prevents database seed flakiness from parallel cold-boot worker contention.
+  CI=1 E2E_USE_STATIC=1 COMMIT_SHA="$commit_sha" \
     npx playwright test "$@" --project=mobile
 }
 


### PR DESCRIPTION
## Problem

The agent-runtime daily audit (`scripts/daily-audit.sh`) was running Playwright without `CI=1`, so `playwright.config.ts` selected `retries: 0` and `workers: undefined` (half the logical CPUs). Under parallel cold-boot contention against the single shared `npx serve -s dist` static origin, the lazy `test-seed` chunk fetch dropped or missed the 15s gate. On 2026-07-11 this caused 14 failures vs 1 the prior day.

GitHub Actions (`.github/workflows/ux-audit.yml`) already sets `CI: 'true'`, which maps to `workers: 1` + `retries: 2` — deterministic and stable.

## Fix

Add `CI=1` to the `npx playwright test` invocation in `run_scenarios()` to match the known-stable GitHub Actions path.

## Verification

- `bash -n scripts/daily-audit.sh` — syntax clean ✅
- `grep CI=1 scripts/daily-audit.sh` — present ✅
- No `.only` in `e2e/` (would hard-fail with `forbidOnly: true`) ✅
- `playwright.config.ts` unchanged ✅

Closes BLD-3253 / child BLD-3255.