### PR TITLE
feat: use two-issue REVIEW PICKUP pattern for audit handoff (BLD-3256)

### DIFF
--- a/scripts/__tests__/audit-handoff.test.ts
+++ b/scripts/__tests__/audit-handoff.test.ts
@@ -202,7 +202,7 @@ d("audit-handoff.sh — BLD-2109", () => {
     ).not.toThrow();
   });
 
-  describe("AC1: happy path — end state is in_review assigned to ux-designer", () => {
+  describe("AC1: happy path — end state is todo/in_progress assigned to ux-designer with REVIEW PICKUP issue", () => {
     it("exits 0", () => {
       const { dir, run } = buildSandbox({});
       try {
@@ -213,35 +213,38 @@ d("audit-handoff.sh — BLD-2109", () => {
       }
     });
 
-    it("issue ends with status=in_review", () => {
+    it("creates two issues with status=todo", () => {
       const { dir, run, readState } = buildSandbox({});
       try {
         run();
         const state = readState();
-        expect(state.issues).toHaveLength(1);
-        expect(state.issues[0].status).toBe("in_review");
+        expect(state.issues).toHaveLength(2);
+        expect(state.issues[0].status).toBe("todo");
+        expect(state.issues[1].status).toBe("todo");
       } finally {
         cleanup(dir);
       }
     });
 
-    it("issue ends with assigneeAgentId=ux-designer", () => {
+    it("both issues end with assigneeAgentId=ux-designer", () => {
       const { dir, run, readState } = buildSandbox({});
       try {
         run();
         const state = readState();
         expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+        expect(state.issues[1].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
       } finally {
         cleanup(dir);
       }
     });
 
-    it("issue is NEVER left in backlog", () => {
+    it("neither issue is left in backlog", () => {
       const { dir, run, readState } = buildSandbox({});
       try {
         run();
         const state = readState();
         expect(state.issues[0].status).not.toBe("backlog");
+        expect(state.issues[1].status).not.toBe("backlog");
       } finally {
         cleanup(dir);
       }
@@ -264,7 +267,7 @@ d("audit-handoff.sh — BLD-2109", () => {
       }
     });
 
-    it("update-issue PATCH carries BOTH status=in_review AND assigneeAgentId=ux-designer", () => {
+    it("update-issue PATCH carries BOTH status=todo AND assigneeAgentId=ux-designer", () => {
       const { dir, run, readCallLog } = buildSandbox({ trackCalls: true });
       try {
         run();
@@ -273,7 +276,7 @@ d("audit-handoff.sh — BLD-2109", () => {
         const patchCalls = calls.filter((c) => c.startsWith("update-issue"));
         expect(patchCalls).toHaveLength(1);
         expect(patchCalls[0]).toContain("--status");
-        expect(patchCalls[0]).toContain("in_review");
+        expect(patchCalls[0]).toContain("todo");
         expect(patchCalls[0]).toContain("--assignee-agent-id");
         expect(patchCalls[0]).toContain(UX_DESIGNER_AGENT_ID);
       } finally {
@@ -297,7 +300,7 @@ d("audit-handoff.sh — BLD-2109", () => {
   });
 
   describe("AC2: partial failure — NEVER leaves backlog", () => {
-    it("--capture-failed: issue still ends in_review assigned to ux-designer", () => {
+    it("--capture-failed: issue still ends todo assigned to ux-designer", () => {
       const { dir, run, readState } = buildSandbox({});
       try {
         const r = run([
@@ -307,7 +310,7 @@ d("audit-handoff.sh — BLD-2109", () => {
         ]);
         expect(r.status).toBe(0);
         const state = readState();
-        expect(state.issues[0].status).toBe("in_review");
+        expect(state.issues[0].status).toBe("todo");
         expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
         expect(state.issues[0].status).not.toBe("backlog");
       } finally {
@@ -315,7 +318,7 @@ d("audit-handoff.sh — BLD-2109", () => {
       }
     });
 
-    it("--upload-failed: issue still ends in_review assigned to ux-designer", () => {
+    it("--upload-failed: issue still ends todo assigned to ux-designer", () => {
       const { dir, run, readState } = buildSandbox({});
       try {
         const r = run([
@@ -325,7 +328,7 @@ d("audit-handoff.sh — BLD-2109", () => {
         ]);
         expect(r.status).toBe(0);
         const state = readState();
-        expect(state.issues[0].status).toBe("in_review");
+        expect(state.issues[0].status).toBe("todo");
         expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
         expect(state.issues[0].status).not.toBe("backlog");
       } finally {
@@ -374,14 +377,14 @@ d("audit-handoff.sh — BLD-2109", () => {
       }
     });
 
-    it("PATCH fail → issue status never changed to in_review (still in original state)", () => {
+    it("PATCH fail → issue status never changed to todo assigned to ux-designer", () => {
       const { dir, run, readState } = buildSandbox({ patchFail: true });
       try {
         run();
         const state = readState();
         // Issue was created but PATCH failed → status should still be 'todo'
-        // (create-issue default), not in_review.
-        expect(state.issues[0].status).not.toBe("in_review");
+        // (create-issue default), and assignee is still creating agent.
+        expect(state.issues[0].status).toBe("todo");
         // And the assignee should still be creating-agent, not ux-designer.
         expect(state.issues[0].assigneeAgentId).toBe(CREATING_AGENT_ID);
       } finally {
@@ -413,8 +416,16 @@ d("audit-handoff.sh — BLD-2109", () => {
         status: "in_review",
         assigneeAgentId: UX_DESIGNER_AGENT_ID,
       };
+      const existingPickup: ClipIssue = {
+        id: "issue-preexisting-001-pickup",
+        identifier: "BLD-2106-pickup",
+        title: "REVIEW PICKUP: AUDIT 2026-06-27 — Visual UX Review",
+        description: "ux-designer: please review [BLD-2106](/BLD/issues/BLD-2106)",
+        status: "todo",
+        assigneeAgentId: UX_DESIGNER_AGENT_ID,
+      };
       const { dir, run, readState } = buildSandbox({
-        initialState: { issues: [existingIssue], nextIdentifier: "BLD-9001", nextId: "issue-stub-002" },
+        initialState: { issues: [existingIssue, existingPickup], nextIdentifier: "BLD-9001", nextId: "issue-stub-002" },
         trackCalls: false,
       });
       try {
@@ -427,7 +438,7 @@ d("audit-handoff.sh — BLD-2109", () => {
         expect(r.status).toBe(0);
         // State must be unchanged — no new issues, no status change.
         const state = readState();
-        expect(state.issues).toHaveLength(1);
+        expect(state.issues).toHaveLength(2);
         expect(state.issues[0].status).toBe("in_review");
         expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
       } finally {
@@ -443,8 +454,16 @@ d("audit-handoff.sh — BLD-2109", () => {
         status: "done",
         assigneeAgentId: UX_DESIGNER_AGENT_ID,
       };
+      const existingPickup: ClipIssue = {
+        id: "issue-preexisting-002-pickup",
+        identifier: "BLD-2106-pickup",
+        title: "REVIEW PICKUP: AUDIT prior",
+        description: "ux-designer: please review [BLD-2106](/BLD/issues/BLD-2106)",
+        status: "done",
+        assigneeAgentId: UX_DESIGNER_AGENT_ID,
+      };
       const { dir, run, readState } = buildSandbox({
-        initialState: { issues: [existingIssue], nextIdentifier: "BLD-9001", nextId: "issue-stub-003" },
+        initialState: { issues: [existingIssue, existingPickup], nextIdentifier: "BLD-9001", nextId: "issue-stub-003" },
       });
       try {
         const r = run([
@@ -482,8 +501,43 @@ d("audit-handoff.sh — BLD-2109", () => {
         ]);
         expect(r.status).toBe(0);
         const state = readState();
-        expect(state.issues[0].status).toBe("in_review");
+        expect(state.issues).toHaveLength(2);
+        expect(state.issues[0].status).toBe("todo");
         expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+        expect(state.issues[1].status).toBe("todo");
+        expect(state.issues[1].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("--issue-id pointing to a todo/ux-designer issue but REVIEW PICKUP is missing → does NOT no-op, proceeds and creates REVIEW PICKUP", () => {
+      const existingIssue: ClipIssue = {
+        id: "issue-preexisting-004",
+        identifier: "BLD-2106",
+        title: "AUDIT 2026-06-27 — Visual UX Review",
+        status: "todo",
+        assigneeAgentId: UX_DESIGNER_AGENT_ID,
+      };
+      const { dir, run, readState } = buildSandbox({
+        initialState: { issues: [existingIssue], nextIdentifier: "BLD-9001", nextId: "issue-stub-002" },
+        trackCalls: false,
+      });
+      try {
+        const r = run([
+          "--title",
+          "AUDIT 2026-06-27 — Visual UX Review",
+          "--issue-id",
+          "BLD-2106",
+        ]);
+        expect(r.status).toBe(0);
+        const state = readState();
+        expect(state.issues).toHaveLength(2);
+        expect(state.issues[0].status).toBe("todo");
+        expect(state.issues[0].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+        expect(state.issues[1].title).toBe("REVIEW PICKUP: AUDIT 2026-06-27 — Visual UX Review");
+        expect(state.issues[1].status).toBe("todo");
+        expect(state.issues[1].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
       } finally {
         cleanup(dir);
       }
@@ -502,7 +556,7 @@ d("audit-handoff.sh — BLD-2109", () => {
         // PATCH did apply to stored state, but the script must not trust that
         // without a successful re-read.
         const state = readState();
-        expect(state.issues[0].status).toBe("in_review");
+        expect(state.issues[0].status).toBe("todo");
       } finally {
         cleanup(dir);
       }
@@ -522,14 +576,14 @@ d("audit-handoff.sh — BLD-2109", () => {
       }
     });
 
-    it("verified status != in_review (e.g. reverted to todo) → exit 4", () => {
-      // Simulate PATCH 2xx but a concurrent mutation leaving status=todo.
-      const { dir, run } = buildSandbox({ getStatusOverride: "todo" });
+    it("verified status != todo (e.g. reverted to blocked) → exit 4", () => {
+      // Simulate PATCH 2xx but a concurrent mutation leaving status=blocked.
+      const { dir, run } = buildSandbox({ getStatusOverride: "blocked" });
       try {
         const r = run();
         expect(r.status).toBe(4);
         expect(r.stderr).toMatch(/FATAL/i);
-        expect(r.stderr).toMatch(/expected in_review/i);
+        expect(r.stderr).toMatch(/expected todo/i);
       } finally {
         cleanup(dir);
       }
@@ -547,12 +601,12 @@ d("audit-handoff.sh — BLD-2109", () => {
       }
     });
 
-    it("verified status=in_review but assignee != ux-designer → exit 4 (FATAL, not WARN)", () => {
+    it("verified status=todo but assignee != ux-designer → exit 4 (FATAL, not WARN)", () => {
       // The exact failure this script prevents: status looks fine but the wake
       // would target the wrong agent. Must be fatal.
       const wrongAssignee = "00000000-0000-0000-0000-000000000000";
       const { dir, run } = buildSandbox({
-        getStatusOverride: "in_review",
+        getStatusOverride: "todo",
         getAssigneeOverride: wrongAssignee,
       });
       try {
@@ -566,7 +620,7 @@ d("audit-handoff.sh — BLD-2109", () => {
       }
     });
 
-    it("fully-correct verified end-state (in_review + ux-designer) → exit 0, VERIFIED", () => {
+    it("fully-correct verified end-state (todo + ux-designer) → exit 0, VERIFIED", () => {
       // Control case: with no overrides the re-read matches the PATCH, so the
       // strict verification passes and the script reports VERIFIED + DONE.
       const { dir, run } = buildSandbox({});

--- a/scripts/__tests__/audit-handoff.test.ts
+++ b/scripts/__tests__/audit-handoff.test.ts
@@ -1,7 +1,7 @@
 /**
- * BLD-2109 — audit-handoff.sh: Daily AUDIT issue must end each run assigned
- * to ux-designer with status=in_review (NOT backlog) so the assignment-wake
- * fires.
+ * BLD-3256 / BLD-2109 — audit-handoff.sh: Daily AUDIT issue must end each run
+ * assigned to ux-designer at status=todo/in_progress (NOT backlog) so the
+ * assignment-wake fires, accompanied by a separate REVIEW PICKUP issue.
  *
  * ## Background
  * BLD-2106 (AUDIT 2026-06-28) was left in backlog assigned to ux-designer.
@@ -9,33 +9,41 @@
  * backlog issues, so ux-designer was never woken. The root cause was the
  * status transition being a manual prose step that was silently skipped.
  *
- * The fix (this script) bakes the create+transition into a single idempotent
- * helper so the status-advance is code, not prose.
+ * BLD-3256 refactored the script to use the two-issue REVIEW PICKUP pattern
+ * (origin BLD-3188) after the server began returning HTTP 422 for in_review
+ * transitions without a 'real review path' (BLD-3254):
+ *   1. Create the AUDIT issue assigned to CREATING_AGENT (claudecoder).
+ *   2. PATCH the AUDIT issue: status=todo + assigneeAgentId=ux-designer.
+ *   3. Create a separate REVIEW PICKUP todo issue assigned to ux-designer,
+ *      referencing the AUDIT issue. This fresh assignment wakes ux-designer.
  *
  * ## Auth-boundary ordering asserted here
  * The clip.sh stub tracks the call sequence so we can assert that:
  *   1. create-issue was called with assigneeAgentId = CREATING_AGENT (not ux-designer)
- *   2. update-issue was called in a single PATCH with BOTH status=in_review
+ *   2. update-issue was called in a single PATCH with BOTH status=todo
  *      AND assigneeAgentId=ux-designer
  *
  * If the test stub received create-issue with assigneeAgentId=ux-designer, a
  * real Paperclip server would assign the issue to ux-designer first, and the
  * subsequent PATCH would be denied (403) because claudecoder ≠ ux-designer.
  *
- * ## Acceptance Criteria (from BLD-2109)
- *   AC1: Normal run → end state is assigneeAgentId=ux-designer + status=in_review
+ * ## Acceptance Criteria (from BLD-3256 / BLD-2109)
+ *   AC1: Normal run → end state is two issues at todo/in_progress, both
+ *        assigned to ux-designer (AUDIT + REVIEW PICKUP)
  *   AC2: Partial failure (capture/upload) → NEVER status=backlog
  *   AC3: PATCH failure → exit non-zero (loud failure, not silent backlog)
- *   AC4: Issue already in_review or further → no-op, exit 0
+ *   AC4: Issue already ≥ todo with REVIEW PICKUP → no-op, exit 0.
+ *        cancelled AUDIT → always fatal (exit 4), never a no-op.
  *   AC5: PATCH call ordering → create with creating-agent; PATCH switches
- *        BOTH status and assignee in one call
+ *        BOTH status=todo and assignee in one call
  *   AC6: Post-PATCH verification is strict — the verified end-state must be
- *        re-read successfully AND status==in_review AND assignee==ux-designer.
- *        Any unverifiable/wrong end-state exits non-zero (exit 4), because each
- *        case independently breaks ux-designer's assignment-wake. (QD review of
- *        PR #660: a "not backlog" check + WARN-only assignee was too weak.)
+ *        re-read successfully AND status==todo/in_progress AND
+ *        assignee==ux-designer. Any unverifiable/wrong end-state exits
+ *        non-zero (exit 4), because each case independently breaks
+ *        ux-designer's assignment-wake. (QD review of PR #660: a "not backlog"
+ *        check + WARN-only assignee was too weak.)
  *
- * Refs: BLD-2109, BLD-2107, BLD-2105.
+ * Refs: BLD-3256, BLD-3254, BLD-3188, BLD-2109, BLD-2107, BLD-2105.
  */
 import { execFileSync, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
@@ -538,6 +546,49 @@ d("audit-handoff.sh — BLD-2109", () => {
         expect(state.issues[1].title).toBe("REVIEW PICKUP: AUDIT 2026-06-27 — Visual UX Review");
         expect(state.issues[1].status).toBe("todo");
         expect(state.issues[1].assigneeAgentId).toBe(UX_DESIGNER_AGENT_ID);
+      } finally {
+        cleanup(dir);
+      }
+    });
+
+    it("--issue-id pointing to a cancelled ux-designer AUDIT issue with existing REVIEW PICKUP → exits 4 (not a silent no-op)", () => {
+      // Regression test for QD finding: cancelled is NOT a valid handoff end-state.
+      // Step 3 verifier only accepts todo/in_progress/done; treating a cancelled
+      // issue as a no-op would allow exit 0 with ux-designer never woken.
+      const cancelledAudit: ClipIssue = {
+        id: "issue-preexisting-cancelled-001",
+        identifier: "BLD-2106",
+        title: "AUDIT prior",
+        status: "cancelled",
+        assigneeAgentId: UX_DESIGNER_AGENT_ID,
+      };
+      const existingPickup: ClipIssue = {
+        id: "issue-preexisting-cancelled-001-pickup",
+        identifier: "BLD-2106-pickup",
+        title: "REVIEW PICKUP: AUDIT prior",
+        description: "ux-designer: please review [BLD-2106](/BLD/issues/BLD-2106)",
+        status: "todo",
+        assigneeAgentId: UX_DESIGNER_AGENT_ID,
+      };
+      const { dir, run } = buildSandbox({
+        initialState: {
+          issues: [cancelledAudit, existingPickup],
+          nextIdentifier: "BLD-9001",
+          nextId: "issue-stub-cancelled-001",
+        },
+      });
+      try {
+        const r = run([
+          "--title",
+          "AUDIT prior",
+          "--issue-id",
+          "BLD-2106",
+        ]);
+        // Must NOT exit 0 — a cancelled AUDIT is not a valid no-op end-state.
+        expect(r.status).toBe(4);
+        expect(r.stderr).toMatch(/FATAL/i);
+        expect(r.stderr).toMatch(/cancelled/i);
+        expect(r.stderr).toMatch(/ACTION REQUIRED/i);
       } finally {
         cleanup(dir);
       }

--- a/scripts/__tests__/fixtures/audit-handoff-stubs/clip.sh
+++ b/scripts/__tests__/fixtures/audit-handoff-stubs/clip.sh
@@ -53,6 +53,31 @@ fi
 CMD="${1:-}"; shift || true
 
 case "$CMD" in
+  list-issues)
+    status_filter=""; assignee_filter=""; project_filter=""; search_query=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --status)     status_filter="$2"; shift 2;;
+        --assignee)   assignee_filter="$2"; shift 2;;
+        --project)    project_filter="$2"; shift 2;;
+        -q|--search)  search_query="$2"; shift 2;;
+        *) shift;;
+      esac
+    done
+
+    jq --arg status "$status_filter" \
+       --arg assignee "$assignee_filter" \
+       --arg project "$project_filter" \
+       --arg q "$search_query" '
+      .issues[] |
+      select($status == "" or .status == $status) |
+      select($assignee == "" or .assigneeAgentId == $assignee) |
+      select($q == "" or (.title | contains($q)) or (.description // "" | contains($q)) or (.identifier == $q)) |
+      {identifier, title, status, priority}
+    ' "$STATE" 2>/dev/null || true
+    exit 0
+    ;;
+
   create-issue)
     if [[ "$CREATE_FAIL" == "1" ]]; then
       echo '{"error":"simulated create-issue failure","code":"STUB_FAIL"}' >&2
@@ -75,6 +100,11 @@ case "$CMD" in
     # Read nextIdentifier and nextId from state.
     next_id=$(jq -r '.nextId // "issue-stub-001"' "$STATE")
     next_ident=$(jq -r '.nextIdentifier // "BLD-9001"' "$STATE")
+
+    if [[ "$title" == REVIEW\ PICKUP:* ]]; then
+      next_id="${next_id}-pickup"
+      next_ident="${next_ident}-pickup"
+    fi
 
     # Append new issue to state.
     tmp=$(mktemp)

--- a/scripts/audit-handoff.sh
+++ b/scripts/audit-handoff.sh
@@ -1,40 +1,24 @@
 #!/usr/bin/env bash
-# audit-handoff.sh — BLD-2109: create the daily AUDIT issue and reliably
-# advance it to in_review so ux-designer's assignment-wake fires.
+# audit-handoff.sh — BLD-3256: create the daily AUDIT issue and a separate
+# REVIEW PICKUP issue to wake ux-designer under the new in_review constraints.
 #
-# ## Auth-boundary ordering (CRITICAL — do not reorder without understanding)
+# ## The Two-Issue REVIEW PICKUP Pattern (BLD-3188, BLD-3256)
 #
-# Paperclip's authorization check (server/src/services/authorization.ts:1266-1295)
-# evaluates the CURRENT (pre-mutation) assignee when deciding if an agent PATCH
-# is allowed:
+# To avoid HTTP 422 errors due to the in_review 'real review path' constraints (BLD-3254),
+# the daily UX audit is handed off using a reliable two-issue pattern:
 #
-#   allowed iff: actor == current.assigneeAgentId  OR  current has no agent assignee
-#
-# The trap that caused BLD-2106 to get stuck in backlog (BLD-2107 forensics):
-#   create-issue assigned to ux-designer
-#   ↓
-#   PATCH status=in_review → denied (actor=claudecoder ≠ assignee=ux-designer)
-#   ↓
-#   Issue left in backlog, ux-designer never woken (server skips backlog for
-#   queueIssueAssignmentWakeup, server/src/services/issue-assignment-wakeup.ts:31)
-#
-# Safe ordering used here:
-#   1. create-issue assigned to CREATING AGENT (claudecoder), status=todo
-#      → issue created with assignee=claudecoder; claudecoder has full mutation authority
-#   2. single PATCH: status=in_review + assigneeAgentId=ux-designer
-#      → pre-mutation assignee is still claudecoder == actor → ALLOWED
-#      → post-mutation assignee is ux-designer; server wakes ux-designer because
-#        status (in_review) is not backlog
-#
-# Do NOT split step 2 into two PATCHes — after the first PATCH switches the
-# assignee to ux-designer, the second PATCH (changing status) would be denied.
+#   1. Create the AUDIT issue assigned to the creating agent (claudecoder), status=todo.
+#   2. PATCH the AUDIT issue: status=todo + assigneeAgentId=ux-designer.
+#      This is safe because the pre-mutation assignee is still claudecoder.
+#   3. Create a separate todo issue titled "REVIEW PICKUP: <AUDIT title>"
+#      assigned to ux-designer, referencing the AUDIT issue in its description.
+#      This fresh todo issue wakes ux-designer (assignment-wake) reliably.
 #
 # ## Idempotency
 #
-# If the AUDIT issue already exists for today's date (detected by listing issues
-# with --label "audit" or by the --issue-id override), and its status is already
-# ≥ in_review, the script is a no-op and exits 0. This prevents clobbering
-# ux-designer if she has already advanced the issue further (in_progress / done).
+# If the AUDIT issue already exists for today's date (detected by the --issue-id override),
+# and its status is already todo/in_progress/done, and it is assigned to ux-designer,
+# the script is a no-op and exits 0 to prevent clobbering ux-designer.
 #
 # ## Partial-failure contract (BLD-2109 requirement)
 #
@@ -46,17 +30,16 @@
 # can compose the right default status comment.
 #
 # ## Exit codes
-#   0  — Issue created-or-reused and VERIFIED at status=in_review assigned to
-#          ux-designer (or already ≥ in_review assigned to ux-designer; no-op)
+#   0  — Issues created-or-reused and VERIFIED at status=todo/in_progress/done
+#          assigned to ux-designer (or already ≥ todo; no-op)
 #   1  — Usage error
 #   2  — clip.sh create-issue failed
-#   3  — clip.sh PATCH (status + assignee transition) failed (exits loudly;
-#          never leaves issue in backlog assigned to ux-designer)
-#   4  — post-PATCH verification failed: re-read errored, OR status != in_review,
+#   3  — clip.sh PATCH or REVIEW PICKUP issue creation failed (exits loudly)
+#   4  — post-PATCH verification failed: re-read errored, OR status is backlog,
 #          OR assignee != ux-designer. Any unverifiable/wrong end-state is fatal
 #          because it means ux-designer's assignment-wake will not fire.
 #
-# Refs: BLD-2109, BLD-2107, BLD-2106, BLD-2105.
+# Refs: BLD-3256, BLD-3254, BLD-3188, BLD-2109.
 
 set -euo pipefail
 
@@ -98,19 +81,18 @@ Usage: audit-handoff.sh \
          [--ux-designer-agent-id <uuid>] \
          [--creating-agent-id <uuid>]
 
-Creates (or reuses) the daily AUDIT issue and transitions it to in_review
-assigned to ux-designer — all in one run so the creating agent retains
-mutation authority for the PATCH (auth-boundary-safe ordering, BLD-2109).
+Creates (or reuses) the daily AUDIT issue, assigns it to ux-designer,
+and creates a separate REVIEW PICKUP issue to wake ux-designer (BLD-3256).
 
 The --issue-id flag is for the partial-rerun case (issue already created in a
 prior attempt; skip create and go straight to the transition).
 
 Exit codes:
-  0  success (issue VERIFIED at in_review assigned to ux-designer)
+  0  success (issues VERIFIED at todo/in_progress assigned to ux-designer)
   1  usage error
   2  create-issue failed
-  3  PATCH (status + assignee transition) failed — NEVER leaves backlog
-  4  post-PATCH verify failed: read errored, status != in_review, or
+  3  PATCH (status + assignee transition) or REVIEW PICKUP creation failed
+  4  post-PATCH verify failed: read errored, status is backlog, or
      assignee != ux-designer (any unverifiable/wrong end-state is fatal)
 EOF
   exit "${1:-1}"
@@ -169,7 +151,10 @@ except:
   fi
 }
 
-# ─── Step 0: Check if already at in_review or further (idempotency) ───
+existing_status=""
+existing_assignee=""
+
+# ─── Step 0: Check if already at todo or further (idempotency) ───
 if [[ -n "$ISSUE_ID" ]]; then
   echo "[audit-handoff] --issue-id provided ($ISSUE_ID); skipping create step."
   echo "[audit-handoff] Fetching current status to check idempotency..."
@@ -185,12 +170,55 @@ if [[ -n "$ISSUE_ID" ]]; then
     existing_status=$(json_field "$existing_json" "status")
     existing_assignee=$(json_field "$existing_json" "assigneeAgentId")
 
-    # If already ≥ in_review and assigned to ux-designer, nothing to do.
+    # If already ≥ todo and assigned to ux-designer, we also require that
+    # the corresponding REVIEW PICKUP issue exists before we can no-op.
     case "$existing_status" in
-      in_review|in_progress|done|cancelled)
+      todo|in_review|in_progress|done|cancelled)
         if [[ "$existing_assignee" == "$UX_DESIGNER_AGENT_ID" ]]; then
-          echo "[audit-handoff] Issue $ISSUE_ID is already $existing_status assigned to ux-designer — no-op."
-          exit 0
+          echo "[audit-handoff] Issue $ISSUE_ID is already $existing_status assigned to ux-designer."
+          echo "[audit-handoff] Checking if corresponding REVIEW PICKUP issue exists..."
+          set +e
+          candidates_json=$(run_clip list-issues --assignee "$UX_DESIGNER_AGENT_ID" -q "$ISSUE_ID" 2>&1)
+          list_rc=$?
+          set -e
+
+          if [[ $list_rc -eq 0 ]]; then
+            has_pickup=$(echo "$candidates_json" | python3 -c '
+import sys, json
+def check():
+    text = sys.stdin.read().strip()
+    if not text:
+        return False
+    decoder = json.JSONDecoder()
+    pos = 0
+    while pos < len(text):
+        text = text[pos:].strip()
+        if not text:
+            break
+        try:
+            obj, pos = decoder.raw_decode(text)
+            title = obj.get("title", "")
+            status = obj.get("status", "")
+            if "REVIEW PICKUP" in title and status in ("todo", "in_progress", "in_review", "done"):
+                return True
+        except Exception:
+            break
+    return False
+
+if check():
+    print("true")
+else:
+    print("false")
+')
+            if [[ "$has_pickup" == "true" ]]; then
+              echo "[audit-handoff] Found existing REVIEW PICKUP issue assigned to ux-designer — no-op."
+              exit 0
+            else
+              echo "[audit-handoff] No active REVIEW PICKUP issue found for $ISSUE_ID assigned to ux-designer."
+            fi
+          else
+            echo "[audit-handoff] WARN: could not search issues for REVIEW PICKUP — proceeding." >&2
+          fi
         fi
         ;;
     esac
@@ -262,53 +290,102 @@ ${BUNDLE_URL}"
   echo "[audit-handoff] Issue created: $ISSUE_ID"
 fi
 
-# ─── Step 2: Atomic PATCH — status=in_review + assignee=ux-designer ───
+# ─── Step 2: PATCH — status=todo + assignee=ux-designer ───
 #
 # AUTH BOUNDARY: At this point, the issue's assigneeAgentId == CREATING_AGENT_ID
 # (claudecoder), because either:
 #   (a) we just created it with --assignee-agent-id CREATING_AGENT_ID, or
 #   (b) caller passed --issue-id for a prior partial-create, and step 0 confirmed
-#       the issue is NOT yet at in_review (meaning ux-designer hasn't claimed it yet).
+#       the issue is NOT yet assigned to ux-designer.
 #
 # The Paperclip auth check evaluates the PRE-MUTATION assignee:
 #   actor (claudecoder) == pre-mutation assignee (claudecoder) → ALLOWED
 #
-# After this PATCH: assignee=ux-designer AND status=in_review → server
-# triggers queueIssueAssignmentWakeup (skips backlog; in_review is fine).
+# After this PATCH: assignee=ux-designer AND status=todo.
 
-echo "[audit-handoff] PATCH $ISSUE_ID: status=in_review + assigneeAgentId=ux-designer ..."
+if [[ "$existing_assignee" == "$UX_DESIGNER_AGENT_ID" ]]; then
+  echo "[audit-handoff] AUDIT issue $ISSUE_ID is already assigned to ux-designer — skipping Step 2 PATCH."
+else
+  echo "[audit-handoff] PATCH $ISSUE_ID: status=todo + assigneeAgentId=ux-designer ..."
 
-patch_json=""
+  patch_json=""
+  set +e
+  patch_json=$(run_clip update-issue "$ISSUE_ID" \
+    --status "todo" \
+    --assignee-agent-id "$UX_DESIGNER_AGENT_ID" 2>&1)
+  patch_rc=$?
+  set -e
+
+  if [[ $patch_rc -ne 0 ]]; then
+    echo "[audit-handoff] FATAL: PATCH failed (rc=$patch_rc). Issue $ISSUE_ID may still be in backlog." >&2
+    echo "[audit-handoff] PATCH output: $patch_json" >&2
+    echo "[audit-handoff] ACTION REQUIRED: board must manually advance $ISSUE_ID to todo and assign ux-designer." >&2
+    # Exit 3 — caller should surface this loudly (set -e / CI failure).
+    exit 3
+  fi
+
+  echo "[audit-handoff] PATCH succeeded."
+fi
+
+# ─── Step 2b: Create the REVIEW PICKUP issue ───
+#
+# Create a separate todo issue titled `REVIEW PICKUP: <AUDIT title>` assigned to ux-designer
+# that references the AUDIT issue. This is the reliable assignment-wake per BLD-3188.
+
+echo "[audit-handoff] Creating separate REVIEW PICKUP issue..."
+
+if [[ "$ISSUE_ID" =~ ^BLD-[0-9]+$ ]]; then
+  REVIEW_DESC="ux-designer: please review [${ISSUE_ID}](/BLD/issues/${ISSUE_ID}) and mark it done once your audit findings are filed."
+else
+  REVIEW_DESC="ux-designer: please review issue ${ISSUE_ID} and mark it done once your audit findings are filed."
+fi
+if [[ -n "$BUNDLE_URL" ]]; then
+  REVIEW_DESC="${REVIEW_DESC}
+
+Bundle URL: ${BUNDLE_URL}"
+fi
+
+pickup_json=""
 set +e
-patch_json=$(run_clip update-issue "$ISSUE_ID" \
-  --status "in_review" \
-  --assignee-agent-id "$UX_DESIGNER_AGENT_ID" 2>&1)
-patch_rc=$?
+pickup_json=$(run_clip create-issue \
+  --title "REVIEW PICKUP: $TITLE" \
+  --description "$REVIEW_DESC" \
+  --status "todo" \
+  --priority "$PRIORITY" \
+  --assignee-agent-id "$UX_DESIGNER_AGENT_ID" \
+  --project-id "$PROJECT_ID" 2>&1)
+pickup_rc=$?
 set -e
 
-if [[ $patch_rc -ne 0 ]]; then
-  echo "[audit-handoff] FATAL: PATCH failed (rc=$patch_rc). Issue $ISSUE_ID may still be in backlog." >&2
-  echo "[audit-handoff] PATCH output: $patch_json" >&2
-  echo "[audit-handoff] ACTION REQUIRED: board must manually advance $ISSUE_ID to in_review and assign ux-designer." >&2
-  # Exit 3 — caller should surface this loudly (set -e / CI failure).
+if [[ $pickup_rc -ne 0 ]]; then
+  echo "[audit-handoff] FATAL: REVIEW PICKUP issue creation failed (rc=$pickup_rc)." >&2
+  echo "[audit-handoff] create-issue output: $pickup_json" >&2
   exit 3
 fi
 
-echo "[audit-handoff] PATCH succeeded."
+PICKUP_ISSUE_ID=$(json_field "$pickup_json" "identifier")
+if [[ -z "$PICKUP_ISSUE_ID" ]]; then
+  PICKUP_ISSUE_ID=$(json_field "$pickup_json" "id")
+fi
 
-# ─── Step 3: Verify — re-read the issue and confirm end-state ─────────
-#
-# We never trust the PATCH response alone. A 2xx response with an unexpected
-# body (or a concurrent mutation) could leave the issue in an unexpected state.
-# Re-reading and asserting is the only way to guarantee the downstream wake fires.
-#
-# The verified end-state must satisfy ALL THREE invariants, each FATAL on failure
-# (exit 4) because each independently breaks ux-designer's assignment-wake:
-#   (a) the re-read itself must succeed (else the end-state is unverifiable),
-#   (b) status MUST be exactly in_review (not merely "not backlog"),
-#   (c) assignee MUST be ux-designer (else the wake targets the wrong agent).
+if [[ -z "$PICKUP_ISSUE_ID" ]]; then
+  echo "[audit-handoff] ERROR: REVIEW PICKUP issue created but could not extract issue ID from response." >&2
+  echo "[audit-handoff] Response: $pickup_json" >&2
+  exit 3
+fi
 
-echo "[audit-handoff] Verifying end-state for $ISSUE_ID ..."
+echo "[audit-handoff] REVIEW PICKUP issue created: $PICKUP_ISSUE_ID"
+
+# ─── Step 3: Verify — re-read both issues and confirm end-state ─────────
+#
+# We never trust the responses alone. Re-reading and asserting is the only way to
+# guarantee the downstream wake fires.
+#
+# The verified end-state must satisfy:
+#   (a) the re-read of AUDIT issue must succeed, and status must be todo/in_progress/done, and assignee must be ux-designer.
+#   (b) the re-read of REVIEW PICKUP issue must succeed, and status must be todo/in_progress/done, and assignee must be ux-designer.
+
+echo "[audit-handoff] Verifying end-state for AUDIT issue $ISSUE_ID ..."
 
 verify_json=""
 set +e
@@ -316,44 +393,78 @@ verify_json=$(run_clip get-issue "$ISSUE_ID" 2>&1)
 verify_rc=$?
 set -e
 
-# (a) Read failure is FATAL. An unverifiable end-state must NOT pass: if we
-# cannot re-read the issue we cannot prove ux-designer's wake will fire, which
-# is the entire purpose of this script (BLD-2109). Exit non-zero so the caller
-# (and CI) surfaces it loudly instead of silently assuming success.
 if [[ $verify_rc -ne 0 ]]; then
-  echo "[audit-handoff] FATAL: could not re-read $ISSUE_ID for verification (rc=$verify_rc)." >&2
+  echo "[audit-handoff] FATAL: could not re-read AUDIT issue $ISSUE_ID for verification (rc=$verify_rc)." >&2
   echo "[audit-handoff] Output: $verify_json" >&2
   echo "[audit-handoff] End-state is UNVERIFIABLE; refusing to report success." >&2
-  echo "[audit-handoff] ACTION REQUIRED: board must confirm $ISSUE_ID is in_review assigned to ux-designer." >&2
+  echo "[audit-handoff] ACTION REQUIRED: board must confirm AUDIT issue $ISSUE_ID is todo/in_progress assigned to ux-designer." >&2
   exit 4
 fi
 
 final_status=$(json_field "$verify_json" "status")
 final_assignee=$(json_field "$verify_json" "assigneeAgentId")
 
-# (b) Status must POSITIVELY be in_review. Asserting "not backlog" is too weak —
-# any other status (todo, blocked, an empty/garbled read, a concurrent mutation
-# that reverted the PATCH) also means the verified end-state is wrong. Only
-# in_review proves the assignment-wake will fire, so require it explicitly.
-if [[ "$final_status" != "in_review" ]]; then
-  echo "[audit-handoff] FATAL: $ISSUE_ID status=$final_status after PATCH (expected in_review)." >&2
-  if [[ "$final_status" == "backlog" ]]; then
-    echo "[audit-handoff] Issue is STILL in backlog — ux-designer will NOT be woken." >&2
-  fi
-  echo "[audit-handoff] ACTION REQUIRED: board must manually advance $ISSUE_ID to in_review." >&2
-  exit 4
-fi
+case "$final_status" in
+  todo|in_progress|done)
+    # Status is fine.
+    ;;
+  *)
+    echo "[audit-handoff] FATAL: $ISSUE_ID status=$final_status after PATCH (expected todo/in_progress)." >&2
+    if [[ "$final_status" == "backlog" ]]; then
+      echo "[audit-handoff] Issue is STILL in backlog — ux-designer will NOT be woken." >&2
+    fi
+    echo "[audit-handoff] ACTION REQUIRED: board must manually advance $ISSUE_ID to todo." >&2
+    exit 4
+    ;;
+esac
 
-# (c) Assignee must be ux-designer. A wrong assignee means ux-designer is never
-# woken — the exact failure this script exists to prevent — so this is FATAL,
-# not a warning. (in_review alone is insufficient: the assignment-wake targets
-# the assignee, and only ux-designer should review the audit.)
 if [[ "$final_assignee" != "$UX_DESIGNER_AGENT_ID" ]]; then
-  echo "[audit-handoff] FATAL: $ISSUE_ID status=in_review but assignee=$final_assignee (expected ux-designer $UX_DESIGNER_AGENT_ID)." >&2
+  echo "[audit-handoff] FATAL: $ISSUE_ID status=$final_status but assignee=$final_assignee (expected ux-designer $UX_DESIGNER_AGENT_ID)." >&2
   echo "[audit-handoff] ux-designer will NOT be woken on the audit." >&2
   echo "[audit-handoff] ACTION REQUIRED: board must reassign $ISSUE_ID to ux-designer." >&2
   exit 4
 fi
 
+echo "[audit-handoff] Verifying end-state for REVIEW PICKUP issue $PICKUP_ISSUE_ID ..."
+
+verify_pickup_json=""
+set +e
+verify_pickup_json=$(run_clip get-issue "$PICKUP_ISSUE_ID" 2>&1)
+verify_pickup_rc=$?
+set -e
+
+if [[ $verify_pickup_rc -ne 0 ]]; then
+  echo "[audit-handoff] FATAL: could not re-read REVIEW PICKUP issue $PICKUP_ISSUE_ID for verification (rc=$verify_pickup_rc)." >&2
+  echo "[audit-handoff] Output: $verify_pickup_json" >&2
+  echo "[audit-handoff] End-state is UNVERIFIABLE; refusing to report success." >&2
+  echo "[audit-handoff] ACTION REQUIRED: board must confirm REVIEW PICKUP issue $PICKUP_ISSUE_ID is todo assigned to ux-designer." >&2
+  exit 4
+fi
+
+pickup_status=$(json_field "$verify_pickup_json" "status")
+pickup_assignee=$(json_field "$verify_pickup_json" "assigneeAgentId")
+
+case "$pickup_status" in
+  todo|in_progress|done)
+    # Status is fine.
+    ;;
+  *)
+    echo "[audit-handoff] FATAL: $PICKUP_ISSUE_ID status=$pickup_status (expected todo/in_progress)." >&2
+    if [[ "$pickup_status" == "backlog" ]]; then
+      echo "[audit-handoff] REVIEW PICKUP is in backlog — ux-designer will NOT be woken." >&2
+    fi
+    echo "[audit-handoff] ACTION REQUIRED: board must manually advance $PICKUP_ISSUE_ID to todo." >&2
+    exit 4
+    ;;
+esac
+
+if [[ "$pickup_assignee" != "$UX_DESIGNER_AGENT_ID" ]]; then
+  echo "[audit-handoff] FATAL: $PICKUP_ISSUE_ID status=$pickup_status but assignee=$pickup_assignee (expected ux-designer $UX_DESIGNER_AGENT_ID)." >&2
+  echo "[audit-handoff] ux-designer will NOT be woken on the REVIEW PICKUP." >&2
+  echo "[audit-handoff] ACTION REQUIRED: board must reassign $PICKUP_ISSUE_ID to ux-designer." >&2
+  exit 4
+fi
+
 echo "[audit-handoff] VERIFIED: $ISSUE_ID status=$final_status assignee=$final_assignee"
-echo "[audit-handoff] DONE: ux-designer will be woken on $ISSUE_ID."
+echo "[audit-handoff] VERIFIED: $PICKUP_ISSUE_ID status=$pickup_status assignee=$pickup_assignee"
+echo "[audit-handoff] DONE: ux-designer will be woken on REVIEW PICKUP issue $PICKUP_ISSUE_ID."

--- a/scripts/audit-handoff.sh
+++ b/scripts/audit-handoff.sh
@@ -172,8 +172,17 @@ if [[ -n "$ISSUE_ID" ]]; then
 
     # If already ≥ todo and assigned to ux-designer, we also require that
     # the corresponding REVIEW PICKUP issue exists before we can no-op.
+    # NOTE: cancelled is intentionally excluded from the no-op path.
+    # Step 3 verifier only accepts todo/in_progress/done; treating a cancelled
+    # issue as a no-op would allow exit 0 with ux-designer never woken.
     case "$existing_status" in
-      todo|in_review|in_progress|done|cancelled)
+      cancelled)
+        echo "[audit-handoff] FATAL: Issue $ISSUE_ID has status=cancelled — not a valid handoff end-state." >&2
+        echo "[audit-handoff] A cancelled issue cannot be handed off to ux-designer for an active audit." >&2
+        echo "[audit-handoff] ACTION REQUIRED: create a fresh AUDIT issue or re-open $ISSUE_ID manually." >&2
+        exit 4
+        ;;
+      todo|in_review|in_progress|done)
         if [[ "$existing_assignee" == "$UX_DESIGNER_AGENT_ID" ]]; then
           echo "[audit-handoff] Issue $ISSUE_ID is already $existing_status assigned to ux-designer."
           echo "[audit-handoff] Checking if corresponding REVIEW PICKUP issue exists..."


### PR DESCRIPTION
## Summary

Paperclip server hardened the transition to `in_review` by requiring a 'real review path' (returning HTTP 422 otherwise). This broke the single-issue `in_review` handoff pattern in `scripts/audit-handoff.sh`. This PR refactors it to use the proven-reliable two-issue REVIEW PICKUP pattern, which leaves the main AUDIT issue at `todo` assigned to the ux-designer and creates a separate `todo` issue titled `REVIEW PICKUP: <title>` assigned to the ux-designer to trigger her assignment-wake.

## Changes

- Refactored `scripts/audit-handoff.sh` to leave the AUDIT issue at status `todo` and create a separate `REVIEW PICKUP: <title>` issue assigned to ux-designer.
- Updated Step 3 verification to assert both issues are properly created, assigned, and placed at `todo`.
- Updated test stub fixtures (`scripts/__tests__/fixtures/audit-handoff-stubs/clip.sh`) to uniquely generate ID/identifier on consecutive create-issue calls.
- Updated unit tests (`scripts/__tests__/audit-handoff.test.ts`) to verify the two-issue end-state, partial failure cases, idempotency, and strict verification logic.

## Testing

- Ran `npm test scripts/__tests__/audit-handoff.test.ts` successfully with 100% pass rate.
- Verified TypeScript compilation with `npm run typecheck`.

## Issue

Resolves BLD-3256